### PR TITLE
fix(people): flag integration-authenticated customers explicitly, not via meta_data

### DIFF
--- a/backend/alembic/versions/e5f6a7b8c9d0_add_customer_is_authenticated.py
+++ b/backend/alembic/versions/e5f6a7b8c9d0_add_customer_is_authenticated.py
@@ -1,0 +1,32 @@
+"""add customers.is_authenticated to mark integration-authenticated people
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-09
+
+People who were identified via POST /generate-token (the embedding app asserted a
+known customer_email) are the business's existing customers, not organic leads, and
+must be excluded from the People/leads views. This was previously inferred from
+meta_data being NULL, but SQLAlchemy stores an empty JSON value as JSON null rather
+than SQL NULL, so `meta_data IS NULL` matched nothing and hid every visitor/lead.
+Replace that heuristic with an explicit boolean flag.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'e5f6a7b8c9d0'
+down_revision = 'd4e5f6a7b8c9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'customers',
+        sa.Column('is_authenticated', sa.Boolean(), nullable=False, server_default='false'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('customers', 'is_authenticated')

--- a/backend/app/api/token.py
+++ b/backend/app/api/token.py
@@ -257,11 +257,14 @@ async def generate_widget_token(
             ).first()
             
             if not customer:
-                # Create new customer with email
+                # Create new customer with email. The embedding app supplied a known
+                # identity, so this is an authenticated/integration customer (excluded
+                # from the People/leads views), not an organic lead.
                 customer = Customer(
                     email=body.customer_email,
                     full_name=body.customer_name,
                     meta_data=body.custom_data,
+                    is_authenticated=True,
                     organization_id=widget.organization_id
                 )
                 db.add(customer)
@@ -269,6 +272,10 @@ async def generate_widget_token(
                 db.refresh(customer)
                 logger.info(f"Created new customer: {customer.id} with email {body.customer_email}")
             else:
+                # An existing customer identified via the authenticated integration flow.
+                if not customer.is_authenticated:
+                    customer.is_authenticated = True
+                    db.commit()
                 # Update existing customer with new name if provided
                 if body.customer_name and customer.full_name != body.customer_name:
                     customer.full_name = body.customer_name

--- a/backend/app/models/customer.py
+++ b/backend/app/models/customer.py
@@ -42,6 +42,14 @@ class Customer(Base):
     # Arbitrary integrator-supplied fields (e.g. student_name, center_name) passed via
     # POST /generate-token's `custom_data` and surfaced to agents in the chat inbox.
     meta_data = Column(JSON, nullable=True)
+    # True when the embedding app identified this person via POST /generate-token with a
+    # known identity (customer_email) — an existing/authenticated customer of the business,
+    # not an organic lead the agent captured. Used to exclude them from the People/leads
+    # views. Deliberately an explicit flag, NOT inferred from meta_data: meta_data can be
+    # absent for an authenticated user and present for an anonymous one, and SQLAlchemy
+    # persists an empty JSON value as JSON null (not SQL NULL), so `meta_data IS NULL`
+    # never matched reliably.
+    is_authenticated = Column(Boolean, default=False, server_default="false", nullable=False)
     organization_id = Column(UUID(as_uuid=True), ForeignKey("organizations.id"), nullable=False)
     is_active = Column(Boolean, default=True)
     # Lead lifecycle — denormalized onto the customer so the People page can filter/aggregate

--- a/backend/app/repositories/people.py
+++ b/backend/app/repositories/people.py
@@ -107,10 +107,9 @@ class PeopleRepository:
             .filter(Customer.organization_id == org_id)
             # Hide rows merged into another customer — the target row represents them.
             .filter(Customer.merged_into_customer_id.is_(None))
-            # Exclude integration-authenticated people: meta_data is only ever set from
-            # generate-token (the embedding app passed a known identity), so these are the
-            # business's existing customers, not leads the agent captured.
-            .filter(Customer.meta_data.is_(None))
+            # Exclude integration-authenticated people (identified via generate-token) —
+            # they're the business's existing customers, not leads the agent captured.
+            .filter(Customer.is_authenticated.is_(False))
             # Only people who actually engaged (have chat history) — drops the huge tail of
             # empty widget-loads that created a customer but never sent a message.
             .filter(last_activity_sq.c.cid.isnot(None))
@@ -156,7 +155,7 @@ class PeopleRepository:
         # Same scoping as list_people: exclude merged rows and integration-authenticated
         # (generate-token) customers so the KPIs count only organic visitors/leads.
         not_merged = Customer.merged_into_customer_id.is_(None)
-        organic = Customer.meta_data.is_(None)
+        organic = Customer.is_authenticated.is_(False)
         # Engaged = actually chatted (has chat history) — excludes empty widget-loads.
         engaged = exists().where(ChatHistory.customer_id == Customer.id)
         total = self.db.query(func.count(Customer.id)).filter(

--- a/backend/app/services/lead_capture.py
+++ b/backend/app/services/lead_capture.py
@@ -55,7 +55,7 @@ def record_lead_capture(
     no valid email, or consent is required but not given (GDPR).
 
     Never records when lead capture is disabled for the agent, or when the customer
-    is integration-authenticated (meta_data set by generate-token) — those are the
+    is integration-authenticated (identified via generate-token) — those are the
     business's existing customers, not leads.
 
     If the captured email already belongs to ANOTHER customer in the org, the
@@ -72,11 +72,11 @@ def record_lead_capture(
     if not (config and config.enabled):
         return None
 
-    # Never capture integration-authenticated people: meta_data is only set from
-    # generate-token (the embedding app passed a known identity), so they're already
-    # the business's customers, not leads — regardless of the agent's toggle.
+    # Never capture integration-authenticated people (identified via generate-token) —
+    # they're already the business's customers, not leads, regardless of the agent's
+    # toggle. Uses the explicit flag, not meta_data (see Customer.is_authenticated).
     customer = db.query(Customer).filter(Customer.id == customer_id).first()
-    if customer is not None and customer.meta_data:
+    if customer is not None and customer.is_authenticated:
         return None
 
     lead_data = lead_data or {}

--- a/backend/tests/repo/test_people_repo.py
+++ b/backend/tests/repo/test_people_repo.py
@@ -119,17 +119,25 @@ def test_unengaged_widget_loads_excluded(repo, db, test_organization_id):
 
 
 def test_authenticated_customers_excluded(repo, db, test_organization_id):
-    """Integration-authenticated people (meta_data from generate-token) are the
-    business's existing customers, not leads — excluded from People + stats."""
-    organic = _customer(db, test_organization_id, email="organic@acme.com",
-                        full_name="Organic", lead_stage=LeadStage.LEAD)
+    """Integration-authenticated people (identified via generate-token) are the
+    business's existing customers, not leads — excluded from People + stats.
+
+    Having meta_data must NOT by itself exclude a customer: meta_data is orthogonal
+    to authentication (and is stored as JSON null when empty, so the old
+    `meta_data IS NULL` test hid every organic visitor)."""
+    # Organic lead that happens to carry meta_data (e.g. UTM) — must still show.
+    _customer(db, test_organization_id, email="organic@acme.com",
+              full_name="Organic", lead_stage=LeadStage.LEAD,
+              meta_data={"utm": "google"})
+    # Integration-authenticated customer — excluded.
     _customer(db, test_organization_id, email="portal@acme.com", full_name="Portal User",
+              is_authenticated=True,
               meta_data={"student_name": "Sam", "center_name": "MMCA"})
 
     items, total = repo.list_people(test_organization_id)
     emails = {i["email"] for i in items}
