### PR TITLE
fix(inbox): status badge pill stretches across the row instead of hugging its text

### DIFF
--- a/frontend/src/components/conversations/ChatInfoPanel.vue
+++ b/frontend/src/components/conversations/ChatInfoPanel.vue
@@ -507,6 +507,13 @@ const confirmReassign = async () => {
   text-transform: uppercase;
 }
 
+/* Higher specificity than ".info-item .value" so the pill hugs the status text
+   instead of inheriting .value's flex:1 and stretching its background across
+   the rest of the row. */
+.info-item .value.status-badge {
+  flex: none;
+}
+
 .status-badge.open {
   background: rgba(201,242,78,.12);
   color: var(--accent-ink);


### PR DESCRIPTION
The status pill (e.g. "OPEN") in the chat inbox sidebar had its green background stretched across the whole row instead of hugging just the text.

**Cause:** the badge's `class="value status-badge"` combined two rules — `.info-item .value { flex: 1; ... }` and `.status-badge { padding, border-radius, ... }`. The `flex: 1` from `.value` made the badge grow to fill the row's remaining space, so its rounded background extended the full width instead of wrapping the word.

**Fix:** add `.info-item .value.status-badge { flex: none; }`. Needed the compound (3-class) selector specifically — a bare `.status-badge { flex: none }` has lower specificity (0,1,0) than `.info-item .value` (0,2,0) and would silently lose the cascade.

**Verification:** built an isolated repro of the exact CSS and measured the badge's rendered width in a real browser — 223px (bug, stretched) → 52px (fixed, content width) — confirming the fix actually wins the cascade rather than just looking plausible in code.