### PR TITLE
hotfix: 500 on /agent/list — customization length caps to write-only

### DIFF
--- a/backend/app/models/schemas/agent_customization.py
+++ b/backend/app/models/schemas/agent_customization.py
@@ -73,17 +73,25 @@ class CustomizationBase(BaseModel):
     customization_metadata: Optional[Dict] = {}
     chat_style: Optional[ChatStyle] = ChatStyle.CHATBOT
     widget_position: Optional[WidgetPosition] = WidgetPosition.FLOATING
-    welcome_title: Optional[str] = Field(default=None, max_length=100)
-    welcome_subtitle: Optional[str] = Field(default=None, max_length=250)
-    welcome_message: Optional[str] = Field(default=None, max_length=500)
-    chat_initiation_messages: Optional[List[InitiationMessage]] = None
+    # NOTE: length caps live on CustomizationCreate (input), NOT here — the response
+    # model also inherits this base, and existing rows may exceed a newly-lowered cap;
+    # enforcing on the response would 500 the whole agent list.
+    welcome_title: Optional[str] = None
+    welcome_subtitle: Optional[str] = None
+    welcome_message: Optional[str] = None
+    chat_initiation_messages: Optional[List[str]] = None
     quick_actions: Optional[List[str]] = None
     show_citations: Optional[bool] = False
     collect_email: Optional[bool] = False
 
 
 class CustomizationCreate(CustomizationBase):
-    pass
+    # Enforce length caps on write only, so the UI can't submit values the widget
+    # can't display. Reads (CustomizationResponse) intentionally stay unconstrained.
+    welcome_title: Optional[str] = Field(default=None, max_length=100)
+    welcome_subtitle: Optional[str] = Field(default=None, max_length=250)
+    welcome_message: Optional[str] = Field(default=None, max_length=500)
+    chat_initiation_messages: Optional[List[InitiationMessage]] = None
 
 
 class CustomizationResponse(CustomizationBase):


### PR DESCRIPTION
**Prod down:** the AI Agents page 500s. #179 put `max_length` on `CustomizationBase`, which the **response** model inherits, so serializing an existing agent whose welcome/nudge text exceeds a cap (CoachIQ's ~106-char chat initiation) raised `ValidationError` → 500 on `/agent/list`.

**Fix:** move the caps to `CustomizationCreate` (write) only; `CustomizationResponse` stays unconstrained so existing data always reads back. Verified: response accepts a 106-char nudge; create still rejects >100. Backend-only, no migration.