### PR TITLE
feat(auth): Personal Access Token support + propagate plan-gated errors

### DIFF
--- a/backend/app/api/agent.py
+++ b/backend/app/api/agent.py
@@ -273,8 +273,10 @@ async def update_agent(
         update_dict = update_data.model_dump(
             exclude={'photo_url'}, exclude_unset=True)
         
-        # Check rating feature availability and override ask_for_rating if necessary
-        if HAS_ENTERPRISE and auth_info['auth_type'] == 'jwt':
+        # Check rating feature availability and override ask_for_rating if necessary.
+        # Applies to both JWT and Personal Access Token (PAT) sessions; Shopify auth
+        # enforces plan features separately.
+        if HAS_ENTERPRISE and auth_info['auth_type'] in ('jwt', 'pat'):
             from app.enterprise.repositories.plan import PlanRepository
             subscription_repo = SubscriptionRepository(db)
             subscription = subscription_repo.get_by_organization(auth_info["organization_id"])

--- a/backend/app/api/workflow.py
+++ b/backend/app/api/workflow.py
@@ -113,6 +113,10 @@ async def create_workflow(
     except ValueError as e:
         logger.error(f"Validation error creating workflow: {str(e)}")
         raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        # Let intended HTTP errors (e.g. 403 plan feature-gate, 400, 404) propagate
+        # instead of being masked as a generic 500.
+        raise
     except Exception as e:
         logger.error(f"Error creating workflow: {str(e)}")
         db.rollback()
@@ -164,6 +168,10 @@ async def get_workflow_by_agent_id(
     except ValueError as e:
         logger.error(f"Validation error getting workflow by agent ID: {str(e)}")
         raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        # Let intended HTTP errors (e.g. 403 plan feature-gate, 400, 404) propagate
+        # instead of being masked as a generic 500.
+        raise
     except Exception as e:
         logger.error(f"Error getting workflow by agent ID: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to get workflow")
@@ -216,6 +224,10 @@ async def update_workflow(
     except ValueError as e:
         logger.error(f"Validation error updating workflow: {str(e)}")
         raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        # Let intended HTTP errors (e.g. 403 plan feature-gate, 400, 404) propagate
+        # instead of being masked as a generic 500.
+        raise
     except Exception as e:
         logger.error(f"Error updating workflow: {str(e)}")
         db.rollback()
@@ -249,6 +261,10 @@ async def delete_workflow(
     except ValueError as e:
         logger.error(f"Validation error deleting workflow: {str(e)}")
         raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        # Let intended HTTP errors (e.g. 403 plan feature-gate, 400, 404) propagate
+        # instead of being masked as a generic 500.
+        raise
     except Exception as e:
         logger.error(f"Error deleting workflow: {str(e)}")
         db.rollback()

--- a/backend/app/api/workflow_node.py
+++ b/backend/app/api/workflow_node.py
@@ -103,6 +103,10 @@ async def replace_workflow_nodes(
     except ValueError as e:
         logger.error(f"Validation error updating workflow nodes: {str(e)}")
         raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        # Let intended HTTP errors (e.g. 403 plan feature-gate, 400, 404) propagate
+        # instead of being masked as a generic 500.
+        raise
     except Exception as e:
         logger.error(f"Error replacing workflow nodes: {str(e)}")
         db.rollback()
@@ -166,6 +170,10 @@ async def get_workflow_nodes(
     except ValueError as e:
         logger.error(f"Validation error getting workflow nodes: {str(e)}")
         raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        # Let intended HTTP errors (e.g. 403 plan feature-gate, 400, 404) propagate
+        # instead of being masked as a generic 500.
+        raise
     except Exception as e:
         logger.error(f"Error getting workflow nodes: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to get workflow nodes")
@@ -197,6 +205,10 @@ async def update_workflow_node(
         
         return updated_node
         
+    except HTTPException:
+        # Let intended HTTP errors (e.g. 403 plan feature-gate, 400, 404) propagate
+        # instead of being masked as a generic 500.
+        raise
     except Exception as e:
         logger.error(f"Error updating workflow node: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Failed to update workflow node: {str(e)}")
@@ -226,6 +238,10 @@ async def get_workflow_node(
         
         return node
         
+    except HTTPException:
+        # Let intended HTTP errors (e.g. 403 plan feature-gate, 400, 404) propagate
+        # instead of being masked as a generic 500.
+        raise
     except Exception as e:
         logger.error(f"Error getting workflow node: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Failed to get workflow node: {str(e)}") 

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -30,6 +30,32 @@ from app.models.role import Role
 
 logger = get_logger(__name__)
 
+# Enterprise: Personal Access Tokens (PATs). PATs are an enterprise-only feature, so the
+# resolver lives in the enterprise package. In the community edition that package is absent
+# and this falls back to a no-op, meaning "cmat_" bearer tokens simply fail normal JWT
+# verification like any other invalid token. See app/enterprise/services/pat.py.
+#
+# The enterprise resolver is imported lazily (on first use) rather than at module load: the
+# enterprise package pulls in the API routers, which import this module, so an eager import
+# here would create a circular import during application start-up.
+PAT_TOKEN_PREFIX = "cmat_"
+_pat_resolver = None
+_pat_resolver_loaded = False
+
+
+def _resolve_pat_user(token: str, db: Session) -> Optional[User]:
+    global _pat_resolver, _pat_resolver_loaded
+    if not _pat_resolver_loaded:
+        _pat_resolver_loaded = True
+        try:
+            from app.enterprise.services.pat import resolve_pat_user
+            _pat_resolver = resolve_pat_user
+        except ImportError:  # community edition / enterprise package not installed
+            _pat_resolver = None
+    if _pat_resolver is None:
+        return None
+    return _pat_resolver(token, db)
+
 def check_permissions(user: User, required_permissions: List[str]) -> bool:
     """Check if user has required permissions through their role"""
     if not user.role or not user.role.permissions:
@@ -81,6 +107,17 @@ async def get_current_user(
                     detail="Not authenticated",
                     headers={"WWW-Authenticate": "Bearer"},
                 )
+
+        # Enterprise: a Personal Access Token resolves directly to its owning user.
+        if access_token.startswith(PAT_TOKEN_PREFIX):
+            pat_user = _resolve_pat_user(access_token, db)
+            if pat_user is not None and pat_user.is_active:
+                return pat_user
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or revoked access token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
 
         payload = verify_token(access_token)
         if payload is None:
@@ -222,6 +259,24 @@ async def get_unified_auth(request: Request, db: Session = Depends(get_db)) -> d
                             headers={"WWW-Authenticate": "Bearer"},
                         )
 
+                # Enterprise: a Personal Access Token resolves directly to its owning user.
+                if access_token.startswith(PAT_TOKEN_PREFIX):
+                    current_user = _resolve_pat_user(access_token, db)
+                    if current_user is None or not current_user.is_active:
+                        raise HTTPException(
+                            status_code=status.HTTP_401_UNAUTHORIZED,
+                            detail="Invalid or revoked access token",
+                            headers={"WWW-Authenticate": "Bearer"},
+                        )
+                    if not check_permissions(current_user, ["manage_agents"]):
+                        raise HTTPException(status_code=403, detail="Not enough permissions")
+                    return {
+                        "auth_type": "pat",
+                        "organization_id": current_user.organization_id,
+                        "user_id": current_user.id,
+                        "current_user": current_user
+                    }
+
                 payload = verify_token(access_token)
                 if payload is None:
                     raise HTTPException(
@@ -315,6 +370,29 @@ async def get_unified_chat_auth(request: Request, db: Session = Depends(get_db))
                             headers={"WWW-Authenticate": "Bearer"},
                         )
 
+                # Enterprise: a Personal Access Token resolves directly to its owning user.
+                if access_token.startswith(PAT_TOKEN_PREFIX):
+                    current_user = _resolve_pat_user(access_token, db)
+                    if current_user is None or not current_user.is_active:
+                        raise HTTPException(
+                            status_code=status.HTTP_401_UNAUTHORIZED,
+                            detail="Invalid or revoked access token",
+                            headers={"WWW-Authenticate": "Bearer"},
+                        )
+                    pat_permissions = {p.name for p in current_user.role.permissions}
+                    pat_can_view_all = "view_all_chats" in pat_permissions
+                    pat_can_view_assigned = "view_assigned_chats" in pat_permissions
+                    if not (pat_can_view_all or pat_can_view_assigned):
+                        raise HTTPException(status_code=403, detail="Not enough permissions")
+                    return {
+                        "auth_type": "pat",
+                        "organization_id": current_user.organization_id,
+                        "user_id": current_user.id,
+                        "current_user": current_user,
+                        "can_view_all": pat_can_view_all,
+                        "can_view_assigned": pat_can_view_assigned
+                    }
+
                 payload = verify_token(access_token)
                 if payload is None:
                     raise HTTPException(
@@ -350,7 +428,7 @@ async def get_unified_chat_auth(request: Request, db: Session = Depends(get_db))
                 user_permissions = {p.name for p in current_user.role.permissions}
                 can_view_all = "view_all_chats" in user_permissions
                 can_view_assigned = "view_assigned_chats" in user_permissions
-                
+
                 if not (can_view_all or can_view_assigned):
                     raise HTTPException(
                         status_code=403,

--- a/backend/tests/test_personal_access_token.py
+++ b/backend/tests/test_personal_access_token.py
@@ -1,0 +1,189 @@
+"""
+ChatterMate - Personal Access Token Tests
+Copyright (C) 2024 ChatterMate
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+# Personal Access Tokens are an enterprise-only feature; skip cleanly in community checkouts.
+pytest.importorskip("app.enterprise.repositories.personal_access_token")
+
+from app.enterprise.repositories.personal_access_token import (  # noqa: E402
+    PersonalAccessTokenRepository,
+    generate_pat,
+    TOKEN_PREFIX,
+)
+from app.enterprise.services.pat import resolve_pat_user  # noqa: E402
+
+
+def test_generate_pat_format():
+    token, prefix = generate_pat()
+    assert token.startswith(TOKEN_PREFIX)
+    assert prefix == token[: len(prefix)]
+    assert len(token) > len(prefix)
+    # two calls produce different secrets
+    other, _ = generate_pat()
+    assert other != token
+
+
+def test_create_token_persists_hash_not_plaintext(db, test_user):
+    repo = PersonalAccessTokenRepository(db)
+    row, plain = repo.create_token(
+        user_id=test_user.id, organization_id=test_user.organization_id, name="cli"
+    )
+    assert plain.startswith(TOKEN_PREFIX)
+    assert row.token_hash != plain            # stored hashed, not plaintext
+    assert row.token_prefix == plain[: len(row.token_prefix)]
+    assert row.is_active is True
+    assert row.user_id == test_user.id
+
+
+def test_validate_token_roundtrip_and_last_used(db, test_user):
+    repo = PersonalAccessTokenRepository(db)
+    row, plain = repo.create_token(
+        user_id=test_user.id, organization_id=test_user.organization_id, name="cli"
+    )
+    assert row.last_used_at is None
+
+    validated = repo.validate_token(plain)
+    assert validated is not None
+    assert validated.id == row.id
+    assert validated.last_used_at is not None   # touched on use
+
+
+def test_validate_token_rejects_wrong_and_garbage(db, test_user):
+    repo = PersonalAccessTokenRepository(db)
+    repo.create_token(user_id=test_user.id, organization_id=test_user.organization_id, name="cli")
+    assert repo.validate_token("cmat_not-a-real-token") is None
+    assert repo.validate_token("jwt-style-token") is None
+    assert repo.validate_token("") is None
+
+
+def test_validate_token_rejects_revoked(db, test_user):
+    repo = PersonalAccessTokenRepository(db)
+    row, plain = repo.create_token(
+        user_id=test_user.id, organization_id=test_user.organization_id, name="cli"
+    )
+    assert repo.revoke(row.id, test_user.id) is True
+    assert repo.validate_token(plain) is None
+
+
+def test_validate_token_rejects_expired(db, test_user):
+    repo = PersonalAccessTokenRepository(db)
+    row, plain = repo.create_token(
+        user_id=test_user.id, organization_id=test_user.organization_id, name="cli"
+    )
+    # Force expiry into the past.
+    row.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
+    db.commit()
+    assert repo.validate_token(plain) is None
+
+
+def test_list_and_scope(db, test_user):
+    repo = PersonalAccessTokenRepository(db)
+    repo.create_token(user_id=test_user.id, organization_id=test_user.organization_id, name="a")
+    repo.create_token(user_id=test_user.id, organization_id=test_user.organization_id, name="b")
+    tokens = repo.list_for_user(test_user.id)
+    assert len(tokens) == 2
+    # get_by_id is scoped to the owning user
+    assert repo.get_by_id(tokens[0].id, test_user.id) is not None
+
+
+def test_resolve_pat_user_returns_owner(db, test_user):
+    repo = PersonalAccessTokenRepository(db)
+    _, plain = repo.create_token(
+        user_id=test_user.id, organization_id=test_user.organization_id, name="cli"
+    )
+    user = resolve_pat_user(plain, db)
+    assert user is not None
+    assert user.id == test_user.id
+
+
+def test_resolve_pat_user_rejects_inactive_user(db, test_user):
+    repo = PersonalAccessTokenRepository(db)
+    _, plain = repo.create_token(
+        user_id=test_user.id, organization_id=test_user.organization_id, name="cli"
+    )
+    test_user.is_active = False
+    db.commit()
+    assert resolve_pat_user(plain, db) is None
+
+
+def test_resolve_pat_user_rejects_non_pat_token(db):
+    assert resolve_pat_user("not-a-pat", db) is None
+    assert resolve_pat_user("", db) is None
+
+
+# --- Integration: the open-source get_current_user hook resolves cmat_ tokens ---
+
+import asyncio  # noqa: E402
+
+from fastapi import HTTPException  # noqa: E402
+from starlette.requests import Request  # noqa: E402
+
+from app.core.auth import get_current_user  # noqa: E402
+
+
+def _request_with_bearer(token: str) -> Request:
+    headers = [(b"authorization", f"Bearer {token}".encode())]
+    scope = {
+        "type": "http", "method": "GET", "path": "/", "query_string": b"",
+        "headers": headers,
+    }
+    return Request(scope)
+
+
+def test_get_current_user_accepts_valid_pat(db, test_user):
+    repo = PersonalAccessTokenRepository(db)
+    _, plain = repo.create_token(
+        user_id=test_user.id, organization_id=test_user.organization_id, name="cli"
+    )
+    user = asyncio.run(get_current_user(_request_with_bearer(plain), None, db))
+    assert user.id == test_user.id
+
+
+def test_get_current_user_rejects_bogus_pat(db, test_user):
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(get_current_user(_request_with_bearer("cmat_bogus"), None, db))
+    assert exc.value.status_code == 401
+
+
+# --- Security: a PAT cannot be used to mint further PATs ---
+
+from app.enterprise.routes.personal_access_token import (  # noqa: E402
+    create_personal_access_token,
+)
+from app.enterprise.schemas.personal_access_token import PATCreate  # noqa: E402
+
+
+def test_create_pat_rejected_when_request_uses_a_pat(db, test_user):
+    req = _request_with_bearer("cmat_sometoken")
+    with pytest.raises(HTTPException) as exc:
+        # current_user/request are passed as kwargs, matching how FastAPI invokes the
+        # handler (the rate-limit decorator reads current_user from kwargs).
+        asyncio.run(create_personal_access_token(
+            PATCreate(name="child"), request=req, db=db, current_user=test_user))
+    assert exc.value.status_code == 403
+
+
+def test_create_pat_allowed_with_interactive_session(db, test_user):
+    # A JWT bearer (not cmat_) represents an interactive login and is allowed.
+    req = _request_with_bearer("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.payload.sig")
+    resp = asyncio.run(create_personal_access_token(
+        PATCreate(name="ok"), request=req, db=db, current_user=test_user))
+    assert resp.token.startswith("cmat_")


### PR DESCRIPTION
## Summary

Open-source half of the **CLI / MCP / Personal Access Token (PAT)** feature. PATs are long-lived, revocable `cmat_…` bearer credentials for headless/CLI/AI-agent use. All PAT/CLI/MCP code lives in the `enterprise_backend` submodule (companion PR); this PR is the **minimal OSS surface** plus two pre-existing bug fixes uncovered while building it.

## Changes

**1. Guarded PAT auth hook** — `app/core/auth.py`
- `cmat_`-prefixed bearer tokens resolve to a user via a **lazily-imported** enterprise resolver (`app.enterprise.services.pat.resolve_pat_user`), wired into `get_current_user`, `get_unified_auth`, and `get_unified_chat_auth`.
- Lazy import avoids a circular import at startup; community editions without the enterprise package are a **no-op** — `cmat_` tokens simply fail normal JWT verification, so behaviour is unchanged.
- PAT sessions are subject to the same RBAC and `is_active` checks as JWT sessions (the hook only authenticates).

**2. Stop masking plan-gated errors as 500s** — `app/api/workflow.py`, `app/api/workflow_node.py`
- Added `except HTTPException: raise` before the broad `except Exception` in each handler. A Free-plan org creating a workflow now gets the intended **403 "upgrade your plan"** instead of a confusing **500 "Failed to create workflow"** (and 400/404s propagate correctly too).

**3. Apply the rating plan-gate to PAT sessions** — `app/api/agent.py`
- Agent update gated the `rating` feature-check on `auth_type == 'jwt'`; now `auth_type in ('jwt', 'pat')` so a PAT session can't bypass it.

## Tests

`backend/tests/test_personal_access_token.py` (skips cleanly when the enterprise package is absent): PAT validation (valid / revoked / expired / wrong / garbage), the `get_current_user` hook (accepts valid PAT, rejects bogus), and the "a PAT cannot mint PATs" rule. Verified end-to-end against a live backend; full suite green.

> Companion PR in `enterprise_backend`: PAT model/repo/route + migration, the `chattermate-sdk` CLI & MCP server, rate limiting, and the PyPI publish workflow.