### PR TITLE
feat(customer): persist generate-token custom_data and show it in the inbox

### DIFF
--- a/backend/alembic/versions/b2c3d4e5f6a7_add_customer_meta_data.py
+++ b/backend/alembic/versions/b2c3d4e5f6a7_add_customer_meta_data.py
@@ -1,0 +1,50 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""add meta_data column to customers
+
+Adds:
+- `meta_data` (JSON): arbitrary integrator-supplied fields (e.g. student_name,
+  center_name) passed via POST /generate-token's `custom_data`, surfaced to agents
+  in the chat inbox.
+
+Revision ID: b2c3d4e5f6a7
+Revises: f4a5b6c7d8e9
+Create Date: 2026-07-06 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b2c3d4e5f6a7'
+down_revision: Union[str, None] = 'f4a5b6c7d8e9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'customers',
+        sa.Column('meta_data', sa.JSON(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('customers', 'meta_data')

--- a/backend/app/api/token.py
+++ b/backend/app/api/token.py
@@ -40,10 +40,17 @@ from app.core.security import (
     get_all_active_sessions as security_get_all_active_sessions
 )
 from app.repositories.widget_app import WidgetAppRepository
-from pydantic import BaseModel
+from app.repositories.customer import CustomerRepository
+from pydantic import BaseModel, field_validator
+import json
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+# custom_data is embedded in both the JWT and the customer's stored meta_data, so cap
+# its size to keep tokens small and prevent unbounded growth of the DB column.
+CUSTOM_DATA_MAX_KEYS = 20
+CUSTOM_DATA_MAX_BYTES = 4096
 
 # ============================================================================
 # MODELS
@@ -56,6 +63,18 @@ class GenerateTokenRequest(BaseModel):
     customer_name: Optional[str] = None
     custom_data: Optional[Dict[str, Any]] = None
     ttl_seconds: Optional[int] = 3600  # Default 1 hour
+
+    @field_validator('custom_data')
+    @classmethod
+    def validate_custom_data_size(cls, value):
+        if value is None:
+            return value
+        if len(value) > CUSTOM_DATA_MAX_KEYS:
+            raise ValueError(f"custom_data supports at most {CUSTOM_DATA_MAX_KEYS} keys")
+        size = len(json.dumps(value))
+        if size > CUSTOM_DATA_MAX_BYTES:
+            raise ValueError(f"custom_data must be at most {CUSTOM_DATA_MAX_BYTES} bytes when serialized")
+        return value
 
 class RevokeTokenRequest(BaseModel):
     """Request to revoke a token"""
@@ -242,6 +261,7 @@ async def generate_widget_token(
                 customer = Customer(
                     email=body.customer_email,
                     full_name=body.customer_name,
+                    meta_data=body.custom_data,
                     organization_id=widget.organization_id
                 )
                 db.add(customer)
@@ -254,16 +274,22 @@ async def generate_widget_token(
                     customer.full_name = body.customer_name
                     db.commit()
                     logger.info(f"Updated customer {customer.id} name to {body.customer_name}")
+                # Merge in any new/changed custom_data (e.g. student_name, center_name)
+                # so agents see the latest values in the inbox; existing keys not
+                # present in this call are preserved.
+                if body.custom_data:
+                    customer = CustomerRepository(db).update_meta_data(customer.id, body.custom_data) or customer
         else:
             # No email provided - create anonymous customer
             # Generate a unique email for anonymous customers
             import time
             timestamp = int(time.time() * 1000)
             anonymous_email = f"anonymous-{timestamp}@{widget.organization_id}.local"
-            
+
             customer = Customer(
                 email=anonymous_email,
                 full_name=body.customer_name or "Anonymous",
+                meta_data=body.custom_data,
                 organization_id=widget.organization_id
             )
             db.add(customer)

--- a/backend/app/models/customer.py
+++ b/backend/app/models/customer.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey, func, UniqueConstraint
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey, JSON, func, UniqueConstraint
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import UUID
 import uuid
@@ -30,6 +30,9 @@ class Customer(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     email = Column(String, nullable=False)
     full_name = Column(String)
+    # Arbitrary integrator-supplied fields (e.g. student_name, center_name) passed via
+    # POST /generate-token's `custom_data` and surfaced to agents in the chat inbox.
+    meta_data = Column(JSON, nullable=True)
     organization_id = Column(UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False)
     is_active = Column(Boolean, default=True)
     created_at = Column(DateTime, server_default=func.now())

--- a/backend/app/models/schemas/chat.py
+++ b/backend/app/models/schemas/chat.py
@@ -26,6 +26,9 @@ class CustomerInfo(BaseModel):
     id: UUID
     email: Optional[str]
     full_name: Optional[str]
+    # Integrator-supplied fields (e.g. student_name, center_name) set via
+    # POST /generate-token's `custom_data`, shown to agents in the chat inbox.
+    meta_data: Optional[Dict[str, Any]] = None
 class AgentInfo(BaseModel):
     id: UUID
     name: str

--- a/backend/app/repositories/chat.py
+++ b/backend/app/repositories/chat.py
@@ -388,6 +388,7 @@ class ChatRepository:
                 Customer.id.label('customer_id'),
                 Customer.email.label('customer_email'),
                 Customer.full_name.label('customer_full_name'),
+                Customer.meta_data.label('customer_meta_data'),
                 Agent.id.label('agent_id'),
                 Agent.name.label('agent_name'),
                 Agent.display_name.label('agent_display_name'),
@@ -411,6 +412,7 @@ class ChatRepository:
                 Customer.id,
                 Customer.email,
                 Customer.full_name,
+                Customer.meta_data,
                 Agent.id,
                 Agent.name,
                 Agent.display_name,
@@ -460,7 +462,8 @@ class ChatRepository:
             'customer': {
                 'id': result.customer_id,
                 'email': result.customer_email,
-                'full_name': result.customer_full_name
+                'full_name': result.customer_full_name,
+                'meta_data': result.customer_meta_data
             },
             'agent': {
                 'id': result.agent_id,

--- a/backend/app/repositories/customer.py
+++ b/backend/app/repositories/customer.py
@@ -45,13 +45,15 @@ class CustomerRepository:
         self,
         email: str,
         organization_id: UUID,
-        full_name: str = None
+        full_name: str = None,
+        meta_data: dict = None
     ) -> Customer:
         """Create a new customer"""
         try:
             customer = Customer(
                 email=email,
                 full_name=full_name,
+                meta_data=meta_data,
                 organization_id=organization_id
             )
             self.db.add(customer)
@@ -62,6 +64,30 @@ class CustomerRepository:
             logger.error(f"Error creating customer: {str(e)}")
             self.db.rollback()
             raise
+
+    def update_meta_data(
+        self,
+        customer_id: UUID,
+        meta_data: dict
+    ) -> Customer | None:
+        """Merge integrator-supplied fields (e.g. student_name, center_name) into a
+        customer's existing meta_data, so agents see the latest values in the inbox.
+        New keys are added and existing keys are overwritten; unrelated keys are kept.
+        """
+        if not meta_data:
+            return None
+        try:
+            customer = self.get_by_id(customer_id)
+            if not customer:
+                return None
+            customer.meta_data = {**(customer.meta_data or {}), **meta_data}
+            self.db.commit()
+            self.db.refresh(customer)
+            return customer
+        except Exception as e:
+            logger.error(f"Error updating customer meta_data: {str(e)}")
+            self.db.rollback()
+            return None
 
     def get_or_create_customer(
         self,

--- a/backend/tests/api/test_token.py
+++ b/backend/tests/api/test_token.py
@@ -1060,6 +1060,94 @@ class TestTokenCustomData:
 
         app.dependency_overrides.clear()
 
+    def test_generate_token_existing_customer_merges_custom_data(
+        self, mock_db, mock_widget_app, mock_widget, mock_customer, valid_api_key
+    ):
+        """custom_data for a returning customer is merged into their stored meta_data
+        (not just embedded in the JWT), so it shows up in the agent inbox."""
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        mock_widget_filter = MagicMock()
+        mock_widget_filter.first.return_value = mock_widget
+
+        mock_customer_filter = MagicMock()
+        mock_customer_filter.first.return_value = mock_customer
+
+        mock_query = MagicMock()
+        mock_query.filter.side_effect = [mock_widget_filter, mock_customer_filter]
+        mock_db.query.return_value = mock_query
+
+        custom_data = {"student_name": "Aarav Krishnan", "center_name": "Special Academy U12"}
+
+        with patch('app.api.token.WidgetAppRepository') as MockRepo, \
+             patch('app.api.token.get_existing_valid_token_jti', return_value=None), \
+             patch('app.api.token._store_token_in_redis'), \
+             patch('app.api.token.CustomerRepository') as MockCustomerRepo:
+
+            mock_repo = MagicMock()
+            mock_repo.validate_api_key.return_value = mock_widget_app
+            MockRepo.return_value = mock_repo
+
+            mock_customer_repo = MagicMock()
+            mock_customer_repo.update_meta_data.return_value = mock_customer
+            MockCustomerRepo.return_value = mock_customer_repo
+
+            mock_db.commit = MagicMock()
+
+            client = TestClient(app)
+
+            response = client.post(
+                "/api/v1/generate-token",
+                json={
+                    "widget_id": mock_widget.id,
+                    "customer_email": mock_customer.email,
+                    "custom_data": custom_data,
+                    "ttl_seconds": 3600
+                },
+                headers={"Authorization": f"Bearer {valid_api_key}"}
+            )
+
+            assert response.status_code == 201
+            # The merge happens on the existing customer, not the create path
+            mock_customer_repo.update_meta_data.assert_called_once_with(
+                mock_customer.id, custom_data
+            )
+
+        app.dependency_overrides.clear()
+
+    def test_generate_token_custom_data_too_many_keys_rejected(
+        self, mock_db, mock_widget_app, mock_widget, valid_api_key
+    ):
+        """custom_data past the key-count cap is rejected with a 422 before touching the DB."""
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        with patch('app.api.token.WidgetAppRepository') as MockRepo:
+            mock_repo = MagicMock()
+            mock_repo.validate_api_key.return_value = mock_widget_app
+            MockRepo.return_value = mock_repo
+
+            client = TestClient(app)
+
+            response = client.post(
+                "/api/v1/generate-token",
+                json={
+                    "widget_id": mock_widget.id,
+                    "custom_data": {f"key_{i}": "v" for i in range(21)},
+                    "ttl_seconds": 3600
+                },
+                headers={"Authorization": f"Bearer {valid_api_key}"}
+            )
+
+            assert response.status_code == 422
+
+        app.dependency_overrides.clear()
+
     def test_generate_token_ttl_too_large(self, mock_db, mock_widget_app, mock_widget, valid_api_key):
         """Test token generation with TTL too large."""
         def override_get_db():

--- a/backend/tests/repo/test_chat_repo.py
+++ b/backend/tests/repo/test_chat_repo.py
@@ -202,6 +202,7 @@ async def test_get_chat_detail(chat_repo, test_data):
     
     assert detail is not None
     assert detail["customer"]["email"] == "customer@test.com"
+    assert detail["customer"]["meta_data"] is None
     assert detail["agent"]["name"] == "test-agent"
     assert detail["status"] == SessionStatus.OPEN
     assert detail["group_id"] == str(test_data["group"].id)
@@ -213,4 +214,24 @@ async def test_get_chat_detail(chat_repo, test_data):
 async def test_get_nonexistent_chat_detail(chat_repo):
     """Test retrieving detail for nonexistent chat"""
     detail = await chat_repo.get_chat_detail(uuid4(), uuid4())
-    assert detail is None 
+    assert detail is None
+
+@pytest.mark.asyncio
+async def test_get_chat_detail_includes_customer_meta_data(chat_repo, db, test_data):
+    """meta_data set on the customer (e.g. via /generate-token custom_data) is
+    surfaced in the chat detail response so the inbox can display it."""
+    test_data["customer"].meta_data = {
+        "student_name": "Aarav Krishnan",
+        "center_name": "Special Academy U12"
+    }
+    db.commit()
+
+    detail = await chat_repo.get_chat_detail(
+        test_data["session_id"],
+        test_data["org_id"]
+    )
+
+    assert detail["customer"]["meta_data"] == {
+        "student_name": "Aarav Krishnan",
+        "center_name": "Special Academy U12"
+    } 

--- a/backend/tests/repo/test_customer_repo.py
+++ b/backend/tests/repo/test_customer_repo.py
@@ -152,4 +152,77 @@ def test_get_or_create_customer_no_name(customer_repo, test_organization_id):
     assert customer is not None
     assert customer.email == email
     assert customer.full_name is None
-    assert customer.organization_id == test_organization_id 
+    assert customer.organization_id == test_organization_id
+
+def test_create_customer_with_meta_data(customer_repo, test_organization_id):
+    """Test creating a customer with integrator-supplied meta_data"""
+    email = "student@example.com"
+    meta_data = {"student_name": "Aarav Krishnan", "center_name": "Special Academy U12"}
+
+    customer = customer_repo.create_customer(
+        email=email,
+        organization_id=test_organization_id,
+        full_name="Parent Name",
+        meta_data=meta_data
+    )
+
+    assert customer is not None
+    assert customer.meta_data == meta_data
+
+def test_create_customer_without_meta_data(customer_repo, test_organization_id):
+    """Test creating a customer with no meta_data leaves the column null"""
+    customer = customer_repo.create_customer(
+        email="nometa@example.com",
+        organization_id=test_organization_id
+    )
+
+    assert customer.meta_data is None
+
+def test_update_meta_data_merges_new_keys(customer_repo, test_organization_id):
+    """A second call adds new keys and overwrites changed ones, keeping the rest"""
+    customer = customer_repo.create_customer(
+        email="merge@example.com",
+        organization_id=test_organization_id,
+        meta_data={"student_name": "Aarav", "grade": "U12"}
+    )
+
+    updated = customer_repo.update_meta_data(
+        customer.id,
+        {"student_name": "Aarav Krishnan", "center_name": "Special Academy U12"}
+    )
+
+    assert updated is not None
+    assert updated.meta_data == {
+        "student_name": "Aarav Krishnan",  # overwritten
+        "grade": "U12",                    # preserved
+        "center_name": "Special Academy U12"  # added
+    }
+
+def test_update_meta_data_on_customer_with_no_existing_data(customer_repo, test_organization_id):
+    """Merging onto a customer created without meta_data starts from an empty dict"""
+    customer = customer_repo.create_customer(
+        email="firstmeta@example.com",
+        organization_id=test_organization_id
+    )
+
+    updated = customer_repo.update_meta_data(customer.id, {"plan": "premium"})
+
+    assert updated.meta_data == {"plan": "premium"}
+
+def test_update_meta_data_empty_input_is_noop(customer_repo, test_organization_id):
+    """Calling with no data returns None and leaves the customer untouched"""
+    customer = customer_repo.create_customer(
+        email="noop@example.com",
+        organization_id=test_organization_id,
+        meta_data={"a": "b"}
+    )
+
+    result = customer_repo.update_meta_data(customer.id, {})
+
+    assert result is None
+    assert customer_repo.get_by_id(customer.id).meta_data == {"a": "b"}
+
+def test_update_meta_data_nonexistent_customer(customer_repo):
+    """Updating meta_data for a customer that doesn't exist returns None"""
+    result = customer_repo.update_meta_data(uuid4(), {"a": "b"})
+    assert result is None 

--- a/frontend/src/components/conversations/ChatInfoPanel.vue
+++ b/frontend/src/components/conversations/ChatInfoPanel.vue
@@ -193,6 +193,21 @@ const formatDate = (dateString: string): string => {
   return date.toLocaleDateString() + ' ' + date.toLocaleTimeString()
 }
 
+// Integrator-supplied fields (e.g. student_name, center_name) passed via
+// POST /generate-token's `custom_data`. Shown as a label/value list below the
+// customer's name and email; snake_case keys are prettified for display.
+const metaDataEntries = computed(() => {
+  const metaData = props.chatInfo?.customer?.meta_data
+  if (!metaData || typeof metaData !== 'object') return []
+  return Object.entries(metaData)
+    .filter(([, value]) => value !== null && value !== undefined && value !== '')
+    .map(([key, value]) => ({
+      key,
+      label: key.replace(/[_-]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()),
+      value: typeof value === 'object' ? JSON.stringify(value) : String(value)
+    }))
+})
+
 // Load users for reassign dropdown
 const loadUsers = async () => {
   if (loadingUsers.value) return
@@ -258,8 +273,12 @@ const confirmReassign = async () => {
           <span class="label">Email:</span>
           <span class="value">{{ chatInfo.customer.email || 'N/A' }}</span>
         </div>
+        <div v-for="entry in metaDataEntries" :key="entry.key" class="info-item">
+          <span class="label">{{ entry.label }}:</span>
+          <span class="value">{{ entry.value }}</span>
+        </div>
       </div>
-      
+
       <div class="info-section">
         <h4>Assignment</h4>
         <div class="info-item">

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -18,6 +18,9 @@ export interface CustomerInfo {
   id: string
   email: string
   full_name?: string
+  // Integrator-supplied fields (e.g. student_name, center_name) set via
+  // POST /generate-token's `custom_data`.
+  meta_data?: Record<string, unknown>
 }
 
 export interface Message {


### PR DESCRIPTION
## Why
`POST /generate-token` already accepted a `custom_data` field and embedded it in the issued JWT, but nothing ever read it back out — it wasn't persisted anywhere or shown anywhere. For integrations like CoachIQ that want to pass context (student name, coaching center, etc.) for quick agent reference, that data just evaporated after the JWT was minted.

## What
- **Migration + model**: add `meta_data` (JSON, nullable) to `customers`.
- **`token.py`**: when `custom_data` is supplied to `/generate-token`, persist it onto the customer:
  - New customer → set directly.
  - Returning customer → **merged** via `CustomerRepository.update_meta_data` (new/changed keys win, untouched keys are kept — so a second call for the same customer doesn't clobber fields you didn't send this time).
  - Bounded to 20 keys / 4KB serialized (new `custom_data` validator) so the JWT and DB column can't grow unbounded.
- **API**: `CustomerInfo`/`ChatDetailResponse` schema gains `meta_data`; `ChatRepository.get_chat_detail`'s query now selects/groups on `Customer.meta_data` and returns it.
- **Frontend**: `CustomerInfo` type gains `meta_data`; `ChatInfoPanel.vue` renders each entry (snake_case key prettified to a label) right under the customer's name/email in the inbox sidebar — no new section needed, it reuses the existing `info-item` styling.

## Testing
- `tests/repo/test_customer_repo.py`: create-with-meta_data, merge semantics (overwrite/preserve/add), empty-input no-op, nonexistent-customer.
- `tests/api/test_token.py`: existing-customer merge is invoked with the right args; oversized `custom_data` (21 keys) is rejected with 422.
- `tests/repo/test_chat_repo.py`: `get_chat_detail` round-trips `meta_data` through the real (non-mocked) query — regression coverage for the new `select`/`group_by` columns.
- Full backend suite: 1419 passed, 14 skipped (pre-existing skips, unrelated).
- `vue-tsc` clean.

## Docs
Docs PR (chattermate/docs#8, not yet merged) updated in the same branch to document `custom_data`: size limits, merge-on-repeat-call semantics, and a worked example.

## Notes
- Deliberately did **not** touch the anonymous/email-optional widget-load path (`widget.py`) — `custom_data` is scoped to the authenticated `/generate-token` flow, matching how `customer_email`/`customer_name` already work there.
- Used plain `sa.JSON` (not Postgres `JSONB`) to match the existing convention for JSON columns in this codebase (`quick_actions`, `workflow_history`) and so the test suite's SQLite fixture can compile the schema.