### PR TITLE
fix(widget): accept source query param on /widgets/{id}/data

### DIFF
--- a/backend/app/api/widget.py
+++ b/backend/app/api/widget.py
@@ -222,6 +222,7 @@ async def get_widget_data(
     widget_id: str,
     response: Response,
     email: Optional[str] = None,
+    source: Optional[str] = Query(None),
     authorization: Optional[str] = Header(None),
     db: Session = Depends(get_db)
 ):
@@ -301,10 +302,14 @@ async def get_widget_data(
         if customer:
             human_agent_info = await get_human_agent_session_info(db, str(customer.id))
         
-        # Generate new token with customer_id and preserve source if applicable
+        # Generate new token with customer_id and preserve source if applicable.
+        # Prefer the fresh `source` query param (first-visit Explore flow) and
+        # fall back to any source already captured in a prior token.
         new_token_extra_data = {}
-        if widget_id == settings.EXPLORE_WIDGET_ID and old_token_source:
-            new_token_extra_data["source"] = old_token_source
+        if widget_id == settings.EXPLORE_WIDGET_ID:
+            effective_source = source or old_token_source
+            if effective_source:
+                new_token_extra_data["source"] = effective_source
 
         new_token = create_conversation_token(
             customer_id=str(customer.id),


### PR DESCRIPTION
## Summary

- Declares `source: Optional[str] = Query(None)` on `get_widget_data` — the param the ExploreView frontend has been sending since Aug 2025 but was silently dropped by FastAPI
- Generates the new conversation token with that source when `widget_id == EXPLORE_WIDGET_ID`, falling back to the previously-captured `old_token_source` when it's not supplied

## Why

ExploreView calls `/api/v1/widgets/{demoWidgetId}/data?source=<websiteUrl>` directly without first hitting the `/widget/{id}` HTML endpoint. Because `get_widget_data`'s signature didn't declare `source`, FastAPI ignored the query param. The handler then tried to preserve source via `old_token_source` — which only exists on return visits with an existing token. First-time Explore visitors therefore always had `source=None` flowing into `ChatAgent`, breaking analytics/attribution on the Explore flow.

## Timeline of the bug

- 2025-08-05 15:42:48 IST — `0095ad2` in `enterprise_frontend`: frontend starts sending `?source=...` to `/data`
- 2025-08-05 15:43:18 IST — `61e3287` in this repo: backend adds source handling to `get_widget_ui` (correct) and `old_token_source` logic to `get_widget_data` (incomplete — signature not updated)
- Bug has been latent for ~8 months

## Test plan

- [ ] Deploy to staging/prod
- [ ] Open `https://app.chattermate.chat/explore`, enter any website URL, start a chat
- [ ] Tail backend logs: expect `Initializing chat agent for agent_id: ... and source: <the website url>` instead of `source: None`
- [ ] Confirm `/api/v1/widgets/{EXPLORE_WIDGET_ID}/data?source=X` still returns 200 (no breaking change)
- [ ] Confirm non-Explore widgets (widget_id != EXPLORE_WIDGET_ID) are unaffected — the conditional short-circuits for them

🤖 Generated with [Claude Code](https://claude.com/claude-code)