### PR TITLE
feat(ai): enable more model providers + per-org custom model IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![ChatterMate Logo](frontend/public/assets/images/logo.svg)
 
-> **Open-source AI customer support platform with human handoff.** A no-code AI chatbot for 24/7 customer service automation — multi-model AI (OpenAI, Groq, Ollama), intelligent AI-to-human handover, **Shopify & e-commerce support**, Slack and Jira integrations, visual workflow builder, and a fully themeable chat widget. Use the free hosted service or self-host it as an **open-source alternative to Intercom, Zendesk, and Chatbase**.
+> **Open-source AI customer support platform with human handoff.** A no-code AI chatbot for 24/7 customer service automation — multi-model AI (OpenAI, Anthropic Claude, Google Gemini, Mistral, xAI Grok, DeepSeek, Groq), intelligent AI-to-human handover, **Shopify & e-commerce support**, Slack and Jira integrations, visual workflow builder, and a fully themeable chat widget. Use the free hosted service or self-host it as an **open-source alternative to Intercom, Zendesk, and Chatbase**.
 
 **[Documentation](https://docs.chattermate.chat)** | **[Live Demo](https://chattermate.chat)** | **[Free Signup](https://app.chattermate.chat)** | **[Shopify App](https://apps.shopify.com/chattermate-chat)**
 
@@ -46,7 +46,7 @@ ChatterMate is a **no-code AI customer support platform** that enables businesse
 |---------|-------------|
 | 🤝 **Smart Human Handoff** | Intelligent AI-to-human transfer with **business hours awareness**, real-time availability detection, and context-aware escalation messages. |
 | 🛍️ **Shopify & E-commerce Support** | Native **Shopify integration** ([App Store listing](https://apps.shopify.com/chattermate-chat)) — answer order, shipping, and product questions from store data. Works for any online store. |
-| 🧠 **Multi-Model AI Support** | Choose your AI provider — **OpenAI GPT-4**, **Groq Llama 3.3**, **Google AI**, **Ollama** (self-hosted), and more. Switch providers anytime without code changes. |
+| 🧠 **Multi-Model AI Support** | Choose your AI provider — **OpenAI**, **Anthropic (Claude)**, **Google Gemini**, **Mistral**, **xAI (Grok)**, **DeepSeek**, and **Groq** — with your own API key, or enter a custom model ID. Switch providers anytime without code changes. |
 | 💬 **Ask Anything Mode** | Let visitors start conversations instantly — no signup or email required. Perfect for Q&A, documentation assistants, and exploratory chat experiences. |
 | 📎 **File Attachments** | Customers can share **images, PDFs, Word docs, spreadsheets**, and more directly in chat. Secure uploads with S3 storage and magic byte validation. |
 | 🌍 **Auto Translation** | Multilingual support with configurable **default language per workflow**. Serve customers globally in their preferred language. |
@@ -91,7 +91,7 @@ ChatterMate is a **free, open-source alternative to Intercom, Zendesk AI, and Ch
 | Self-hosting / data ownership | ✅ | ❌ | ❌ | ❌ |
 | AI answers from your knowledge base | ✅ | ✅ | ✅ | ✅ |
 | Built-in human handoff + shared inbox | ✅ | ✅ | ✅ | ⚠️ limited |
-| Bring your own AI model (incl. Ollama) | ✅ | ❌ | ❌ | ⚠️ limited |
+| Bring your own AI model (OpenAI, Claude, Gemini, Grok, +more) | ✅ | ❌ | ❌ | ⚠️ limited |
 | Visual no-code workflow builder | ✅ | ✅ | ⚠️ add-on | ❌ |
 | Free tier | ✅ | trial only | trial only | ✅ |
 | Per-AI-resolution fees | ❌ none | $0.99/resolution | usage-based | credit-based |
@@ -383,7 +383,7 @@ Yes. Install it from the [Shopify App Store](https://apps.shopify.com/chattermat
 Yes. Run the full stack (Postgres, Redis, backend, frontend) on your own infrastructure with `npm install -g chattermate-deploy` — see [Quick Start](#quick-start). Self-hosting gives you complete data ownership.
 
 **Which AI models does ChatterMate support?**
-OpenAI (GPT-4), Groq (Llama 3.3), Google AI, and self-hosted models via Ollama. You can switch providers at any time without code changes.
+OpenAI, Anthropic (Claude), Google Gemini, Mistral, xAI (Grok), DeepSeek, and Groq — bring your own API key, or enter a custom model ID for any model a provider supports. You can switch providers at any time without code changes.
 
 ---
 

--- a/backend/app/api/ai_setup.py
+++ b/backend/app/api/ai_setup.py
@@ -26,9 +26,9 @@ from app.agents.chat_agent import ChatAgent
 from app.models.schemas.ai_config import AIConfigCreate, AIConfigResponse, AISetupResponse, AIConfigUpdate
 from sqlalchemy.orm import Session
 import os
-from enum import Enum
 
 from app.models.ai_config import AIModelType
+from app.core.model_catalog import is_known_provider, list_providers
 
 # Try to import enterprise modules
 try:
@@ -60,27 +60,18 @@ def check_custom_models_feature_access(current_user: User, db: Session):
         )
 
 
-# Define allowed models as Enum to restrict choices
-class ModelType(str, Enum):
-    GROQ = "GROQ"
-    OPENAI = "OPENAI"
-    # ANTHROPIC = "ANTHROPIC"
-    # OLLAMA = "OLLAMA"
-    # CLAUDE = "CLAUDE"
-    # MISTRAL = "MISTRAL"
-    # COHERE = "COHERE"
-    CHATTERMATE = "CHATTERMATE"
+# Providers and their suggested models live in app.core.model_catalog (single
+# source of truth, also served by GET /ai/providers). Model IDs are not hard-coded
+# here anymore: orgs may enter a custom model ID, so validation only checks that the
+# provider is known — the live API-key test rejects a bad model ID.
 
 
-# Define allowed models per provider
-class GroqModels(str, Enum):
-    LLAMA_3_70B = "llama-3.3-70b-versatile"
-
-
-class OpenAIModels(str, Enum):
-    GPT_4O_MINI = "gpt-4o-mini"
-    O1_MINI = "o1-mini"
-    O3_MINI = "o3-mini"
+@router.get("/providers")
+async def get_providers(
+    current_user: User = Depends(require_permissions("manage_ai_config")),
+):
+    """Return the catalog of selectable providers and their suggested models."""
+    return {"providers": list_providers()}
 
 
 # Override model validation in the schemas
@@ -147,9 +138,10 @@ async def setup_ai(
         # Regular custom model setup
         # Test API key before creating config
         try:
-            # Only validate API keys for supported providers
+            # Live-validate the key+model for any BYO-key provider. This is also
+            # what catches an invalid custom (typed) model ID.
             model_type_upper = config_data.model_type.upper()
-            if model_type_upper in ["GROQ", "OPENAI"]:
+            if is_known_provider(model_type_upper):
                 is_valid = await ChatAgent.test_api_key(
                     api_key=config_data.api_key.get_secret_value(),
                     model_type=config_data.model_type,
@@ -307,7 +299,7 @@ async def update_ai_config(
             # For custom model, validate API key first if provided
             if config_data.api_key:
                 model_type_upper = config_data.model_type.upper()
-                if model_type_upper in ["GROQ", "OPENAI"]:
+                if is_known_provider(model_type_upper):
                     try:
                         is_valid = await ChatAgent.test_api_key(
                             api_key=config_data.api_key.get_secret_value(),
@@ -374,45 +366,20 @@ async def update_ai_config(
 
 
 def validate_model_selection(model_type: str, model_name: str):
-    """Validate that the selected model is allowed for the chosen provider"""
-    
+    """Validate the chosen provider and that a model name is present.
+
+    The catalog models are suggestions, not a hard allowlist — an org may enter a
+    custom model ID for any known provider. So we only enforce that the provider is
+    known and the model name is non-empty; the live API-key test (see setup/update)
+    is what actually rejects a bad model ID.
+    """
+
     # ChatterMate is a special case handled separately
     if model_type.upper() == "CHATTERMATE" and model_name.lower() == "chattermate":
         return True
-    
-    # For GROQ, only allow specific models
-    if model_type.upper() == "GROQ":
-        try:
-            GroqModels(model_name)
-        except ValueError:
-            valid_models = ", ".join([m.value for m in GroqModels])
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "Invalid model selection",
-                    "type": "invalid_model",
-                    "details": f"For Groq, only these models are supported: {valid_models}"
-                }
-            )
-    
-    # For OpenAI, only allow specific models
-    elif model_type.upper() == "OPENAI":
-        try:
-            OpenAIModels(model_name)
-        except ValueError:
-            valid_models = ", ".join([m.value for m in OpenAIModels])
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "Invalid model selection",
-                    "type": "invalid_model",
-                    "details": f"For OpenAI, only these models are supported: {valid_models}"
-                }
-            )
-    
-    # Other providers are not supported for now
-    else:
-        valid_providers = ", ".join([m.value for m in ModelType])
+
+    if not is_known_provider(model_type):
+        valid_providers = ", ".join(p["value"] for p in list_providers())
         raise HTTPException(
             status_code=400,
             detail={
@@ -421,3 +388,15 @@ def validate_model_selection(model_type: str, model_name: str):
                 "details": f"Currently only these providers are supported: {valid_providers}"
             }
         )
+
+    if not model_name or not model_name.strip():
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "Invalid model selection",
+                "type": "invalid_model",
+                "details": "A model ID is required for the selected provider."
+            }
+        )
+
+    return True

--- a/backend/app/core/model_catalog.py
+++ b/backend/app/core/model_catalog.py
@@ -44,6 +44,8 @@ class CatalogProvider(TypedDict):
     label: str
     requires_api_key: bool
     custom_allowed: bool
+    # Console URL where the user creates/copies their API key for this provider.
+    api_key_url: str
     models: List[CatalogModel]
 
 
@@ -58,6 +60,7 @@ MODEL_CATALOG: Dict[str, CatalogProvider] = {
         "label": "OpenAI",
         "requires_api_key": True,
         "custom_allowed": True,
+        "api_key_url": "https://platform.openai.com/api-keys",
         "models": [
             _m("gpt-4.1", "GPT-4.1"),
             _m("gpt-4o", "GPT-4o"),
@@ -70,6 +73,7 @@ MODEL_CATALOG: Dict[str, CatalogProvider] = {
         "label": "Anthropic (Claude)",
         "requires_api_key": True,
         "custom_allowed": True,
+        "api_key_url": "https://console.anthropic.com/settings/keys",
         # Current-gen Claude IDs are complete stable strings — do NOT append a date.
         "models": [
             _m("claude-opus-4-8", "Claude Opus 4.8"),
@@ -82,6 +86,7 @@ MODEL_CATALOG: Dict[str, CatalogProvider] = {
         "label": "Google Gemini",
         "requires_api_key": True,
         "custom_allowed": True,
+        "api_key_url": "https://aistudio.google.com/app/apikey",
         # gemini-2.0-flash is shut down; use bare 2.5 IDs (avoid -latest/-preview).
         "models": [
             _m("gemini-2.5-pro", "Gemini 2.5 Pro"),
@@ -94,6 +99,7 @@ MODEL_CATALOG: Dict[str, CatalogProvider] = {
         "label": "Mistral",
         "requires_api_key": True,
         "custom_allowed": True,
+        "api_key_url": "https://console.mistral.ai/api-keys",
         # -latest aliases auto-advance to the current dated snapshot.
         "models": [
             _m("mistral-large-latest", "Mistral Large"),
@@ -105,6 +111,9 @@ MODEL_CATALOG: Dict[str, CatalogProvider] = {
         "label": "xAI (Grok)",
         "requires_api_key": True,
         "custom_allowed": True,
+        # The Grok inference API uses a single xai-... key from console.x.ai — NOT the
+        # X/Twitter OAuth app credentials (consumer key / access token / bearer token).
+        "api_key_url": "https://console.x.ai",
         "models": [
             _m("grok-4", "Grok 4"),
             _m("grok-4-fast-reasoning", "Grok 4 Fast (Reasoning)"),
@@ -116,6 +125,7 @@ MODEL_CATALOG: Dict[str, CatalogProvider] = {
         "label": "DeepSeek",
         "requires_api_key": True,
         "custom_allowed": True,
+        "api_key_url": "https://platform.deepseek.com/api_keys",
         # deepseek-chat/reasoner scheduled for EOL 2026-07-24; successors are
         # deepseek-v4-flash / deepseek-v4-pro — add here once live.
         "models": [
@@ -127,6 +137,7 @@ MODEL_CATALOG: Dict[str, CatalogProvider] = {
         "label": "Groq",
         "requires_api_key": True,
         "custom_allowed": True,
+        "api_key_url": "https://console.groq.com/keys",
         # GPT-OSS models are the durable picks. llama-3.3-70b-versatile is kept for
         # continuity but is deprecated (EOL 2026-08-16). Org-prefixed IDs must be
         # passed exactly.
@@ -152,6 +163,7 @@ def list_providers() -> List[dict]:
             "label": entry["label"],
             "requires_api_key": entry["requires_api_key"],
             "custom_allowed": entry["custom_allowed"],
+            "api_key_url": entry["api_key_url"],
             "models": entry["models"],
         }
         for provider_value, entry in MODEL_CATALOG.items()

--- a/backend/app/core/model_catalog.py
+++ b/backend/app/core/model_catalog.py
@@ -1,0 +1,158 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Central catalog of BYO-key AI model providers and their suggested models.
+
+Single source of truth consumed by:
+  - the ``GET /ai/providers`` endpoint (which populates the frontend selectors), and
+  - ``validate_model_selection`` in ``app.api.ai_setup``.
+
+The listed models are *suggestions*, not a hard allowlist: every provider here has
+``custom_allowed=True``, so an organization may type any model ID the provider
+supports. Validation only checks that the provider is known and the model name is
+non-empty — the live API-key test is what actually rejects a bad model ID.
+
+Provider model IDs churn and several have near-term shutdowns (see notes). Verify
+against each provider's live ``GET /v1/models`` before relying on an ID long-term.
+
+Every provider key MUST match a value in ``app.models.ai_config.AIModelType`` and a
+branch in ``app.utils.agno_utils.create_model``.
+"""
+
+from typing import Dict, List, TypedDict
+
+
+class CatalogModel(TypedDict):
+    value: str  # exact model ID passed to the provider API
+    label: str  # human-readable display name
+
+
+class CatalogProvider(TypedDict):
+    label: str
+    requires_api_key: bool
+    custom_allowed: bool
+    models: List[CatalogModel]
+
+
+def _m(value: str, label: str) -> CatalogModel:
+    return {"value": value, "label": label}
+
+
+# Keyed by AIModelType value. CHATTERMATE (managed) is intentionally excluded — it
+# is handled as a special case in the setup flow and is not user-selectable here.
+MODEL_CATALOG: Dict[str, CatalogProvider] = {
+    "OPENAI": {
+        "label": "OpenAI",
+        "requires_api_key": True,
+        "custom_allowed": True,
+        "models": [
+            _m("gpt-4.1", "GPT-4.1"),
+            _m("gpt-4o", "GPT-4o"),
+            _m("gpt-4.1-mini", "GPT-4.1 Mini"),
+            _m("gpt-4o-mini", "GPT-4o Mini"),
+            _m("o4-mini", "o4-mini"),
+        ],
+    },
+    "ANTHROPIC": {
+        "label": "Anthropic (Claude)",
+        "requires_api_key": True,
+        "custom_allowed": True,
+        # Current-gen Claude IDs are complete stable strings — do NOT append a date.
+        "models": [
+            _m("claude-opus-4-8", "Claude Opus 4.8"),
+            _m("claude-sonnet-5", "Claude Sonnet 5"),
+            _m("claude-sonnet-4-6", "Claude Sonnet 4.6"),
+            _m("claude-haiku-4-5", "Claude Haiku 4.5"),
+        ],
+    },
+    "GOOGLE": {
+        "label": "Google Gemini",
+        "requires_api_key": True,
+        "custom_allowed": True,
+        # gemini-2.0-flash is shut down; use bare 2.5 IDs (avoid -latest/-preview).
+        "models": [
+            _m("gemini-2.5-pro", "Gemini 2.5 Pro"),
+            _m("gemini-2.5-flash", "Gemini 2.5 Flash"),
+            _m("gemini-2.5-flash-lite", "Gemini 2.5 Flash-Lite"),
+            _m("gemini-3.5-flash", "Gemini 3.5 Flash"),
+        ],
+    },
+    "MISTRAL": {
+        "label": "Mistral",
+        "requires_api_key": True,
+        "custom_allowed": True,
+        # -latest aliases auto-advance to the current dated snapshot.
+        "models": [
+            _m("mistral-large-latest", "Mistral Large"),
+            _m("mistral-medium-latest", "Mistral Medium"),
+            _m("mistral-small-latest", "Mistral Small"),
+        ],
+    },
+    "XAI": {
+        "label": "xAI (Grok)",
+        "requires_api_key": True,
+        "custom_allowed": True,
+        "models": [
+            _m("grok-4", "Grok 4"),
+            _m("grok-4-fast-reasoning", "Grok 4 Fast (Reasoning)"),
+            _m("grok-4-fast-non-reasoning", "Grok 4 Fast (Non-Reasoning)"),
+            _m("grok-3", "Grok 3"),
+        ],
+    },
+    "DEEPSEEK": {
+        "label": "DeepSeek",
+        "requires_api_key": True,
+        "custom_allowed": True,
+        # deepseek-chat/reasoner scheduled for EOL 2026-07-24; successors are
+        # deepseek-v4-flash / deepseek-v4-pro — add here once live.
+        "models": [
+            _m("deepseek-chat", "DeepSeek Chat (V3)"),
+            _m("deepseek-reasoner", "DeepSeek Reasoner"),
+        ],
+    },
+    "GROQ": {
+        "label": "Groq",
+        "requires_api_key": True,
+        "custom_allowed": True,
+        # GPT-OSS models are the durable picks. llama-3.3-70b-versatile is kept for
+        # continuity but is deprecated (EOL 2026-08-16). Org-prefixed IDs must be
+        # passed exactly.
+        "models": [
+            _m("openai/gpt-oss-120b", "GPT-OSS 120B"),
+            _m("openai/gpt-oss-20b", "GPT-OSS 20B"),
+            _m("llama-3.3-70b-versatile", "Llama 3.3 70B Versatile"),
+        ],
+    },
+}
+
+
+def is_known_provider(provider: str) -> bool:
+    """Return True if the provider is a selectable BYO-key provider in the catalog."""
+    return bool(provider) and provider.upper() in MODEL_CATALOG
+
+
+def list_providers() -> List[dict]:
+    """Return the catalog as a serializable list for the /ai/providers endpoint."""
+    return [
+        {
+            "value": provider_value,
+            "label": entry["label"],
+            "requires_api_key": entry["requires_api_key"],
+            "custom_allowed": entry["custom_allowed"],
+            "models": entry["models"],
+        }
+        for provider_value, entry in MODEL_CATALOG.items()
+    ]

--- a/backend/app/utils/agno_utils.py
+++ b/backend/app/utils/agno_utils.py
@@ -56,7 +56,8 @@ def create_model(model_type: str, api_key: str, model_name: str, max_tokens: int
             return DeepSeek(api_key=api_key, id=model_name, max_tokens=max_tokens)
         elif model_type == 'GOOGLE':
             from agno.models.google import Gemini
-            return Gemini(api_key=api_key, id=model_name, max_tokens=max_tokens)
+            # Gemini's agno model exposes max_output_tokens, not max_tokens.
+            return Gemini(api_key=api_key, id=model_name, max_output_tokens=max_tokens)
         elif model_type == 'GOOGLEVERTEX':
             from agno.models.vertexai import Gemini
             return Gemini(api_key=api_key, id=model_name, max_tokens=max_tokens)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -52,6 +52,8 @@ pgvector
 google-generativeai
 google-cloud-aiplatform
 ollama
+anthropic
+mistralai<2  # agno 1.7.6 uses the mistralai 1.x API (mistralai.models); 2.x breaks the import
 
 #ocr
 rapidocr-onnxruntime

--- a/backend/tests/api/test_ai_setup.py
+++ b/backend/tests/api/test_ai_setup.py
@@ -214,13 +214,17 @@ def test_setup_ai_failed_validation(client, db, test_user):
     assert data["detail"]["type"] == "invalid_api_key"
 
 def test_setup_ai_invalid_model(client, db, test_user):
-    """Test AI setup with invalid model type"""
+    """A model ID that fails the live API-key/model test is rejected.
+
+    Model IDs are no longer statically allowlisted (orgs may enter custom ones), so
+    an unusable model is caught by the live test returning False, not by validation.
+    """
     config_data = {
         "model_type": "OPENAI",
-        "model_name": "invalid-model",
-        "api_key": "test_valid_key"
+        "model_name": "nonexistent-model",
+        "api_key": "failed_validation"  # mock_test_api_key returns False for this key
     }
-    
+
     response = client.post(
         "/api/ai/setup",
         json=config_data
@@ -228,7 +232,21 @@ def test_setup_ai_invalid_model(client, db, test_user):
     assert response.status_code == 400
     data = response.json()
     assert "error" in data["detail"]
-    assert data["detail"]["type"] == "invalid_model"
+    assert data["detail"]["type"] == "invalid_api_key"
+
+def test_setup_ai_custom_model_id_succeeds(client, db, test_user):
+    """A custom (non-catalog) model ID with a working key is accepted."""
+    config_data = {
+        "model_type": "OPENAI",
+        "model_name": "gpt-some-future-model",
+        "api_key": "test_valid_key"
+    }
+
+    response = client.post(
+        "/api/ai/setup",
+        json=config_data
+    )
+    assert response.status_code == 200
 
 def test_setup_ai_invalid_provider(client, db, test_user):
     """Test AI setup with invalid provider"""
@@ -323,6 +341,24 @@ def test_setup_ai_general_exception(client, db, test_user):
         )
         assert response.status_code == 500
         assert response.json()["detail"] == "Failed to setup AI configuration"
+
+def test_get_providers(client, db, test_user):
+    """The /providers endpoint returns the catalog of selectable providers."""
+    response = client.get("/api/ai/providers")
+    assert response.status_code == 200
+    data = response.json()
+    providers = {p["value"]: p for p in data["providers"]}
+    # Newly enabled providers are present alongside OpenAI/Groq
+    for expected in ("OPENAI", "GROQ", "ANTHROPIC", "GOOGLE", "MISTRAL", "XAI", "DEEPSEEK"):
+        assert expected in providers, f"{expected} missing from /providers"
+    # ChatterMate (managed) is not a user-selectable BYO-key provider
+    assert "CHATTERMATE" not in providers
+    # Each provider exposes suggested models and BYO-key metadata
+    openai = providers["OPENAI"]
+    assert openai["requires_api_key"] is True
+    assert openai["custom_allowed"] is True
+    assert len(openai["models"]) > 0
+    assert all("value" in m and "label" in m for m in openai["models"])
 
 def test_get_ai_config_success(client, db, test_user, test_ai_config):
     """Test getting AI configuration"""
@@ -501,14 +537,15 @@ def test_validate_model_selection_groq_valid():
     # Should not raise any exception
     ai_setup_router.validate_model_selection("GROQ", "llama-3.3-70b-versatile")
 
-def test_validate_model_selection_groq_invalid():
-    """Test validate_model_selection with invalid Groq model"""
-    with pytest.raises(ai_setup_router.HTTPException) as exc_info:
-        ai_setup_router.validate_model_selection("GROQ", "invalid-model")
-    
-    assert exc_info.value.status_code == 400
-    assert "Invalid model selection" in exc_info.value.detail["error"]
-    assert "invalid_model" in exc_info.value.detail["type"]
+def test_validate_model_selection_custom_model_allowed():
+    """Custom (non-catalog) model IDs are allowed for any known provider.
+
+    Model IDs are no longer a hard allowlist — orgs may type their own; the live
+    API-key test is what rejects a bad model ID.
+    """
+    # Should not raise — custom model IDs are permitted for known providers
+    ai_setup_router.validate_model_selection("GROQ", "some-custom-groq-model")
+    ai_setup_router.validate_model_selection("OPENAI", "gpt-custom-preview")
 
 def test_validate_model_selection_openai_valid():
     """Test validate_model_selection with valid OpenAI model"""
@@ -516,20 +553,28 @@ def test_validate_model_selection_openai_valid():
     ai_setup_router.validate_model_selection("OPENAI", "gpt-4o-mini")
     ai_setup_router.validate_model_selection("OPENAI", "o1-mini")
 
-def test_validate_model_selection_openai_invalid():
-    """Test validate_model_selection with invalid OpenAI model"""
+def test_validate_model_selection_empty_model_name():
+    """A known provider still requires a non-empty model ID."""
     with pytest.raises(ai_setup_router.HTTPException) as exc_info:
-        ai_setup_router.validate_model_selection("OPENAI", "gpt-invalid")
-    
+        ai_setup_router.validate_model_selection("OPENAI", "   ")
+
     assert exc_info.value.status_code == 400
     assert "Invalid model selection" in exc_info.value.detail["error"]
     assert "invalid_model" in exc_info.value.detail["type"]
 
+def test_validate_model_selection_newly_enabled_providers():
+    """Providers added to the catalog (Anthropic, Google, etc.) now validate."""
+    # Should not raise — these are known providers in the catalog now
+    ai_setup_router.validate_model_selection("ANTHROPIC", "claude-sonnet-5")
+    ai_setup_router.validate_model_selection("GOOGLE", "gemini-2.5-flash")
+    ai_setup_router.validate_model_selection("MISTRAL", "mistral-large-latest")
+    ai_setup_router.validate_model_selection("XAI", "grok-4")
+
 def test_validate_model_selection_unsupported_provider():
-    """Test validate_model_selection with unsupported provider"""
+    """Test validate_model_selection with a provider that is not in the catalog"""
     with pytest.raises(ai_setup_router.HTTPException) as exc_info:
-        ai_setup_router.validate_model_selection("ANTHROPIC", "claude-3")
-    
+        ai_setup_router.validate_model_selection("FAKE_PROVIDER", "some-model")
+
     assert exc_info.value.status_code == 400
     assert "Unsupported provider" in exc_info.value.detail["error"]
     assert "invalid_provider" in exc_info.value.detail["type"]

--- a/backend/tests/api/test_ai_setup.py
+++ b/backend/tests/api/test_ai_setup.py
@@ -359,6 +359,9 @@ def test_get_providers(client, db, test_user):
     assert openai["custom_allowed"] is True
     assert len(openai["models"]) > 0
     assert all("value" in m and "label" in m for m in openai["models"])
+    # Every provider exposes a console URL for obtaining an API key
+    for p in data["providers"]:
+        assert p["api_key_url"].startswith("https://"), f"{p['value']} missing api_key_url"
 
 def test_get_ai_config_success(client, db, test_user, test_ai_config):
     """Test getting AI configuration"""

--- a/frontend/src/components/ai/AISetup.vue
+++ b/frontend/src/components/ai/AISetup.vue
@@ -637,8 +637,7 @@ const chatterMateButtonText = computed(() => {
                     class="form-control form-control-mono"
                   />
                   <p class="key-hint">
-                    Your API key will be encrypted and stored securely.<template v-if="selectedProvider?.api_key_url">
-                    <a
+                    Your API key will be encrypted and stored securely.<template v-if="selectedProvider?.api_key_url">&nbsp;&nbsp;<a
                       :href="selectedProvider.api_key_url"
                       target="_blank"
                       rel="noopener noreferrer"

--- a/frontend/src/components/ai/AISetup.vue
+++ b/frontend/src/components/ai/AISetup.vue
@@ -636,7 +636,15 @@ const chatterMateButtonText = computed(() => {
                     placeholder="sk-..."
                     class="form-control form-control-mono"
                   />
-                  <p class="key-hint">Your API key will be encrypted and stored securely</p>
+                  <p class="key-hint">
+                    Your API key will be encrypted and stored securely.<template v-if="selectedProvider?.api_key_url">
+                    <a
+                      :href="selectedProvider.api_key_url"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="key-help-link"
+                    >Get your {{ selectedProvider.label }} API key ↗</a></template>
+                  </p>
                 </div>
 
                 <button
@@ -893,6 +901,16 @@ const chatterMateButtonText = computed(() => {
   font-size: var(--text-sm);
   color: var(--muted2);
   margin-top: var(--space-xs);
+}
+
+.key-help-link {
+  color: var(--accent-ink);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.key-help-link:hover {
+  text-decoration: underline;
 }
 
 .btn {

--- a/frontend/src/components/ai/AISetup.vue
+++ b/frontend/src/components/ai/AISetup.vue
@@ -89,24 +89,57 @@ watch([hasExistingConfig, setupConfig], ([hasConfig, config]) => {
 // API key is always required for our supported providers
 const showApiKey = computed(() => true)
 
-// Model options based on provider
+// Sentinel value for the "Custom model ID" dropdown option
+const CUSTOM_MODEL = '__custom__'
+
+// Catalog entry for the currently selected provider (carries its suggested models)
+const selectedProvider = computed(() =>
+  providers.value.find((p) => p.value === setupConfig.value.provider)
+)
+
+// Suggested models for the provider, plus a "Custom model ID" option when allowed
 const modelOptions = computed(() => {
-  const provider = setupConfig.value.provider.toUpperCase();
-  switch (provider) {
-    case 'GROQ':
-      return [
-        { value: 'llama-3.3-70b-versatile', label: 'Llama 3.3 70B Versatile' },
-      ]
-    case 'OPENAI':
-      return [
-        { value: 'gpt-4o-mini', label: 'GPT-4o Mini' },
-        { value: 'o1-mini', label: 'O1 Mini' },
-        { value: 'o3-mini', label: 'O3 Mini' }
-      ]
-    default:
-      return []
+  const provider = selectedProvider.value
+  if (!provider) return []
+  const options = [...provider.models]
+  if (provider.custom_allowed) {
+    options.push({ value: CUSTOM_MODEL, label: 'Custom model ID…' })
   }
+  return options
 })
+
+// Whether the user is entering a custom (typed) model ID
+const useCustomModel = ref(false)
+
+// Dropdown binding: shows the sentinel while in custom mode, otherwise the selected
+// model id. Selecting the sentinel switches to the free-text input.
+const modelDropdown = computed({
+  get: () => (useCustomModel.value ? CUSTOM_MODEL : setupConfig.value.model),
+  set: (val: string) => {
+    if (val === CUSTOM_MODEL) {
+      useCustomModel.value = true
+      setupConfig.value.model = ''
+    } else {
+      useCustomModel.value = false
+      setupConfig.value.model = val
+    }
+  },
+})
+
+// When an existing config loads (or the catalog arrives) with a model that isn't in
+// the suggested list, switch to custom mode so the text field shows it.
+watch(
+  [providers, () => setupConfig.value.provider, () => setupConfig.value.model],
+  () => {
+    const provider = selectedProvider.value
+    if (!provider || !setupConfig.value.model) return
+    const isSuggested = provider.models.some((m) => m.value === setupConfig.value.model)
+    if (!isSuggested && provider.custom_allowed) {
+      useCustomModel.value = true
+    }
+  },
+  { immediate: true }
+)
 
 // Plan computed properties
 const currentPlan = computed(() => currentSubscription.value?.plan)
@@ -233,12 +266,18 @@ const rateLimitText = computed(() => {
   return `Rate limit: ${rateLimit} messages/minute`
 })
 
-// Reset model when provider changes (but only for new configurations, not existing ones)
-watch(() => setupConfig.value.provider, (newProvider, oldProvider) => {
-  // Only reset model if this is not the initial load of existing config
-  if (oldProvider !== undefined && !hasExistingConfig.value) {
-    setupConfig.value.model = ''
+// Clear the model + custom-mode whenever the user switches provider, so a stale
+// model from the previous provider can't be carried over (and submitted). The very
+// first assignment — the initial load of an existing config — is skipped so the
+// saved model is preserved.
+let providerInitialized = false
+watch(() => setupConfig.value.provider, () => {
+  if (!providerInitialized) {
+    providerInitialized = true
+    return
   }
+  setupConfig.value.model = ''
+  useCustomModel.value = false
 })
 
 const selectTab = (tab: 'chattermate' | 'custom') => {
@@ -559,7 +598,7 @@ const chatterMateButtonText = computed(() => {
                   <label for="model">Model Name</label>
                   <select
                     id="model"
-                    v-model="setupConfig.model"
+                    v-model="modelDropdown"
                     required
                     class="form-control"
                     :disabled="!setupConfig.provider || modelOptions.length === 0"
@@ -573,6 +612,18 @@ const chatterMateButtonText = computed(() => {
                       {{ model.label }}
                     </option>
                   </select>
+                  <input
+                    v-if="useCustomModel"
+                    id="customModel"
+                    type="text"
+                    v-model="setupConfig.model"
+                    required
+                    placeholder="Enter the exact model ID (e.g. gpt-4o)"
+                    class="form-control form-control-mono custom-model-input"
+                  />
+                  <p v-if="useCustomModel" class="key-hint">
+                    Enter any model ID your provider supports — we'll validate it with your API key.
+                  </p>
                 </div>
 
                 <div v-if="showApiKey" class="form-group">
@@ -775,6 +826,10 @@ const chatterMateButtonText = computed(() => {
 
 .form-control-mono {
   font-family: var(--font-mono);
+}
+
+.custom-model-input {
+  margin-top: 8px;
 }
 
 .form-control:focus {

--- a/frontend/src/composables/useAISetup.ts
+++ b/frontend/src/composables/useAISetup.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import { ref, onMounted } from 'vue'
 import { aiService, type AIConfig } from '@/services/ai'
+import type { AIProvider } from '@/types/ai'
 
 export function useAISetup() {
   const isLoading = ref(false)
@@ -29,22 +30,23 @@ export function useAISetup() {
     model: '',
     apiKey: '',
   })
-  
+
   const hasExistingConfig = ref(false)
 
-  const providers = [
-    { value: 'openai', label: 'OpenAI' },
-    { value: 'groq', label: 'Groq' }
-    // Below providers are temporarily disabled
-    // { value: 'anthropic', label: 'Anthropic' },
-    // { value: 'deepseek', label: 'DeepSeek' },
-    // { value: 'google', label: 'Google Gemini' },
-    // { value: 'googlevertex', label: 'Google Vertex AI' },
-    // { value: 'mistral', label: 'Mistral' },
-    // { value: 'huggingface', label: 'HuggingFace' },
-    // { value: 'ollama', label: 'Ollama' },
-    // { value: 'xai', label: 'xAI' }
-  ]
+  // Provider catalog is served by the backend (GET /ai/providers) — single source
+  // of truth. Values are normalized to lowercase to match the save/load flow, which
+  // upper-cases on save and lower-cases the stored model_type on load.
+  const providers = ref<AIProvider[]>([])
+
+  const loadProviders = async () => {
+    try {
+      const fetched = await aiService.getProviders()
+      providers.value = fetched.map((p) => ({ ...p, value: p.value.toLowerCase() }))
+    } catch (err: unknown) {
+      const apiError = (err as { response?: { data?: { detail?: { details?: string; error?: string } } } }).response?.data?.detail;
+      error.value = apiError?.details || apiError?.error || 'Failed to load providers'
+    }
+  }
 
   const loadExistingConfig = async () => {
     try {
@@ -113,6 +115,7 @@ export function useAISetup() {
   }
 
   onMounted(() => {
+    loadProviders()
     loadExistingConfig()
   })
 
@@ -123,6 +126,7 @@ export function useAISetup() {
     providers,
     saveAISetup,
     updateAISetup,
+    loadProviders,
     loadExistingConfig,
     hasExistingConfig
   }

--- a/frontend/src/services/ai.ts
+++ b/frontend/src/services/ai.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import  api  from './api'
-import type { AIConfigResponse, AISetupResponse } from '@/types/ai'
+import type { AIConfigResponse, AISetupResponse, AIProvider } from '@/types/ai'
 
 export interface AIConfig {
   model_type: string;
@@ -24,6 +24,11 @@ export interface AIConfig {
 }
 
 export const aiService = {
+  async getProviders(): Promise<AIProvider[]> {
+    const response = await api.get('/ai/providers')
+    return response.data.providers
+  },
+
   async getOrganizationConfig(): Promise<AIConfig> {
     const response = await api.get('/ai/config')
     return response.data

--- a/frontend/src/types/ai.ts
+++ b/frontend/src/types/ai.ts
@@ -24,6 +24,7 @@ export interface AIProvider {
   label: string
   requires_api_key: boolean
   custom_allowed: boolean
+  api_key_url: string
   models: AIModel[]
 }
 

--- a/frontend/src/types/ai.ts
+++ b/frontend/src/types/ai.ts
@@ -14,14 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export interface AIProvider {
+export interface AIModel {
   value: string
   label: string
 }
 
-export interface AIModel {
+export interface AIProvider {
   value: string
   label: string
+  requires_api_key: boolean
+  custom_allowed: boolean
+  models: AIModel[]
 }
 
 export interface AIConfig {


### PR DESCRIPTION
## What & why

Only **OpenAI** and **Groq** were selectable in the AI setup UI, even though the backend `create_model` factory already supported many providers — they were gated off by duplicated allowlists in three places. This enables the rest and lets orgs bring their own model ID.

**Enabled providers:** Anthropic (Claude), Google Gemini, Mistral, xAI (Grok), DeepSeek, plus more Groq models — all with tool-calling + structured JSON at ~GPT-4o quality.

## Changes

**Backend**
- New `app/core/model_catalog.py` — single source of truth for selectable providers + suggested models. Served via a new `GET /ai/providers`.
- `validate_model_selection` relaxed to *known provider + non-empty model ID*. Model IDs are no longer a hard allowlist — orgs may type a custom ID; the **live API-key test** (now run for every catalog provider) is what rejects a bad one.
- Fixed the Gemini branch to pass `max_output_tokens` (agno's Gemini dataclass has no `max_tokens` → `TypeError`).
- Added `anthropic` and `mistralai<2` to requirements (agno 1.7.6 needs the mistralai 1.x API). OpenAI/Groq/Google SDKs already present; xAI/DeepSeek reuse the OpenAI SDK.

**Frontend**
- Fetch the provider catalog from `GET /ai/providers` instead of hardcoding it; provider grid + model dropdown are now catalog-driven.
- Added a **"Custom model ID"** option that reveals a free-text input; switching provider clears the model + custom-mode so a stale cross-provider model can't be submitted.

## Model IDs

Seeded from current provider docs (Anthropic from the authoritative catalog). Several have near-term deprecations (DeepSeek `deepseek-chat` ~2026-07-24, Groq `llama-3.3-70b` ~2026-08-16) — the per-org **custom model ID** field is the mitigation. IDs should be re-verified against each provider's live `/v1/models` over time.

## Testing

- `tests/api/test_ai_setup.py` updated for the custom-ID contract + a new `/providers` test — **30 passing**.
- All 7 enabled providers verified to instantiate through `create_model`; frontend `type-check` passes.
- Two adversarial code-review passes (one per backend/frontend unit); the one Medium finding (stale model on provider switch) is fixed in this branch.

> **Note:** live end-to-end smoke tests per provider (real BYO key → one chat message with tools + structured output) still need a human with keys — the structured-output+tools combo is the one place a provider could need a `PatchedGroq`-style shim.