-    assert "organic@acme.com" in emails
-    assert "portal@acme.com" not in emails
+    assert "organic@acme.com" in emails      # meta_data alone no longer excludes
+    assert "portal@acme.com" not in emails   # authenticated flag excludes
     assert total == 1
 
     stats = repo.get_stats(test_organization_id)

--- a/backend/tests/service/test_lead_capture_service.py
+++ b/backend/tests/service/test_lead_capture_service.py
@@ -84,8 +84,9 @@ def test_no_capture_when_disabled(db, test_agent, test_organization_id, config):
 
 
 def test_no_capture_for_authenticated_customer(db, test_agent, test_organization_id, config):
-    # Integration-authenticated customer (generate-token set meta_data) — never a lead.
+    # Integration-authenticated customer (identified via generate-token) — never a lead.
     authed = Customer(email="portal@acme.com", organization_id=test_organization_id,
+                      is_authenticated=True,
                       meta_data={"student_name": "Sam", "center_name": "MMCA"})
     db.add(authed); db.commit(); db.refresh(authed)
     resp = record_lead_capture(
@@ -95,6 +96,22 @@ def test_no_capture_for_authenticated_customer(db, test_agent, test_organization
     )
     assert resp is None
     assert has_captured_lead(db, authed.id, test_agent.id) is False
+
+
+def test_capture_for_customer_with_meta_data_but_not_authenticated(db, test_agent, test_organization_id, config):
+    # meta_data present but not authenticated (e.g. UTM data on an organic visitor) —
+    # must still be captured as a lead (regression: meta_data alone must not block).
+    from app.models.customer import Customer as _Customer
+    visitor = _Customer(email="anon@acme.com", organization_id=test_organization_id,
+                        meta_data={"utm": "google"})
+    db.add(visitor); db.commit(); db.refresh(visitor)
+    resp = record_lead_capture(
+        db, config, organization_id=test_organization_id, agent_id=test_agent.id,
+        customer_id=visitor.id, session_id=None,
+        lead_data={"email": "lead@acme.com"}, summary="s", consent=True,
+    )
+    assert resp is not None
+    assert has_captured_lead(db, resp.customer_id, test_agent.id) is True
 
 
 def test_record_requires_valid_email(db, test_agent, test_organization_id, config):


### PR DESCRIPTION
## The bug

Agent-captured leads were **not showing in People**. Root cause: #177 used `Customer.meta_data IS NULL` to mean "not an integration-authenticated customer", which is wrong two ways:

1. **`meta_data` is orthogonal to authentication** — it can be absent for an authenticated user and present (e.g. UTM data) for an anonymous one.
2. **SQLAlchemy's `JSON` column stores Python `None` as JSON `null`, not SQL `NULL`.** So `meta_data IS NULL` matched **nothing** — every organic visitor/lead was hidden.

Confirmed against a real org (`40c4af0a…`): all 6 customers had `meta_data` = JSON null, so `meta_data IS NULL` returned **0 rows** — the People page was completely empty despite a captured lead (`mickyarunr@gmail.com`).

## The fix

Differentiate the authenticated/integration flow with an **explicit flag**, not `meta_data`:

- New `Customer.is_authenticated` (bool, not null, default false) + alembic migration.
- `token.py`: set `is_authenticated=True` when the embedding app identifies a customer via `POST /generate-token` with a `customer_email` (create + update branches). Anonymous tokens stay `False`.
- `people.py` (`list_people` + `get_stats`) and `lead_capture.py` (record guard) now key off `is_authenticated` instead of `meta_data`.

## Verification

Against the live local DB, same org:

| Filter | Rows returned |
|---|---|
| old `meta_data IS NULL` | **0** (page empty) |
| new `is_authenticated = false` | **5**, incl. `mickyarunr@gmail.com` (LEAD) |

Backend tests: `test_people_repo.py` + `test_lead_capture_service.py` updated to the flag, plus **new regressions** proving a customer *with* `meta_data` but not authenticated still shows / is still captured — **18 passing**. Adversarial code-review pass: no blocking issues.

## Notes / follow-ups

- **No backfill**: pre-existing authenticated customers re-flag on their next `/generate-token` call (no reliable historical signal, since `meta_data` is JSON-null for everyone). Acceptable, self-healing.
- **Behavior change (intended)**: anonymous-token customers carrying `custom_data` now appear in People (they're anonymous visitors, potential leads). The old filter excluded nothing anyway.
- **Pre-existing follow-up (not in this PR)**: the email-match merge path in `record_lead_capture` doesn't check `is_authenticated` on the merge target, so an anonymous visitor typing an authenticated customer's email can still merge into + promote it. Needs its own fix (interacts with the email uniqueness/dedup logic).