### PR TITLE
chore(backend): pin dependency versions for reproducible prod builds

### DIFF
--- a/Dockerfile.backend.prod
+++ b/Dockerfile.backend.prod
@@ -13,7 +13,6 @@ RUN apt-get update && apt-get install -y \
 # Install Python dependencies
 COPY backend/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install -U crawl4ai
 RUN crawl4ai-setup
 
 # Copy application code
@@ -56,4 +55,4 @@ ENV PYTORCH_TRANSFORMERS_CACHE=/app/.cache/pytorch_transformers
 EXPOSE 8000
 
 # Run the startup script
-CMD ["./scripts/start.sh"] 
+CMD ["./scripts/start.sh"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -54,7 +54,9 @@ google-cloud-aiplatform
 ollama
 
 #ocr
-rapidocr-onnxruntime
+rapidocr-onnxruntime==1.4.4
+onnxruntime==1.23.0
+opencv-python==4.12.0.88
 
 #pdf
 pypdf
@@ -78,9 +80,12 @@ boto3
 
 groq
 
-sentence-transformers
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.8.0+cpu
+transformers==4.57.0
+sentence-transformers==5.1.1
 
-fastembed
+fastembed==0.7.3
 
 # Shopify API
 ShopifyAPI
@@ -95,4 +100,6 @@ uv
 
 # Web Crawling
 httpx
+pyOpenSSL==26.0.0
+cryptography==46.0.3
 crawl4ai>=0.7.0


### PR DESCRIPTION
## Summary
Was trying to run the backend locally and the Docker build kept failing —
several deps (torch, transformers, sentence-transformers, fastembed,
onnxruntime, opencv, rapidocr, crawl4ai's TLS deps) were unpinned and
resolving to whatever was latest at build time, which broke the build.
Pinned them to known-good versions to get it running, and dropped the
redundant `pip install -U crawl4ai` in Dockerfile.backend.prod that was
upgrading past the version already pinned in requirements.txt.

## Test plan
- [ ] `docker compose -f docker-compose.prod.yml build backend` completes
- [ ] Backend container starts and `/health` returns OK
- [ ] Model preloading still succeeds on startup