### PR TITLE
fix(people): exclude integration-authenticated customers from People

### DIFF
--- a/backend/app/repositories/people.py
+++ b/backend/app/repositories/people.py
@@ -107,6 +107,10 @@ class PeopleRepository:
             .filter(Customer.organization_id == org_id)
             # Hide rows merged into another customer — the target row represents them.
             .filter(Customer.merged_into_customer_id.is_(None))
+            # Exclude integration-authenticated people: meta_data is only ever set from
+            # generate-token (the embedding app passed a known identity), so these are the
+            # business's existing customers, not leads the agent captured.
+            .filter(Customer.meta_data.is_(None))
         )
 
         if stage and stage != "all":
@@ -146,18 +150,21 @@ class PeopleRepository:
 
     def get_stats(self, org_id: UUID) -> dict:
         week_ago = datetime.now(timezone.utc) - timedelta(days=7)
+        # Same scoping as list_people: exclude merged rows and integration-authenticated
+        # (generate-token) customers so the KPIs count only organic visitors/leads.
         not_merged = Customer.merged_into_customer_id.is_(None)
+        organic = Customer.meta_data.is_(None)
         total = self.db.query(func.count(Customer.id)).filter(
-            Customer.organization_id == org_id, not_merged).scalar() or 0
+            Customer.organization_id == org_id, not_merged, organic).scalar() or 0
         new_leads = self.db.query(func.count(Customer.id)).filter(
             Customer.organization_id == org_id,
-            not_merged,
+            not_merged, organic,
             Customer.lead_stage == LeadStage.LEAD,
             Customer.lead_qualified_at >= week_ago,
         ).scalar() or 0
         customers = self.db.query(func.count(Customer.id)).filter(
             Customer.organization_id == org_id,
-            not_merged,
+            not_merged, organic,
             Customer.lead_stage == LeadStage.CUSTOMER,
         ).scalar() or 0
         return {

--- a/backend/app/repositories/people.py
+++ b/backend/app/repositories/people.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from sqlalchemy.orm import Session
-from sqlalchemy import func, or_, desc
+from sqlalchemy import func, or_, desc, exists
 from typing import Optional, Tuple, List
 from uuid import UUID
 from datetime import datetime, timedelta, timezone
@@ -111,6 +111,9 @@ class PeopleRepository:
             # generate-token (the embedding app passed a known identity), so these are the
             # business's existing customers, not leads the agent captured.
             .filter(Customer.meta_data.is_(None))
+            # Only people who actually engaged (have chat history) — drops the huge tail of
+            # empty widget-loads that created a customer but never sent a message.
+            .filter(last_activity_sq.c.cid.isnot(None))
         )
 
         if stage and stage != "all":
@@ -154,8 +157,10 @@ class PeopleRepository:
         # (generate-token) customers so the KPIs count only organic visitors/leads.
         not_merged = Customer.merged_into_customer_id.is_(None)
         organic = Customer.meta_data.is_(None)
