### PR TITLE
fix(security): anonymous conversation tokens rejected by jwt.decode

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -122,12 +122,18 @@ def create_conversation_token(widget_id: str, customer_id: Optional[str] = None,
     """
     jti = str(uuid.uuid4())
     data = {
-        "sub": customer_id,  # Keep as None if not provided, don't convert to string "None"
         "widget_id": widget_id,
         "type": "conversation",
         "jti": jti
     }
-    
+
+    # Only include `sub` when a customer_id is present. RFC 7519 (and python-jose)
+    # require `sub` to be a string — encoding it as JSON null causes decode to fail
+    # with JWTError("Subject must be a string") for anonymous widget visitors
+    # (e.g. Explore flow), which silently drops all downstream claims (like `source`).
+    if customer_id is not None:
+        data["sub"] = customer_id
+
     # Add email to token if provided
     if customer_email:
         data["email"] = customer_email
@@ -156,8 +162,13 @@ def verify_conversation_token(token: str) -> Optional[dict]:
         Token payload dict if valid and not revoked, None otherwise
     """
     try:
+        # verify_sub=False tolerates existing tokens (already in browsers' localStorage)
+        # that were issued with `sub: null`. New tokens from create_conversation_token
+        # omit `sub` entirely when anonymous, so this option only matters for in-flight
+        # tokens until the old 30-day TTLs expire.
         payload = jwt.decode(token, CONVERSATION_SECRET_KEY,
-                             algorithms=[ALGORITHM])
+                             algorithms=[ALGORITHM],
+                             options={"verify_sub": False})
 
         if payload.get("type") != "conversation":
             return None


### PR DESCRIPTION
## Summary

Anonymous widget tokens (Explore flow, public widgets without auth) were failing JWT decode because `create_conversation_token` encoded `customer_id=None` as `{"sub": null}` — python-jose rejects this per RFC 7519 with `JWTError("Subject must be a string")`. `verify_conversation_token` silently caught it and returned None, dropping all other claims.

## Why this was silently broken

- ANY anonymous token → decode fails → `token_data=None` → `old_token_source`, `customer_id`, and any `**extra_data` claims all get ignored
- This is why my PR #143 fix to accept `source` as a query param didn't end up working for real Explore visits: the frontend relies on the token's source being carried forward on the follow-up `/widgets/{id}` call, but decode was failing on every anonymous token

## Evidence

Instrumented `verify_conversation_token` in a live container:
```
[VCT-DBG] JWTError: Subject must be a string.
```
on every anonymous token decode.

## Fix

1. `create_conversation_token` now **omits `sub` entirely** when `customer_id is None` (instead of setting it to `null`). New anonymous tokens are valid per spec.
2. `verify_conversation_token` passes `options={"verify_sub": False}` to `jwt.decode` so **existing anonymous tokens already in browsers' localStorage continue to work** until their 30-day TTLs expire. Without this, every active anonymous session would break on deploy.

## Impact

- All anonymous widget flows (Explore, public widgets without `require_token_auth`) were failing JWT decode
- Any extra claims in anonymous tokens (source, custom extras) were silently lost
- Combined with PR #143, this completes the Explore source-tracking fix

## Test plan

- [ ] Deploy to prod (via `scripts/deploy.sh`)
- [ ] Open `https://chattermate.chat` → click "See It in Action" → enter a URL → start chat
- [ ] Backend log should show `Initializing chat agent for agent_id: ... and source: <the URL>` (not `source: None`)
- [ ] Confirm existing widget embeds on customer sites still connect (existing tokens in localStorage don't break)
- [ ] Verify `/api/v1/widgets/{id}/data?source=X` response still includes a decodable token (check with JWT decoder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)