### PR TITLE
fix(chat): retry transient 429 rate limits with backoff

### DIFF
--- a/backend/app/agents/chat_agent.py
+++ b/backend/app/agents/chat_agent.py
@@ -556,7 +556,14 @@ Keep your responses concise and focused. Provide clear, actionable information i
            structured_outputs=True,
            system_message_role="system",
            user_message_role="user",
-           show_tool_calls=settings.ENVIRONMENT == "development"
+           show_tool_calls=settings.ENVIRONMENT == "development",
+           # Retry transient model errors (e.g. OpenAI 429 rate limits, which
+           # typically clear within a few hundred ms) with exponential backoff so
+           # they recover instead of surfacing "I encountered an error" to visitors.
+           # The LLM call fails before any reply/side-effect, so retrying is safe.
+           retries=2,
+           delay_between_retries=1,
+           exponential_backoff=True,
           )
 
     async def _get_llm_response_only(self, message: str, session_id: str = None, org_id: str = None, agent_id: str = None, customer_id: str = None) -> ChatResponse:


### PR DESCRIPTION
Prod chats were intermittently failing with *'I apologize, but I encountered an error, please try again later.'*

**Root cause:** OpenAI `429 rate_limit_exceeded` on the shared managed gpt-4o-mini key (200k TPM ceiling, saturated by aggregate load). The agno Agent defaulted to `retries=0` → one attempt → the transient 429 (which the API says clears in ~300ms) was surfaced straight to the visitor (`Failed after 1 attempts` in the logs).

**Fix:** `retries=2, delay_between_retries=1, exponential_backoff=True` on the chat Agent. The model call fails before any reply/side-effect, so retrying is safe; transient 429s now recover invisibly (worst case ~3s added latency instead of a hard error).

Backend-only, no migration.