+        # Engaged = actually chatted (has chat history) — excludes empty widget-loads.
+        engaged = exists().where(ChatHistory.customer_id == Customer.id)
         total = self.db.query(func.count(Customer.id)).filter(
-            Customer.organization_id == org_id, not_merged, organic).scalar() or 0
+            Customer.organization_id == org_id, not_merged, organic, engaged).scalar() or 0
         new_leads = self.db.query(func.count(Customer.id)).filter(
             Customer.organization_id == org_id,
             not_merged, organic,

--- a/backend/app/services/lead_capture.py
+++ b/backend/app/services/lead_capture.py
@@ -54,6 +54,10 @@ def record_lead_capture(
     an AI qualification summary). Returns None — recording nothing — when there is
     no valid email, or consent is required but not given (GDPR).
 
+    Never records when lead capture is disabled for the agent, or when the customer
+    is integration-authenticated (meta_data set by generate-token) — those are the
+    business's existing customers, not leads.
+
     If the captured email already belongs to ANOTHER customer in the org, the
     anonymous visitor is MERGED into that existing customer (history/sessions
     reassigned, visitor row marked merged) so People shows one entry. The returned
@@ -62,6 +66,18 @@ def record_lead_capture(
     No CRM/Slack/assignment side effects in phase 1 — routing config is stored only.
     """
     from app.models.customer import Customer
+
+    # Never capture when lead capture is off for this agent (authoritative guard,
+    # independent of any caller-side check).
+    if not (config and config.enabled):
+        return None
+
+    # Never capture integration-authenticated people: meta_data is only set from
+    # generate-token (the embedding app passed a known identity), so they're already
+    # the business's customers, not leads — regardless of the agent's toggle.
+    customer = db.query(Customer).filter(Customer.id == customer_id).first()
+    if customer is not None and customer.meta_data:
+        return None
 
     lead_data = lead_data or {}
     # Keep only configured field keys (defensive: the model shouldn't inject others).

--- a/backend/tests/repo/test_people_repo.py
+++ b/backend/tests/repo/test_people_repo.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 from app.models.customer import Customer, LeadStage
 from app.models.lead_capture import LeadCaptureResponse
+from app.models.chat_history import ChatHistory
 from app.repositories.people import PeopleRepository
 
 
@@ -27,10 +28,17 @@ def repo(db):
     return PeopleRepository(db)
 
 
-def _customer(db, org_id, **kw):
+def _customer(db, org_id, chatted=True, **kw):
+    """Create a customer. By default also adds a chat message so it counts as
+    'engaged' (People only shows people who actually chatted). Pass chatted=False
+    to simulate an empty widget-load."""
     c = Customer(email=kw.pop("email", f"{uuid4().hex}@noemail.com"),
                  organization_id=org_id, **kw)
     db.add(c); db.commit(); db.refresh(c)
+    if chatted:
+        db.add(ChatHistory(organization_id=org_id, customer_id=c.id,
+                           message="hi", message_type="user"))
+        db.commit()
     return c
 
 
@@ -96,6 +104,18 @@ def test_get_detail_and_mark_customer(repo, db, test_organization_id, test_agent
 
 def test_get_detail_missing_returns_none(repo, test_organization_id):
     assert repo.get_detail(test_organization_id, uuid4()) is None
+
+
+def test_unengaged_widget_loads_excluded(repo, db, test_organization_id):
+    """A customer that never chatted (empty widget-load) is excluded from People."""
+    _customer(db, test_organization_id, email="chatted@acme.com", chatted=True,
+              lead_stage=LeadStage.LEAD)
+    _customer(db, test_organization_id, chatted=False)  # loaded widget, never messaged
+
+    items, total = repo.list_people(test_organization_id)
+    assert total == 1
+    assert items[0]["email"] == "chatted@acme.com"
+    assert repo.get_stats(test_organization_id)["total_people"] == 1
 
 
 def test_authenticated_customers_excluded(repo, db, test_organization_id):

--- a/backend/tests/repo/test_people_repo.py
+++ b/backend/tests/repo/test_people_repo.py
@@ -98,6 +98,24 @@ def test_get_detail_missing_returns_none(repo, test_organization_id):
     assert repo.get_detail(test_organization_id, uuid4()) is None
 
 
+def test_authenticated_customers_excluded(repo, db, test_organization_id):
+    """Integration-authenticated people (meta_data from generate-token) are the
+    business's existing customers, not leads — excluded from People + stats."""
+    organic = _customer(db, test_organization_id, email="organic@acme.com",
+                        full_name="Organic", lead_stage=LeadStage.LEAD)
+    _customer(db, test_organization_id, email="portal@acme.com", full_name="Portal User",
+              meta_data={"student_name": "Sam", "center_name": "MMCA"})
+
+    items, total = repo.list_people(test_organization_id)
+    emails = {i["email"] for i in items}
+    assert "organic@acme.com" in emails
+    assert "portal@acme.com" not in emails
+    assert total == 1
+
+    stats = repo.get_stats(test_organization_id)
+    assert stats["total_people"] == 1  # the authenticated customer is not counted
+
+
 def test_merged_rows_hidden_and_resolved(repo, db, test_organization_id):
     target = _customer(db, test_organization_id, email="t@acme.com", full_name="Target",
                        lead_stage=LeadStage.LEAD)

--- a/backend/tests/service/test_lead_capture_service.py
+++ b/backend/tests/service/test_lead_capture_service.py
@@ -70,6 +70,33 @@ def test_has_captured_lead(db, test_agent, test_organization_id, config):
     assert has_captured_lead(db, customer.id, test_agent.id) is True
 
 
+def test_no_capture_when_disabled(db, test_agent, test_organization_id, config):
+    config.enabled = False
+    db.commit()
+    customer = _anon(db, test_organization_id)
+    resp = record_lead_capture(
+        db, config, organization_id=test_organization_id, agent_id=test_agent.id,
+        customer_id=customer.id, session_id=None,
+        lead_data={"email": "jane@acme.com"}, summary="s", consent=True,
+    )
+    assert resp is None
+    assert has_captured_lead(db, customer.id, test_agent.id) is False
+
+
+def test_no_capture_for_authenticated_customer(db, test_agent, test_organization_id, config):
+    # Integration-authenticated customer (generate-token set meta_data) — never a lead.
+    authed = Customer(email="portal@acme.com", organization_id=test_organization_id,
+                      meta_data={"student_name": "Sam", "center_name": "MMCA"})
+    db.add(authed); db.commit(); db.refresh(authed)
+    resp = record_lead_capture(
+        db, config, organization_id=test_organization_id, agent_id=test_agent.id,
+        customer_id=authed.id, session_id=None,
+        lead_data={"email": "portal@acme.com"}, summary="s", consent=True,
+    )
+    assert resp is None
+    assert has_captured_lead(db, authed.id, test_agent.id) is False
+
+
 def test_record_requires_valid_email(db, test_agent, test_organization_id, config):
     customer = _anon(db, test_organization_id)
     resp = record_lead_capture(


### PR DESCRIPTION
People was listing **generate-token authenticated users** (a portal passing a known user's identity via `custom_data`) as 'Visitor' rows. Those are the business's existing customers, not leads the agent captured.

`meta_data` is only ever set from generate-token, so it's the exact 'authenticated' signal. Exclude `meta_data`-bearing customers from the People list **and** the KPI stats. People now shows only organic widget visitors + agent-captured leads. Backend-only, no migration; repo test added.