### PR TITLE
fix(ai): drop Groq gpt-oss-20b from catalog; warn on custom model IDs

### DIFF
--- a/backend/app/core/model_catalog.py
+++ b/backend/app/core/model_catalog.py
@@ -138,12 +138,13 @@ MODEL_CATALOG: Dict[str, CatalogProvider] = {
         "requires_api_key": True,
         "custom_allowed": True,
         "api_key_url": "https://console.groq.com/keys",
-        # GPT-OSS models are the durable picks. llama-3.3-70b-versatile is kept for
-        # continuity but is deprecated (EOL 2026-08-16). Org-prefixed IDs must be
-        # passed exactly.
+        # gpt-oss-120b is the durable pick. gpt-oss-20b is intentionally NOT listed: the
+        # smaller model leaks OpenAI "harmony" formatting (calls the response tool as
+        # `functions/json`), which Groq rejects, making structured output unreliable.
+        # llama-3.3-70b-versatile is kept for continuity but is deprecated (EOL
+        # 2026-08-16). Org-prefixed IDs must be passed exactly.
         "models": [
             _m("openai/gpt-oss-120b", "GPT-OSS 120B"),
-            _m("openai/gpt-oss-20b", "GPT-OSS 20B"),
             _m("llama-3.3-70b-versatile", "Llama 3.3 70B Versatile"),
         ],
     },

--- a/frontend/src/components/ai/AISetup.vue
+++ b/frontend/src/components/ai/AISetup.vue
@@ -624,6 +624,9 @@ const chatterMateButtonText = computed(() => {
                   <p v-if="useCustomModel" class="key-hint">
                     Enter any model ID your provider supports — we'll validate it with your API key.
                   </p>
+                  <p v-if="useCustomModel" class="model-warning">
+                    ⚠️ Custom models aren't verified by ChatterMate. Smaller or older models may not reliably support tool calling and structured output, which can affect knowledge search, lead capture, and ending chats. Prefer a larger, tool-calling-capable model.
+                  </p>
                 </div>
 
                 <div v-if="showApiKey" class="form-group">
@@ -837,6 +840,17 @@ const chatterMateButtonText = computed(() => {
 
 .custom-model-input {
   margin-top: 8px;
+}
+
+.model-warning {
+  margin-top: var(--space-xs);
+  padding: 8px 10px;
+  font-size: var(--text-sm);
+  line-height: 1.4;
+  color: var(--text);
+  background: var(--warning-bg);
+  border: 1px solid var(--warning-light);
+  border-radius: 8px;
 }
 
 .form-control:focus {


### PR DESCRIPTION
The model dropdown still lists **GPT-OSS 20B** on `main` because the removal was committed on `feat/add-model-providers` but never merged (only the earlier #182 commit landed).

## What this does
- **Removes `openai/gpt-oss-20b`** from the Groq catalog. The 20B model leaks OpenAI "harmony" formatting — it calls the response tool as `functions/json`, which Groq rejects — making structured output/tool calling unreliable. `gpt-oss-120b` is the durable Groq pick.
- **Adds a reliability warning** under the "Custom model ID" field: custom models aren't verified, and smaller/older ones may not reliably support tool calling and structured output (affecting knowledge search, lead capture, and ending chats).

The dropdown is populated from the backend catalog (`/ai/providers`), so removing the entry is what actually clears it from the UI. Matches the backend Groq hardening in #184 and the docs note in chattermate/docs#15.