### PR TITLE
feat(knowledge): crawled sub-page explorer with edit + re-embed and dedicated KB page

### DIFF
--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -958,6 +958,28 @@ async def get_knowledge_by_agent(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+def _enum_value(enum_field):
+    """Safely unwrap an enum field to its string value (or None)."""
+    if enum_field is None:
+        return None
+    return enum_field.value if hasattr(enum_field, 'value') else str(enum_field)
+
+
+def _serialize_queue_item(item: KnowledgeQueue) -> dict:
+    """Shape a KnowledgeQueue row for the queue-list API responses."""
+    return {
+        "id": item.id,
+        "source": item.source,
+        "source_type": item.source_type,
+        "status": _enum_value(item.status),
+        "error": item.error,
+        "created_at": item.created_at.isoformat() if item.created_at else None,
+        "updated_at": item.updated_at.isoformat() if item.updated_at else None,
+        "processing_stage": _enum_value(item.processing_stage),
+        "progress_percentage": item.progress_percentage or 0,
+    }
+
+
 @router.get("/queue/agent/{agent_id}")
 async def get_agent_queue_items(
     agent_id: str,
@@ -973,7 +995,6 @@ async def get_agent_queue_items(
             raise HTTPException(status_code=400, detail="Invalid agent ID format")
 
         logger.debug(f"Getting queue items for agent {agent_uuid}")
-        queue_repo = KnowledgeQueueRepository(db)
 
         # Get queue items for this agent (excluding completed ones)
         queue_items = db.query(KnowledgeQueue).filter(
@@ -982,32 +1003,37 @@ async def get_agent_queue_items(
             KnowledgeQueue.status.in_([QueueStatus.PENDING, QueueStatus.PROCESSING, QueueStatus.FAILED])
         ).order_by(KnowledgeQueue.created_at.desc()).all()
 
-        result = []
-        for item in queue_items:
-            # Safely get enum values
-            def get_enum_value(enum_field):
-                if enum_field is None:
-                    return None
-                return enum_field.value if hasattr(enum_field, 'value') else str(enum_field)
-
-            result.append({
-                "id": item.id,
-                "source": item.source,
-                "source_type": item.source_type,
-                "status": get_enum_value(item.status),
-                "error": item.error,
-                "created_at": item.created_at.isoformat() if item.created_at else None,
-                "updated_at": item.updated_at.isoformat() if item.updated_at else None,
-                "processing_stage": get_enum_value(item.processing_stage),
-                "progress_percentage": item.progress_percentage or 0
-            })
-
-        return {"queue_items": result}
+        return {"queue_items": [_serialize_queue_item(item) for item in queue_items]}
 
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error getting queue items for agent: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/queue/organization/{org_id}")
+async def get_organization_queue_items(
+    org_id: UUID,
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db)
+):
+    """Get all in-flight queue items (pending, processing, failed) for an org."""
+    try:
+        if current_user.organization_id != org_id:
+            raise HTTPException(status_code=403, detail="Unauthorized access to organization")
+
+        queue_items = db.query(KnowledgeQueue).filter(
+            KnowledgeQueue.organization_id == org_id,
+            KnowledgeQueue.status.in_([QueueStatus.PENDING, QueueStatus.PROCESSING, QueueStatus.FAILED])
+        ).order_by(KnowledgeQueue.created_at.desc()).all()
+
+        return {"queue_items": [_serialize_queue_item(item) for item in queue_items]}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting queue items for org: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -70,6 +70,7 @@ class UrlsRequest(BaseModel):
     org_id: UUID
     pdf_urls: List[str] = []
     websites: List[str] = []
+    sitemaps: List[str] = []
     agent_id: Optional[str] = None
     # Optional crawl-scope cap for websites (e.g. 1 = "this page only"). Always
     # clamped to the plan's max_sub_pages server-side; None uses the plan limit.
@@ -83,10 +84,10 @@ class UrlsRequest(BaseModel):
         return v
 
 
-    @field_validator('websites')
+    @field_validator('websites', 'sitemaps')
     @classmethod
     def validate_website_url_format(cls, v):
-        """Validate that each website URL is in https://domainname format"""
+        """Validate that each website/sitemap URL is in https://domainname format"""
         import re
         validated_urls = []
         
@@ -519,8 +520,8 @@ async def add_urls(
             # Get current knowledge sources count
             current_count = knowledge_repo.count_by_organization(request.org_id)
 
-            # Calculate total new URLs to be added
-            total_new_urls = len(request.pdf_urls) + len(request.websites)
+            # Calculate total new URLs to be added (each sitemap is one source)
+            total_new_urls = len(request.pdf_urls) + len(request.websites) + len(request.sitemaps)
 
             # Check if adding these URLs would exceed the limit
             new_count = current_count + total_new_urls
@@ -543,7 +544,7 @@ async def add_urls(
         )
 
         # Check for duplicate URLs
-        all_urls = request.pdf_urls + request.websites
+        all_urls = request.pdf_urls + request.websites + request.sitemaps
         existing_sources = knowledge_repo.get_by_sources(request.org_id, all_urls)
 
         if existing_sources:
@@ -576,6 +577,20 @@ async def add_urls(
                 source=url,
                 status=QueueStatus.PENDING,
                 queue_metadata={"max_links": website_max_links}
+            )
+            queued_items.append(queue_repo.create(queue_item))
+
+        # Queue sitemaps — one source each; pages are discovered from the sitemap
+        # and capped at the plan's sub-page limit (no per-request crawl scope).
+        for url in request.sitemaps:
+            queue_item = KnowledgeQueue(
+                organization_id=request.org_id,
+                agent_id=agent_uuid,
+                user_id=current_user.id,
+                source_type='sitemap',
+                source=url,
+                status=QueueStatus.PENDING,
+                queue_metadata={"max_links": plan_sub_pages}
             )
             queued_items.append(queue_repo.create(queue_item))
 

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -1523,6 +1523,7 @@ async def add_subpage(
     knowledge_id: int,
     subpage_name: str = Body(..., embed=True),
     content: str = Body(..., embed=True),
+    url: Optional[str] = Body(None, embed=True),
     current_user: User = Depends(require_permissions("manage_knowledge")),
     db: Session = Depends(get_db)
 ):
@@ -1591,7 +1592,7 @@ async def add_subpage(
                 )
 
             # Embed and insert the new subpage into the vector database
-            page_editor.insert_subpage(knowledge, subpage_name, content)
+            page_editor.insert_subpage(knowledge, subpage_name, content, (url or "").strip() or None)
 
             logger.info(f"Added new subpage '{subpage_name}' to knowledge {knowledge_id}")
             

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -1419,24 +1419,25 @@ async def update_chunk_content(
         knowledge = _require_editable_knowledge(db, knowledge_id, current_user)
 
         try:
-            # Get existing chunk to preserve metadata
+            # Verify the chunk exists AND belongs to this source (the vector
+            # table is shared across the org's sources, so scope by name).
             query = text(f"""
-                SELECT meta_data
+                SELECT 1
                 FROM {knowledge.schema}."{knowledge.table_name}"
-                WHERE id = :chunk_id
+                WHERE id = :chunk_id AND name = :source
             """)
-            row = db.execute(query, {"chunk_id": chunk_id}).fetchone()
-            
+            row = db.execute(
+                query, {"chunk_id": chunk_id, "source": knowledge.source}
+            ).fetchone()
+
             if not row:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail="Chunk not found"
                 )
 
-            # Re-embed the updated content in place (preserving metadata)
-            page_editor.reembed_chunk(
-                db, knowledge, chunk_id, content, row.meta_data
-            )
+            # Re-embed the updated content in place
+            page_editor.reembed_chunk(db, knowledge, chunk_id, content)
             db.commit()
             
             logger.info(f"Updated chunk {chunk_id} for knowledge {knowledge_id}")
@@ -1475,13 +1476,16 @@ async def delete_chunk(
         knowledge = _require_editable_knowledge(db, knowledge_id, current_user)
 
         try:
-            # Delete the chunk from the database
+            # Delete the chunk from the database (scoped to this source, since the
+            # vector table is shared across the org's sources).
             delete_query = text(f"""
                 DELETE FROM {knowledge.schema}."{knowledge.table_name}"
-                WHERE id = :chunk_id
+                WHERE id = :chunk_id AND name = :source
             """)
-            
-            result = db.execute(delete_query, {"chunk_id": chunk_id})
+
+            result = db.execute(
+                delete_query, {"chunk_id": chunk_id, "source": knowledge.source}
+            )
             db.commit()
             
             if result.rowcount == 0:
@@ -1571,12 +1575,14 @@ async def add_subpage(
                 pass
         
         try:
-            # Check if subpage name already exists
+            # Check if subpage name already exists within this source
             check_query = text(f"""
                 SELECT id FROM {knowledge.schema}."{knowledge.table_name}"
-                WHERE id = :subpage_name
+                WHERE id = :subpage_name AND name = :source
             """)
-            existing = db.execute(check_query, {"subpage_name": subpage_name}).fetchone()
+            existing = db.execute(
+                check_query, {"subpage_name": subpage_name, "source": knowledge.source}
+            ).fetchone()
             
             if existing:
                 raise HTTPException(

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -71,7 +71,18 @@ class UrlsRequest(BaseModel):
     pdf_urls: List[str] = []
     websites: List[str] = []
     agent_id: Optional[str] = None
-    
+    # Optional crawl-scope cap for websites (e.g. 1 = "this page only"). Always
+    # clamped to the plan's max_sub_pages server-side; None uses the plan limit.
+    max_links: Optional[int] = None
+
+    @field_validator('max_links')
+    @classmethod
+    def validate_max_links(cls, v):
+        if v is not None and v < 1:
+            raise ValueError('max_links must be at least 1')
+        return v
+
+
     @field_validator('websites')
     @classmethod
     def validate_website_url_format(cls, v):
@@ -523,6 +534,14 @@ async def add_urls(
         knowledge_repo = KnowledgeRepository(db)
         queued_items = []
 
+        # Per-source sub-page cap: the plan limit, optionally narrowed by the
+        # request's crawl scope (e.g. "this page only" -> max_links=1), never
+        # allowed to exceed the plan limit.
+        plan_sub_pages = subscription.plan.max_sub_pages if (HAS_ENTERPRISE and subscription) else 10
+        website_max_links = (
+            min(request.max_links, plan_sub_pages) if request.max_links else plan_sub_pages
+        )
+
         # Check for duplicate URLs
         all_urls = request.pdf_urls + request.websites
         existing_sources = knowledge_repo.get_by_sources(request.org_id, all_urls)
@@ -543,9 +562,7 @@ async def add_urls(
                 source_type='pdf_url',
                 source=url,
                 status=QueueStatus.PENDING,
-                queue_metadata={
-                    "max_links": subscription.plan.max_sub_pages if HAS_ENTERPRISE and subscription else 10
-                }
+                queue_metadata={"max_links": plan_sub_pages}
             )
             queued_items.append(queue_repo.create(queue_item))
 
@@ -558,9 +575,7 @@ async def add_urls(
                 source_type='website',
                 source=url,
                 status=QueueStatus.PENDING,
-                queue_metadata={
-                    "max_links": subscription.plan.max_sub_pages if HAS_ENTERPRISE and subscription else 10
-                }
+                queue_metadata={"max_links": website_max_links}
             )
             queued_items.append(queue_repo.create(queue_item))
 
@@ -574,6 +589,84 @@ async def add_urls(
     except Exception as e:
         logger.error(f"Error adding URLs: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to add URLs")
+
+
+class TextSourceRequest(BaseModel):
+    org_id: UUID
+    title: str
+    content: str
+    agent_id: Optional[str] = None
+
+    @field_validator('title')
+    @classmethod
+    def validate_title(cls, v):
+        if not v or not v.strip():
+            raise ValueError('Title cannot be empty')
+        return v.strip()
+
+    @field_validator('content')
+    @classmethod
+    def validate_content(cls, v):
+        if not v or not v.strip():
+            raise ValueError('Content cannot be empty')
+        return v
+
+
+@router.post("/add/text")
+async def add_text_source(
+    request: TextSourceRequest = Body(...),
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db)
+):
+    """Create a knowledge source from pasted text and index it immediately."""
+    try:
+        if current_user.organization_id != request.org_id:
+            raise HTTPException(status_code=403, detail="Unauthorized access to organization")
+
+        # Validate the agent (format + ownership) up front.
+        agent_uuid = None
+        if request.agent_id:
+            try:
+                agent_uuid = UUID(request.agent_id)
+            except (ValueError, TypeError):
+                raise HTTPException(status_code=400, detail="Invalid agent_id")
+            agent = AgentRepository(db).get_agent(agent_uuid)
+            if not agent or agent.organization_id != request.org_id:
+                raise HTTPException(status_code=404, detail="Agent not found")
+
+        knowledge_repo = KnowledgeRepository(db)
+
+        # Enforce the source-count limit (enterprise only).
+        if HAS_ENTERPRISE:
+            subscription = require_accessible_subscription(db, request.org_id)
+            current_count = knowledge_repo.count_by_organization(request.org_id)
+            max_sources = subscription.plan.max_knowledge_sources
+            if max_sources is not None and current_count + 1 > max_sources:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Cannot add source: Maximum number of knowledge sources ({max_sources}) would be exceeded"
+                )
+
+        # Reject a duplicate source title.
+        if knowledge_repo.get_by_sources(request.org_id, [request.title]):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A knowledge source with this title already exists"
+            )
+
+        knowledge = page_editor.create_text_source(
+            db, request.org_id, request.title, request.content, agent_uuid
+        )
+        return {
+            "message": "Text source added",
+            "knowledge": {"id": knowledge.id, "name": knowledge.source, "type": knowledge.source_type.value},
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error adding text source: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to add text source")
 
 
 @router.post("/link")

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -28,7 +28,9 @@ from sqlalchemy import text
 from uuid import UUID
 from app.database import get_db
 from app.models.knowledge_to_agent import KnowledgeToAgent
+from app.models.knowledge import Knowledge
 from app.repositories.knowledge import KnowledgeRepository
+from app.knowledge import page_editor
 from app.repositories.knowledge_to_agent import KnowledgeToAgentRepository
 from app.repositories.agent import AgentRepository
 from app.models.knowledge_queue import KnowledgeQueue, QueueStatus
@@ -815,11 +817,7 @@ async def get_knowledge_by_agent(
                     # Create a safe query to get unique records with cleaned source
                     query = text(f"""
                         SELECT DISTINCT
-                            CASE
-                                WHEN id LIKE '%\\_%%' ESCAPE '\\'
-                                THEN substring(id, 1, length(id) - position('_' in reverse(id)))
-                                ELSE id
-                            END as subpage,
+                            {page_editor.PAGE_ID_EXPR} as subpage,
                             id,
                             created_at,
                             updated_at
@@ -1010,11 +1008,7 @@ async def get_knowledge_by_organization(
                     # Create a safe query to get unique records with cleaned source
                     query = text(f"""
                         SELECT DISTINCT
-                            CASE
-                                WHEN id LIKE '%\\_%%' ESCAPE '\\'
-                                THEN substring(id, 1, length(id) - position('_' in reverse(id)))
-                                ELSE id
-                            END as subpage,
+                            {page_editor.PAGE_ID_EXPR} as subpage,
                             id,
                             created_at,
                             updated_at
@@ -1266,6 +1260,33 @@ async def get_knowledge_content(
         )
 
 
+def _require_editable_knowledge(
+    db: Session, knowledge_id: int, current_user: User
+) -> Knowledge:
+    """Load a knowledge source, enforcing ownership and a usable vector table.
+
+    Raises 404 if missing, 403 if it belongs to another org, 400 if it has no
+    vector table yet (e.g. a crawl that has not produced any rows).
+    """
+    knowledge = KnowledgeRepository(db).get_by_id(knowledge_id)
+    if not knowledge:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Knowledge source not found"
+        )
+    if knowledge.organization_id != current_user.organization_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Unauthorized access to knowledge source"
+        )
+    if not knowledge.table_name or not knowledge.schema:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Knowledge source has no vector database table"
+        )
+    return knowledge
+
+
 @router.put("/{knowledge_id}/chunk/{chunk_id:path}")
 async def update_chunk_content(
     knowledge_id: int,
@@ -1276,28 +1297,8 @@ async def update_chunk_content(
 ):
     """Update a single chunk's content in vector database"""
     try:
-        knowledge_repo = KnowledgeRepository(db)
-        
-        # Verify knowledge exists and belongs to user's org
-        knowledge = knowledge_repo.get_by_id(knowledge_id)
-        if not knowledge:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Knowledge source not found"
-            )
-        
-        if knowledge.organization_id != current_user.organization_id:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Unauthorized access to knowledge source"
-            )
-        
-        if not knowledge.table_name or not knowledge.schema:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Knowledge source has no vector database table"
-            )
-        
+        knowledge = _require_editable_knowledge(db, knowledge_id, current_user)
+
         try:
             # Get existing chunk to preserve metadata
             query = text(f"""
@@ -1312,41 +1313,11 @@ async def update_chunk_content(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail="Chunk not found"
                 )
-            
-            # Re-embed the updated content
-            from app.knowledge.knowledge_base import KnowledgeManager
-            from agno.document import Document
-            
-            # Initialize KnowledgeManager for re-embedding
-            manager = KnowledgeManager(
-                org_id=knowledge.organization_id,
-                agent_id=None
+
+            # Re-embed the updated content in place (preserving metadata)
+            page_editor.reembed_chunk(
+                db, knowledge, chunk_id, content, row.meta_data
             )
-            
-            # Create document with new content
-            doc = Document(
-                name=knowledge.source,
-                id=chunk_id,
-                content=content,
-                meta_data=row.meta_data
-            )
-            
-            # Embed the document using the vector_db's embedder
-            doc.embed(embedder=manager.vector_db.embedder)
-            
-            # Update the chunk in the database
-            update_query = text(f"""
-                UPDATE {knowledge.schema}."{knowledge.table_name}"
-                SET content = :content,
-                    embedding = :embedding
-                WHERE id = :chunk_id
-            """)
-            
-            db.execute(update_query, {
-                "content": content,
-                "embedding": doc.embedding,
-                "chunk_id": chunk_id
-            })
             db.commit()
             
             logger.info(f"Updated chunk {chunk_id} for knowledge {knowledge_id}")
@@ -1382,28 +1353,8 @@ async def delete_chunk(
 ):
     """Delete a single chunk from vector database"""
     try:
-        knowledge_repo = KnowledgeRepository(db)
-        
-        # Verify knowledge exists and belongs to user's org
-        knowledge = knowledge_repo.get_by_id(knowledge_id)
-        if not knowledge:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Knowledge source not found"
-            )
-        
-        if knowledge.organization_id != current_user.organization_id:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Unauthorized access to knowledge source"
-            )
-        
-        if not knowledge.table_name or not knowledge.schema:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Knowledge source has no vector database table"
-            )
-        
+        knowledge = _require_editable_knowledge(db, knowledge_id, current_user)
+
         try:
             # Delete the chunk from the database
             delete_query = text(f"""
@@ -1486,13 +1437,7 @@ async def add_subpage(
 
                 if subscription and subscription.plan:
                     # Count existing subpages for this knowledge source
-                    count_query = text(f"""
-                        SELECT COUNT(*) as count
-                        FROM {knowledge.schema}."{knowledge.table_name}"
-                        WHERE name = :source
-                    """)
-                    result = db.execute(count_query, {"source": knowledge.source}).fetchone()
-                    current_count = result.count if result else 0
+                    current_count = page_editor.count_subpages(db, knowledge)
 
                     # Check against max_sub_pages limit from the plan
                     subpages_limit = subscription.plan.max_sub_pages
@@ -1519,40 +1464,10 @@ async def add_subpage(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Subpage name already exists. Please use a unique name."
                 )
-            
-            # Create and embed the new subpage
-            from app.knowledge.knowledge_base import KnowledgeManager
-            from agno.document import Document
-            
-            # Initialize KnowledgeManager for embedding
-            manager = KnowledgeManager(
-                org_id=knowledge.organization_id,
-                agent_id=None
-            )
-            
-            # Get agent_ids for metadata
-            agent_ids = [str(link.agent_id) for link in knowledge.agent_links]
-            
-            # Create document with new content
-            doc = Document(
-                name=knowledge.source,
-                id=subpage_name,
-                content=content,
-                meta_data={"agent_id": agent_ids}
-            )
-            
-            # Embed the document using the vector_db's embedder
-            doc.embed(embedder=manager.vector_db.embedder)
-            
-            # Insert into vector database
-            filters = {
-                "name": knowledge.source,
-                "agent_id": agent_ids,
-                "org_id": str(knowledge.organization_id)
-            }
-            
-            manager.vector_db.insert([doc], filters=filters)
-            
+
+            # Embed and insert the new subpage into the vector database
+            page_editor.insert_subpage(knowledge, subpage_name, content)
+
             logger.info(f"Added new subpage '{subpage_name}' to knowledge {knowledge_id}")
             
             return {"message": "Subpage added successfully", "subpage_id": subpage_name}
@@ -1573,6 +1488,79 @@ async def add_subpage(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=str(e)
+        )
+
+
+@router.put("/{knowledge_id}/page/{page_id:path}")
+async def update_page_content(
+    knowledge_id: int,
+    page_id: str,
+    content: str = Body(..., embed=True),
+    title: Optional[str] = Body(None, embed=True),
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db)
+):
+    """Replace a sub-page's content and re-embed it.
+
+    A page may span several ``_N`` chunks; this collapses it into one freshly
+    embedded chunk keyed by the page id, keeping the source's answers current.
+    """
+    if not (content or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Page content cannot be empty"
+        )
+
+    knowledge = _require_editable_knowledge(db, knowledge_id, current_user)
+    try:
+        replaced = page_editor.replace_page(db, knowledge, page_id, content, title)
+        if replaced == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Page not found"
+            )
+        logger.info(f"Updated page '{page_id}' for knowledge {knowledge_id}")
+        return {"message": "Page updated successfully", "page_id": page_id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error updating page '{page_id}': {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error updating page: {str(e)}"
+        )
+
+
+@router.delete("/{knowledge_id}/page/{page_id:path}")
+async def delete_page(
+    knowledge_id: int,
+    page_id: str,
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db)
+):
+    """Delete a whole sub-page (all of its chunks) from a knowledge source."""
+    knowledge = _require_editable_knowledge(db, knowledge_id, current_user)
+    try:
+        removed = page_editor.delete_page_chunks(db, knowledge, page_id)
+        if removed == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Page not found"
+            )
+        db.commit()
+        logger.info(
+            f"Deleted page '{page_id}' ({removed} chunk(s)) from knowledge {knowledge_id}"
+        )
+        return {"message": "Page deleted successfully", "removed_chunks": removed}
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error deleting page '{page_id}': {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error deleting page: {str(e)}"
         )
 
 

--- a/backend/app/knowledge/crawl4ai_fallback.py
+++ b/backend/app/knowledge/crawl4ai_fallback.py
@@ -132,26 +132,29 @@ class Crawl4AIFallback:
             )
             
             # Wait out short bot-check interstitials (WordPress.com / Cloudflare
-            # "Checking your browser… Secured by wp.com") which JS-redirect to the
-            # real page after a few seconds. Only *unambiguous* interstitial
-            # markers are used, so the predicate is immediately true for normal
-            # pages (no added latency, no false timeouts); it only waits when a
-            # real challenge is present, and if it never clears it times out and
-            # we fall back to whatever HTML we have (the reader then skips it).
+            # "Checking your browser… will only take a few seconds") which
+            # JS-redirect to the real page after a few seconds. Resolve as soon as
+            # the page has substantial real content (>800 chars — fast for normal
+            # pages), OR, on a still-short page, once the visible interstitial
+            # phrases are gone. This actually waits through the redirect instead
+            # of returning the challenge immediately; if it never clears it times
+            # out and the reader skips the page.
             wait_for_real_content = (
-                "js:() => { const t = document.body ? "
-                "document.body.innerText.toLowerCase() : ''; "
+                "js:() => { const t = document.body ? document.body.innerText : ''; "
+                "if (t.length > 800) return true; "
+                "const low = t.toLowerCase(); "
                 "return t.length > 0 "
-                "&& !t.includes('secured by wp.com') "
-                "&& !t.includes('cf-browser-verification') "
-                "&& !t.includes('verifying you are human'); }"
+                "&& !low.includes('checking your browser') "
+                "&& !low.includes('just a moment') "
+                "&& !low.includes('secured by wp.com') "
+                "&& !low.includes('verifying you are human'); }"
             )
             crawler_config = CrawlerRunConfig(
                 cache_mode=CacheMode.BYPASS,
                 wait_until="domcontentloaded",
                 page_timeout=self.timeout * 1000,
                 wait_for=wait_for_real_content,
-                delay_before_return_html=2.0,
+                delay_before_return_html=3.0,
                 screenshot=False,
                 # Anti-bot: simulate a real user and hide automation flags so
                 # WordPress.com / Cloudflare interstitials clear for the headless

--- a/backend/app/knowledge/crawl4ai_fallback.py
+++ b/backend/app/knowledge/crawl4ai_fallback.py
@@ -131,12 +131,34 @@ class Crawl4AIFallback:
                 ]
             )
             
+            # Wait out short bot-check interstitials (WordPress.com / Cloudflare
+            # "Checking your browser… Secured by wp.com") which JS-redirect to the
+            # real page after a few seconds. Only *unambiguous* interstitial
+            # markers are used, so the predicate is immediately true for normal
+            # pages (no added latency, no false timeouts); it only waits when a
+            # real challenge is present, and if it never clears it times out and
+            # we fall back to whatever HTML we have (the reader then skips it).
+            wait_for_real_content = (
+                "js:() => { const t = document.body ? "
+                "document.body.innerText.toLowerCase() : ''; "
+                "return t.length > 0 "
+                "&& !t.includes('secured by wp.com') "
+                "&& !t.includes('cf-browser-verification') "
+                "&& !t.includes('verifying you are human'); }"
+            )
             crawler_config = CrawlerRunConfig(
                 cache_mode=CacheMode.BYPASS,
                 wait_until="domcontentloaded",
                 page_timeout=self.timeout * 1000,
+                wait_for=wait_for_real_content,
                 delay_before_return_html=2.0,
                 screenshot=False,
+                # Anti-bot: simulate a real user and hide automation flags so
+                # WordPress.com / Cloudflare interstitials clear for the headless
+                # browser instead of looping on "Checking your browser…".
+                magic=True,
+                simulate_user=True,
+                override_navigator=True,
             )
             
             logger.info(f"🌐 Starting Crawl4AI for content extraction: {url}")

--- a/backend/app/knowledge/enhanced_website_kb.py
+++ b/backend/app/knowledge/enhanced_website_kb.py
@@ -30,7 +30,7 @@ from app.core.config import settings
 from app.models.knowledge_queue import ProcessingStage, QueueStatus
 from pydantic import model_validator
 
-from app.knowledge.enhanced_website_reader import EnhancedWebsiteReader
+from app.knowledge.enhanced_website_reader import EnhancedWebsiteReader, BotProtectionError
 
 # Initialize logger for this module
 logger = get_logger(__name__)
@@ -296,6 +296,17 @@ class EnhancedWebsiteKnowledgeBase(AgentKnowledge):
             total_duration = total_end_time - total_start_time
             logger.info(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Completed processing all {len(self.urls)} URLs with immediate embedding (Total time: {total_duration:.2f}s)")
 
+    def _raise_if_bot_blocked(self, total_documents: int) -> None:
+        """Raise BotProtectionError if the crawl yielded nothing because a
+        bot-check blocked every page (so the queue item fails with a clear
+        reason instead of silently completing with zero pages)."""
+        if total_documents == 0 and getattr(self.reader, '_challenge_blocked', 0) > 0:
+            raise BotProtectionError(
+                "This site blocked automated crawling (its bot protection served a "
+                "“Checking your browser” page). Add the content manually with "
+                "Upload PDF or Text."
+            )
+
     def load(
         self,
         recreate: bool = False,
@@ -496,7 +507,12 @@ class EnhancedWebsiteKnowledgeBase(AgentKnowledge):
         # Calculate embedding statistics
         final_embedded_count = sum(1 for doc in all_documents if doc.embedding is not None)
         embedding_rate = (final_embedded_count / len(all_documents) * 100) if all_documents else 0
-        
+
+        # If nothing was crawled solely because a bot-check blocked every page,
+        # fail loudly so the user is told to add the content manually — rather
+        # than silently "completing" with zero pages.
+        self._raise_if_bot_blocked(total_documents)
+
         # Mark as completed after all processing is done
         if self.queue_item and self.queue_repo:
             self.queue_repo.update_status(

--- a/backend/app/knowledge/enhanced_website_reader.py
+++ b/backend/app/knowledge/enhanced_website_reader.py
@@ -20,7 +20,7 @@ import time
 from datetime import datetime
 from dataclasses import dataclass, field
 from typing import Dict, List, Set, Tuple, Optional, Callable
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urldefrag, urlunparse
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -105,7 +105,22 @@ class EnhancedWebsiteReader(WebsiteReader):
         # Add https:// by default if no protocol is present
         logger.debug(f"URL '{url}' is missing protocol, adding 'https://'")
         return f"https://{url}"
-    
+
+    def _canonical_url(self, url: str) -> str:
+        """Canonicalize a URL so variants of the same page collapse to one id.
+
+        Drops the ``#fragment`` and any query string, and strips a trailing
+        slash (the root path stays as-is). Without this the same page linked as
+        ``/``, ``/#features`` and ``/#pricing`` would be crawled and stored three
+        times under distinct ids, producing duplicate sub-pages.
+        """
+        if not url:
+            return url
+        url = urldefrag(url).url  # remove #fragment
+        parsed = urlparse(url)
+        path = parsed.path.rstrip('/') or ('/' if not parsed.netloc else '')
+        return urlunparse((parsed.scheme, parsed.netloc, path, '', '', ''))
+
     def _get_primary_domain(self, url: str) -> str:
         """
         Extract primary domain from the given URL.
@@ -889,41 +904,51 @@ class EnhancedWebsiteReader(WebsiteReader):
         :return: A list of absolute URLs.
         """
         links = []
+        seen = set()
         primary_domain = self._get_primary_domain(base_url)
-        
+        base_canonical = self._canonical_url(base_url)
+
         all_links = soup.find_all("a", href=True)
-        
+
         for link in all_links:
             if not isinstance(link, Tag):
                 continue
-            
+
             href_str = str(link["href"])
             full_url = urljoin(base_url, href_str)
-            
+
             if not isinstance(full_url, str):
                 continue
-                
+
+            # Skip query-string URLs before canonicalizing (kept for simplicity).
+            if "?" in full_url:
+                continue
+
+            # Canonicalize (drop #fragment / trailing slash) so page variants
+            # collapse to a single link and don't get crawled/stored twice.
+            full_url = self._canonical_url(full_url)
+
             # Filter out unwanted URLs
             parsed_url = urlparse(full_url)
-            
-            # Ignore self-links
-            if full_url == base_url:
+
+            # Ignore self-links and already-collected duplicates
+            if full_url == base_canonical or full_url in seen:
                 continue
-                
+
             # Check if it's in the same domain
             link_domain = parsed_url.netloc
             is_same_domain = link_domain.endswith(primary_domain)
-            
+
             if (
                 is_same_domain
                 and not any(parsed_url.path.endswith(ext) for ext in [
                     ".pdf", ".jpg", ".png", ".gif", ".zip", ".mp3", ".mp4", ".exe", ".dll"
                 ])
                 and not parsed_url.path.startswith("#")  # Skip anchors
-                and "?" not in full_url  # Skip query parameters for simplicity
             ):
+                seen.add(full_url)
                 links.append(full_url)
-                
+
         logger.info(f"Extracted {len(links)} valid links from {base_url}")
         return links
 

--- a/backend/app/knowledge/enhanced_website_reader.py
+++ b/backend/app/knowledge/enhanced_website_reader.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from dataclasses import dataclass, field
 from typing import Dict, List, Set, Tuple, Optional, Callable
 from urllib.parse import urljoin, urlparse, urldefrag, urlunparse
+from app.knowledge.url_safety import is_blocked_host
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -533,14 +534,19 @@ class EnhancedWebsiteReader(WebsiteReader):
         :return: Tuple of (URL, content, new_links) or None if failed
         """
         current_url, current_depth = url_info
-        
+
         # Normalize URL to ensure it has a protocol
         current_url = self._normalize_url(current_url)
-        
+
         # Skip if URL meets any skip conditions
         if current_url in self._visited:
             return None
-            
+
+        # SSRF guard: never fetch a literal private/loopback/link-local IP.
+        if is_blocked_host(current_url):
+            logger.warning(f"Refusing to crawl blocked host: {current_url}")
+            return None
+
         if not urlparse(current_url).netloc.endswith(primary_domain):
             return None
             
@@ -889,63 +895,15 @@ class EnhancedWebsiteReader(WebsiteReader):
         crawl_start_time = time.time()
         logger.info(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Starting parallel crawl of {url} with max_depth={self.max_depth}, max_links={self.max_links}, and max_workers={self.max_workers}")
         
-        crawler_result: Dict[str, str] = {}
         primary_domain = self._get_primary_domain(url)
-        
+
         # Add starting URL with its depth to the queue
         urls_to_process = [(url, starting_depth)]
         logger.info(f"Added starting URL to crawl queue: {url} (depth: {starting_depth})")
-        
-        # Use ThreadPoolExecutor for parallel processing
-        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            # Process URLs in batches until no more URLs or max_links reached
-            while urls_to_process and len(crawler_result) < self.max_links:
-                # Take a batch of URLs to process
-                batch_size = min(self.max_workers, len(urls_to_process))
-                current_batch = urls_to_process[:batch_size]
-                urls_to_process = urls_to_process[batch_size:]
-                
 
-                
-                # Submit all URLs in the current batch for parallel processing
-                future_to_url = {
-                    executor.submit(self._process_url, url_info, primary_domain): url_info[0]
-                    for url_info in current_batch
-                }
-                
-                # Process completed futures as they finish
-                for future in as_completed(future_to_url):
-                    url = future_to_url[future]
-                    try:
-                        result = future.result()
-                        if result:
-                            processed_url, content, new_links = result
-                            
-                            # Add the content to our results
-                            crawler_result[processed_url] = content
-                            
-                            # Call the URL crawled callback first (for progress tracking)
-                            if on_url_crawled_callback:
-                                logger.debug(f"📞 Calling URL crawled callback for: {processed_url}")
-                                on_url_crawled_callback(processed_url)
-                            
-                            # Call the callback for immediate processing if provided
-                            if on_document_callback:
-                                on_document_callback(processed_url, content)
-                            
-                            # Add new links to the processing queue
-                            for new_link, depth in new_links:
-                                if new_link not in self._visited and (new_link, depth) not in urls_to_process:
-                                    urls_to_process.append((new_link, depth))
-                            
-                            # If we've reached max_links, break early
-                            if len(crawler_result) >= self.max_links:
-                                logger.info(f"Reached maximum number of links ({self.max_links}), stopping further crawling")
-                                break
-                                
-                    except Exception as exc:
-                        logger.error(f"URL {url} generated an exception: {exc}")
-                        self._failed_crawls += 1
+        crawler_result = self._run_crawl_queue(
+            urls_to_process, primary_domain, on_document_callback, on_url_crawled_callback
+        )
 
         # Log crawling summary
         crawl_end_time = time.time()
@@ -953,7 +911,72 @@ class EnhancedWebsiteReader(WebsiteReader):
         logger.info(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Parallel crawl completed: {len(crawler_result)} pages crawled successfully")
         logger.info(f"Crawling statistics: Total: {self._crawled_pages_count}, Successful: {self._successful_crawls}, Failed: {self._failed_crawls}")
         logger.info(f"Total crawling time: {crawl_duration:.2f}s, Average time per page: {crawl_duration/max(1, self._crawled_pages_count):.2f}s")
-        
+
+        return crawler_result
+
+    def _run_crawl_queue(
+        self,
+        urls_to_process: List[Tuple[str, int]],
+        primary_domain: str,
+        on_document_callback: Optional[Callable[[str, str], None]] = None,
+        on_url_crawled_callback: Optional[Callable[[str], None]] = None,
+    ) -> Dict[str, str]:
+        """Process a seed queue of (url, depth) in parallel until it drains or the
+        ``max_links`` cap is hit, extracting content per URL and enqueuing any new
+        links a page yields. Shared by website crawling (seeds one URL, follows
+        links) and sitemap crawling (seeds the listed pages, which yield no links).
+        """
+        crawler_result: Dict[str, str] = {}
+        urls_to_process = list(urls_to_process)
+
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            # Process URLs in batches until no more URLs or max_links reached
+            while urls_to_process and len(crawler_result) < self.max_links:
+                # Take a batch of URLs to process
+                batch_size = min(self.max_workers, len(urls_to_process))
+                current_batch = urls_to_process[:batch_size]
+                urls_to_process = urls_to_process[batch_size:]
+
+                # Submit all URLs in the current batch for parallel processing
+                future_to_url = {
+                    executor.submit(self._process_url, url_info, primary_domain): url_info[0]
+                    for url_info in current_batch
+                }
+
+                # Process completed futures as they finish
+                for future in as_completed(future_to_url):
+                    url = future_to_url[future]
+                    try:
+                        result = future.result()
+                        if result:
+                            processed_url, content, new_links = result
+
+                            # Add the content to our results
+                            crawler_result[processed_url] = content
+
+                            # Call the URL crawled callback first (for progress tracking)
+                            if on_url_crawled_callback:
+                                logger.debug(f"📞 Calling URL crawled callback for: {processed_url}")
+                                on_url_crawled_callback(processed_url)
+
+                            # Call the callback for immediate processing if provided
+                            if on_document_callback:
+                                on_document_callback(processed_url, content)
+
+                            # Add new links to the processing queue
+                            for new_link, depth in new_links:
+                                if new_link not in self._visited and (new_link, depth) not in urls_to_process:
+                                    urls_to_process.append((new_link, depth))
+
+                            # If we've reached max_links, break early
+                            if len(crawler_result) >= self.max_links:
+                                logger.info(f"Reached maximum number of links ({self.max_links}), stopping further crawling")
+                                break
+
+                    except Exception as exc:
+                        logger.error(f"URL {url} generated an exception: {exc}")
+                        self._failed_crawls += 1
+
         return crawler_result
 
     def _extract_links(self, soup: BeautifulSoup, base_url: str) -> List[str]:

--- a/backend/app/knowledge/enhanced_website_reader.py
+++ b/backend/app/knowledge/enhanced_website_reader.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from dataclasses import dataclass, field
 from typing import Dict, List, Set, Tuple, Optional, Callable
 from urllib.parse import urljoin, urlparse, urldefrag, urlunparse
-from app.knowledge.url_safety import is_blocked_host
+from app.knowledge.url_safety import safe_get, BlockedHostError
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -542,11 +542,6 @@ class EnhancedWebsiteReader(WebsiteReader):
         if current_url in self._visited:
             return None
 
-        # SSRF guard: never fetch a literal private/loopback/link-local IP.
-        if is_blocked_host(current_url):
-            logger.warning(f"Refusing to crawl blocked host: {current_url}")
-            return None
-
         if not urlparse(current_url).netloc.endswith(primary_domain):
             return None
             
@@ -587,7 +582,8 @@ class EnhancedWebsiteReader(WebsiteReader):
                     verify=self.verify_ssl
                 ) as client:
                     logger.debug(f"Making HTTP GET request to {current_url}")
-                    response = client.get(current_url)
+                    # Follows redirects manually, re-validating each hop's host (SSRF).
+                    response = safe_get(client, current_url)
                     logger.info(f"Received response: status={response.status_code}, url={response.url}")
                     response.raise_for_status()
                     
@@ -764,6 +760,12 @@ class EnhancedWebsiteReader(WebsiteReader):
                     new_links = [(link, next_depth) for link in links 
                                 if link not in self._visited]
                     
+            except BlockedHostError as e:
+                # A redirect pointed at an internal host — abort, don't retry or
+                # fall back to the browser (which would also reach it).
+                logger.warning(str(e))
+                self._failed_crawls += 1
+                return None
             except httpx.HTTPStatusError as e:
                 retry_count += 1
                 status_code = e.response.status_code

--- a/backend/app/knowledge/enhanced_website_reader.py
+++ b/backend/app/knowledge/enhanced_website_reader.py
@@ -121,6 +121,43 @@ class EnhancedWebsiteReader(WebsiteReader):
         path = parsed.path.rstrip('/') or ('/' if not parsed.netloc else '')
         return urlunparse((parsed.scheme, parsed.netloc, path, '', '', ''))
 
+    # Unambiguous bot-challenge / interstitial signatures.
+    _STRONG_CHALLENGE_MARKERS = (
+        "secured by wp.com",
+        "cf-browser-verification",
+        "cf_chl_",
+        "ddos protection by cloudflare",
+        "verifying you are human",
+        "attention required! | cloudflare",
+    )
+    # Weaker signatures — only treated as a challenge on a short page, since these
+    # phrases can legitimately appear inside real content.
+    _WEAK_CHALLENGE_MARKERS = (
+        "checking your browser",
+        "just a moment",
+        "please enable javascript",
+        "please turn javascript on",
+        "enable cookies and reload",
+        "please stand by, while we are checking",
+    )
+
+    def _looks_like_bot_challenge(self, text: str) -> bool:
+        """True if the extracted text is a bot-check/interstitial, not real content.
+
+        Sites behind Cloudflare / WordPress.com serve a short "Checking your
+        browser…" page to non-browser clients. Its text is just long enough to
+        pass the min-length check, so without this it would be stored as the
+        page's content.
+        """
+        if not text:
+            return False
+        lowered = text.lower()
+        if any(marker in lowered for marker in self._STRONG_CHALLENGE_MARKERS):
+            return True
+        if len(text) < 500 and any(marker in lowered for marker in self._WEAK_CHALLENGE_MARKERS):
+            return True
+        return False
+
     def _get_primary_domain(self, url: str) -> str:
         """
         Extract primary domain from the given URL.
@@ -601,10 +638,17 @@ class EnhancedWebsiteReader(WebsiteReader):
                 # Log extracted content length for debugging
                 logger.info(f"Extracted content length: {len(content) if content else 0} characters from {current_url}")
 
-                # For JavaScript-heavy sites, always try Crawl4AI for better content
-                # Even if we extracted some content, it might just be static elements
-                if is_javascript_heavy:
-                    logger.info(f"🔄 JavaScript-heavy site detected - attempting Crawl4AI for better content extraction")
+                # A bot-challenge interstitial (wp.com / Cloudflare "Checking your
+                # browser…") is short enough to pass the length check, so detect it
+                # explicitly and route it through the JS browser, which can clear it.
+                is_challenge = self._looks_like_bot_challenge(content)
+                if is_challenge:
+                    logger.warning(f"🛡️  Bot-challenge interstitial detected for {current_url} - routing through Crawl4AI")
+
+                # For JavaScript-heavy sites (or a detected challenge), try Crawl4AI
+                # for real content. Even static extraction may just be interstitials.
+                if is_javascript_heavy or is_challenge:
+                    logger.info(f"🔄 Attempting Crawl4AI for better content extraction: {current_url}")
                     crawl4ai = get_crawl4ai_fallback(timeout=self.timeout, verify_ssl=self.verify_ssl)
 
                     if crawl4ai.is_available:
@@ -631,6 +675,14 @@ class EnhancedWebsiteReader(WebsiteReader):
                     else:
                         logger.warning(f"⚠️  Crawl4AI not available for JS-heavy site. Install with: pip install crawl4ai>=0.7.0")
                         logger.warning(f"   Falling back to BeautifulSoup (may have incomplete content)")
+
+                # If the content is still a bot-challenge interstitial (the browser
+                # fallback couldn't clear it or wasn't available), skip the page
+                # rather than storing the "Checking your browser…" text as content.
+                if self._looks_like_bot_challenge(content):
+                    logger.warning(f"⚠️  Skipping {current_url}: bot-challenge interstitial could not be cleared")
+                    self._failed_crawls += 1
+                    return None
 
                 # Check content quality
                 if not content or len(content) < self.min_content_length:

--- a/backend/app/knowledge/enhanced_website_reader.py
+++ b/backend/app/knowledge/enhanced_website_reader.py
@@ -37,6 +37,12 @@ from app.knowledge.content_summarizer import get_content_summarizer
 logger = get_logger(__name__)
 
 
+class BotProtectionError(Exception):
+    """Raised when a crawl produced no content because the site's bot protection
+    (Cloudflare / WordPress.com "Checking your browser…" interstitial) blocked the
+    automated browser. Signals the user should add the content manually."""
+
+
 @dataclass
 class EnhancedWebsiteReader(WebsiteReader):
     """Enhanced Reader for Websites with more robust content extraction"""
@@ -83,6 +89,7 @@ class EnhancedWebsiteReader(WebsiteReader):
     _crawled_pages_count: int = 0
     _successful_crawls: int = 0
     _failed_crawls: int = 0
+    _challenge_blocked: int = 0  # Pages skipped because a bot-check couldn't be cleared
     _current_url: str = None  # Track current URL being processed for link resolution
     
     def _normalize_url(self, url: str) -> str:
@@ -682,6 +689,7 @@ class EnhancedWebsiteReader(WebsiteReader):
                 if self._looks_like_bot_challenge(content):
                     logger.warning(f"⚠️  Skipping {current_url}: bot-challenge interstitial could not be cleared")
                     self._failed_crawls += 1
+                    self._challenge_blocked += 1
                     return None
 
                 # Check content quality
@@ -876,7 +884,8 @@ class EnhancedWebsiteReader(WebsiteReader):
         self._crawled_pages_count = 0
         self._successful_crawls = 0
         self._failed_crawls = 0
-        
+        self._challenge_blocked = 0
+
         crawl_start_time = time.time()
         logger.info(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Starting parallel crawl of {url} with max_depth={self.max_depth}, max_links={self.max_links}, and max_workers={self.max_workers}")
         

--- a/backend/app/knowledge/knowledge_base.py
+++ b/backend/app/knowledge/knowledge_base.py
@@ -22,6 +22,7 @@ from app.core.config import settings
 from app.core.logger import get_logger
 from app.knowledge.enhanced_website_kb import EnhancedWebsiteKnowledgeBase
 from app.knowledge.enhanced_website_reader import EnhancedWebsiteReader
+from app.knowledge.sitemap_reader import SitemapReader
 from app.knowledge.enhanced_pdf_kb import EnhancedPDFKnowledgeBase
 from app.knowledge.enhanced_pdf_url_kb import EnhancedPDFUrlKnowledgeBase
 from app.core.s3 import delete_file_from_s3
@@ -492,8 +493,64 @@ class KnowledgeManager:
                     logger.info(f"Completed website processing for {queue_item.source}")
                     self._add_knowledge_source(queue_item.source, SourceType.WEBSITE)
                     success = True
-                    
+
                     # Completion status is handled internally by EnhancedWebsiteKnowledgeBase
+
+                elif queue_item.source_type == 'sitemap':
+                    # Crawl exactly the pages listed in the sitemap.xml (parsed
+                    # from <loc> entries, incl. sitemap-index recursion) — no BFS.
+                    queue_repo.update_progress(queue_item.id, ProcessingStage.CRAWLING)
+
+                    max_links = queue_item.queue_metadata.get(
+                        'max_links', 10) if queue_item.queue_metadata else 10
+
+                    logger.info(f"Using SitemapReader for queue item: {queue_item.source}")
+                    reader = SitemapReader(
+                        max_depth=1,  # never follow <a href>; pages come from the sitemap
+                        max_links=max_links,
+                        min_content_length=settings.KB_MIN_CONTENT_LENGTH,
+                        timeout=settings.KB_TIMEOUT,
+                        max_retries=settings.KB_MAX_RETRIES,
+                        max_workers=settings.KB_MAX_WORKERS,
+                        verify_ssl=False
+                    )
+
+                    # One source (the sitemap URL); its listed pages are the sub-pages.
+                    knowledge_base = EnhancedWebsiteKnowledgeBase(
+                        urls=[queue_item.source],
+                        max_links=max_links,
+                        vector_db=self.vector_db,
+                        reader=reader
+                    )
+                    knowledge_base.queue_item = queue_item
+                    knowledge_base.queue_repo = queue_repo
+
+                    agent_id_filter = [str(self.agent_id)] if self.agent_id else []
+                    filters = {
+                        "name": queue_item.source,
+                        "agent_id": agent_id_filter,
+                        "org_id": str(self.org_id)
+                    }
+
+                    await asyncio.to_thread(
+                        knowledge_base.load,
+                        recreate=False,
+                        upsert=True,
+                        filters=filters
+                    )
+
+                    # Fail clearly if the sitemap listed no pages (wrong URL / not a
+                    # sitemap) rather than creating an empty knowledge source.
+                    if getattr(reader, '_sitemap_page_count', 0) == 0:
+                        raise ValueError(
+                            "No pages found in the sitemap. Make sure the URL points "
+                            "to a valid sitemap.xml."
+                        )
+
+                    logger.info(f"Completed sitemap processing for {queue_item.source}")
+                    self._add_knowledge_source(queue_item.source, SourceType.WEBSITE)
+                    success = True
+
                 else:
                     raise ValueError(f"Unsupported source type: {
                                      queue_item.source_type}")

--- a/backend/app/knowledge/page_editor.py
+++ b/backend/app/knowledge/page_editor.py
@@ -275,17 +275,26 @@ def create_text_source(
     return knowledge
 
 
-def insert_subpage(knowledge: Knowledge, subpage_name: str, content: str) -> None:
+def insert_subpage(
+    knowledge: Knowledge,
+    subpage_name: str,
+    content: str,
+    url: Optional[str] = None,
+) -> None:
     """Embed and insert a brand-new sub-page chunk.
 
-    The write happens on the vector store's own session (which commits itself);
-    there is nothing to commit on the request session.
+    ``subpage_name`` is the page id/title; ``url`` is an optional source link
+    stored in metadata so the UI can render it (and derive the title from the
+    name rather than from a URL the user pasted). The write happens on the vector
+    store's own session (which commits itself); there is nothing to commit on the
+    request session.
     """
     agent_ids = agent_ids_for(knowledge)
+    meta_data: Dict[str, Any] = {"agent_id": agent_ids, "title": subpage_name}
+    if url:
+        meta_data["url"] = url
     manager = get_manager(knowledge.organization_id)
-    doc = embed_document(
-        manager, knowledge.source, subpage_name, content, {"agent_id": agent_ids}
-    )
+    doc = embed_document(manager, knowledge.source, subpage_name, content, meta_data)
     filters = {
         "name": knowledge.source,
         "agent_id": agent_ids,

--- a/backend/app/knowledge/page_editor.py
+++ b/backend/app/knowledge/page_editor.py
@@ -28,6 +28,7 @@ replacing a whole page all go through one code path.
 """
 
 from typing import Any, Dict, List, Optional
+from uuid import UUID
 
 from agno.document import Document
 from sqlalchemy import text
@@ -35,7 +36,10 @@ from sqlalchemy.orm import Session
 
 from app.core.logger import get_logger
 from app.knowledge.knowledge_base import KnowledgeManager
-from app.models.knowledge import Knowledge
+from app.models.knowledge import Knowledge, SourceType
+from app.models.knowledge_to_agent import KnowledgeToAgent
+from app.repositories.knowledge import KnowledgeRepository
+from app.repositories.knowledge_to_agent import KnowledgeToAgentRepository
 
 logger = get_logger(__name__)
 
@@ -207,6 +211,63 @@ def reembed_chunk(
         update_query,
         {"content": content, "embedding": doc.embedding, "chunk_id": chunk_id},
     )
+
+
+def create_text_source(
+    db: Session,
+    organization_id: UUID,
+    title: str,
+    content: str,
+    agent_id: Optional[UUID] = None,
+) -> Knowledge:
+    """Create a knowledge source from pasted text and embed it as one page.
+
+    Unlike a URL/PDF source (which is crawled asynchronously via the queue), a
+    text source is indexed inline and is immediately ``synced``. Returns the new
+    ``Knowledge`` row. Caller is responsible for the enclosing request context;
+    the vector write commits on its own session.
+    """
+    manager = KnowledgeManager(
+        org_id=organization_id, agent_id=str(agent_id) if agent_id else None
+    )
+    agent_ids = [str(agent_id)] if agent_id else []
+
+    # Embed first — an embedding failure then creates no source row at all.
+    doc = embed_document(
+        manager, title, title, content, {"agent_id": agent_ids, "url": title, "title": title}
+    )
+
+    repo = KnowledgeRepository(db)
+    # KnowledgeRepository.create dedupes on (org, source); track whether the row
+    # already existed so we only compensate-delete a row we actually created.
+    pre_existing = bool(repo.get_by_sources(organization_id, [title]))
+    knowledge = repo.create(
+        Knowledge(
+            organization_id=organization_id,
+            source=title,
+            source_type=SourceType.CUSTOM,
+            table_name=manager.vector_db.table_name,
+            schema=manager.vector_db.schema,
+        )
+    )
+    try:
+        if agent_id is not None:
+            KnowledgeToAgentRepository(db).create(
+                KnowledgeToAgent(knowledge_id=knowledge.id, agent_id=agent_id)
+            )
+        # upsert (not insert) is idempotent on the id, so a raced duplicate title
+        # overwrites its own chunk instead of raising a duplicate-key error.
+        manager.vector_db.upsert(
+            [doc],
+            filters={"name": title, "agent_id": agent_ids, "org_id": str(organization_id)},
+        )
+    except Exception:
+        # Don't leave a chunkless orphan source behind if indexing fails.
+        if not pre_existing:
+            repo.delete(knowledge.id)
+        raise
+    logger.info(f"Created text knowledge source '{title}' for org {organization_id}")
+    return knowledge
 
 
 def insert_subpage(knowledge: Knowledge, subpage_name: str, content: str) -> None:

--- a/backend/app/knowledge/page_editor.py
+++ b/backend/app/knowledge/page_editor.py
@@ -198,18 +198,23 @@ def reembed_chunk(
     knowledge: Knowledge,
     chunk_id: str,
     content: str,
-    meta_data: Dict[str, Any],
 ) -> None:
-    """Re-embed one chunk's content in place. Caller commits."""
+    """Re-embed one chunk's content in place (scoped to its source). Caller commits."""
     manager = get_manager(knowledge.organization_id)
-    doc = embed_document(manager, knowledge.source, chunk_id, content, meta_data)
+    doc = embed_document(manager, knowledge.source, chunk_id, content)
     update_query = text(
         f'UPDATE {knowledge.schema}."{knowledge.table_name}" '
-        "SET content = :content, embedding = :embedding WHERE id = :chunk_id"
+        "SET content = :content, embedding = :embedding "
+        "WHERE id = :chunk_id AND name = :source"
     )
     db.execute(
         update_query,
-        {"content": content, "embedding": doc.embedding, "chunk_id": chunk_id},
+        {
+            "content": content,
+            "embedding": doc.embedding,
+            "chunk_id": chunk_id,
+            "source": knowledge.source,
+        },
     )
 
 

--- a/backend/app/knowledge/page_editor.py
+++ b/backend/app/knowledge/page_editor.py
@@ -1,0 +1,228 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Shared helpers for reading, re-embedding and deleting knowledge sub-pages.
+
+A knowledge "source" (``Knowledge`` row) stores its crawled/extracted content as
+rows in the pgvector table ``{schema}."{table}"``. Each row is a *chunk*; a
+*page* (aka sub-page) is the group of chunks that share a base ``id`` — the page
+URL/name — with optional ``_N`` chunk suffixes (e.g. ``site.com/docs`` and
+``site.com/docs_1``, ``site.com/docs_2``).
+
+These helpers centralise the embed/upsert/delete logic that the knowledge API
+endpoints previously duplicated inline, so editing a chunk, adding a sub-page and
+replacing a whole page all go through one code path.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from agno.document import Document
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.core.logger import get_logger
+from app.knowledge.knowledge_base import KnowledgeManager
+from app.models.knowledge import Knowledge
+
+logger = get_logger(__name__)
+
+# SQL expression that maps a chunk ``id`` back to its page id by stripping a
+# trailing ``_<number>`` chunk suffix (agno splits a page's content into
+# ``<page>_1``, ``<page>_2`` … chunks). Only a *numeric* suffix is stripped, so
+# legitimate underscores in a page name (e.g. ``getting_started``) are kept and
+# distinct pages are never collapsed together. This is the single source of
+# truth for page grouping — the source-listing queries import it too, and the
+# frontend ``basePageId`` mirrors it — so page membership is identical
+# everywhere edit/delete/list operate.
+PAGE_ID_EXPR = "CASE WHEN id ~ '_[0-9]+$' THEN substring(id from '^(.*)_[0-9]+$') ELSE id END"
+
+
+def get_manager(organization_id) -> KnowledgeManager:
+    """Build a KnowledgeManager bound to an org's vector table (no agent link)."""
+    return KnowledgeManager(org_id=organization_id, agent_id=None)
+
+
+def agent_ids_for(knowledge: Knowledge) -> List[str]:
+    """Return the agent ids linked to a knowledge source (for vector filters)."""
+    return [str(link.agent_id) for link in knowledge.agent_links]
+
+
+def embed_document(
+    manager: KnowledgeManager,
+    source: str,
+    doc_id: str,
+    content: str,
+    meta_data: Optional[Dict[str, Any]] = None,
+) -> Document:
+    """Create a Document for ``doc_id`` and embed it with the org's embedder."""
+    doc = Document(
+        name=source,
+        id=doc_id,
+        content=content,
+        meta_data=meta_data or {},
+    )
+    doc.embed(embedder=manager.vector_db.embedder)
+    return doc
+
+
+def count_subpages(db: Session, knowledge: Knowledge) -> int:
+    """Count the distinct sub-pages stored for a knowledge source.
+
+    Counts pages, not raw chunks, so a page split into several ``_N`` chunks
+    counts once — matching the ``max_sub_pages`` plan limit's intent.
+    """
+    query = text(
+        f"SELECT COUNT(DISTINCT {PAGE_ID_EXPR}) AS count "
+        f'FROM {knowledge.schema}."{knowledge.table_name}" WHERE name = :source'
+    )
+    row = db.execute(query, {"source": knowledge.source}).fetchone()
+    return row.count if row else 0
+
+
+def get_page_chunks(db: Session, knowledge: Knowledge, page_id: str) -> List[Any]:
+    """Return all chunk rows (id, content, meta_data) belonging to a page."""
+    query = text(
+        f'SELECT id, content, meta_data FROM {knowledge.schema}."{knowledge.table_name}" '
+        f"WHERE name = :source AND {PAGE_ID_EXPR} = :page_id "
+        "ORDER BY id ASC"
+    )
+    return db.execute(
+        query, {"source": knowledge.source, "page_id": page_id}
+    ).fetchall()
+
+
+def delete_page_chunks(
+    db: Session,
+    knowledge: Knowledge,
+    page_id: str,
+    exclude_canonical: bool = False,
+) -> int:
+    """Delete the chunks of a page. Returns the number of rows removed.
+
+    When ``exclude_canonical`` is True the row whose id equals ``page_id`` is
+    kept — used by :func:`replace_page` to clear leftover ``_N`` chunks after the
+    canonical row has been upserted. The caller commits the transaction.
+    """
+    sql = (
+        f'DELETE FROM {knowledge.schema}."{knowledge.table_name}" '
+        f"WHERE name = :source AND {PAGE_ID_EXPR} = :page_id"
+    )
+    if exclude_canonical:
+        sql += " AND id != :page_id"
+    result = db.execute(text(sql), {"source": knowledge.source, "page_id": page_id})
+    return result.rowcount
+
+
+def replace_page(
+    db: Session,
+    knowledge: Knowledge,
+    page_id: str,
+    content: str,
+    title: Optional[str] = None,
+) -> int:
+    """Replace a page's content with a single freshly re-embedded chunk.
+
+    Collapses the page into one chunk keyed by ``page_id`` holding ``content``.
+    Metadata (including the page ``url`` and agent linkage) is preserved from the
+    existing chunks where available, so the edited page stays attributed to the
+    same agents and keeps its source URL.
+
+    Ordering is chosen so the page can never be lost:
+
+    1. Embed the new content (if this raises, nothing has changed).
+    2. ``upsert`` the canonical ``page_id`` row on the vector store's own
+       connection — this overwrites the existing single-chunk page in place, or
+       inserts the collapsed row for a multi-chunk page. The new content is now
+       durably stored before anything is deleted.
+    3. Delete any leftover ``_N`` chunks (``exclude_canonical``) and commit.
+
+    A failure at step 2 leaves the original page intact; a failure at step 3
+    leaves the correct new content in place plus at most some stale extra chunks
+    (no data loss). ``upsert`` (vs ``insert``) also avoids a duplicate-key error
+    when the canonical row already exists. This function commits the request
+    session itself.
+
+    Returns the number of chunks the page had before the replace (0 if the page
+    does not exist).
+    """
+    existing = get_page_chunks(db, knowledge, page_id)
+    if not existing:
+        return 0
+
+    # Preserve the first chunk's metadata (url, etc.); refresh agent linkage.
+    base_meta: Dict[str, Any] = dict(existing[0].meta_data or {})
+    agent_ids = agent_ids_for(knowledge)
+    base_meta["agent_id"] = agent_ids
+    if title is not None:
+        base_meta["title"] = title
+
+    manager = get_manager(knowledge.organization_id)
+    doc = embed_document(manager, knowledge.source, page_id, content, base_meta)
+    filters = {
+        "name": knowledge.source,
+        "agent_id": agent_ids,
+        "org_id": str(knowledge.organization_id),
+    }
+
+    # Persist the new content first, then clear leftover chunks of the page.
+    manager.vector_db.upsert([doc], filters=filters)
+    removed_extra = delete_page_chunks(db, knowledge, page_id, exclude_canonical=True)
+    db.commit()
+
+    logger.info(
+        f"Replaced page '{page_id}' ({len(existing)} chunk(s), "
+        f"{removed_extra} extra removed) for source '{knowledge.source}'"
+    )
+    return len(existing)
+
+
+def reembed_chunk(
+    db: Session,
+    knowledge: Knowledge,
+    chunk_id: str,
+    content: str,
+    meta_data: Dict[str, Any],
+) -> None:
+    """Re-embed one chunk's content in place. Caller commits."""
+    manager = get_manager(knowledge.organization_id)
+    doc = embed_document(manager, knowledge.source, chunk_id, content, meta_data)
+    update_query = text(
+        f'UPDATE {knowledge.schema}."{knowledge.table_name}" '
+        "SET content = :content, embedding = :embedding WHERE id = :chunk_id"
+    )
+    db.execute(
+        update_query,
+        {"content": content, "embedding": doc.embedding, "chunk_id": chunk_id},
+    )
+
+
+def insert_subpage(knowledge: Knowledge, subpage_name: str, content: str) -> None:
+    """Embed and insert a brand-new sub-page chunk.
+
+    The write happens on the vector store's own session (which commits itself);
+    there is nothing to commit on the request session.
+    """
+    agent_ids = agent_ids_for(knowledge)
+    manager = get_manager(knowledge.organization_id)
+    doc = embed_document(
+        manager, knowledge.source, subpage_name, content, {"agent_id": agent_ids}
+    )
+    filters = {
+        "name": knowledge.source,
+        "agent_id": agent_ids,
+        "org_id": str(knowledge.organization_id),
+    }
+    manager.vector_db.insert([doc], filters=filters)

--- a/backend/app/knowledge/sitemap_parser.py
+++ b/backend/app/knowledge/sitemap_parser.py
@@ -1,0 +1,200 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Fetch and parse ``sitemap.xml`` files into a flat list of page URLs.
+
+Supports plain ``<urlset>`` sitemaps and ``<sitemapindex>`` files that point to
+child sitemaps (recursed breadth-first, bounded), gzip-compressed sitemaps, and
+namespaced tags. Parsing uses ``defusedxml`` to avoid XML-bomb / XXE attacks.
+
+Because the sitemap URL (and every child ``<loc>``) is user-supplied, fetches are
+hardened against abuse: downloads and decompression are size-capped (gzip-bomb
+protection), literal private/loopback/link-local IP hosts are blocked (SSRF), and
+recursed child sitemaps are restricted to the root's registrable domain so an
+index can't fan out to arbitrary hosts.
+"""
+
+import gzip
+import io
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+import httpx
+
+from defusedxml import ElementTree as DefusedET
+
+from app.core.logger import get_logger
+from app.knowledge.url_safety import is_blocked_host as _is_blocked_host
+
+logger = get_logger(__name__)
+
+# Sitemaps.org limits are 50 MB uncompressed / 50k URLs per file; cap a little
+# above that and bound decompression so a gzip bomb can't exhaust memory.
+MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024
+MAX_DECOMPRESSED_BYTES = 60 * 1024 * 1024
+
+
+def _local_name(tag: str) -> str:
+    """Strip an XML namespace from a tag: ``{ns}loc`` -> ``loc`` (lowercased)."""
+    return tag.rsplit("}", 1)[-1].lower()
+
+
+def _registrable_domain(host: str) -> str:
+    """Best-effort registrable domain (last two labels) for same-site checks."""
+    host = (host or "").lower().rstrip(".")
+    if host.startswith("www."):
+        host = host[4:]
+    parts = host.split(".")
+    return ".".join(parts[-2:]) if len(parts) >= 2 else host
+
+
+def _bounded_gunzip(data: bytes) -> Optional[bytes]:
+    """Decompress gzip bytes, bounded to MAX_DECOMPRESSED_BYTES. None if not gzip
+    or the decompressed size would exceed the cap (gzip-bomb protection)."""
+    try:
+        with gzip.GzipFile(fileobj=io.BytesIO(data)) as gz:
+            out = gz.read(MAX_DECOMPRESSED_BYTES + 1)
+    except OSError:
+        return None
+    if len(out) > MAX_DECOMPRESSED_BYTES:
+        logger.warning("Sitemap decompressed size exceeds cap; rejecting")
+        return None
+    return out
+
+
+def _maybe_gunzip(url: str, content: bytes) -> bytes:
+    """Decompress a ``.gz`` sitemap; leave anything else untouched."""
+    if url.lower().endswith(".gz"):
+        out = _bounded_gunzip(content)
+        if out is not None:
+            return out
+    return content
+
+
+def _fetch(client: httpx.Client, url: str) -> Optional[bytes]:
+    """GET a sitemap URL (size-capped, SSRF-guarded); (gunzipped) bytes or None."""
+    if _is_blocked_host(url):
+        logger.warning(f"Refusing to fetch sitemap at blocked host: {url}")
+        return None
+    try:
+        with client.stream("GET", url) as resp:
+            resp.raise_for_status()
+            chunks: List[bytes] = []
+            total = 0
+            for chunk in resp.iter_bytes():
+                total += len(chunk)
+                if total > MAX_DOWNLOAD_BYTES:
+                    logger.warning(f"Sitemap '{url}' exceeds size cap; rejecting")
+                    return None
+                chunks.append(chunk)
+        return _maybe_gunzip(url, b"".join(chunks))
+    except Exception as e:
+        logger.warning(f"Failed to fetch sitemap '{url}': {e}")
+        return None
+
+
+def _parse(content: bytes) -> Tuple[List[str], List[str]]:
+    """Parse sitemap XML into (page_urls, child_sitemap_urls).
+
+    A ``<url>`` entry is a page; a ``<sitemap>`` entry points to a child sitemap.
+    Falls back to a bounded gunzip once if the bytes aren't valid XML (some
+    servers return gzip without a ``.gz`` extension).
+    """
+    try:
+        root = DefusedET.fromstring(content)
+    except Exception:
+        unzipped = _bounded_gunzip(content)
+        if unzipped is None:
+            return [], []
+        try:
+            root = DefusedET.fromstring(unzipped)
+        except Exception as e:
+            logger.warning(f"Failed to parse sitemap XML: {e}")
+            return [], []
+
+    pages: List[str] = []
+    children: List[str] = []
+    for entry in root:
+        kind = _local_name(entry.tag)
+        if kind not in ("url", "sitemap"):
+            continue
+        loc: Optional[str] = None
+        for child in entry:
+            if _local_name(child.tag) == "loc" and child.text and child.text.strip():
+                loc = child.text.strip()
+                break
+        if not loc:
+            continue
+        (children if kind == "sitemap" else pages).append(loc)
+    return pages, children
+
+
+def fetch_sitemap_urls(
+    url: str,
+    *,
+    headers: Optional[Dict[str, str]] = None,
+    timeout: float = 30,
+    verify_ssl: bool = True,
+    max_urls: int = 50,
+    max_sitemaps: int = 50,
+) -> List[str]:
+    """Return the deduped page URLs listed in a sitemap (or sitemap index).
+
+    Recurses child sitemaps breadth-first, bounded by ``max_sitemaps`` fetches
+    and ``max_urls`` total pages (the plan's per-source sub-page limit). Child
+    sitemaps outside the root's registrable domain, and errors on individual
+    (child) sitemaps, are skipped.
+    """
+    headers = headers or {}
+    root_domain = _registrable_domain(urlparse(url).hostname or "")
+    to_visit: List[str] = [url]
+    visited_sitemaps: set = set()
+    seen_pages: set = set()
+    pages: List[str] = []
+
+    with httpx.Client(
+        timeout=timeout, follow_redirects=True, headers=headers, verify=verify_ssl
+    ) as client:
+        while to_visit and len(pages) < max_urls and len(visited_sitemaps) < max_sitemaps:
+            sitemap_url = to_visit.pop(0)
+            if sitemap_url in visited_sitemaps:
+                continue
+            visited_sitemaps.add(sitemap_url)
+
+            content = _fetch(client, sitemap_url)
+            if not content:
+                continue
+
+            found_pages, child_sitemaps = _parse(content)
+            for page in found_pages:
+                if page not in seen_pages:
+                    seen_pages.add(page)
+                    pages.append(page)
+                    if len(pages) >= max_urls:
+                        break
+            for child in child_sitemaps:
+                if child in visited_sitemaps or child in to_visit:
+                    continue
+                if _registrable_domain(urlparse(child).hostname or "") != root_domain:
+                    logger.warning(f"Skipping cross-domain child sitemap: {child}")
+                    continue
+                to_visit.append(child)
+
+    logger.info(
+        f"Sitemap '{url}': discovered {len(pages)} page(s) from "
+        f"{len(visited_sitemaps)} sitemap file(s)"
+    )
+    return pages[:max_urls]

--- a/backend/app/knowledge/sitemap_parser.py
+++ b/backend/app/knowledge/sitemap_parser.py
@@ -30,14 +30,14 @@ index can't fan out to arbitrary hosts.
 import gzip
 import io
 from typing import Dict, List, Optional, Tuple
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
 from defusedxml import ElementTree as DefusedET
 
 from app.core.logger import get_logger
-from app.knowledge.url_safety import is_blocked_host as _is_blocked_host
+from app.knowledge.url_safety import BlockedHostError, MAX_REDIRECTS, guard_url
 
 logger = get_logger(__name__)
 
@@ -85,25 +85,41 @@ def _maybe_gunzip(url: str, content: bytes) -> bytes:
 
 
 def _fetch(client: httpx.Client, url: str) -> Optional[bytes]:
-    """GET a sitemap URL (size-capped, SSRF-guarded); (gunzipped) bytes or None."""
-    if _is_blocked_host(url):
-        logger.warning(f"Refusing to fetch sitemap at blocked host: {url}")
-        return None
-    try:
-        with client.stream("GET", url) as resp:
-            resp.raise_for_status()
-            chunks: List[bytes] = []
-            total = 0
-            for chunk in resp.iter_bytes():
-                total += len(chunk)
-                if total > MAX_DOWNLOAD_BYTES:
-                    logger.warning(f"Sitemap '{url}' exceeds size cap; rejecting")
-                    return None
-                chunks.append(chunk)
-        return _maybe_gunzip(url, b"".join(chunks))
-    except Exception as e:
-        logger.warning(f"Failed to fetch sitemap '{url}': {e}")
-        return None
+    """GET a sitemap URL (size-capped, SSRF-guarded); (gunzipped) bytes or None.
+
+    Redirects are followed manually so each hop's host is re-validated against
+    internal addresses before it is fetched.
+    """
+    current = url
+    for _ in range(MAX_REDIRECTS + 1):
+        try:
+            guard_url(current)
+        except BlockedHostError as e:
+            logger.warning(str(e))
+            return None
+        try:
+            with client.stream("GET", current, follow_redirects=False) as resp:
+                if resp.is_redirect:
+                    location = resp.headers.get("location")
+                    if not location:
+                        return None
+                    current = urljoin(str(resp.url), location)
+                    continue
+                resp.raise_for_status()
+                chunks: List[bytes] = []
+                total = 0
+                for chunk in resp.iter_bytes():
+                    total += len(chunk)
+                    if total > MAX_DOWNLOAD_BYTES:
+                        logger.warning(f"Sitemap '{current}' exceeds size cap; rejecting")
+                        return None
+                    chunks.append(chunk)
+            return _maybe_gunzip(current, b"".join(chunks))
+        except Exception as e:
+            logger.warning(f"Failed to fetch sitemap '{current}': {e}")
+            return None
+    logger.warning(f"Too many redirects while fetching sitemap {url}")
+    return None
 
 
 def _parse(content: bytes) -> Tuple[List[str], List[str]]:

--- a/backend/app/knowledge/sitemap_reader.py
+++ b/backend/app/knowledge/sitemap_reader.py
@@ -1,0 +1,76 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Callable, Dict, Optional
+
+from app.core.logger import get_logger
+from app.knowledge.enhanced_website_reader import EnhancedWebsiteReader
+from app.knowledge.sitemap_parser import fetch_sitemap_urls
+
+logger = get_logger(__name__)
+
+
+class SitemapReader(EnhancedWebsiteReader):
+    """Crawl exactly the pages listed in a ``sitemap.xml`` — no ``<a href>`` following.
+
+    Reuses EnhancedWebsiteReader's whole per-page pipeline (httpx fetch, Crawl4AI
+    fallback, bot-challenge detection, content extraction, Document creation, and
+    the ``name = <sitemap url>`` / ``id = <page url>`` grouping); only the URL
+    source differs — pages come from the sitemap rather than BFS link discovery.
+
+    Construct with ``max_depth=1`` so ``_process_url`` never yields child links,
+    and ``max_links`` = the plan's ``max_sub_pages`` so the discovered page list
+    is capped at ingest.
+    """
+
+    def crawl(
+        self,
+        url: str,
+        starting_depth: int = 1,
+        on_document_callback: Optional[Callable[[str, str], None]] = None,
+        on_url_crawled_callback: Optional[Callable[[str], None]] = None,
+    ) -> Dict[str, str]:
+        url = self._normalize_url(url)
+
+        # Reset per-crawl state exactly as the base crawl does — the counters are
+        # read by the progress logs and by _raise_if_bot_blocked (a fully
+        # bot-blocked sitemap must still fail with the "add manually" message).
+        self._visited = set()
+        self._urls_to_crawl = []
+        self._crawled_pages_count = 0
+        self._successful_crawls = 0
+        self._failed_crawls = 0
+        self._challenge_blocked = 0
+
+        primary_domain = self._get_primary_domain(url)
+        page_urls = fetch_sitemap_urls(
+            url,
+            headers=self.headers,
+            timeout=self.timeout,
+            verify_ssl=self.verify_ssl,
+            max_urls=self.max_links,
+        )
+        # Exposed so the dispatcher can fail a sitemap that lists no pages
+        # (wrong URL / not a sitemap) instead of silently creating an empty source.
+        self._sitemap_page_count = len(page_urls)
+        logger.info(f"Sitemap {url}: crawling {len(page_urls)} listed page(s)")
+        if not page_urls:
+            return {}
+
+        seeds = [(page_url, starting_depth) for page_url in page_urls]
+        return self._run_crawl_queue(
+            seeds, primary_domain, on_document_callback, on_url_crawled_callback
+        )

--- a/backend/app/knowledge/url_safety.py
+++ b/backend/app/knowledge/url_safety.py
@@ -1,0 +1,45 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Shared SSRF guards for the crawler / sitemap fetchers."""
+
+import ipaddress
+from urllib.parse import urlparse
+
+
+def is_blocked_host(url: str) -> bool:
+    """True if the URL targets a literal private/loopback/link-local IP (SSRF guard).
+
+    Only IP-literal hosts are rejected here — this catches the obvious internal
+    targets (cloud metadata ``169.254.169.254``, ``127.0.0.1``, RFC1918 ranges,
+    ``localhost``). Hostnames are not DNS-resolved (resolving + per-redirect
+    re-validation is a deeper, separate hardening), matching the crawler's
+    existing behaviour for hostname targets.
+    """
+    host = (urlparse(url).hostname or "").lower()
+    if host in ("localhost", "localhost.localdomain"):
+        return True
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return False
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+    )

--- a/backend/app/knowledge/url_safety.py
+++ b/backend/app/knowledge/url_safety.py
@@ -24,7 +24,9 @@ from app.core.logger import get_logger
 
 logger = get_logger(__name__)
 
-MAX_REDIRECTS = 5
+# Match httpx's default so the manual (SSRF-checked) redirect following doesn't
+# reject legitimate sites with longer redirect chains.
+MAX_REDIRECTS = 20
 
 
 class BlockedHostError(Exception):

--- a/backend/app/knowledge/url_safety.py
+++ b/backend/app/knowledge/url_safety.py
@@ -17,29 +17,95 @@ limitations under the License.
 """Shared SSRF guards for the crawler / sitemap fetchers."""
 
 import ipaddress
-from urllib.parse import urlparse
+import socket
+from urllib.parse import urljoin, urlparse
+
+from app.core.logger import get_logger
+
+logger = get_logger(__name__)
+
+MAX_REDIRECTS = 5
 
 
-def is_blocked_host(url: str) -> bool:
-    """True if the URL targets a literal private/loopback/link-local IP (SSRF guard).
+class BlockedHostError(Exception):
+    """Raised when a fetch target resolves to a private/internal address."""
 
-    Only IP-literal hosts are rejected here — this catches the obvious internal
-    targets (cloud metadata ``169.254.169.254``, ``127.0.0.1``, RFC1918 ranges,
-    ``localhost``). Hostnames are not DNS-resolved (resolving + per-redirect
-    re-validation is a deeper, separate hardening), matching the crawler's
-    existing behaviour for hostname targets.
-    """
-    host = (urlparse(url).hostname or "").lower()
-    if host in ("localhost", "localhost.localdomain"):
-        return True
-    try:
-        ip = ipaddress.ip_address(host)
-    except ValueError:
-        return False
+
+def _ip_is_internal(ip: ipaddress._BaseAddress) -> bool:
     return (
         ip.is_private
         or ip.is_loopback
         or ip.is_link_local
         or ip.is_reserved
         or ip.is_multicast
+        or ip.is_unspecified
     )
+
+
+def is_blocked_host(url: str) -> bool:
+    """True if the URL targets a literal private/loopback/link-local IP host.
+
+    Catches the obvious internal targets given as an IP literal (cloud metadata
+    ``169.254.169.254``, ``127.0.0.1``, RFC1918 ranges) plus ``localhost``.
+    """
+    host = (urlparse(url).hostname or "").lower()
+    if host in ("localhost", "localhost.localdomain"):
+        return True
+    try:
+        return _ip_is_internal(ipaddress.ip_address(host))
+    except ValueError:
+        return False
+
+
+def resolves_to_blocked_host(url: str) -> bool:
+    """True if the URL's host is, or DNS-resolves to, an internal address.
+
+    Extends :func:`is_blocked_host` by resolving hostnames — this closes the
+    "attacker domain with an A record pointing at 169.254.169.254 / an RFC1918
+    IP" SSRF vector. Hosts that can't be resolved are not blocked here (the
+    request will simply fail to connect).
+    """
+    if is_blocked_host(url):
+        return True
+    host = (urlparse(url).hostname or "").lower()
+    if not host:
+        return False
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except (socket.gaierror, UnicodeError, ValueError, OSError):
+        return False
+    for info in infos:
+        addr = info[4][0]
+        try:
+            if _ip_is_internal(ipaddress.ip_address(addr)):
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def guard_url(url: str) -> None:
+    """Raise BlockedHostError if the URL targets an internal address."""
+    if resolves_to_blocked_host(url):
+        raise BlockedHostError(f"Refusing to fetch internal/blocked host: {url}")
+
+
+def safe_get(client, url: str, *, max_redirects: int = MAX_REDIRECTS, **kwargs):
+    """httpx GET that follows redirects manually, re-validating each hop's host.
+
+    Prevents the "public URL 302-redirects to an internal IP" SSRF: every hop
+    (including the initial URL) is checked with :func:`guard_url` before it is
+    fetched. Returns the final non-redirect response; the caller handles status.
+    """
+    current = url
+    for _ in range(max_redirects + 1):
+        guard_url(current)
+        resp = client.get(current, follow_redirects=False, **kwargs)
+        if resp.is_redirect:
+            location = resp.headers.get("location")
+            if not location:
+                return resp
+            current = urljoin(str(resp.url), location)
+            continue
+        return resp
+    raise BlockedHostError(f"Too many redirects while fetching {url}")

--- a/backend/app/workers/knowledge_processor.py
+++ b/backend/app/workers/knowledge_processor.py
@@ -115,6 +115,8 @@ async def process_queue_item(queue_item_id: int):
             logger.error(f"Error processing queue item {queue_item_id}: {str(e)}")
             try:
                 queue_item.status = QueueStatus.FAILED
+                # Persist the reason so the UI can show why it failed.
+                queue_item.error = str(e)
 
                 # Create notification for failed processing
                 user_friendly_name = get_user_friendly_filename(queue_item.source, queue_item.source_type)

--- a/backend/app/workers/knowledge_processor.py
+++ b/backend/app/workers/knowledge_processor.py
@@ -33,8 +33,8 @@ logger = get_logger(__name__)
 def get_user_friendly_filename(source: str, source_type: str) -> str:
     """Extract a user-friendly filename from the source URL or path"""
     try:
-        if source_type == 'website':
-            # For websites, just return the domain
+        if source_type in ('website', 'sitemap'):
+            # For websites/sitemaps, just return the domain
             parsed = urlparse(source)
             return parsed.netloc or source
         

--- a/backend/tests/api/test_knowledge.py
+++ b/backend/tests/api/test_knowledge.py
@@ -682,4 +682,70 @@ def test_replace_page_upserts_before_deleting(monkeypatch):
     # upsert (persist new content) must happen before the destructive delete.
     assert calls[0] == "upsert"
     assert calls[1] == ("delete", True)
-    assert "commit" in calls 
+    assert "commit" in calls
+
+
+# Test cases for crawl-scope (max_links) on add/urls
+def test_add_urls_crawl_scope_clamps_max_links(client: TestClient, test_organization, db):
+    """A website queued with max_links=1 ('this page only') records that cap."""
+    response = client.post("/api/v1/knowledge/add/urls", json={
+        "org_id": str(test_organization.id),
+        "websites": ["https://scope.example.com"],
+        "max_links": 1,
+    })
+    assert response.status_code == 200
+    item = db.query(KnowledgeQueue).filter(
+        KnowledgeQueue.source == "https://scope.example.com"
+    ).first()
+    assert item is not None
+    assert item.queue_metadata.get("max_links") == 1
+
+
+def test_add_urls_rejects_zero_max_links(client: TestClient, test_organization):
+    """max_links below 1 is rejected by request validation."""
+    response = client.post("/api/v1/knowledge/add/urls", json={
+        "org_id": str(test_organization.id),
+        "websites": ["https://scope2.example.com"],
+        "max_links": 0,
+    })
+    assert response.status_code == 422
+
+
+# Test cases for add/text endpoint
+def test_add_text_unauthorized_org(client: TestClient):
+    """Adding a text source for a different org is rejected."""
+    response = client.post("/api/v1/knowledge/add/text", json={
+        "org_id": str(uuid4()),
+        "title": "Refund policy",
+        "content": "Full refund within 14 days.",
+    })
+    assert response.status_code == 403
+
+
+def test_add_text_empty_content_rejected(client: TestClient, test_organization):
+    """Blank content is rejected by request validation."""
+    response = client.post("/api/v1/knowledge/add/text", json={
+        "org_id": str(test_organization.id),
+        "title": "Refund policy",
+        "content": "   ",
+    })
+    assert response.status_code == 422
+
+
+def test_add_text_agent_not_found(client: TestClient, test_organization):
+    """A text source targeting a non-existent agent returns 404."""
+    response = client.post("/api/v1/knowledge/add/text", json={
+        "org_id": str(test_organization.id),
+        "title": "Refund policy",
+        "content": "Full refund within 14 days.",
+        "agent_id": str(uuid4()),
+    })
+    assert response.status_code == 404
+
+
+def test_add_text_endpoint_registered():
+    """The add/text endpoint is registered on the router."""
+    from app.api.knowledge import router
+    assert any(
+        hasattr(route, 'path') and route.path == '/add/text' for route in router.routes
+    ), "add/text endpoint should be registered" 

--- a/backend/tests/api/test_knowledge.py
+++ b/backend/tests/api/test_knowledge.py
@@ -321,6 +321,20 @@ def test_get_queue_status(client: TestClient, test_knowledge_queue):
     assert data["id"] == test_knowledge_queue.id
     assert data["status"] == "pending"
 
+def test_get_organization_queue_items(client: TestClient, test_organization, test_knowledge_queue):
+    """The org queue endpoint returns in-flight items for the org."""
+    response = client.get(f"/api/v1/knowledge/queue/organization/{test_organization.id}")
+    assert response.status_code == 200
+    sources = [item["source"] for item in response.json()["queue_items"]]
+    assert test_knowledge_queue.source in sources
+
+
+def test_get_organization_queue_items_wrong_org(client: TestClient):
+    """The org queue endpoint rejects a different organization."""
+    response = client.get(f"/api/v1/knowledge/queue/organization/{uuid4()}")
+    assert response.status_code == 403
+
+
 def test_get_processor_status(client: TestClient):
     """Test getting processor status"""
     response = client.get("/api/v1/knowledge/processor/status")

--- a/backend/tests/api/test_knowledge.py
+++ b/backend/tests/api/test_knowledge.py
@@ -587,4 +587,99 @@ def test_add_subpage_with_enterprise_limits_mocked():
                 ))
 
             assert exc_info.value.status_code == 402
-            assert "Subpage limit reached" in exc_info.value.detail 
+            assert "Subpage limit reached" in exc_info.value.detail
+
+
+# Test cases for update_page_content / delete_page endpoints
+def test_update_page_empty_content(client: TestClient, test_knowledge):
+    """Empty page content is rejected before any DB work."""
+    response = client.put(
+        f"/api/v1/knowledge/{test_knowledge.id}/page/some-page",
+        json={"content": "   "}
+    )
+    assert response.status_code == 400
+    assert "Page content cannot be empty" in response.json()["detail"]
+
+
+def test_update_page_knowledge_not_found(client: TestClient):
+    """Updating a page on a non-existent knowledge source returns 404."""
+    response = client.put(
+        "/api/v1/knowledge/999999/page/some-page",
+        json={"content": "New content"}
+    )
+    assert response.status_code == 404
+    assert "Knowledge source not found" in response.json()["detail"]
+
+
+def test_update_page_no_table_name(client: TestClient, test_knowledge):
+    """Updating a page when the source has no vector table returns 400."""
+    response = client.put(
+        f"/api/v1/knowledge/{test_knowledge.id}/page/some-page",
+        json={"content": "New content"}
+    )
+    assert response.status_code == 400
+    assert "Knowledge source has no vector database table" in response.json()["detail"]
+
+
+def test_delete_page_knowledge_not_found(client: TestClient):
+    """Deleting a page on a non-existent knowledge source returns 404."""
+    response = client.delete("/api/v1/knowledge/999999/page/some-page")
+    assert response.status_code == 404
+    assert "Knowledge source not found" in response.json()["detail"]
+
+
+def test_delete_page_no_table_name(client: TestClient, test_knowledge):
+    """Deleting a page when the source has no vector table returns 400."""
+    response = client.delete(f"/api/v1/knowledge/{test_knowledge.id}/page/some-page")
+    assert response.status_code == 400
+    assert "Knowledge source has no vector database table" in response.json()["detail"]
+
+
+def test_page_endpoints_registered():
+    """The page update/delete endpoints are registered on the router."""
+    from app.api.knowledge import router
+    paths = [route.path for route in router.routes if hasattr(route, 'path')]
+    assert any('/{knowledge_id}/page/{page_id:path}' in p for p in paths), \
+        "page endpoints should be registered"
+
+
+def test_replace_page_upserts_before_deleting(monkeypatch):
+    """replace_page persists the new content (upsert) before clearing old chunks,
+    so an insert failure can never leave the page empty. Ordering is asserted via
+    a call log."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+    from app.knowledge import page_editor
+
+    calls = []
+
+    knowledge = SimpleNamespace(
+        schema="ai", table_name="d_test", source="site.com",
+        organization_id=uuid4(), agent_links=[],
+    )
+
+    # One existing chunk for the page so replace_page proceeds.
+    existing_chunk = SimpleNamespace(id="site.com/docs", content="old", meta_data={"url": "site.com/docs"})
+    monkeypatch.setattr(page_editor, "get_page_chunks", lambda db, k, pid: [existing_chunk])
+
+    fake_manager = MagicMock()
+    fake_manager.vector_db.embedder = object()
+    fake_manager.vector_db.upsert.side_effect = lambda *a, **kw: calls.append("upsert")
+    monkeypatch.setattr(page_editor, "get_manager", lambda org_id: fake_manager)
+    monkeypatch.setattr(page_editor, "embed_document", lambda *a, **kw: SimpleNamespace(embedding=[0.1]))
+
+    def fake_delete(db, k, pid, exclude_canonical=False):
+        calls.append(("delete", exclude_canonical))
+        return 1
+    monkeypatch.setattr(page_editor, "delete_page_chunks", fake_delete)
+
+    db = MagicMock()
+    db.commit.side_effect = lambda: calls.append("commit")
+
+    replaced = page_editor.replace_page(db, knowledge, "site.com/docs", "new content", title="Docs")
+
+    assert replaced == 1
+    # upsert (persist new content) must happen before the destructive delete.
+    assert calls[0] == "upsert"
+    assert calls[1] == ("delete", True)
+    assert "commit" in calls 

--- a/backend/tests/api/test_knowledge.py
+++ b/backend/tests/api/test_knowledge.py
@@ -236,6 +236,22 @@ def test_add_urls(client: TestClient, test_organization):
     assert len(data["queue_items"]) == 2  # One for PDF, one for website
     assert all(item["status"] == "pending" for item in data["queue_items"])
 
+def test_add_sitemap(client: TestClient, test_organization, db):
+    """A sitemaps request enqueues one source_type='sitemap' queue item."""
+    response = client.post("/api/v1/knowledge/add/urls", json={
+        "org_id": str(test_organization.id),
+        "sitemaps": ["https://example.com/sitemap.xml"],
+    })
+    assert response.status_code == 200
+    assert len(response.json()["queue_items"]) == 1
+    item = db.query(KnowledgeQueue).filter(
+        KnowledgeQueue.source == "https://example.com/sitemap.xml"
+    ).first()
+    assert item is not None
+    assert item.source_type == "sitemap"
+    assert item.queue_metadata.get("max_links") == 10  # non-enterprise default
+
+
 def test_link_knowledge_to_agent(client: TestClient, test_knowledge, test_agent):
     """Test linking knowledge to an agent"""
     response = client.post(

--- a/backend/tests/knowledge/test_enhanced_website_kb.py
+++ b/backend/tests/knowledge/test_enhanced_website_kb.py
@@ -98,10 +98,30 @@ class TestEnhancedWebsiteKnowledgeBase:
         """Test initialization with a custom reader"""
         custom_reader = EnhancedWebsiteReader(max_depth=4, max_links=15)
         kb = EnhancedWebsiteKnowledgeBase(urls=TEST_URLS, reader=custom_reader)
-        
+
         assert kb.reader is custom_reader
         assert kb.reader.max_depth == 4
         assert kb.reader.max_links == 15
+
+    def test_raise_if_bot_blocked(self):
+        """A fully bot-blocked crawl (0 docs, pages skipped) raises, so the queue
+        item fails with a clear reason instead of silently completing."""
+        from app.knowledge.enhanced_website_reader import BotProtectionError
+        reader = EnhancedWebsiteReader(max_links=5)
+        kb = EnhancedWebsiteKnowledgeBase(urls=TEST_URLS, reader=reader)
+
+        # Nothing blocked → never raises, regardless of doc count.
+        reader._challenge_blocked = 0
+        kb._raise_if_bot_blocked(0)
+        kb._raise_if_bot_blocked(5)
+
+        # Blocked pages AND zero documents extracted → raise.
+        reader._challenge_blocked = 3
+        with pytest.raises(BotProtectionError):
+            kb._raise_if_bot_blocked(0)
+
+        # Blocked some pages but others succeeded → don't raise.
+        kb._raise_if_bot_blocked(2)
     
     def test_document_lists_property(self, mock_reader):
         """Test the document_lists property"""

--- a/backend/tests/knowledge/test_enhanced_website_reader.py
+++ b/backend/tests/knowledge/test_enhanced_website_reader.py
@@ -158,6 +158,37 @@ class TestEnhancedWebsiteReader(unittest.TestCase):
         self.assertIsNotNone(soup_copy.find('footer'))
         self.assertIsNotNone(soup_copy.find('main'))
         
+    def test_canonical_url(self):
+        """Fragments/trailing slashes are stripped so page variants collapse."""
+        c = self.reader._canonical_url
+        self.assertEqual(c('https://x.com/'), 'https://x.com')
+        self.assertEqual(c('https://x.com/#features'), 'https://x.com')
+        self.assertEqual(c('https://x.com/#pricing'), 'https://x.com')
+        self.assertEqual(c('https://x.com/pricing/'), 'https://x.com/pricing')
+        self.assertEqual(c('https://x.com/blogs#top'), 'https://x.com/blogs')
+        # The homepage and its anchored variants all canonicalize to one id.
+        variants = {c(u) for u in [
+            'https://x.com', 'https://x.com/', 'https://x.com/#a', 'https://x.com/#b'
+        ]}
+        self.assertEqual(len(variants), 1)
+
+    def test_extract_links_dedupes_page_variants(self):
+        """The homepage linked via #anchors and trailing slash yields one link."""
+        html = """
+        <html><body>
+          <a href="https://site.com/#features">Features</a>
+          <a href="https://site.com/#pricing">Pricing</a>
+          <a href="https://site.com/">Home</a>
+          <a href="https://site.com/docs">Docs</a>
+          <a href="https://site.com/docs/">Docs slash</a>
+        </body></html>
+        """
+        soup = BeautifulSoup(html, 'html.parser')
+        links = self.reader._extract_links(soup, 'https://site.com')
+        # All homepage variants collapse (and equal the base, so are dropped);
+        # /docs and /docs/ collapse to a single canonical link.
+        self.assertEqual(links, ['https://site.com/docs'])
+
     @patch('httpx.Client')
     def test_crawl_with_successful_request(self, mock_client):
         """Test crawling with successful HTTP requests"""

--- a/backend/tests/knowledge/test_enhanced_website_reader.py
+++ b/backend/tests/knowledge/test_enhanced_website_reader.py
@@ -172,6 +172,24 @@ class TestEnhancedWebsiteReader(unittest.TestCase):
         ]}
         self.assertEqual(len(variants), 1)
 
+    def test_looks_like_bot_challenge(self):
+        """Bot-check interstitials are detected so they aren't stored as content."""
+        f = self.reader._looks_like_bot_challenge
+        # The exact wp.com interstitial from the reported bug (strong marker).
+        self.assertTrue(f(
+            "Checking your browser This will only take a few seconds... "
+            "Secured by wp.com (URL: https://wordpress.com)"
+        ))
+        # Cloudflare markers.
+        self.assertTrue(f("cf-browser-verification"))
+        self.assertTrue(f("Just a moment..."))  # weak, but short
+        # Real content is not flagged, even if long and mentioning a weak phrase.
+        long_text = ("Our pricing is simple. " * 40) + "checking your browser settings is optional."
+        self.assertFalse(f(long_text))
+        self.assertFalse(f("Welcome to our pricing page. Plans start at $10 per seat."))
+        self.assertFalse(f(""))
+        self.assertFalse(f(None))
+
     def test_extract_links_dedupes_page_variants(self):
         """The homepage linked via #anchors and trailing slash yields one link."""
         html = """

--- a/backend/tests/knowledge/test_enhanced_website_reader.py
+++ b/backend/tests/knowledge/test_enhanced_website_reader.py
@@ -33,6 +33,16 @@ class TestEnhancedWebsiteReader(unittest.TestCase):
             max_links=5,
             min_content_length=50
         )
+
+        # The fetch path now runs an SSRF guard (url_safety.resolves_to_blocked_host)
+        # which does a DNS lookup — stub it to a fixed public IP so tests don't hit
+        # the network and aren't blocked.
+        dns_patcher = patch(
+            'app.knowledge.url_safety.socket.getaddrinfo',
+            return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+        )
+        self.addCleanup(dns_patcher.stop)
+        dns_patcher.start()
         
         # Create a simple HTML response for testing
         self.test_html = """
@@ -213,13 +223,14 @@ class TestEnhancedWebsiteReader(unittest.TestCase):
         # Mock HTTP client response
         mock_response = MagicMock()
         mock_response.text = self.test_html
+        mock_response.is_redirect = False
         mock_response.raise_for_status = MagicMock()
-        
+
         # Setup mock client
         mock_client_instance = MagicMock()
         mock_client_instance.get.return_value = mock_response
         mock_client.return_value.__enter__.return_value = mock_client_instance
-        
+
         # Test crawling
         result = self.reader.crawl('https://example.com')
         
@@ -237,17 +248,24 @@ class TestEnhancedWebsiteReader(unittest.TestCase):
         """Test crawling with retries on failed requests"""
         # Mock HTTP errors for the first two attempts, then success
         mock_response_error = MagicMock()
+        mock_response_error.is_redirect = False
         mock_response_error.raise_for_status.side_effect = httpx.HTTPStatusError("Error", request=MagicMock(), response=MagicMock(status_code=500))
-        
+
+        mock_response_request_error = MagicMock(
+            is_redirect=False,
+            raise_for_status=MagicMock(side_effect=httpx.RequestError("Timeout", request=MagicMock())),
+        )
+
         mock_response_success = MagicMock()
         mock_response_success.text = self.test_html
+        mock_response_success.is_redirect = False
         mock_response_success.raise_for_status = MagicMock()
-        
+
         # Setup mock client - the parallel processing may create multiple client instances
         mock_client_instance = MagicMock()
         mock_client_instance.get.side_effect = [
             mock_response_error,  # First attempt fails with HTTP error
-            MagicMock(raise_for_status=MagicMock(side_effect=httpx.RequestError("Timeout", request=MagicMock()))),  # Second attempt fails with request error
+            mock_response_request_error,  # Second attempt fails with request error
             mock_response_success  # Third attempt succeeds
         ]
         mock_client.return_value.__enter__.return_value = mock_client_instance
@@ -268,13 +286,14 @@ class TestEnhancedWebsiteReader(unittest.TestCase):
         # Mock HTTP response
         mock_response = MagicMock()
         mock_response.text = self.test_html
+        mock_response.is_redirect = False
         mock_response.raise_for_status = MagicMock()
-        
+
         # Setup mock client
         mock_client_instance = MagicMock()
         mock_client_instance.get.return_value = mock_response
         mock_client.return_value.__enter__.return_value = mock_client_instance
-        
+
         # Test read method
         documents = self.reader.read('https://example.com')
         

--- a/backend/tests/knowledge/test_sitemap_parser.py
+++ b/backend/tests/knowledge/test_sitemap_parser.py
@@ -92,16 +92,6 @@ def test_invalid_xml_returns_empty():
     assert urls == []
 
 
-def test_is_blocked_host_rejects_private_and_loopback():
-    f = sitemap_parser._is_blocked_host
-    assert f("http://169.254.169.254/latest/meta-data/")  # cloud metadata
-    assert f("http://127.0.0.1/sitemap.xml")
-    assert f("http://10.0.0.5/sitemap.xml")
-    assert f("http://localhost/sitemap.xml")
-    assert not f("https://site.com/sitemap.xml")
-    assert not f("https://8.8.8.8/sitemap.xml")  # public IP allowed
-
-
 def test_cross_domain_child_sitemap_is_skipped():
     evil_index = f"""<sitemapindex {NS}>
       <sitemap><loc>https://site.com/ok.xml</loc></sitemap>

--- a/backend/tests/knowledge/test_sitemap_parser.py
+++ b/backend/tests/knowledge/test_sitemap_parser.py
@@ -1,0 +1,146 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import gzip
+from unittest.mock import patch
+
+from app.knowledge import sitemap_parser
+
+NS = 'xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'
+
+URLSET = f"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset {NS}>
+  <url><loc>https://site.com/a</loc></url>
+  <url><loc>https://site.com/b</loc></url>
+  <url><loc>https://site.com/a</loc></url>
+</urlset>""".encode()
+
+INDEX = f"""<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex {NS}>
+  <sitemap><loc>https://site.com/sitemap-1.xml</loc></sitemap>
+  <sitemap><loc>https://site.com/sitemap-2.xml</loc></sitemap>
+</sitemapindex>""".encode()
+
+CHILD1 = f"""<urlset {NS}><url><loc>https://site.com/1</loc></url></urlset>""".encode()
+CHILD2 = f"""<urlset {NS}><url><loc>https://site.com/2</loc></url></urlset>""".encode()
+
+
+def _fake_fetch(mapping):
+    """Return a _fetch replacement that serves bytes from a url->bytes mapping."""
+    def _fetch(client, url):
+        return mapping.get(url)
+    return _fetch
+
+
+def test_parse_urlset_dedupes_and_preserves_order():
+    with patch.object(sitemap_parser, "_fetch", _fake_fetch({"https://site.com/sitemap.xml": URLSET})):
+        urls = sitemap_parser.fetch_sitemap_urls("https://site.com/sitemap.xml", max_urls=50)
+    assert urls == ["https://site.com/a", "https://site.com/b"]
+
+
+def test_sitemap_index_recurses_into_children():
+    mapping = {
+        "https://site.com/sitemap.xml": INDEX,
+        "https://site.com/sitemap-1.xml": CHILD1,
+        "https://site.com/sitemap-2.xml": CHILD2,
+    }
+    with patch.object(sitemap_parser, "_fetch", _fake_fetch(mapping)):
+        urls = sitemap_parser.fetch_sitemap_urls("https://site.com/sitemap.xml", max_urls=50)
+    assert urls == ["https://site.com/1", "https://site.com/2"]
+
+
+def test_max_urls_caps_the_result():
+    with patch.object(sitemap_parser, "_fetch", _fake_fetch({"https://site.com/sitemap.xml": URLSET})):
+        urls = sitemap_parser.fetch_sitemap_urls("https://site.com/sitemap.xml", max_urls=1)
+    assert urls == ["https://site.com/a"]
+
+
+def test_gzip_content_without_extension_is_parsed():
+    gzipped = gzip.compress(URLSET)
+    with patch.object(sitemap_parser, "_fetch", _fake_fetch({"https://site.com/sitemap.xml": gzipped})):
+        urls = sitemap_parser.fetch_sitemap_urls("https://site.com/sitemap.xml", max_urls=50)
+    assert urls == ["https://site.com/a", "https://site.com/b"]
+
+
+def test_child_fetch_failure_is_skipped():
+    mapping = {
+        "https://site.com/sitemap.xml": INDEX,
+        "https://site.com/sitemap-1.xml": CHILD1,
+        # sitemap-2.xml returns None (fetch failure)
+    }
+    with patch.object(sitemap_parser, "_fetch", _fake_fetch(mapping)):
+        urls = sitemap_parser.fetch_sitemap_urls("https://site.com/sitemap.xml", max_urls=50)
+    assert urls == ["https://site.com/1"]
+
+
+def test_invalid_xml_returns_empty():
+    with patch.object(sitemap_parser, "_fetch", _fake_fetch({"https://site.com/sitemap.xml": b"not xml <<<"})):
+        urls = sitemap_parser.fetch_sitemap_urls("https://site.com/sitemap.xml", max_urls=50)
+    assert urls == []
+
+
+def test_is_blocked_host_rejects_private_and_loopback():
+    f = sitemap_parser._is_blocked_host
+    assert f("http://169.254.169.254/latest/meta-data/")  # cloud metadata
+    assert f("http://127.0.0.1/sitemap.xml")
+    assert f("http://10.0.0.5/sitemap.xml")
+    assert f("http://localhost/sitemap.xml")
+    assert not f("https://site.com/sitemap.xml")
+    assert not f("https://8.8.8.8/sitemap.xml")  # public IP allowed
+
+
+def test_cross_domain_child_sitemap_is_skipped():
+    evil_index = f"""<sitemapindex {NS}>
+      <sitemap><loc>https://site.com/ok.xml</loc></sitemap>
+      <sitemap><loc>https://evil.com/steal.xml</loc></sitemap>
+    </sitemapindex>""".encode()
+    mapping = {
+        "https://site.com/sitemap.xml": evil_index,
+        "https://site.com/ok.xml": CHILD1,
+        "https://evil.com/steal.xml": CHILD2,  # must NOT be fetched
+    }
+    with patch.object(sitemap_parser, "_fetch", _fake_fetch(mapping)):
+        urls = sitemap_parser.fetch_sitemap_urls("https://site.com/sitemap.xml", max_urls=50)
+    assert urls == ["https://site.com/1"]  # evil.com child skipped
+
+
+def test_bounded_gunzip_rejects_oversize(monkeypatch):
+    monkeypatch.setattr(sitemap_parser, "MAX_DECOMPRESSED_BYTES", 100)
+    bomb = gzip.compress(b"A" * 5000)  # decompresses to 5000 > 100
+    assert sitemap_parser._bounded_gunzip(bomb) is None
+    small = gzip.compress(b"A" * 50)
+    assert sitemap_parser._bounded_gunzip(small) == b"A" * 50
+
+
+def test_max_sitemaps_bounds_index_fanout():
+    # A sitemap index pointing at many children; only max_sitemaps files are fetched
+    # (1 index + 1 child when max_sitemaps=2).
+    big_index = (
+        f'<sitemapindex {NS}>'
+        + "".join(f"<sitemap><loc>https://site.com/s{i}.xml</loc></sitemap>" for i in range(10))
+        + "</sitemapindex>"
+    ).encode()
+    mapping = {"https://site.com/sitemap.xml": big_index}
+    for i in range(10):
+        mapping[f"https://site.com/s{i}.xml"] = (
+            f"<urlset {NS}><url><loc>https://site.com/p{i}</loc></url></urlset>".encode()
+        )
+    with patch.object(sitemap_parser, "_fetch", _fake_fetch(mapping)):
+        urls = sitemap_parser.fetch_sitemap_urls(
+            "https://site.com/sitemap.xml", max_urls=50, max_sitemaps=2
+        )
+    # index + first child only
+    assert urls == ["https://site.com/p0"]

--- a/backend/tests/knowledge/test_sitemap_reader.py
+++ b/backend/tests/knowledge/test_sitemap_reader.py
@@ -1,0 +1,81 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest.mock import patch
+
+from app.knowledge.sitemap_reader import SitemapReader
+
+SITEMAP = "https://site.com/sitemap.xml"
+
+
+def test_crawl_uses_sitemap_pages_and_caps_at_max_links():
+    reader = SitemapReader(max_depth=1, max_links=2, min_content_length=10)
+    pages = ["https://site.com/a", "https://site.com/b", "https://site.com/c"]
+    collected = []
+
+    with patch(
+        "app.knowledge.sitemap_reader.fetch_sitemap_urls", return_value=pages
+    ) as mock_parse, patch.object(
+        reader, "_process_url", side_effect=lambda info, domain: (info[0], f"content {info[0]}", [])
+    ):
+        result = reader.crawl(SITEMAP, on_document_callback=lambda u, c: collected.append(u))
+
+    # The parser is asked for at most max_links pages.
+    assert mock_parse.call_args.kwargs["max_urls"] == 2
+    # _run_crawl_queue caps stored pages at max_links even if more were seeded.
+    assert len(result) == 2
+    assert len(collected) == 2
+    assert all(url in pages for url in result)
+
+
+def test_crawl_empty_sitemap_returns_empty():
+    reader = SitemapReader(max_depth=1, max_links=5)
+    with patch("app.knowledge.sitemap_reader.fetch_sitemap_urls", return_value=[]):
+        result = reader.crawl(SITEMAP)
+    assert result == {}
+
+
+def test_document_groups_under_sitemap_name_with_page_id():
+    # Every discovered page is one sub-page of the single sitemap source:
+    # document.name = sitemap url (the group), document.id = page url.
+    reader = SitemapReader(max_depth=1, max_links=5)
+    doc = reader._create_document_from_content(
+        "https://site.com/pricing", "Plans and pricing content", SITEMAP, 1
+    )
+    assert doc.id == "https://site.com/pricing"
+    assert doc.name == SITEMAP
+
+
+def test_sitemap_page_count_signals_empty_vs_found():
+    reader = SitemapReader(max_depth=1, max_links=5)
+    with patch("app.knowledge.sitemap_reader.fetch_sitemap_urls", return_value=[]):
+        reader.crawl(SITEMAP)
+    assert reader._sitemap_page_count == 0  # dispatcher fails the source on this
+
+    with patch(
+        "app.knowledge.sitemap_reader.fetch_sitemap_urls",
+        return_value=["https://site.com/a", "https://site.com/b"],
+    ), patch.object(reader, "_process_url", side_effect=lambda info, domain: (info[0], "c", [])):
+        reader.crawl(SITEMAP)
+    assert reader._sitemap_page_count == 2
+
+
+def test_crawl_resets_challenge_counter():
+    reader = SitemapReader(max_depth=1, max_links=5)
+    reader._challenge_blocked = 7  # stale from a previous run
+    with patch("app.knowledge.sitemap_reader.fetch_sitemap_urls", return_value=[]):
+        reader.crawl(SITEMAP)
+    assert reader._challenge_blocked == 0

--- a/backend/tests/knowledge/test_url_safety.py
+++ b/backend/tests/knowledge/test_url_safety.py
@@ -1,0 +1,102 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.knowledge import url_safety
+from app.knowledge.url_safety import (
+    BlockedHostError,
+    guard_url,
+    is_blocked_host,
+    resolves_to_blocked_host,
+    safe_get,
+)
+
+
+def test_is_blocked_host_literal_ips():
+    assert is_blocked_host("http://169.254.169.254/latest/meta-data/")  # cloud metadata
+    assert is_blocked_host("http://127.0.0.1/x")
+    assert is_blocked_host("http://10.0.0.5/x")
+    assert is_blocked_host("http://192.168.1.1/x")
+    assert is_blocked_host("http://localhost/x")
+    assert not is_blocked_host("https://site.com/x")
+    assert not is_blocked_host("https://8.8.8.8/x")  # public IP allowed
+
+
+def test_resolves_to_blocked_host_when_hostname_maps_to_internal_ip():
+    # Attacker domain whose A record points at the metadata IP (DNS rebinding).
+    with patch.object(
+        url_safety.socket, "getaddrinfo",
+        return_value=[(2, 1, 6, "", ("169.254.169.254", 0))],
+    ):
+        assert resolves_to_blocked_host("http://imds.attacker.com/latest/meta-data/")
+
+
+def test_resolves_to_blocked_host_allows_public_resolution():
+    with patch.object(
+        url_safety.socket, "getaddrinfo",
+        return_value=[(2, 1, 6, "", ("93.184.216.34", 0))],
+    ):
+        assert not resolves_to_blocked_host("https://example.com/x")
+
+
+def test_resolves_to_blocked_host_unresolvable_is_not_blocked():
+    import socket as _socket
+    with patch.object(url_safety.socket, "getaddrinfo", side_effect=_socket.gaierror):
+        assert not resolves_to_blocked_host("https://nope.invalid/x")
+
+
+def _redirect_response(location, url="https://site.com/start"):
+    resp = MagicMock()
+    resp.is_redirect = True
+    resp.headers = {"location": location}
+    resp.url = url
+    return resp
+
+
+def _ok_response():
+    resp = MagicMock()
+    resp.is_redirect = False
+    return resp
+
+
+def test_safe_get_blocks_redirect_to_internal_ip():
+    # A public URL 302-redirects to the metadata IP; safe_get must refuse the hop.
+    client = MagicMock()
+    client.get.return_value = _redirect_response("http://169.254.169.254/")
+    with patch.object(url_safety, "resolves_to_blocked_host", side_effect=lambda u: "169.254" in u):
+        with pytest.raises(BlockedHostError):
+            safe_get(client, "https://site.com/start")
+
+
+def test_safe_get_follows_safe_redirect():
+    client = MagicMock()
+    client.get.side_effect = [
+        _redirect_response("https://site.com/final"),
+        _ok_response(),
+    ]
+    with patch.object(url_safety, "resolves_to_blocked_host", return_value=False):
+        resp = safe_get(client, "https://site.com/start")
+    assert resp.is_redirect is False
+    assert client.get.call_count == 2
+
+
+def test_guard_url_raises_on_blocked():
+    with patch.object(url_safety, "resolves_to_blocked_host", return_value=True):
+        with pytest.raises(BlockedHostError):
+            guard_url("http://127.0.0.1/x")

--- a/frontend/src/__tests__/utils/knowledgePages.spec.ts
+++ b/frontend/src/__tests__/utils/knowledgePages.spec.ts
@@ -1,0 +1,88 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from 'vitest'
+import { basePageId, groupChunksIntoPages, titleFromId } from '../../utils/knowledgePages'
+import type { KnowledgeContentChunk } from '../../types/knowledge'
+
+describe('basePageId', () => {
+  // These MUST stay aligned with the backend PAGE_ID_EXPR
+  // (backend/app/knowledge/page_editor.py): strip only a trailing `_<number>`
+  // chunk suffix, never a real underscore in the page name.
+  it('strips a trailing numeric chunk suffix', () => {
+    expect(basePageId('https://site.com/docs_1')).toBe('https://site.com/docs')
+    expect(basePageId('https://site.com/docs_12')).toBe('https://site.com/docs')
+  })
+
+  it('keeps a bare page id with no chunk suffix', () => {
+    expect(basePageId('https://site.com/docs')).toBe('https://site.com/docs')
+  })
+
+  it('preserves real underscores in the page name', () => {
+    expect(basePageId('getting_started')).toBe('getting_started')
+    expect(basePageId('getting_started_2')).toBe('getting_started')
+  })
+
+  it('strips only the last numeric group', () => {
+    expect(basePageId('x_10_3')).toBe('x_10')
+  })
+})
+
+describe('titleFromId', () => {
+  it('uses the last non-empty url/path segment', () => {
+    expect(titleFromId('https://site.com/docs/getting-started')).toBe('getting-started')
+    expect(titleFromId('https://site.com/docs/')).toBe('docs')
+    expect(titleFromId('Product Handbook.pdf#billing')).toBe('Product Handbook.pdf')
+  })
+})
+
+describe('groupChunksIntoPages', () => {
+  const chunk = (
+    id: string,
+    content: string,
+    metadata: Record<string, unknown> = {},
+    created_at: string | null = null,
+  ): KnowledgeContentChunk => ({ id, content, metadata, created_at: created_at ?? undefined })
+
+  it('groups multi-chunk pages and concatenates content in order', () => {
+    const pages = groupChunksIntoPages([
+      chunk('p/a', 'first', { url: 'https://x/a', title: 'Alpha' }, '2024-01-01T00:00:00Z'),
+      chunk('p/a_1', 'second', {}, '2024-01-02T00:00:00Z'),
+      chunk('p/b', 'other', {}, '2024-01-01T00:00:00Z'),
+    ])
+    expect(pages).toHaveLength(2)
+    const a = pages[0]
+    expect(a.page_id).toBe('p/a')
+    expect(a.url).toBe('https://x/a')
+    expect(a.title).toBe('Alpha')
+    expect(a.content).toBe('first\n\nsecond')
+    expect(a.chunk_count).toBe(2)
+    expect(a.word_count).toBe(2)
+    expect(a.chunk_ids).toEqual(['p/a', 'p/a_1'])
+    // updated_at is the latest of the group's chunk timestamps
+    expect(a.updated_at).toBe('2024-01-02T00:00:00Z')
+  })
+
+  it('falls back to id-derived url/title when metadata is missing', () => {
+    const [page] = groupChunksIntoPages([chunk('https://site.com/docs/help', 'body')])
+    expect(page.url).toBe('https://site.com/docs/help')
+    expect(page.title).toBe('help')
+  })
+
+  it('returns an empty array for no chunks', () => {
+    expect(groupChunksIntoPages([])).toEqual([])
+  })
+})

--- a/frontend/src/components/agent/AgentDetail.vue
+++ b/frontend/src/components/agent/AgentDetail.vue
@@ -20,7 +20,7 @@ import type { AgentWithCustomization, AgentCustomization } from '@/types/agent'
 import { getAvatarUrl, isAbsoluteUrl } from '@/utils/avatars'
 import { ORB_PALETTE_COUNT, getOrbStyleAt, resolveOrbStyle, orbSvgDataUri, terminalMarkSvgDataUri } from '@/utils/orb'
 
-import KnowledgeGrid from './KnowledgeGrid.vue'
+import KnowledgeExplorer from '@/components/knowledge/KnowledgeExplorer.vue'
 import AgentCustomizationView from './AgentCustomizationView.vue'
 import AgentChatPreviewPanel from './AgentChatPreviewPanel.vue'
 import AgentIntegrationsTab from './AgentIntegrationsTab.vue'
@@ -1090,7 +1090,11 @@ onMounted(async () => {
                         <!-- Knowledge Tab -->
                         <div v-if="activeTab === 'knowledge'" class="tab-content">
                             <div class="knowledge-tab-container">
-                                <KnowledgeGrid :agent-id="agentData.id" :organization-id="agentData.organization_id" />
+                                <KnowledgeExplorer
+                                    mode="agent"
+                                    :agent-id="agentData.id"
+                                    :organization-id="agentData.organization_id"
+                                />
                             </div>
                         </div>
 

--- a/frontend/src/components/agent/AgentDetail.vue
+++ b/frontend/src/components/agent/AgentDetail.vue
@@ -1092,9 +1092,19 @@ onMounted(async () => {
                             <div class="knowledge-tab-container">
                                 <KnowledgeExplorer
                                     mode="agent"
+                                    variant="section"
+                                    title="Knowledge sources"
+                                    description="Every page this agent learns from. Review the extracted content and choose what grounds its answers."
                                     :agent-id="agentData.id"
                                     :organization-id="agentData.organization_id"
-                                />
+                                >
+                                    <template #actions>
+                                        <router-link to="/knowledge" class="kb-open-link">
+                                            Open knowledge base
+                                            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><path d="M15 3h6v6"></path><path d="M10 14 21 3"></path></svg>
+                                        </router-link>
+                                    </template>
+                                </KnowledgeExplorer>
                             </div>
                         </div>
 
@@ -2648,6 +2658,26 @@ input:checked + .slider:before {
   margin: 0 auto;
   width: 100%;
   padding: 0 var(--space-lg);
+}
+
+.kb-open-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 47px;
+  padding: 0 18px;
+  border-radius: 11px;
+  background: var(--o05);
+  border: 1px solid var(--o12);
+  color: var(--text2);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.kb-open-link:hover {
+  background: var(--o08);
 }
 
 .section-title {

--- a/frontend/src/components/knowledge/KnowledgeAddSourceModal.vue
+++ b/frontend/src/components/knowledge/KnowledgeAddSourceModal.vue
@@ -1,0 +1,540 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { AddSourcePayload } from '@/composables/useKnowledgeExplorer'
+
+type SourceKind = 'website' | 'sitemap' | 'pdf' | 'text'
+
+const props = withDefaults(
+  defineProps<{
+    initialUrl?: string
+    initialType?: SourceKind
+    submitting?: boolean
+  }>(),
+  { initialUrl: '', initialType: 'website', submitting: false },
+)
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'submit', payload: AddSourcePayload): void
+}>()
+
+const kind = ref<SourceKind>(props.initialType)
+const url = ref(props.initialUrl)
+const followLinks = ref(true)
+const files = ref<File[]>([])
+const title = ref('')
+const content = ref('')
+const dragOver = ref(false)
+const fileInput = ref<HTMLInputElement | null>(null)
+
+const types: { key: SourceKind; title: string; sub: string }[] = [
+  { key: 'website', title: 'Website', sub: 'Crawl a page or whole site' },
+  { key: 'sitemap', title: 'Sitemap', sub: 'Index every listed page' },
+  { key: 'pdf', title: 'Document', sub: 'PDF file, up to 25 MB' },
+  { key: 'text', title: 'Text', sub: 'Paste content directly' },
+]
+
+const willQueue = computed(() => kind.value !== 'text')
+const submitLabel = computed(() => (kind.value === 'text' ? 'Add page' : 'Add to crawl queue'))
+
+const canSubmit = computed(() => {
+  if (props.submitting) return false
+  if (kind.value === 'website' || kind.value === 'sitemap') return url.value.trim().length > 0
+  if (kind.value === 'pdf') return files.value.length > 0
+  return title.value.trim().length > 0 && content.value.trim().length > 0
+})
+
+function normalizeUrl(raw: string): string {
+  const v = raw.trim()
+  // Leave an explicit scheme alone; otherwise assume https.
+  return v.includes('://') ? v : `https://${v}`
+}
+
+function pickFiles() {
+  fileInput.value?.click()
+}
+
+function onFilesSelected(event: Event) {
+  const input = event.target as HTMLInputElement
+  if (input.files) files.value = Array.from(input.files)
+}
+
+function onDrop(event: DragEvent) {
+  dragOver.value = false
+  const dropped = event.dataTransfer?.files
+  if (dropped && dropped.length) files.value = Array.from(dropped)
+}
+
+function submit() {
+  if (!canSubmit.value) return
+  if (kind.value === 'website') {
+    emit('submit', { type: 'website', url: normalizeUrl(url.value), followLinks: followLinks.value })
+  } else if (kind.value === 'sitemap') {
+    emit('submit', { type: 'sitemap', url: normalizeUrl(url.value) })
+  } else if (kind.value === 'pdf') {
+    emit('submit', { type: 'pdf', files: files.value })
+  } else {
+    emit('submit', { type: 'text', title: title.value.trim(), content: content.value })
+  }
+}
+</script>
+
+<template>
+  <div class="scrim" @click.self="emit('close')">
+    <div class="modal" role="dialog" aria-modal="true" aria-label="Add knowledge source">
+      <div class="modal__head">
+        <div>
+          <h3 class="modal__title">Add knowledge source</h3>
+          <p class="modal__sub">Pick a source type — we crawl and index it in the background.</p>
+        </div>
+        <button class="icon-btn" type="button" aria-label="Close" @click="emit('close')">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg>
+        </button>
+      </div>
+
+      <div class="types">
+        <button
+          v-for="t in types"
+          :key="t.key"
+          type="button"
+          class="type"
+          :class="{ 'type--active': kind === t.key }"
+          @click="kind = t.key"
+        >
+          <span class="type__title">{{ t.title }}</span>
+          <span class="type__sub">{{ t.sub }}</span>
+        </button>
+      </div>
+
+      <div class="body">
+        <!-- website -->
+        <template v-if="kind === 'website'">
+          <label class="field-label" for="kb-add-url">PAGE URL</label>
+          <input id="kb-add-url" v-model="url" class="text-input" type="text"
+            placeholder="https://docs.yourcompany.com/help" @keyup.enter="submit" />
+          <label class="field-label">CRAWL SCOPE</label>
+          <div class="scope">
+            <button type="button" class="scope__opt" :class="{ 'scope__opt--active': !followLinks }"
+              @click="followLinks = false">
+              <span class="radio" :class="{ 'radio--on': !followLinks }"></span>
+              <span>
+                <span class="scope__title">This page only</span>
+                <span class="scope__sub">Index just the URL above.</span>
+              </span>
+            </button>
+            <button type="button" class="scope__opt" :class="{ 'scope__opt--active': followLinks }"
+              @click="followLinks = true">
+              <span class="radio" :class="{ 'radio--on': followLinks }"></span>
+              <span>
+                <span class="scope__title">Follow links on this domain</span>
+                <span class="scope__sub">Discover and queue linked pages, up to your plan limit.</span>
+              </span>
+            </button>
+          </div>
+        </template>
+
+        <!-- sitemap -->
+        <template v-else-if="kind === 'sitemap'">
+          <label class="field-label" for="kb-add-sitemap">SITEMAP URL</label>
+          <input id="kb-add-sitemap" v-model="url" class="text-input" type="text"
+            placeholder="https://yourcompany.com/sitemap.xml" @keyup.enter="submit" />
+          <div class="note note--teal">
+            We read the sitemap, then queue every listed page for crawling. Large sitemaps process in batches.
+          </div>
+        </template>
+
+        <!-- document -->
+        <template v-else-if="kind === 'pdf'">
+          <div
+            class="drop"
+            :class="{ 'drop--over': dragOver }"
+            @click="pickFiles"
+            @dragover.prevent="dragOver = true"
+            @dragleave.prevent="dragOver = false"
+            @drop.prevent="onDrop"
+          >
+            <input ref="fileInput" type="file" accept="application/pdf" multiple class="hidden-file"
+              @change="onFilesSelected" />
+            <span v-if="files.length" class="drop__name">{{ files.map((f) => f.name).join(', ') }}</span>
+            <span v-else class="drop__name">Drop a PDF or click to browse</span>
+            <span class="drop__hint">PDF files · up to 25 MB each</span>
+          </div>
+          <div class="note note--coral">
+            We extract the text, split it into sections, and index each one. Scanned PDFs are run through OCR.
+          </div>
+        </template>
+
+        <!-- text -->
+        <template v-else>
+          <label class="field-label" for="kb-add-title">TITLE</label>
+          <input id="kb-add-title" v-model="title" class="text-input" type="text" placeholder="e.g. Refund policy" />
+          <label class="field-label" for="kb-add-content">CONTENT</label>
+          <textarea id="kb-add-content" v-model="content" class="textarea"
+            placeholder="Paste or type the content your agents should learn…"></textarea>
+        </template>
+      </div>
+
+      <div class="foot">
+        <span class="foot__note">
+          <span class="foot__dot" :class="willQueue ? 'foot__dot--queue' : 'foot__dot--instant'"></span>
+          <template v-if="willQueue">Queued for crawling — you’ll be notified when it’s indexed.</template>
+          <template v-else>Added instantly — no crawling needed.</template>
+        </span>
+        <div class="foot__actions">
+          <button class="btn btn--ghost" type="button" :disabled="submitting" @click="emit('close')">Cancel</button>
+          <button class="btn btn--primary" type="button" :disabled="!canSubmit" @click="submit">
+            {{ submitting ? 'Adding…' : submitLabel }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: var(--scrim);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 60px 20px;
+  overflow-y: auto;
+}
+
+.modal {
+  width: 560px;
+  max-width: 100%;
+  background: var(--bg2);
+  border: 1px solid var(--o12);
+  border-radius: 20px;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+}
+
+.modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--o08);
+}
+
+.modal__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 19px;
+  color: var(--text);
+  margin: 0 0 4px;
+}
+
+.modal__sub {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.icon-btn {
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  border-radius: 9px;
+  background: var(--o05);
+  border: 1px solid var(--o10);
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-btn:hover {
+  background: var(--o08);
+  color: var(--text2);
+}
+
+.types {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 9px;
+  padding: 18px 24px 4px;
+}
+
+.type {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 13px;
+  border-radius: 11px;
+  cursor: pointer;
+  text-align: left;
+  background: transparent;
+  border: 1.5px solid var(--o10);
+}
+
+.type:hover {
+  background: var(--o04);
+}
+
+.type--active {
+  background: var(--accent-bg-06);
+  border-color: var(--accent-solid);
+}
+
+.type__title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text2);
+}
+
+.type__sub {
+  font-size: 11.5px;
+  color: var(--muted2);
+  line-height: 1.3;
+}
+
+.body {
+  padding: 16px 24px 4px;
+  min-height: 172px;
+}
+
+.field-label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.07em;
+  color: var(--muted2);
+  margin-bottom: 8px;
+}
+
+.field-label:not(:first-child) {
+  margin-top: 16px;
+}
+
+.text-input,
+.textarea {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--o12);
+  border-radius: 11px;
+  padding: 12px 14px;
+  font-size: 14px;
+  color: var(--text);
+  outline: none;
+  font-family: var(--font-sans);
+}
+
+.textarea {
+  min-height: 120px;
+  line-height: 1.6;
+  color: var(--text3);
+  resize: vertical;
+}
+
+.text-input:focus,
+.textarea:focus {
+  border-color: var(--accent-border, var(--accent-ink));
+}
+
+.scope {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.scope__opt {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  width: 100%;
+  padding: 12px 13px;
+  border-radius: 11px;
+  cursor: pointer;
+  text-align: left;
+  background: transparent;
+  border: 1.5px solid var(--o10);
+}
+
+.scope__opt--active {
+  background: var(--accent-bg-06);
+  border-color: var(--accent-solid);
+}
+
+.radio {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  border-radius: 50%;
+  border: 2px solid var(--o20);
+}
+
+.radio--on {
+  border-color: var(--accent-solid);
+  background: radial-gradient(circle, var(--accent-solid) 0 45%, transparent 48%);
+}
+
+.scope__title {
+  display: block;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text2);
+}
+
+.scope__sub {
+  display: block;
+  font-size: 12px;
+  color: var(--muted2);
+  margin-top: 1px;
+}
+
+.drop {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 30px 20px;
+  background: var(--bg);
+  border: 1.5px dashed var(--o20);
+  border-radius: 14px;
+  cursor: pointer;
+  text-align: center;
+}
+
+.drop--over {
+  border-color: var(--c-coral);
+  background: var(--coral-bg);
+}
+
+.hidden-file {
+  display: none;
+}
+
+.drop__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text2);
+  word-break: break-word;
+}
+
+.drop__hint {
+  font-size: 12px;
+  color: var(--muted2);
+}
+
+.note {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 12px 14px;
+  border-radius: 11px;
+  font-size: 12.5px;
+  color: var(--text3);
+  line-height: 1.5;
+  margin-top: 14px;
+}
+
+.note--teal {
+  background: var(--teal-bg);
+  border: 1px solid var(--teal-border);
+}
+
+.note--coral {
+  background: var(--coral-bg);
+  border: 1px solid var(--coral-border);
+}
+
+.foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--o08);
+  background: var(--surface);
+}
+
+.foot__note {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.foot__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.foot__dot--queue {
+  background: var(--c-purple);
+}
+
+.foot__dot--instant {
+  background: var(--c-teal);
+}
+
+.foot__actions {
+  display: flex;
+  gap: 9px;
+  flex-shrink: 0;
+}
+
+.btn {
+  padding: 10px 18px;
+  border-radius: 10px;
+  font-size: 13.5px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.btn--ghost {
+  background: transparent;
+  border-color: var(--o12);
+  color: var(--muted);
+}
+
+.btn--ghost:hover:not(:disabled) {
+  background: var(--o05);
+}
+
+.btn--primary {
+  background: var(--accent-solid);
+  color: var(--on-accent-solid);
+}
+
+.btn--primary:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+</style>

--- a/frontend/src/components/knowledge/KnowledgeAddSourceModal.vue
+++ b/frontend/src/components/knowledge/KnowledgeAddSourceModal.vue
@@ -21,11 +21,9 @@ type SourceKind = 'website' | 'sitemap' | 'pdf' | 'text'
 
 const props = withDefaults(
   defineProps<{
-    initialUrl?: string
-    initialType?: SourceKind
     submitting?: boolean
   }>(),
-  { initialUrl: '', initialType: 'website', submitting: false },
+  { submitting: false },
 )
 
 const emit = defineEmits<{
@@ -33,8 +31,8 @@ const emit = defineEmits<{
   (e: 'submit', payload: AddSourcePayload): void
 }>()
 
-const kind = ref<SourceKind>(props.initialType)
-const url = ref(props.initialUrl)
+const kind = ref<SourceKind>('website')
+const url = ref('')
 const followLinks = ref(true)
 const files = ref<File[]>([])
 const title = ref('')
@@ -69,15 +67,20 @@ function pickFiles() {
   fileInput.value?.click()
 }
 
+const isPdf = (file: File) => file.type === 'application/pdf' || /\.pdf$/i.test(file.name)
+
 function onFilesSelected(event: Event) {
   const input = event.target as HTMLInputElement
-  if (input.files) files.value = Array.from(input.files)
+  if (input.files) files.value = Array.from(input.files).filter(isPdf)
 }
 
 function onDrop(event: DragEvent) {
   dragOver.value = false
   const dropped = event.dataTransfer?.files
-  if (dropped && dropped.length) files.value = Array.from(dropped)
+  if (!dropped) return
+  // Only accept PDFs — the backend upload endpoint validates PDF magic bytes.
+  const pdfs = Array.from(dropped).filter(isPdf)
+  if (pdfs.length) files.value = pdfs
 }
 
 function submit() {

--- a/frontend/src/components/knowledge/KnowledgeExplorer.vue
+++ b/frontend/src/components/knowledge/KnowledgeExplorer.vue
@@ -1,0 +1,447 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useKnowledgeExplorer, type ExplorerSource } from '@/composables/useKnowledgeExplorer'
+import { knowledgeService } from '@/services/knowledge'
+import KnowledgeSourceTree from './KnowledgeSourceTree.vue'
+import KnowledgePageDetail from './KnowledgePageDetail.vue'
+import KnowledgePageEditor from './KnowledgePageEditor.vue'
+import KnowledgePlanMeters from './KnowledgePlanMeters.vue'
+
+const props = withDefaults(
+  defineProps<{
+    mode: 'agent' | 'org'
+    organizationId: string
+    agentId?: string
+    showPlanMeters?: boolean
+  }>(),
+  { agentId: undefined, showPlanMeters: false },
+)
+
+const ex = useKnowledgeExplorer(props.mode, props.agentId, props.organizationId)
+
+const srcInput = ref('')
+const isAddingSource = ref(false)
+const fileInput = ref<HTMLInputElement | null>(null)
+const isUploading = ref(false)
+
+// A single, reusable confirm dialog for the two destructive actions.
+const confirmState = ref<{ title: string; message: string; action: () => Promise<void> } | null>(null)
+
+const largestSource = computed(() =>
+  ex.sources.value.reduce<ExplorerSource | null>((max, s) => {
+    if (!max || (s.pages ?? s.pageStubs).length > (max.pages ?? max.pageStubs).length) return s
+    return max
+  }, null),
+)
+const largestSubpageCount = computed(() => {
+  const s = largestSource.value
+  return s ? (s.pages ?? s.pageStubs).length : 0
+})
+
+async function addSource() {
+  const value = srcInput.value.trim()
+  if (!value || isAddingSource.value) return
+  isAddingSource.value = true
+  try {
+    await ex.addSource(value)
+    srcInput.value = ''
+  } catch {
+    // error surfaced via ex.error
+  } finally {
+    isAddingSource.value = false
+  }
+}
+
+function pickFiles() {
+  fileInput.value?.click()
+}
+
+async function onFilesSelected(event: Event) {
+  const input = event.target as HTMLInputElement
+  const files = input.files ? Array.from(input.files) : []
+  if (!files.length) return
+  isUploading.value = true
+  ex.error.value = null
+  try {
+    await knowledgeService.uploadPdfFiles(files, props.organizationId, props.agentId)
+    await ex.refresh()
+  } catch (err: unknown) {
+    ex.error.value = err instanceof Error ? err.message : 'Failed to upload files'
+  } finally {
+    isUploading.value = false
+    if (fileInput.value) fileInput.value.value = ''
+  }
+}
+
+function askDeleteSource(source: ExplorerSource) {
+  confirmState.value = {
+    title: 'Delete source',
+    message: `Delete “${source.name}” and all of its pages? This cannot be undone.`,
+    action: () => ex.deleteSource(source),
+  }
+}
+
+function askDeletePage() {
+  const page = ex.selectedPage.value
+  if (!page) return
+  confirmState.value = {
+    title: 'Delete page',
+    message: `Delete “${page.title}” from this source? This cannot be undone.`,
+    action: () => ex.deletePage(),
+  }
+}
+
+async function runConfirm() {
+  const state = confirmState.value
+  if (!state) return
+  await state.action()
+  confirmState.value = null
+}
+
+onMounted(() => {
+  ex.refresh()
+  ex.startPolling()
+})
+
+onUnmounted(() => {
+  ex.stopPolling()
+})
+</script>
+
+<template>
+  <div class="explorer">
+    <KnowledgePlanMeters
+      v-if="showPlanMeters"
+      class="explorer__meters"
+      :source-count="ex.sources.value.length"
+      :largest-source-name="largestSource?.name ?? null"
+      :largest-subpage-count="largestSubpageCount"
+    />
+
+    <div class="addbar">
+      <div class="addbar__field">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8"
+          stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1" />
+          <path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1" />
+        </svg>
+        <input
+          v-model="srcInput"
+          type="text"
+          placeholder="Paste a URL or sitemap to crawl…"
+          aria-label="Knowledge source URL"
+          @keyup.enter="addSource"
+        />
+      </div>
+      <input ref="fileInput" type="file" accept="application/pdf" multiple class="hidden-file"
+        @change="onFilesSelected" />
+      <button class="btn btn--ghost" type="button" :disabled="isUploading" @click="pickFiles">
+        {{ isUploading ? 'Uploading…' : 'Upload PDF' }}
+      </button>
+      <button class="btn btn--primary" type="button" :disabled="isAddingSource || !srcInput.trim()" @click="addSource">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2"
+          stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14" /></svg>
+        Add source
+      </button>
+    </div>
+
+    <div v-if="ex.error.value" class="banner" role="alert">
+      {{ ex.error.value }}
+      <button class="banner__close" type="button" aria-label="Dismiss" @click="ex.error.value = null">×</button>
+    </div>
+
+    <div class="grid">
+      <KnowledgeSourceTree
+        class="grid__tree"
+        :sources="ex.filteredSources.value"
+        :selected-page-id="ex.selectedPageId.value"
+        :query="ex.query.value"
+        :status-of="ex.sourceStatus"
+        :page-rows-of="ex.pageRows"
+        @update:query="ex.query.value = $event"
+        @toggle="ex.toggleSource"
+        @select="(source, pageId) => ex.selectPage(source, pageId)"
+        @delete-source="askDeleteSource"
+      />
+
+      <div class="grid__detail">
+        <KnowledgePageEditor
+          v-if="ex.editing.value && ex.selectedPage.value"
+          :title="ex.draftTitle.value"
+          :content="ex.draftContent.value"
+          :saving="ex.isSaving.value"
+          @update:title="ex.draftTitle.value = $event"
+          @update:content="ex.draftContent.value = $event"
+          @save="ex.savePage"
+          @cancel="ex.cancelEdit"
+        />
+        <KnowledgePageDetail
+          v-else-if="ex.selectedPage.value && ex.selectedSource.value"
+          :page="ex.selectedPage.value"
+          :source-name="ex.selectedSource.value.name"
+          :source-type="ex.selectedSource.value.type"
+          :status="ex.sourceStatus(ex.selectedSource.value)"
+          :deleting="ex.isDeleting.value"
+          @edit="ex.startEdit"
+          @delete="askDeletePage"
+        />
+        <div v-else class="empty">
+          <div class="empty__orb"></div>
+          <div class="empty__title">Select a page to review</div>
+          <p class="empty__text">
+            Pick any extracted page on the left to read its content, edit it, or remove it — or add a source of your own.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="confirmState" class="confirm" role="dialog" aria-modal="true">
+      <div class="confirm__card">
+        <h3 class="confirm__title">{{ confirmState.title }}</h3>
+        <p class="confirm__msg">{{ confirmState.message }}</p>
+        <div class="confirm__actions">
+          <button class="btn btn--ghost" type="button" :disabled="ex.isDeleting.value" @click="confirmState = null">Cancel</button>
+          <button class="btn btn--danger-solid" type="button" :disabled="ex.isDeleting.value" @click="runConfirm">
+            {{ ex.isDeleting.value ? 'Deleting…' : 'Delete' }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.explorer {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.explorer__meters {
+  margin-bottom: 14px;
+}
+
+.addbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px;
+  background: var(--surface);
+  border: 1px solid var(--o08);
+  border-radius: 16px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.addbar__field {
+  flex: 1;
+  min-width: 220px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--bg);
+  border: 1px solid var(--o10);
+  border-radius: 11px;
+  padding: 0 14px;
+  color: var(--muted2);
+}
+
+.addbar__field input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-size: 14px;
+  padding: 13px 0;
+}
+
+.hidden-file {
+  display: none;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 47px;
+  padding: 0 18px;
+  border-radius: 11px;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.btn--primary {
+  background: var(--accent-solid);
+  color: var(--on-accent-solid);
+}
+
+.btn--primary:hover:not(:disabled) { filter: brightness(1.05); }
+
+.btn--ghost {
+  background: var(--o05);
+  border-color: var(--o12);
+  color: var(--text2);
+}
+
+.btn--ghost:hover:not(:disabled) { background: var(--o08); }
+
+.btn--danger-solid {
+  background: var(--c-coral);
+  color: var(--on-accent-solid);
+}
+
+.btn--danger-solid:hover:not(:disabled) { filter: brightness(1.05); }
+
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 11px 14px;
+  margin-bottom: 16px;
+  background: var(--error-bg);
+  border: 1px solid var(--coral-border);
+  border-radius: 11px;
+  color: var(--c-coral);
+  font-size: 13.5px;
+}
+
+.banner__close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 18px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 344px 1fr;
+  gap: 18px;
+  align-items: stretch;
+}
+
+@media (max-width: 860px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.grid__tree,
+.grid__detail {
+  height: 640px;
+}
+
+.grid__detail {
+  background: var(--surface);
+  border: 1px solid var(--o08);
+  border-radius: 16px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 40px;
+}
+
+.empty__orb {
+  width: 52px;
+  height: 52px;
+  margin-bottom: 18px;
+  border-radius: 50%;
+  background: conic-gradient(from 0deg, var(--c-lime), var(--c-purple), var(--c-teal), var(--c-coral), var(--c-lime));
+  opacity: 0.85;
+}
+
+.empty__title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 18px;
+  color: var(--text2);
+  margin-bottom: 8px;
+}
+
+.empty__text {
+  font-size: 14px;
+  color: var(--muted);
+  max-width: 320px;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.confirm {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: var(--scrim);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.confirm__card {
+  background: var(--surface);
+  border: 1px solid var(--o12);
+  border-radius: 16px;
+  padding: 24px;
+  max-width: 400px;
+  width: 100%;
+}
+
+.confirm__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--text);
+  margin: 0 0 8px;
+}
+
+.confirm__msg {
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1.55;
+  margin: 0 0 20px;
+}
+
+.confirm__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+</style>

--- a/frontend/src/components/knowledge/KnowledgeExplorer.vue
+++ b/frontend/src/components/knowledge/KnowledgeExplorer.vue
@@ -190,14 +190,16 @@ onUnmounted(() => {
         @toggle="ex.toggleSource"
         @select="(source, pageId) => ex.selectPage(source, pageId)"
         @delete-source="askDeleteSource"
+        @add-page="ex.startAddPage"
       />
 
       <div class="grid__detail">
         <KnowledgePageEditor
-          v-if="ex.editing.value && ex.selectedPage.value"
+          v-if="ex.editing.value && (ex.selectedPage.value || ex.isAddingPage.value)"
           :title="ex.draftTitle.value"
           :content="ex.draftContent.value"
           :saving="ex.isSaving.value"
+          :submit-label="ex.isAddingPage.value ? 'Add sub-page' : 'Save page'"
           @update:title="ex.draftTitle.value = $event"
           @update:content="ex.draftContent.value = $event"
           @save="ex.savePage"

--- a/frontend/src/components/knowledge/KnowledgeExplorer.vue
+++ b/frontend/src/components/knowledge/KnowledgeExplorer.vue
@@ -15,12 +15,16 @@ limitations under the License.
 -->
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { useKnowledgeExplorer, type ExplorerSource } from '@/composables/useKnowledgeExplorer'
-import { knowledgeService } from '@/services/knowledge'
+import {
+  useKnowledgeExplorer,
+  type ExplorerSource,
+  type AddSourcePayload,
+} from '@/composables/useKnowledgeExplorer'
 import KnowledgeSourceTree from './KnowledgeSourceTree.vue'
 import KnowledgePageDetail from './KnowledgePageDetail.vue'
 import KnowledgePageEditor from './KnowledgePageEditor.vue'
 import KnowledgePlanMeters from './KnowledgePlanMeters.vue'
+import KnowledgeAddSourceModal from './KnowledgeAddSourceModal.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -35,9 +39,12 @@ const props = withDefaults(
 const ex = useKnowledgeExplorer(props.mode, props.agentId, props.organizationId)
 
 const srcInput = ref('')
-const isAddingSource = ref(false)
-const fileInput = ref<HTMLInputElement | null>(null)
-const isUploading = ref(false)
+
+// Add-source modal state.
+const addOpen = ref(false)
+const addInitialUrl = ref('')
+const addInitialType = ref<'website' | 'sitemap' | 'pdf' | 'text'>('website')
+const isSubmittingSource = ref(false)
 
 // A single, reusable confirm dialog for the two destructive actions.
 const confirmState = ref<{ title: string; message: string; action: () => Promise<void> } | null>(null)
@@ -53,38 +60,25 @@ const largestSubpageCount = computed(() => {
   return s ? (s.pages ?? s.pageStubs).length : 0
 })
 
-async function addSource() {
+// Open the modal, prefilling type/URL from whatever was typed in the quick bar.
+function openAddModal() {
   const value = srcInput.value.trim()
-  if (!value || isAddingSource.value) return
-  isAddingSource.value = true
-  try {
-    await ex.addSource(value)
-    srcInput.value = ''
-  } catch {
-    // error surfaced via ex.error
-  } finally {
-    isAddingSource.value = false
-  }
+  addInitialType.value = /\.xml(\?|$)/i.test(value) ? 'sitemap' : 'website'
+  addInitialUrl.value = value
+  addOpen.value = true
 }
 
-function pickFiles() {
-  fileInput.value?.click()
-}
-
-async function onFilesSelected(event: Event) {
-  const input = event.target as HTMLInputElement
-  const files = input.files ? Array.from(input.files) : []
-  if (!files.length) return
-  isUploading.value = true
-  ex.error.value = null
+async function onSubmitSource(payload: AddSourcePayload) {
+  if (isSubmittingSource.value) return
+  isSubmittingSource.value = true
   try {
-    await knowledgeService.uploadPdfFiles(files, props.organizationId, props.agentId)
-    await ex.refresh()
-  } catch (err: unknown) {
-    ex.error.value = err instanceof Error ? err.message : 'Failed to upload files'
+    const ok = await ex.submitSource(payload)
+    if (ok) {
+      addOpen.value = false
+      srcInput.value = ''
+    }
   } finally {
-    isUploading.value = false
-    if (fileInput.value) fileInput.value.value = ''
+    isSubmittingSource.value = false
   }
 }
 
@@ -143,17 +137,12 @@ onUnmounted(() => {
         <input
           v-model="srcInput"
           type="text"
-          placeholder="Paste a URL or sitemap to crawl…"
+          placeholder="Paste a URL or sitemap, or add a document or text…"
           aria-label="Knowledge source URL"
-          @keyup.enter="addSource"
+          @keyup.enter="openAddModal"
         />
       </div>
-      <input ref="fileInput" type="file" accept="application/pdf" multiple class="hidden-file"
-        @change="onFilesSelected" />
-      <button class="btn btn--ghost" type="button" :disabled="isUploading" @click="pickFiles">
-        {{ isUploading ? 'Uploading…' : 'Upload PDF' }}
-      </button>
-      <button class="btn btn--primary" type="button" :disabled="isAddingSource || !srcInput.trim()" @click="addSource">
+      <button class="btn btn--primary" type="button" @click="openAddModal">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2"
           stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14" /></svg>
         Add source
@@ -222,6 +211,15 @@ onUnmounted(() => {
         </div>
       </div>
     </div>
+
+    <KnowledgeAddSourceModal
+      v-if="addOpen"
+      :initial-url="addInitialUrl"
+      :initial-type="addInitialType"
+      :submitting="isSubmittingSource"
+      @close="addOpen = false"
+      @submit="onSubmitSource"
+    />
   </div>
 </template>
 
@@ -270,10 +268,6 @@ onUnmounted(() => {
   color: var(--text);
   font-size: 14px;
   padding: 13px 0;
-}
-
-.hidden-file {
-  display: none;
 }
 
 .btn {

--- a/frontend/src/components/knowledge/KnowledgeExplorer.vue
+++ b/frontend/src/components/knowledge/KnowledgeExplorer.vue
@@ -200,8 +200,11 @@ onUnmounted(() => {
           :content="ex.draftContent.value"
           :saving="ex.isSaving.value"
           :submit-label="ex.isAddingPage.value ? 'Add sub-page' : 'Save page'"
+          :url="ex.draftUrl.value"
+          :show-url="ex.isAddingPage.value"
           @update:title="ex.draftTitle.value = $event"
           @update:content="ex.draftContent.value = $event"
+          @update:url="ex.draftUrl.value = $event"
           @save="ex.savePage"
           @cancel="ex.cancelEdit"
         />

--- a/frontend/src/components/knowledge/KnowledgeExplorer.vue
+++ b/frontend/src/components/knowledge/KnowledgeExplorer.vue
@@ -171,6 +171,7 @@ onUnmounted(() => {
         class="grid__tree"
         :sources="ex.filteredSources.value"
         :selected-page-id="ex.selectedPageId.value"
+        :selected-source-id="ex.selectedSourceId.value"
         :query="ex.query.value"
         :status-of="ex.sourceStatus"
         :page-rows-of="ex.pageRows"

--- a/frontend/src/components/knowledge/KnowledgeExplorer.vue
+++ b/frontend/src/components/knowledge/KnowledgeExplorer.vue
@@ -32,18 +32,23 @@ const props = withDefaults(
     organizationId: string
     agentId?: string
     showPlanMeters?: boolean
+    title?: string
+    description?: string
+    variant?: 'page' | 'section'
   }>(),
-  { agentId: undefined, showPlanMeters: false },
+  {
+    agentId: undefined,
+    showPlanMeters: false,
+    title: '',
+    description: '',
+    variant: 'section',
+  },
 )
 
 const ex = useKnowledgeExplorer(props.mode, props.agentId, props.organizationId)
 
-const srcInput = ref('')
-
 // Add-source modal state.
 const addOpen = ref(false)
-const addInitialUrl = ref('')
-const addInitialType = ref<'website' | 'sitemap' | 'pdf' | 'text'>('website')
 const isSubmittingSource = ref(false)
 
 // A single, reusable confirm dialog for the destructive actions.
@@ -67,11 +72,7 @@ const largestSubpageCount = computed(() => {
   return s ? (s.pages ?? s.pageStubs).length : 0
 })
 
-// Open the modal, prefilling type/URL from whatever was typed in the quick bar.
-function openAddModal() {
-  const value = srcInput.value.trim()
-  addInitialType.value = /\.xml(\?|$)/i.test(value) ? 'sitemap' : 'website'
-  addInitialUrl.value = value
+function openAdd() {
   addOpen.value = true
 }
 
@@ -80,10 +81,7 @@ async function onSubmitSource(payload: AddSourcePayload) {
   isSubmittingSource.value = true
   try {
     const ok = await ex.submitSource(payload)
-    if (ok) {
-      addOpen.value = false
-      srcInput.value = ''
-    }
+    if (ok) addOpen.value = false
   } finally {
     isSubmittingSource.value = false
   }
@@ -138,6 +136,23 @@ onUnmounted(() => {
 
 <template>
   <div class="explorer">
+    <header class="explorer__header">
+      <div class="explorer__heading">
+        <component :is="variant === 'page' ? 'h1' : 'h3'" class="explorer__title" :class="`explorer__title--${variant}`">
+          {{ title }}
+        </component>
+        <p v-if="description" class="explorer__desc">{{ description }}</p>
+      </div>
+      <div class="explorer__actions">
+        <slot name="actions" />
+        <button class="btn btn--primary" type="button" @click="openAdd">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2"
+            stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14" /></svg>
+          Add source
+        </button>
+      </div>
+    </header>
+
     <KnowledgePlanMeters
       v-if="showPlanMeters"
       class="explorer__meters"
@@ -145,28 +160,6 @@ onUnmounted(() => {
       :largest-source-name="largestSource?.name ?? null"
       :largest-subpage-count="largestSubpageCount"
     />
-
-    <div class="addbar">
-      <div class="addbar__field">
-        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8"
-          stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1" />
-          <path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1" />
-        </svg>
-        <input
-          v-model="srcInput"
-          type="text"
-          placeholder="Paste a URL or sitemap, or add a document or text…"
-          aria-label="Knowledge source URL"
-          @keyup.enter="openAddModal"
-        />
-      </div>
-      <button class="btn btn--primary" type="button" @click="openAddModal">
-        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2"
-          stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14" /></svg>
-        Add source
-      </button>
-    </div>
 
     <div v-if="ex.error.value" class="banner" role="alert">
       {{ ex.error.value }}
@@ -233,8 +226,6 @@ onUnmounted(() => {
 
     <KnowledgeAddSourceModal
       v-if="addOpen"
-      :initial-url="addInitialUrl"
-      :initial-type="addInitialType"
       :submitting="isSubmittingSource"
       @close="addOpen = false"
       @submit="onSubmitSource"
@@ -249,44 +240,52 @@ onUnmounted(() => {
   min-width: 0;
 }
 
-.explorer__meters {
-  margin-bottom: 14px;
-}
-
-.addbar {
+.explorer__header {
   display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 14px;
-  background: var(--surface);
-  border: 1px solid var(--o08);
-  border-radius: 16px;
-  margin-bottom: 16px;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 20px;
   flex-wrap: wrap;
 }
 
-.addbar__field {
-  flex: 1;
-  min-width: 220px;
+.explorer__heading {
+  min-width: 0;
+}
+
+.explorer__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 6px;
+}
+
+.explorer__title--page {
+  font-size: 30px;
+  letter-spacing: -0.02em;
+}
+
+.explorer__title--section {
+  font-size: 20px;
+}
+
+.explorer__desc {
+  font-size: 14px;
+  color: var(--muted);
+  margin: 0;
+  max-width: 560px;
+  line-height: 1.55;
+}
+
+.explorer__actions {
   display: flex;
   align-items: center;
   gap: 10px;
-  background: var(--bg);
-  border: 1px solid var(--o10);
-  border-radius: 11px;
-  padding: 0 14px;
-  color: var(--muted2);
+  flex-shrink: 0;
 }
 
-.addbar__field input {
-  flex: 1;
-  min-width: 0;
-  background: transparent;
-  border: none;
-  outline: none;
-  color: var(--text);
-  font-size: 14px;
-  padding: 13px 0;
+.explorer__meters {
+  margin-bottom: 14px;
 }
 
 .btn {

--- a/frontend/src/components/knowledge/KnowledgeExplorer.vue
+++ b/frontend/src/components/knowledge/KnowledgeExplorer.vue
@@ -88,21 +88,32 @@ async function onSubmitSource(payload: AddSourcePayload) {
 }
 
 function askDeleteSource(source: ExplorerSource) {
-  confirmState.value = source.queued
-    ? {
-        title: 'Cancel crawl',
-        message: `Cancel the queued crawl of “${source.name}”?`,
-        actionLabel: 'Cancel crawl',
-        busyLabel: 'Cancelling…',
-        action: () => ex.deleteSource(source),
-      }
-    : {
-        title: 'Delete source',
-        message: `Delete “${source.name}” and all of its pages? This cannot be undone.`,
-        actionLabel: 'Delete',
-        busyLabel: 'Deleting…',
-        action: () => ex.deleteSource(source),
-      }
+  if (source.queued && source.queuedStatus === 'error') {
+    // A failed crawl — not an in-flight one to "cancel".
+    confirmState.value = {
+      title: 'Dismiss source',
+      message: `Dismiss the failed source “${source.name}”?`,
+      actionLabel: 'Dismiss',
+      busyLabel: 'Dismissing…',
+      action: () => ex.deleteSource(source),
+    }
+  } else if (source.queued) {
+    confirmState.value = {
+      title: 'Cancel crawl',
+      message: `Cancel the queued crawl of “${source.name}”?`,
+      actionLabel: 'Cancel crawl',
+      busyLabel: 'Cancelling…',
+      action: () => ex.deleteSource(source),
+    }
+  } else {
+    confirmState.value = {
+      title: 'Delete source',
+      message: `Delete “${source.name}” and all of its pages? This cannot be undone.`,
+      actionLabel: 'Delete',
+      busyLabel: 'Deleting…',
+      action: () => ex.deleteSource(source),
+    }
+  }
 }
 
 function askDeletePage() {

--- a/frontend/src/components/knowledge/KnowledgeExplorer.vue
+++ b/frontend/src/components/knowledge/KnowledgeExplorer.vue
@@ -46,8 +46,15 @@ const addInitialUrl = ref('')
 const addInitialType = ref<'website' | 'sitemap' | 'pdf' | 'text'>('website')
 const isSubmittingSource = ref(false)
 
-// A single, reusable confirm dialog for the two destructive actions.
-const confirmState = ref<{ title: string; message: string; action: () => Promise<void> } | null>(null)
+// A single, reusable confirm dialog for the destructive actions.
+interface ConfirmState {
+  title: string
+  message: string
+  actionLabel: string
+  busyLabel: string
+  action: () => Promise<void>
+}
+const confirmState = ref<ConfirmState | null>(null)
 
 const largestSource = computed(() =>
   ex.sources.value.reduce<ExplorerSource | null>((max, s) => {
@@ -83,11 +90,21 @@ async function onSubmitSource(payload: AddSourcePayload) {
 }
 
 function askDeleteSource(source: ExplorerSource) {
-  confirmState.value = {
-    title: 'Delete source',
-    message: `Delete “${source.name}” and all of its pages? This cannot be undone.`,
-    action: () => ex.deleteSource(source),
-  }
+  confirmState.value = source.queued
+    ? {
+        title: 'Cancel crawl',
+        message: `Cancel the queued crawl of “${source.name}”?`,
+        actionLabel: 'Cancel crawl',
+        busyLabel: 'Cancelling…',
+        action: () => ex.deleteSource(source),
+      }
+    : {
+        title: 'Delete source',
+        message: `Delete “${source.name}” and all of its pages? This cannot be undone.`,
+        actionLabel: 'Delete',
+        busyLabel: 'Deleting…',
+        action: () => ex.deleteSource(source),
+      }
 }
 
 function askDeletePage() {
@@ -96,6 +113,8 @@ function askDeletePage() {
   confirmState.value = {
     title: 'Delete page',
     message: `Delete “${page.title}” from this source? This cannot be undone.`,
+    actionLabel: 'Delete',
+    busyLabel: 'Deleting…',
     action: () => ex.deletePage(),
   }
 }
@@ -206,7 +225,7 @@ onUnmounted(() => {
         <div class="confirm__actions">
           <button class="btn btn--ghost" type="button" :disabled="ex.isDeleting.value" @click="confirmState = null">Cancel</button>
           <button class="btn btn--danger-solid" type="button" :disabled="ex.isDeleting.value" @click="runConfirm">
-            {{ ex.isDeleting.value ? 'Deleting…' : 'Delete' }}
+            {{ ex.isDeleting.value ? confirmState.busyLabel : confirmState.actionLabel }}
           </button>
         </div>
       </div>

--- a/frontend/src/components/knowledge/KnowledgePageDetail.vue
+++ b/frontend/src/components/knowledge/KnowledgePageDetail.vue
@@ -32,8 +32,9 @@ defineEmits<{
 }>()
 
 const statusText: Record<SourceStatus, string> = {
-  synced: 'Synced',
+  queued: 'Pending',
   crawling: 'Crawling',
+  synced: 'Synced',
   error: 'Needs sync',
 }
 
@@ -275,6 +276,12 @@ const updatedLabel = computed(() => {
   border-color: var(--warning-border, var(--o12));
   background: var(--warning-bg);
   color: var(--warning-color);
+}
+
+.pill--queued {
+  border-color: var(--purple-border, var(--o12));
+  background: var(--purple-bg, var(--o06));
+  color: var(--c-purple);
 }
 
 .pill--error {

--- a/frontend/src/components/knowledge/KnowledgePageDetail.vue
+++ b/frontend/src/components/knowledge/KnowledgePageDetail.vue
@@ -1,0 +1,307 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { KnowledgeSubPage } from '@/types/knowledge'
+import type { SourceStatus } from '@/composables/useKnowledgeExplorer'
+
+const props = defineProps<{
+  page: KnowledgeSubPage
+  sourceName: string
+  sourceType: string
+  status: SourceStatus
+  deleting: boolean
+}>()
+
+defineEmits<{
+  (e: 'edit'): void
+  (e: 'delete'): void
+}>()
+
+const statusText: Record<SourceStatus, string> = {
+  synced: 'Synced',
+  crawling: 'Crawling',
+  error: 'Needs sync',
+}
+
+const paragraphs = computed(() =>
+  (props.page.content || '')
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter(Boolean),
+)
+
+const href = computed(() => {
+  const url = props.page.url || ''
+  return /^https?:/i.test(url) ? url : `https://${url}`
+})
+
+const updatedLabel = computed(() => {
+  if (!props.page.updated_at) return 'unknown'
+  const d = new Date(props.page.updated_at)
+  return Number.isNaN(d.getTime()) ? 'unknown' : d.toLocaleDateString()
+})
+</script>
+
+<template>
+  <div class="detail">
+    <div class="detail__head">
+      <div class="crumbs">
+        <span class="crumbs__src" :title="sourceName">{{ sourceName }}</span>
+        <span class="crumbs__sep">/</span>
+        <span class="crumbs__type">{{ sourceType }}</span>
+      </div>
+
+      <div class="detail__title-row">
+        <div class="detail__title-wrap">
+          <h2 class="detail__title">{{ page.title }}</h2>
+          <a class="detail__url" :href="href" target="_blank" rel="noopener noreferrer">
+            <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.8"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+              <path d="M15 3h6v6" /><path d="M10 14 21 3" />
+            </svg>
+            <span class="detail__url-text">{{ page.url }}</span>
+          </a>
+        </div>
+        <div class="detail__actions">
+          <button class="btn btn--ghost" type="button" @click="$emit('edit')">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M12 20h9" /><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z" />
+            </svg>
+            Edit
+          </button>
+          <button class="btn btn--danger" type="button" :disabled="deleting" title="Delete page"
+            @click="$emit('delete')">
+            <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M4 7h16" /><path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+              <path d="M6 7l1 13a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1l1-13" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <div class="meta">
+        <span class="meta__item">{{ page.word_count }} words</span>
+        <span class="meta__sep"></span>
+        <span class="meta__item">Updated {{ updatedLabel }}</span>
+        <span class="meta__sep"></span>
+        <span class="pill" :class="`pill--${status}`">
+          <span class="pill__dot"></span>{{ statusText[status] }}
+        </span>
+      </div>
+    </div>
+
+    <div class="doc">
+      <p v-for="(para, i) in paragraphs" :key="i">{{ para }}</p>
+      <div v-if="paragraphs.length === 0" class="doc__empty">
+        This page has no content yet. Click <strong>Edit</strong> to add some.
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.detail {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.detail__head {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--o07);
+  flex-shrink: 0;
+}
+
+.crumbs {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted2);
+  margin-bottom: 12px;
+  min-width: 0;
+}
+
+.crumbs__src {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 60%;
+}
+
+.crumbs__sep { color: var(--faint); }
+.crumbs__type { color: var(--text3); }
+
+.detail__title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.detail__title-wrap {
+  flex: 1;
+  min-width: 0;
+}
+
+.detail__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0 0 6px;
+  word-break: break-word;
+}
+
+.detail__url {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--c-teal);
+  text-decoration: none;
+  max-width: 100%;
+}
+
+.detail__url-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detail__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 14px;
+  border-radius: 9px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  border: 1px solid var(--o12);
+  background: var(--o05);
+  color: var(--text2);
+}
+
+.btn:hover { background: var(--o08); }
+
+.btn--danger {
+  width: 34px;
+  padding: 0;
+  justify-content: center;
+  height: 34px;
+  color: var(--muted);
+}
+
+.btn--danger:hover:not(:disabled) {
+  background: var(--coral-bg);
+  color: var(--c-coral);
+  border-color: var(--coral-border);
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 14px;
+  flex-wrap: wrap;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted2);
+}
+
+.meta__sep {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--faint);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 600;
+  border: 1px solid var(--teal-border);
+  background: var(--teal-bg);
+  color: var(--c-teal);
+}
+
+.pill__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.pill--crawling {
+  border-color: var(--warning-border, var(--o12));
+  background: var(--warning-bg);
+  color: var(--warning-color);
+}
+
+.pill--error {
+  border-color: var(--coral-border);
+  background: var(--coral-bg);
+  color: var(--c-coral);
+}
+
+.doc {
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 28px;
+  color: var(--text3);
+  font-size: 15px;
+  line-height: 1.7;
+  font-family: var(--font-sans);
+}
+
+.doc p {
+  margin: 0 0 14px;
+  white-space: pre-wrap;
+}
+
+.doc__empty {
+  text-align: center;
+  color: var(--muted2);
+  font-size: 14px;
+  padding: 40px 0;
+}
+</style>

--- a/frontend/src/components/knowledge/KnowledgePageEditor.vue
+++ b/frontend/src/components/knowledge/KnowledgePageEditor.vue
@@ -22,13 +22,16 @@ const props = withDefaults(
     content: string
     saving: boolean
     submitLabel?: string
+    url?: string
+    showUrl?: boolean
   }>(),
-  { submitLabel: 'Save page' },
+  { submitLabel: 'Save page', url: '', showUrl: false },
 )
 
 const emit = defineEmits<{
   (e: 'update:title', value: string): void
   (e: 'update:content', value: string): void
+  (e: 'update:url', value: string): void
   (e: 'save'): void
   (e: 'cancel'): void
 }>()
@@ -48,6 +51,18 @@ const canSave = computed(() => props.content.trim().length > 0 && !props.saving)
         placeholder="Page title"
         @input="emit('update:title', ($event.target as HTMLInputElement).value)"
       />
+
+      <template v-if="showUrl">
+        <label class="editor__label" for="kb-page-url">SOURCE URL (OPTIONAL)</label>
+        <input
+          id="kb-page-url"
+          class="editor__title editor__url"
+          :value="url"
+          type="url"
+          placeholder="https://example.com/page"
+          @input="emit('update:url', ($event.target as HTMLInputElement).value)"
+        />
+      </template>
 
       <label class="editor__label" for="kb-page-content">PAGE CONTENT</label>
       <textarea
@@ -108,6 +123,13 @@ const canSave = computed(() => props.content.trim().length > 0 && !props.saving)
   color: var(--text);
   padding: 10px 12px;
   margin-bottom: 16px;
+}
+
+.editor__url {
+  font-family: var(--font-mono);
+  font-weight: 400;
+  font-size: 13px;
+  color: var(--c-teal);
 }
 
 .editor__title:focus,

--- a/frontend/src/components/knowledge/KnowledgePageEditor.vue
+++ b/frontend/src/components/knowledge/KnowledgePageEditor.vue
@@ -16,11 +16,15 @@ limitations under the License.
 <script setup lang="ts">
 import { computed } from 'vue'
 
-const props = defineProps<{
-  title: string
-  content: string
-  saving: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    title: string
+    content: string
+    saving: boolean
+    submitLabel?: string
+  }>(),
+  { submitLabel: 'Save page' },
+)
 
 const emit = defineEmits<{
   (e: 'update:title', value: string): void
@@ -62,7 +66,7 @@ const canSave = computed(() => props.content.trim().length > 0 && !props.saving)
       <div class="editor__buttons">
         <button class="btn btn--ghost" type="button" :disabled="saving" @click="emit('cancel')">Cancel</button>
         <button class="btn btn--primary" type="button" :disabled="!canSave" @click="emit('save')">
-          {{ saving ? 'Saving…' : 'Save page' }}
+          {{ saving ? 'Saving…' : submitLabel }}
         </button>
       </div>
     </div>

--- a/frontend/src/components/knowledge/KnowledgePageEditor.vue
+++ b/frontend/src/components/knowledge/KnowledgePageEditor.vue
@@ -1,0 +1,190 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  title: string
+  content: string
+  saving: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:title', value: string): void
+  (e: 'update:content', value: string): void
+  (e: 'save'): void
+  (e: 'cancel'): void
+}>()
+
+const canSave = computed(() => props.content.trim().length > 0 && !props.saving)
+</script>
+
+<template>
+  <div class="editor">
+    <div class="editor__body">
+      <label class="editor__label" for="kb-page-title">PAGE TITLE</label>
+      <input
+        id="kb-page-title"
+        class="editor__title"
+        :value="title"
+        type="text"
+        placeholder="Page title"
+        @input="emit('update:title', ($event.target as HTMLInputElement).value)"
+      />
+
+      <label class="editor__label" for="kb-page-content">PAGE CONTENT</label>
+      <textarea
+        id="kb-page-content"
+        class="editor__content"
+        :value="content"
+        placeholder="Type the page content here. Leave a blank line between paragraphs."
+        @input="emit('update:content', ($event.target as HTMLTextAreaElement).value)"
+      ></textarea>
+    </div>
+
+    <div class="editor__foot">
+      <span class="editor__status">
+        <span class="editor__status-dot"></span>Editing — re-embeds on save
+      </span>
+      <div class="editor__buttons">
+        <button class="btn btn--ghost" type="button" :disabled="saving" @click="emit('cancel')">Cancel</button>
+        <button class="btn btn--primary" type="button" :disabled="!canSave" @click="emit('save')">
+          {{ saving ? 'Saving…' : 'Save page' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.editor__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 24px;
+  display: flex;
+  flex-direction: column;
+}
+
+.editor__label {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  color: var(--muted2);
+  margin-bottom: 8px;
+}
+
+.editor__title {
+  background: var(--bg);
+  border: 1px solid var(--o12);
+  border-radius: 9px;
+  outline: none;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--text);
+  padding: 10px 12px;
+  margin-bottom: 16px;
+}
+
+.editor__title:focus,
+.editor__content:focus {
+  border-color: var(--accent-border, var(--accent-ink));
+}
+
+.editor__content {
+  flex: 1;
+  min-height: 320px;
+  background: var(--bg);
+  border: 1px solid var(--o12);
+  border-radius: 12px;
+  padding: 16px 18px;
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--text3);
+  outline: none;
+  resize: vertical;
+  font-family: var(--font-sans);
+}
+
+.editor__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--o10);
+  background: var(--bg2);
+  flex-shrink: 0;
+}
+
+.editor__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.editor__status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--c-coral);
+}
+
+.editor__buttons {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+
+.btn {
+  padding: 9px 18px;
+  border-radius: 9px;
+  font-size: 13.5px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.btn--ghost {
+  background: transparent;
+  border-color: var(--o12);
+  color: var(--muted);
+}
+
+.btn--ghost:hover:not(:disabled) { background: var(--o05); }
+
+.btn--primary {
+  background: var(--accent-solid);
+  color: var(--on-accent-solid);
+}
+
+.btn--primary:hover:not(:disabled) { filter: brightness(1.05); }
+</style>

--- a/frontend/src/components/knowledge/KnowledgePlanMeters.vue
+++ b/frontend/src/components/knowledge/KnowledgePlanMeters.vue
@@ -1,0 +1,171 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useEnterpriseFeatures } from '@/composables/useEnterpriseFeatures'
+
+const props = defineProps<{
+  sourceCount: number
+  largestSourceName: string | null
+  largestSubpageCount: number
+}>()
+
+const { hasEnterpriseModule, subscriptionStore, initializeSubscriptionStore } =
+  useEnterpriseFeatures()
+
+onMounted(async () => {
+  if (!hasEnterpriseModule) return
+  await initializeSubscriptionStore()
+  if (!subscriptionStore.value.currentPlan) {
+    await subscriptionStore.value.fetchCurrentPlan()
+  }
+})
+
+const plan = computed(() => subscriptionStore.value.currentPlan?.plan ?? null)
+const maxSources = computed<number | null>(() => plan.value?.max_knowledge_sources ?? null)
+const maxSubpages = computed<number | null>(() => plan.value?.max_sub_pages ?? null)
+
+// Clamp a usage ratio to a readable meter width (min 6% so a tiny bar still shows).
+function pct(used: number, limit: number | null): number {
+  if (!limit || limit <= 0) return 0
+  return Math.max(6, Math.min(100, Math.round((used / limit) * 100)))
+}
+
+const sourcesOver = computed(() => maxSources.value !== null && props.sourceCount > maxSources.value)
+const subpagesOver = computed(
+  () => maxSubpages.value !== null && props.largestSubpageCount > maxSubpages.value,
+)
+</script>
+
+<template>
+  <div class="meters">
+    <div class="meter" :class="{ 'meter--over': sourcesOver }">
+      <div class="meter__head">
+        <span class="meter__label">Knowledge sources</span>
+        <span class="meter__value">
+          {{ sourceCount }}<template v-if="maxSources !== null"> / {{ maxSources }}</template>
+        </span>
+      </div>
+      <div v-if="maxSources !== null" class="meter__track">
+        <div class="meter__fill" :style="{ width: pct(sourceCount, maxSources) + '%' }"></div>
+      </div>
+      <div class="meter__note">
+        <template v-if="sourcesOver">You’ve exceeded your plan’s source limit. Upgrade to connect more.</template>
+        <template v-else-if="maxSources !== null">{{ sourceCount }} of {{ maxSources }} sources connected.</template>
+        <template v-else>{{ sourceCount }} sources connected.</template>
+      </div>
+    </div>
+
+    <div class="meter" :class="{ 'meter--over': subpagesOver }">
+      <div class="meter__head">
+        <span class="meter__label">Sub-pages per source</span>
+        <span class="meter__value">
+          <template v-if="maxSubpages !== null">up to {{ maxSubpages }}</template>
+          <template v-else>—</template>
+        </span>
+      </div>
+      <div v-if="maxSubpages !== null" class="meter__track">
+        <div class="meter__fill meter__fill--alt"
+          :style="{ width: pct(largestSubpageCount, maxSubpages) + '%' }"></div>
+      </div>
+      <div class="meter__note">
+        <template v-if="largestSourceName">
+          Largest source: {{ largestSourceName }} — {{ largestSubpageCount }}<template v-if="maxSubpages !== null"> / {{ maxSubpages }}</template> sub-pages
+        </template>
+        <template v-else>No sources yet.</template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.meters {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+@media (max-width: 640px) {
+  .meters {
+    grid-template-columns: 1fr;
+  }
+}
+
+.meter {
+  background: var(--surface);
+  border: 1px solid var(--o08);
+  border-radius: 14px;
+  padding: 16px 18px;
+}
+
+.meter__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 11px;
+}
+
+.meter__label {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text2);
+}
+
+.meter__value {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text3);
+}
+
+.meter--over .meter__value {
+  color: var(--c-coral);
+}
+
+.meter__track {
+  height: 7px;
+  border-radius: 999px;
+  background: var(--o07);
+  overflow: hidden;
+}
+
+.meter__fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--c-teal);
+  transition: width 0.3s ease;
+}
+
+.meter__fill--alt {
+  background: var(--c-purple);
+}
+
+.meter--over .meter__fill {
+  background: var(--c-coral);
+}
+
+.meter__note {
+  font-size: 12.5px;
+  color: var(--muted);
+  margin-top: 10px;
+  line-height: 1.5;
+}
+
+.meter--over .meter__note {
+  color: var(--c-coral);
+}
+</style>

--- a/frontend/src/components/knowledge/KnowledgeSourceTree.vue
+++ b/frontend/src/components/knowledge/KnowledgeSourceTree.vue
@@ -1,0 +1,371 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ExplorerSource, SourceStatus } from '@/composables/useKnowledgeExplorer'
+
+interface PageRow {
+  page_id: string
+  title: string
+  words: number | null
+}
+
+const props = defineProps<{
+  sources: ExplorerSource[]
+  selectedPageId: string | null
+  query: string
+  statusOf: (source: ExplorerSource) => SourceStatus
+  pageRowsOf: (source: ExplorerSource) => PageRow[]
+}>()
+
+// Group page rows once per render (the template reads them twice per source).
+const rowsBySource = computed(() => {
+  const map = new Map<number, PageRow[]>()
+  for (const source of props.sources) map.set(source.id, props.pageRowsOf(source))
+  return map
+})
+
+const emit = defineEmits<{
+  (e: 'update:query', value: string): void
+  (e: 'toggle', source: ExplorerSource): void
+  (e: 'select', source: ExplorerSource, pageId: string): void
+  (e: 'delete-source', source: ExplorerSource): void
+}>()
+
+const statusLabel: Record<SourceStatus, string> = {
+  synced: 'Synced',
+  crawling: 'Crawling',
+  error: 'Needs sync',
+}
+
+function sourceGlyph(type: string): string {
+  const t = (type || '').toLowerCase()
+  if (t.includes('pdf') || t === 'file') return 'P'
+  if (t.includes('site')) return 'S'
+  if (t.includes('web')) return 'W'
+  return 'T'
+}
+</script>
+
+<template>
+  <div class="tree">
+    <div class="tree__search">
+      <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2"
+        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <circle cx="11" cy="11" r="7" />
+        <line x1="21" y1="21" x2="16.65" y2="16.65" />
+      </svg>
+      <input
+        :value="query"
+        type="search"
+        placeholder="Search pages…"
+        aria-label="Search pages"
+        @input="emit('update:query', ($event.target as HTMLInputElement).value)"
+      />
+    </div>
+
+    <div class="tree__body">
+      <div v-for="source in sources" :key="source.id" class="src">
+        <div class="src__row">
+          <button
+            class="src__toggle"
+            type="button"
+            :aria-expanded="source.expanded"
+            @click="emit('toggle', source)"
+          >
+            <svg class="chev" :class="{ 'chev--open': source.expanded }" viewBox="0 0 24 24" width="14" height="14"
+              fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"
+              aria-hidden="true">
+              <path d="M9 6l6 6-6 6" />
+            </svg>
+            <span class="src__glyph" :class="`src__glyph--${sourceGlyph(source.type).toLowerCase()}`">{{ sourceGlyph(source.type) }}</span>
+            <span class="src__meta">
+              <span class="src__name" :title="source.name">{{ source.name }}</span>
+              <span class="src__count">{{ (source.pages ?? source.pageStubs).length }} sub-pages</span>
+            </span>
+          </button>
+          <span class="dot" :class="`dot--${statusOf(source)}`" :title="statusLabel[statusOf(source)]"></span>
+          <button
+            class="src__del"
+            type="button"
+            title="Delete this source"
+            @click="emit('delete-source', source)"
+          >
+            <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.9"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M4 7h16" /><path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+              <path d="M6 7l1 13a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1l1-13" />
+            </svg>
+          </button>
+        </div>
+
+        <div v-if="source.expanded" class="src__pages">
+          <div v-if="source.loadingContent" class="src__hint">Loading pages…</div>
+          <div v-else-if="source.contentError" class="src__hint src__hint--error">{{ source.contentError }}</div>
+          <template v-else>
+            <button
+              v-for="row in (rowsBySource.get(source.id) || [])"
+              :key="row.page_id"
+              type="button"
+              class="pg"
+              :class="{ 'pg--active': row.page_id === selectedPageId }"
+              @click="emit('select', source, row.page_id)"
+            >
+              <span class="pg__dot"></span>
+              <span class="pg__title" :title="row.title">{{ row.title }}</span>
+              <span v-if="row.words !== null" class="pg__words">{{ row.words }}w</span>
+            </button>
+            <div v-if="(rowsBySource.get(source.id) || []).length === 0" class="src__hint">No pages extracted yet.</div>
+          </template>
+        </div>
+      </div>
+
+      <div v-if="sources.length === 0" class="tree__empty">
+        <template v-if="query">No pages match “{{ query }}”.</template>
+        <template v-else>No knowledge sources yet.</template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tree {
+  background: var(--surface);
+  border: 1px solid var(--o08);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  height: 100%;
+  min-height: 0;
+}
+
+.tree__search {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 14px;
+  padding: 0 12px;
+  background: var(--bg);
+  border: 1px solid var(--o10);
+  border-radius: 10px;
+  color: var(--muted2);
+  flex-shrink: 0;
+}
+
+.tree__search input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-size: 13.5px;
+  padding: 10px 0;
+}
+
+.tree__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.src {
+  margin-bottom: 4px;
+}
+
+.src__row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 9px;
+  padding-right: 6px;
+}
+
+.src__row:hover {
+  background: var(--o04);
+}
+
+.src__toggle {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  text-align: left;
+  color: inherit;
+}
+
+.chev {
+  flex-shrink: 0;
+  color: var(--muted2);
+  transition: transform 0.18s ease;
+}
+
+.chev--open {
+  transform: rotate(90deg);
+}
+
+.src__glyph {
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 12px;
+  background: var(--accent-bg-12);
+  color: var(--accent-ink);
+}
+
+.src__glyph--p { background: var(--coral-bg); color: var(--c-coral); }
+.src__glyph--s { background: var(--teal-bg); color: var(--c-teal); }
+.src__glyph--t { background: var(--purple-bg, var(--o08)); color: var(--c-purple); }
+
+.src__meta {
+  flex: 1;
+  min-width: 0;
+}
+
+.src__name {
+  display: block;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.src__count {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--muted2);
+  margin-top: 2px;
+}
+
+.dot {
+  width: 7px;
+  height: 7px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--muted2);
+}
+
+.dot--synced { background: var(--c-teal); box-shadow: 0 0 6px var(--c-teal); }
+.dot--crawling { background: var(--warning-color); }
+.dot--error { background: var(--c-coral); }
+
+.src__del {
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  border-radius: 7px;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--muted2);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.src__row:hover .src__del { opacity: 1; }
+
+.src__del:hover {
+  background: var(--coral-bg);
+  color: var(--c-coral);
+  border-color: var(--coral-border);
+}
+
+.src__pages {
+  padding: 2px 0 6px 18px;
+}
+
+.pg {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 8px 10px;
+  margin: 1px 0;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+}
+
+.pg:hover { background: var(--o04); }
+.pg--active { background: var(--accent-bg-08); }
+
+.pg__dot {
+  width: 6px;
+  height: 6px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--c-teal);
+}
+
+.pg__title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text3);
+}
+
+.pg--active .pg__title {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.pg__words {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--faint);
+}
+
+.src__hint {
+  padding: 8px 10px;
+  font-size: 12.5px;
+  color: var(--muted2);
+}
+
+.src__hint--error { color: var(--c-coral); }
+
+.tree__empty {
+  padding: 40px 20px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--muted2);
+}
+</style>

--- a/frontend/src/components/knowledge/KnowledgeSourceTree.vue
+++ b/frontend/src/components/knowledge/KnowledgeSourceTree.vue
@@ -84,18 +84,22 @@ function sourceGlyph(type: string): string {
           <button
             class="src__toggle"
             type="button"
-            :aria-expanded="source.expanded"
-            @click="emit('toggle', source)"
+            :aria-expanded="source.queued ? undefined : source.expanded"
+            :disabled="source.queued"
+            @click="!source.queued && emit('toggle', source)"
           >
-            <svg class="chev" :class="{ 'chev--open': source.expanded }" viewBox="0 0 24 24" width="14" height="14"
-              fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"
-              aria-hidden="true">
+            <svg v-if="!source.queued" class="chev" :class="{ 'chev--open': source.expanded }" viewBox="0 0 24 24"
+              width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"
+              stroke-linejoin="round" aria-hidden="true">
               <path d="M9 6l6 6-6 6" />
             </svg>
+            <span v-else class="chev-spacer"></span>
             <span class="src__glyph" :class="`src__glyph--${sourceGlyph(source.type).toLowerCase()}`">{{ sourceGlyph(source.type) }}</span>
             <span class="src__meta">
               <span class="src__name" :title="source.name">{{ source.name }}</span>
-              <span class="src__count">{{ (source.pages ?? source.pageStubs).length }} sub-pages</span>
+              <span class="src__count">
+                {{ source.queued ? statusLabel[statusOf(source)] : (source.pages ?? source.pageStubs).length + ' sub-pages' }}
+              </span>
             </span>
           </button>
           <span class="dot" :class="`dot--${statusOf(source)}`" :title="statusLabel[statusOf(source)]"></span>
@@ -113,7 +117,7 @@ function sourceGlyph(type: string): string {
           </button>
         </div>
 
-        <div v-if="source.expanded" class="src__pages">
+        <div v-if="source.expanded && !source.queued" class="src__pages">
           <div v-if="source.loadingContent" class="src__hint">Loading pages…</div>
           <div v-else-if="source.contentError" class="src__hint src__hint--error">{{ source.contentError }}</div>
           <template v-else>
@@ -218,6 +222,15 @@ function sourceGlyph(type: string): string {
   flex-shrink: 0;
   color: var(--muted2);
   transition: transform 0.18s ease;
+}
+
+.chev-spacer {
+  width: 14px;
+  flex-shrink: 0;
+}
+
+.src__toggle:disabled {
+  cursor: default;
 }
 
 .chev--open {

--- a/frontend/src/components/knowledge/KnowledgeSourceTree.vue
+++ b/frontend/src/components/knowledge/KnowledgeSourceTree.vue
@@ -46,8 +46,9 @@ const emit = defineEmits<{
 }>()
 
 const statusLabel: Record<SourceStatus, string> = {
-  synced: 'Synced',
+  queued: 'Pending',
   crawling: 'Crawling',
+  synced: 'Synced',
   error: 'Needs sync',
 }
 
@@ -275,6 +276,7 @@ function sourceGlyph(type: string): string {
 
 .dot--synced { background: var(--c-teal); box-shadow: 0 0 6px var(--c-teal); }
 .dot--crawling { background: var(--warning-color); }
+.dot--queued { background: var(--c-purple); }
 .dot--error { background: var(--c-coral); }
 
 .src__del {

--- a/frontend/src/components/knowledge/KnowledgeSourceTree.vue
+++ b/frontend/src/components/knowledge/KnowledgeSourceTree.vue
@@ -44,6 +44,7 @@ const emit = defineEmits<{
   (e: 'toggle', source: ExplorerSource): void
   (e: 'select', source: ExplorerSource, pageId: string): void
   (e: 'delete-source', source: ExplorerSource): void
+  (e: 'add-page', source: ExplorerSource): void
 }>()
 
 const statusLabel: Record<SourceStatus, string> = {
@@ -112,6 +113,16 @@ function sourceGlyph(type: string): string {
           </button>
           <span class="dot" :class="`dot--${statusOf(source)}`" :title="statusLabel[statusOf(source)]"></span>
           <button
+            v-if="!source.queued"
+            class="src__add"
+            type="button"
+            title="Add a sub-page to this source"
+            @click="emit('add-page', source)"
+          >
+            <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.4"
+              stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14" /></svg>
+          </button>
+          <button
             class="src__del"
             type="button"
             :title="!source.queued ? 'Delete this source' : (statusOf(source) === 'error' ? 'Dismiss failed source' : 'Cancel crawl')"
@@ -146,6 +157,11 @@ function sourceGlyph(type: string): string {
               <span v-if="row.words !== null" class="pg__words">{{ row.words }}w</span>
             </button>
             <div v-if="(rowsBySource.get(source.id) || []).length === 0" class="src__hint">No pages extracted yet.</div>
+            <button type="button" class="pg pg--add" @click="emit('add-page', source)">
+              <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.2"
+                stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14" /></svg>
+              Add sub-page
+            </button>
           </template>
         </div>
       </div>
@@ -308,6 +324,7 @@ function sourceGlyph(type: string): string {
 .dot--queued { background: var(--c-purple); }
 .dot--error { background: var(--c-coral); }
 
+.src__add,
 .src__del {
   width: 26px;
   height: 26px;
@@ -324,7 +341,14 @@ function sourceGlyph(type: string): string {
   transition: opacity 0.15s ease;
 }
 
+.src__row:hover .src__add,
 .src__row:hover .src__del { opacity: 1; }
+
+.src__add:hover {
+  background: var(--accent-bg-08);
+  color: var(--accent-ink);
+  border-color: var(--accent-border, var(--o12));
+}
 
 .src__del:hover {
   background: var(--coral-bg);
@@ -353,6 +377,18 @@ function sourceGlyph(type: string): string {
 
 .pg:hover { background: var(--o04); }
 .pg--active { background: var(--accent-bg-08); }
+
+.pg--add {
+  gap: 8px;
+  font-size: 12.5px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  color: var(--muted2);
+}
+
+.pg--add:hover {
+  color: var(--accent-ink);
+}
 
 .pg__dot {
   width: 6px;

--- a/frontend/src/components/knowledge/KnowledgeSourceTree.vue
+++ b/frontend/src/components/knowledge/KnowledgeSourceTree.vue
@@ -53,6 +53,13 @@ const statusLabel: Record<SourceStatus, string> = {
   error: 'Needs sync',
 }
 
+// A queued placeholder's error state is a failed crawl, not a source that
+// merely "needs sync".
+function queuedLabel(source: ExplorerSource): string {
+  const status = props.statusOf(source)
+  return status === 'error' ? 'Failed' : statusLabel[status]
+}
+
 function sourceGlyph(type: string): string {
   const t = (type || '').toLowerCase()
   if (t.includes('pdf') || t === 'file') return 'P'
@@ -98,8 +105,8 @@ function sourceGlyph(type: string): string {
             <span class="src__glyph" :class="`src__glyph--${sourceGlyph(source.type).toLowerCase()}`">{{ sourceGlyph(source.type) }}</span>
             <span class="src__meta">
               <span class="src__name" :title="source.name">{{ source.name }}</span>
-              <span class="src__count">
-                {{ source.queued ? statusLabel[statusOf(source)] : (source.pages ?? source.pageStubs).length + ' sub-pages' }}
+              <span class="src__count" :class="{ 'src__count--error': source.queued && statusOf(source) === 'error' }">
+                {{ source.queued ? queuedLabel(source) : (source.pages ?? source.pageStubs).length + ' sub-pages' }}
               </span>
             </span>
           </button>
@@ -107,7 +114,7 @@ function sourceGlyph(type: string): string {
           <button
             class="src__del"
             type="button"
-            title="Delete this source"
+            :title="!source.queued ? 'Delete this source' : (statusOf(source) === 'error' ? 'Dismiss failed source' : 'Cancel crawl')"
             @click="emit('delete-source', source)"
           >
             <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.9"
@@ -282,6 +289,10 @@ function sourceGlyph(type: string): string {
   font-size: 10.5px;
   color: var(--muted2);
   margin-top: 2px;
+}
+
+.src__count--error {
+  color: var(--c-coral);
 }
 
 .dot {

--- a/frontend/src/components/knowledge/KnowledgeSourceTree.vue
+++ b/frontend/src/components/knowledge/KnowledgeSourceTree.vue
@@ -118,6 +118,10 @@ function sourceGlyph(type: string): string {
           </button>
         </div>
 
+        <div v-if="source.queued && source.queuedError" class="src__error">
+          {{ source.queuedError }}
+        </div>
+
         <div v-if="source.expanded && !source.queued" class="src__pages">
           <div v-if="source.loadingContent" class="src__hint">Loading pages…</div>
           <div v-else-if="source.contentError" class="src__hint src__hint--error">{{ source.contentError }}</div>
@@ -377,6 +381,17 @@ function sourceGlyph(type: string): string {
 }
 
 .src__hint--error { color: var(--c-coral); }
+
+.src__error {
+  margin: 2px 10px 6px 44px;
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--c-coral);
+  background: var(--coral-bg);
+  border: 1px solid var(--coral-border);
+  border-radius: 8px;
+}
 
 .tree__empty {
   padding: 40px 20px;

--- a/frontend/src/components/knowledge/KnowledgeSourceTree.vue
+++ b/frontend/src/components/knowledge/KnowledgeSourceTree.vue
@@ -26,6 +26,7 @@ interface PageRow {
 const props = defineProps<{
   sources: ExplorerSource[]
   selectedPageId: string | null
+  selectedSourceId: number | null
   query: string
   statusOf: (source: ExplorerSource) => SourceStatus
   pageRowsOf: (source: ExplorerSource) => PageRow[]
@@ -126,7 +127,7 @@ function sourceGlyph(type: string): string {
               :key="row.page_id"
               type="button"
               class="pg"
-              :class="{ 'pg--active': row.page_id === selectedPageId }"
+              :class="{ 'pg--active': source.id === selectedSourceId && row.page_id === selectedPageId }"
               @click="emit('select', source, row.page_id)"
             >
               <span class="pg__dot"></span>

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -30,6 +30,7 @@ const NAV_ICONS: Record<string, string> = {
     inbox: '<rect x="3" y="5" width="18" height="14" rx="3"/><path d="M3 13h5l1.5 2.5h4L19 13h2"/>',
     people: '<circle cx="9" cy="8" r="2.6"/><path d="M4 18a5 4.5 0 0 1 10 0"/><path d="M15.5 6.2a2.6 2.6 0 0 1 0 4.6"/><path d="M16 13.6A5 4.5 0 0 1 20 18"/>',
     analytics: '<line x1="5" y1="17" x2="5" y2="13"/><line x1="10" y1="17" x2="10" y2="9"/><line x1="15" y1="17" x2="15" y2="6"/><line x1="20" y1="17" x2="20" y2="11"/>',
+    knowledge: '<path d="M4 5.5A2 2 0 0 1 6 4h5v16H6a2 2 0 0 0-2 1.5z"/><path d="M20 5.5A2 2 0 0 0 18 4h-5v16h5a2 2 0 0 1 2 1.5z"/>',
     org: '<rect x="4" y="4" width="14" height="16" rx="2"/><line x1="20" y1="20" x2="20" y2="11"/><line x1="18" y1="11" x2="22" y2="11"/><circle cx="8" cy="9" r=".6" fill="currentColor"/><circle cx="12" cy="9" r=".6" fill="currentColor"/><circle cx="8" cy="13" r=".6" fill="currentColor"/><circle cx="12" cy="13" r=".6" fill="currentColor"/>',
     subscription: '<rect x="3" y="6" width="18" height="12" rx="2.5"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="7" y1="14" x2="11" y2="14"/>',
     integrations: '<line x1="12" y1="12" x2="6" y2="6"/><line x1="12" y1="12" x2="18" y2="6"/><line x1="12" y1="12" x2="12" y2="19"/><circle cx="12" cy="12" r="2.2" fill="currentColor"/><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="19" r="2"/>',
@@ -90,6 +91,12 @@ const navItems = computed(() => [
         icon: 'people',
         label: 'People',
         show: permissionChecks.canViewChats()
+    },
+    {
+        to: '/knowledge',
+        icon: 'knowledge',
+        label: 'Knowledge',
+        show: permissionChecks.canManageKnowledge()
     },
     {
         to: '/analytics',

--- a/frontend/src/composables/useKnowledgeExplorer.ts
+++ b/frontend/src/composables/useKnowledgeExplorer.ts
@@ -18,7 +18,7 @@ import { computed, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import type { KnowledgeItem, KnowledgePage, KnowledgeSubPage, QueueItem } from '@/types/knowledge'
 import { knowledgeService } from '@/services/knowledge'
-import { groupChunksIntoPages, titleFromId } from '@/utils/knowledgePages'
+import { basePageId, groupChunksIntoPages, titleFromId } from '@/utils/knowledgePages'
 
 export type ExplorerMode = 'agent' | 'org'
 export type SourceStatus = 'queued' | 'crawling' | 'synced' | 'error'
@@ -73,6 +73,7 @@ export function useKnowledgeExplorer(
   const selectedPageId = ref<string | null>(null)
 
   const editing = ref(false)
+  const isAddingPage = ref(false)
   const draftTitle = ref('')
   const draftContent = ref('')
   const isSaving = ref(false)
@@ -243,6 +244,7 @@ export function useKnowledgeExplorer(
     selectedSourceId.value = source.id
     selectedPageId.value = pageId
     editing.value = false
+    isAddingPage.value = false
     if (source.pages === null) {
       await loadSourceContent(source.id)
     }
@@ -302,17 +304,66 @@ export function useKnowledgeExplorer(
     if (!page) return
     draftTitle.value = page.title
     draftContent.value = page.content
+    isAddingPage.value = false
     editing.value = true
+  }
+
+  // Open the editor with empty fields to add a new sub-page to `source`.
+  const startAddPage = async (source: ExplorerSource) => {
+    if (source.queued) return
+    selectedSourceId.value = source.id
+    selectedPageId.value = null
+    draftTitle.value = ''
+    draftContent.value = ''
+    isAddingPage.value = true
+    editing.value = true
+    source.expanded = true
+    if (source.pages === null) await loadSourceContent(source.id)
   }
 
   const cancelEdit = () => {
     editing.value = false
+    isAddingPage.value = false
+  }
+
+  const addNewPage = async (source: ExplorerSource) => {
+    const title = draftTitle.value.trim()
+    const content = draftContent.value.trim()
+    if (!title) {
+      error.value = 'Give the sub-page a title'
+      toast.error('Give the sub-page a title')
+      return
+    }
+    if (!content) {
+      error.value = 'Sub-page content cannot be empty'
+      return
+    }
+    isSaving.value = true
+    error.value = null
+    try {
+      await knowledgeService.addSubpage(source.id, title, content)
+      await loadSourceContent(source.id, true)
+      selectedPageId.value = basePageId(title)
+      isAddingPage.value = false
+      editing.value = false
+      toast.success('Sub-page added')
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to add sub-page'
+      console.error('Failed to add sub-page:', err)
+      error.value = msg
+      toast.error('Could not add sub-page', { description: msg })
+    } finally {
+      isSaving.value = false
+    }
   }
 
   const savePage = async () => {
     const source = selectedSource.value
+    if (!source) return
+    if (isAddingPage.value) return addNewPage(source)
+
     const page = selectedPage.value
-    if (!source || !page) return
+    if (!page) return
     const content = draftContent.value.trim()
     if (!content) {
       error.value = 'Page content cannot be empty'
@@ -477,6 +528,7 @@ export function useKnowledgeExplorer(
     selectedSourceId,
     selectedPageId,
     editing,
+    isAddingPage,
     draftTitle,
     draftContent,
     isSaving,
@@ -495,6 +547,7 @@ export function useKnowledgeExplorer(
     toggleSource,
     selectPage,
     startEdit,
+    startAddPage,
     cancelEdit,
     savePage,
     deletePage,

--- a/frontend/src/composables/useKnowledgeExplorer.ts
+++ b/frontend/src/composables/useKnowledgeExplorer.ts
@@ -15,12 +15,20 @@ limitations under the License.
 */
 
 import { computed, ref } from 'vue'
+import { toast } from 'vue-sonner'
 import type { KnowledgeItem, KnowledgePage, KnowledgeSubPage, QueueItem } from '@/types/knowledge'
 import { knowledgeService } from '@/services/knowledge'
 import { groupChunksIntoPages, titleFromId } from '@/utils/knowledgePages'
 
 export type ExplorerMode = 'agent' | 'org'
-export type SourceStatus = 'synced' | 'crawling' | 'error'
+export type SourceStatus = 'queued' | 'crawling' | 'synced' | 'error'
+
+// What the add-source modal submits; discriminated by `type`.
+export type AddSourcePayload =
+  | { type: 'website'; url: string; followLinks: boolean }
+  | { type: 'sitemap'; url: string }
+  | { type: 'pdf'; files: File[] }
+  | { type: 'text'; title: string; content: string }
 
 /** A knowledge source enriched with lazily-loaded, grouped sub-page content. */
 export interface ExplorerSource {
@@ -178,7 +186,8 @@ export function useKnowledgeExplorer(
   const sourceStatus = (source: ExplorerSource): SourceStatus => {
     const item = queueItems.value.find((q) => q.source === source.name)
     if (item?.status === 'failed') return 'error'
-    if (item && (item.status === 'pending' || item.status === 'processing')) return 'crawling'
+    if (item?.status === 'processing') return 'crawling'
+    if (item?.status === 'pending') return 'queued'
     return 'synced'
   }
 
@@ -281,17 +290,57 @@ export function useKnowledgeExplorer(
     }
   }
 
-  const addSource = async (rawUrl: string) => {
-    const url = rawUrl.trim()
-    if (!url) return
+  const linkedAgentId = mode === 'agent' ? agentId : undefined
+
+  // Handle add/urls responses that report duplicates instead of throwing.
+  const throwIfError = (res: { error?: string } | undefined) => {
+    if (res?.error) throw new Error(res.error)
+  }
+
+  // Submit a new source from the add-source modal. Resolves true on success.
+  // Crawl sources (website/sitemap/pdf) are queued and indexed in the
+  // background; text is indexed immediately. Toasts announce the outcome.
+  const submitSource = async (payload: AddSourcePayload): Promise<boolean> => {
     error.value = null
     try {
-      await knowledgeService.addUrls(organizationId, [url], mode === 'agent' ? agentId : undefined)
+      if (payload.type === 'website') {
+        throwIfError(
+          await knowledgeService.addUrls(
+            organizationId,
+            [payload.url],
+            linkedAgentId,
+            undefined,
+            payload.followLinks ? undefined : 1,
+          ),
+        )
+        toast.success('Queued for crawling', {
+          description: `${payload.url} — we’ll notify you when indexing is done.`,
+        })
+      } else if (payload.type === 'sitemap') {
+        throwIfError(await knowledgeService.addUrls(organizationId, [payload.url], linkedAgentId))
+        toast.success('Queued for crawling', {
+          description: `${payload.url} — pages are being discovered and indexed.`,
+        })
+      } else if (payload.type === 'pdf') {
+        await knowledgeService.uploadPdfFiles(payload.files, organizationId, linkedAgentId)
+        toast.success('Queued for crawling', {
+          description: 'Your document is being parsed and indexed.',
+        })
+      } else {
+        await knowledgeService.addText(organizationId, payload.title, payload.content, linkedAgentId)
+        toast.success('Page added', {
+          description: `${payload.title} is now in your knowledge base.`,
+        })
+      }
       await Promise.all([fetchSources(), fetchQueue()])
+      return true
     } catch (err: unknown) {
+      // Surface add-source failures via toast only (the inline error banner is
+      // reserved for the read/edit pane), so the user doesn't see it twice.
+      const msg = err instanceof Error ? err.message : 'Failed to add source'
       console.error('Failed to add source:', err)
-      error.value = err instanceof Error ? err.message : 'Failed to add source'
-      throw err
+      toast.error('Could not add source', { description: msg })
+      return false
     }
   }
 
@@ -364,7 +413,7 @@ export function useKnowledgeExplorer(
     savePage,
     deletePage,
     deleteSource,
-    addSource,
+    submitSource,
     startPolling,
     stopPolling,
   }

--- a/frontend/src/composables/useKnowledgeExplorer.ts
+++ b/frontend/src/composables/useKnowledgeExplorer.ts
@@ -43,6 +43,9 @@ export interface ExplorerSource {
   // True for a placeholder built from an in-flight queue item that has not yet
   // produced a real Knowledge source (id is the negated queue-item id).
   queued?: boolean
+  // Status carried from the queue item for a placeholder (its display name may
+  // differ from the queue `source`, so it can't be re-derived by name lookup).
+  queuedStatus?: SourceStatus
 }
 
 const POLL_INTERVAL_MS = 10000
@@ -156,10 +159,24 @@ export function useKnowledgeExplorer(
     return 'custom'
   }
 
+  // A queue item's `source` is a URL for websites but an internal temp path or
+  // S3 signed URL for PDFs — show a readable filename for the placeholder.
+  const queueSourceName = (item: QueueItem): string => {
+    if (!item.source_type.includes('pdf')) return item.source
+    const path = item.source.split(/[?#]/)[0]
+    const base = decodeURIComponent(path.slice(path.lastIndexOf('/') + 1))
+      .replace(/\.[^.]+$/, '') // drop extension
+      .replace(/^[0-9a-f-]{8,}[_-]/i, '') // drop a leading uuid_ prefix
+    return base || item.source
+  }
+
+  const queueStatusToSource = (status: string): SourceStatus =>
+    status === 'failed' ? 'error' : status === 'processing' ? 'crawling' : 'queued'
+
   // Placeholder source for an in-flight queue item (negative id = queue-item id).
   const toSyntheticSource = (item: QueueItem): ExplorerSource => ({
     id: -item.id,
-    name: item.source,
+    name: queueSourceName(item),
     type: queueKind(item.source_type),
     pageStubs: [],
     expanded: false,
@@ -167,6 +184,7 @@ export function useKnowledgeExplorer(
     contentError: null,
     pages: [],
     queued: true,
+    queuedStatus: queueStatusToSource(item.status),
   })
 
   // Real sources plus a placeholder for every in-flight queue item that has not
@@ -238,6 +256,9 @@ export function useKnowledgeExplorer(
   })
 
   const sourceStatus = (source: ExplorerSource): SourceStatus => {
+    // Placeholders carry their own status (their display name differs from the
+    // queue source, so a name lookup wouldn't find the item).
+    if (source.queued) return source.queuedStatus ?? 'queued'
     const item = queueItems.value.find((q) => q.source === source.name)
     if (item?.status === 'failed') return 'error'
     if (item?.status === 'processing') return 'crawling'

--- a/frontend/src/composables/useKnowledgeExplorer.ts
+++ b/frontend/src/composables/useKnowledgeExplorer.ts
@@ -40,6 +40,9 @@ export interface ExplorerSource {
   loadingContent: boolean
   contentError: string | null
   pages: KnowledgeSubPage[] | null
+  // True for a placeholder built from an in-flight queue item that has not yet
+  // produced a real Knowledge source (id is the negated queue-item id).
+  queued?: boolean
 }
 
 const POLL_INTERVAL_MS = 10000
@@ -74,6 +77,19 @@ export function useKnowledgeExplorer(
   // Source names that were crawling on the previous poll tick, so we can force a
   // final content refresh once a crawl finishes.
   let crawlingNames = new Set<string>()
+  // Queue-item ids seen on the previous tick, so we detect a crawl finishing
+  // (an item leaving the queue) even if it was never observed as active.
+  let lastQueueIds = new Set<number>()
+
+  const queueIds = () => new Set(queueItems.value.map((q) => q.id))
+  const activeCrawlNames = () =>
+    new Set(
+      queueItems.value
+        .filter((q) => q.status === 'pending' || q.status === 'processing')
+        .map((q) => q.source),
+    )
+  const setsDiffer = (a: Set<number>, b: Set<number>) =>
+    a.size !== b.size || [...a].some((id) => !b.has(id))
 
   const findSource = (id: number) => sources.value.find((s) => s.id === id)
 
@@ -121,14 +137,52 @@ export function useKnowledgeExplorer(
   }
 
   const fetchQueue = async () => {
-    if (mode !== 'agent' || !agentId) return
     try {
-      const response = await knowledgeService.getAgentQueueItems(agentId)
+      const response =
+        mode === 'agent' && agentId
+          ? await knowledgeService.getAgentQueueItems(agentId)
+          : await knowledgeService.getOrgQueueItems(organizationId)
       queueItems.value = response.queue_items || []
     } catch (err) {
       console.error('Failed to load knowledge queue:', err)
     }
   }
+
+  // A queue item's source_type ('website' | 'pdf_url' | 'pdf_file') mapped to the
+  // tree's source-kind glyph.
+  const queueKind = (sourceType: string): string => {
+    if (sourceType.includes('pdf')) return 'pdf'
+    if (sourceType.includes('web')) return 'web'
+    return 'custom'
+  }
+
+  // Placeholder source for an in-flight queue item (negative id = queue-item id).
+  const toSyntheticSource = (item: QueueItem): ExplorerSource => ({
+    id: -item.id,
+    name: item.source,
+    type: queueKind(item.source_type),
+    pageStubs: [],
+    expanded: false,
+    loadingContent: false,
+    contentError: null,
+    pages: [],
+    queued: true,
+  })
+
+  // Real sources plus a placeholder for every in-flight queue item that has not
+  // yet produced a real source — so a just-queued crawl shows immediately and is
+  // replaced by the real source once indexing completes and the poll refetches.
+  const allSources = computed<ExplorerSource[]>(() => {
+    const realNames = new Set(sources.value.map((s) => s.name))
+    const seen = new Set<string>()
+    const placeholders: ExplorerSource[] = []
+    for (const item of queueItems.value) {
+      if (realNames.has(item.source) || seen.has(item.source)) continue
+      seen.add(item.source)
+      placeholders.push(toSyntheticSource(item))
+    }
+    return [...placeholders, ...sources.value]
+  })
 
   // Resolve the source by id on every mutation. A concurrent (poll-driven)
   // fetchSources() replaces the objects in `sources.value`, so writing to the
@@ -211,8 +265,8 @@ export function useKnowledgeExplorer(
 
   const filteredSources = computed(() => {
     const q = normalizedQuery.value
-    if (!q) return sources.value
-    return sources.value.filter((source) => {
+    if (!q) return allSources.value
+    return allSources.value.filter((source) => {
       if (source.name.toLowerCase().includes(q)) return true
       const rows = pageRows(source)
       return rows.some((r) => r.title.toLowerCase().includes(q) || r.page_id.toLowerCase().includes(q))
@@ -276,12 +330,17 @@ export function useKnowledgeExplorer(
     isDeleting.value = true
     error.value = null
     try {
-      await knowledgeService.deleteKnowledge(source.id)
+      // A queued placeholder isn't a real source yet — cancel its queue item.
+      if (source.queued) {
+        await knowledgeService.deleteQueueItem(-source.id)
+      } else {
+        await knowledgeService.deleteKnowledge(source.id)
+      }
       if (selectedSourceId.value === source.id) {
         selectedSourceId.value = null
         selectedPageId.value = null
       }
-      await fetchSources()
+      await Promise.all([fetchSources(), fetchQueue()])
     } catch (err: unknown) {
       console.error('Failed to delete source:', err)
       error.value = err instanceof Error ? err.message : 'Failed to delete source'
@@ -346,20 +405,22 @@ export function useKnowledgeExplorer(
 
   const refresh = async () => {
     await Promise.all([fetchSources(), fetchQueue()])
+    // Baseline the queue snapshot so the first poll can detect a crawl that
+    // finishes before it is ever observed as active.
+    lastQueueIds = queueIds()
+    crawlingNames = activeCrawlNames()
   }
 
   const startPolling = () => {
-    if (pollTimer || mode !== 'agent') return
+    if (pollTimer) return
     pollTimer = setInterval(async () => {
       await fetchQueue()
-      const active = new Set(
-        queueItems.value
-          .filter((q) => q.status === 'pending' || q.status === 'processing')
-          .map((q) => q.source),
-      )
-      // Reconcile only while a crawl is in flight, or on the tick a crawl just
-      // finished, to avoid needless refetches when the tab sits idle.
-      if (active.size || crawlingNames.size) {
+      const active = activeCrawlNames()
+      const currentIds = queueIds()
+      // Reconcile when a crawl is in flight OR the queue changed since the last
+      // tick (an item was added or finished/removed) — the latter catches a
+      // crawl that completed within a single poll window.
+      if (active.size || setsDiffer(currentIds, lastQueueIds)) {
         await fetchSources(true)
         // Force-refresh the content of any expanded source that is (or just was)
         // crawling, so newly-extracted pages appear without a manual re-expand.
@@ -371,6 +432,7 @@ export function useKnowledgeExplorer(
         }
       }
       crawlingNames = active
+      lastQueueIds = currentIds
     }, POLL_INTERVAL_MS)
   }
 

--- a/frontend/src/composables/useKnowledgeExplorer.ts
+++ b/frontend/src/composables/useKnowledgeExplorer.ts
@@ -159,6 +159,7 @@ export function useKnowledgeExplorer(
   // tree's source-kind glyph.
   const queueKind = (sourceType: string): string => {
     if (sourceType.includes('pdf')) return 'pdf'
+    if (sourceType.includes('site')) return 'sitemap'
     if (sourceType.includes('web')) return 'web'
     return 'custom'
   }
@@ -453,9 +454,9 @@ export function useKnowledgeExplorer(
           description: `${payload.url} — we’ll notify you when indexing is done.`,
         })
       } else if (payload.type === 'sitemap') {
-        throwIfError(await knowledgeService.addUrls(organizationId, [payload.url], linkedAgentId))
+        throwIfError(await knowledgeService.addSitemap(organizationId, payload.url, linkedAgentId))
         toast.success('Queued for crawling', {
-          description: `${payload.url} — pages are being discovered and indexed.`,
+          description: `${payload.url} — discovering pages from the sitemap.`,
         })
       } else if (payload.type === 'pdf') {
         await knowledgeService.uploadPdfFiles(payload.files, organizationId, linkedAgentId)

--- a/frontend/src/composables/useKnowledgeExplorer.ts
+++ b/frontend/src/composables/useKnowledgeExplorer.ts
@@ -46,6 +46,8 @@ export interface ExplorerSource {
   // Status carried from the queue item for a placeholder (its display name may
   // differ from the queue `source`, so it can't be re-derived by name lookup).
   queuedStatus?: SourceStatus
+  // Failure reason for a failed queue item (e.g. blocked by bot protection).
+  queuedError?: string | null
 }
 
 const POLL_INTERVAL_MS = 10000
@@ -185,6 +187,7 @@ export function useKnowledgeExplorer(
     pages: [],
     queued: true,
     queuedStatus: queueStatusToSource(item.status),
+    queuedError: item.status === 'failed' ? item.error ?? null : null,
   })
 
   // Real sources plus a placeholder for every in-flight queue item that has not

--- a/frontend/src/composables/useKnowledgeExplorer.ts
+++ b/frontend/src/composables/useKnowledgeExplorer.ts
@@ -76,6 +76,7 @@ export function useKnowledgeExplorer(
   const isAddingPage = ref(false)
   const draftTitle = ref('')
   const draftContent = ref('')
+  const draftUrl = ref('')
   const isSaving = ref(false)
   const isDeleting = ref(false)
 
@@ -315,6 +316,7 @@ export function useKnowledgeExplorer(
     selectedPageId.value = null
     draftTitle.value = ''
     draftContent.value = ''
+    draftUrl.value = ''
     isAddingPage.value = true
     editing.value = true
     source.expanded = true
@@ -341,7 +343,7 @@ export function useKnowledgeExplorer(
     isSaving.value = true
     error.value = null
     try {
-      await knowledgeService.addSubpage(source.id, title, content)
+      await knowledgeService.addSubpage(source.id, title, content, draftUrl.value.trim() || undefined)
       await loadSourceContent(source.id, true)
       selectedPageId.value = basePageId(title)
       isAddingPage.value = false
@@ -531,6 +533,7 @@ export function useKnowledgeExplorer(
     isAddingPage,
     draftTitle,
     draftContent,
+    draftUrl,
     isSaving,
     isDeleting,
     // computed

--- a/frontend/src/composables/useKnowledgeExplorer.ts
+++ b/frontend/src/composables/useKnowledgeExplorer.ts
@@ -1,0 +1,371 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { computed, ref } from 'vue'
+import type { KnowledgeItem, KnowledgePage, KnowledgeSubPage, QueueItem } from '@/types/knowledge'
+import { knowledgeService } from '@/services/knowledge'
+import { groupChunksIntoPages, titleFromId } from '@/utils/knowledgePages'
+
+export type ExplorerMode = 'agent' | 'org'
+export type SourceStatus = 'synced' | 'crawling' | 'error'
+
+/** A knowledge source enriched with lazily-loaded, grouped sub-page content. */
+export interface ExplorerSource {
+  id: number
+  name: string
+  type: string
+  pageStubs: KnowledgePage[]
+  expanded: boolean
+  loadingContent: boolean
+  contentError: string | null
+  pages: KnowledgeSubPage[] | null
+}
+
+const POLL_INTERVAL_MS = 10000
+
+/**
+ * State engine for the master-detail knowledge explorer, shared by the
+ * agent-editor tab (`mode: 'agent'`) and the dedicated knowledge page
+ * (`mode: 'org'`). Source list is fetched eagerly; each source's sub-page
+ * content is grouped from its chunks lazily on first expand/selection.
+ */
+export function useKnowledgeExplorer(
+  mode: ExplorerMode,
+  agentId: string | undefined,
+  organizationId: string,
+) {
+  const sources = ref<ExplorerSource[]>([])
+  const queueItems = ref<QueueItem[]>([])
+  const isLoading = ref(false)
+  const error = ref<string | null>(null)
+  const query = ref('')
+
+  const selectedSourceId = ref<number | null>(null)
+  const selectedPageId = ref<string | null>(null)
+
+  const editing = ref(false)
+  const draftTitle = ref('')
+  const draftContent = ref('')
+  const isSaving = ref(false)
+  const isDeleting = ref(false)
+
+  let pollTimer: ReturnType<typeof setInterval> | null = null
+  // Source names that were crawling on the previous poll tick, so we can force a
+  // final content refresh once a crawl finishes.
+  let crawlingNames = new Set<string>()
+
+  const findSource = (id: number) => sources.value.find((s) => s.id === id)
+
+  const toExplorerSource = (item: KnowledgeItem): ExplorerSource => ({
+    id: item.id,
+    name: item.name,
+    type: item.type,
+    pageStubs: item.pages || [],
+    expanded: false,
+    loadingContent: false,
+    contentError: null,
+    pages: null,
+  })
+
+  // `background` refetches (from the crawl poll) skip the loading flag so any
+  // bound spinner doesn't flicker every tick.
+  const fetchSources = async (background = false) => {
+    if (!background) isLoading.value = true
+    error.value = null
+    try {
+      const response =
+        mode === 'agent' && agentId
+          ? await knowledgeService.getKnowledgeByAgent(agentId, 1, 100)
+          : await knowledgeService.getKnowledgeByOrganization(organizationId, 1, 100)
+
+      const items: KnowledgeItem[] = response.knowledge || []
+      // Preserve expand/loaded state across refreshes so a running crawl poll
+      // does not collapse the tree or drop already-fetched content.
+      const previous = new Map(sources.value.map((s) => [s.id, s]))
+      sources.value = items.map((item) => {
+        const prev = previous.get(item.id)
+        const next = toExplorerSource(item)
+        if (prev) {
+          next.expanded = prev.expanded
+          next.pages = prev.pages
+        }
+        return next
+      })
+    } catch (err) {
+      console.error('Failed to load knowledge sources:', err)
+      error.value = 'Failed to load knowledge sources'
+    } finally {
+      if (!background) isLoading.value = false
+    }
+  }
+
+  const fetchQueue = async () => {
+    if (mode !== 'agent' || !agentId) return
+    try {
+      const response = await knowledgeService.getAgentQueueItems(agentId)
+      queueItems.value = response.queue_items || []
+    } catch (err) {
+      console.error('Failed to load knowledge queue:', err)
+    }
+  }
+
+  // Resolve the source by id on every mutation. A concurrent (poll-driven)
+  // fetchSources() replaces the objects in `sources.value`, so writing to the
+  // originally-captured `source` would be lost — always re-find the live one.
+  const loadSourceContent = async (sourceId: number, force = false) => {
+    const source = findSource(sourceId)
+    if (!source || source.loadingContent) return
+    if (source.pages && !force) return
+    source.loadingContent = true
+    source.contentError = null
+    try {
+      const content = await knowledgeService.getKnowledgeContent(sourceId)
+      const pages = groupChunksIntoPages(content.chunks || [])
+      const live = findSource(sourceId)
+      if (live) live.pages = pages
+    } catch (err) {
+      console.error(`Failed to load content for source ${sourceId}:`, err)
+      const live = findSource(sourceId)
+      if (live) {
+        live.contentError = 'Failed to load pages'
+        live.pages = []
+      }
+    } finally {
+      const live = findSource(sourceId)
+      if (live) live.loadingContent = false
+    }
+  }
+
+  const toggleSource = async (source: ExplorerSource) => {
+    source.expanded = !source.expanded
+    if (source.expanded && source.pages === null) {
+      await loadSourceContent(source.id)
+    }
+  }
+
+  const selectPage = async (source: ExplorerSource, pageId: string) => {
+    selectedSourceId.value = source.id
+    selectedPageId.value = pageId
+    editing.value = false
+    if (source.pages === null) {
+      await loadSourceContent(source.id)
+    }
+  }
+
+  const selectedSource = computed(
+    () => sources.value.find((s) => s.id === selectedSourceId.value) ?? null,
+  )
+
+  const selectedPage = computed<KnowledgeSubPage | null>(() => {
+    const source = selectedSource.value
+    if (!source || !source.pages || selectedPageId.value === null) return null
+    return source.pages.find((p) => p.page_id === selectedPageId.value) ?? null
+  })
+
+  const sourceStatus = (source: ExplorerSource): SourceStatus => {
+    const item = queueItems.value.find((q) => q.source === source.name)
+    if (item?.status === 'failed') return 'error'
+    if (item && (item.status === 'pending' || item.status === 'processing')) return 'crawling'
+    return 'synced'
+  }
+
+  // Page rows for the tree: grouped pages once loaded, else lightweight stubs.
+  const pageRows = (source: ExplorerSource) => {
+    if (source.pages) {
+      return source.pages.map((p) => ({
+        page_id: p.page_id,
+        title: p.title,
+        words: p.word_count,
+      }))
+    }
+    return source.pageStubs.map((stub: KnowledgePage) => ({
+      page_id: stub.subpage,
+      title: titleFromId(stub.subpage),
+      words: null as number | null,
+    }))
+  }
+
+  const normalizedQuery = computed(() => query.value.trim().toLowerCase())
+
+  const filteredSources = computed(() => {
+    const q = normalizedQuery.value
+    if (!q) return sources.value
+    return sources.value.filter((source) => {
+      if (source.name.toLowerCase().includes(q)) return true
+      const rows = pageRows(source)
+      return rows.some((r) => r.title.toLowerCase().includes(q) || r.page_id.toLowerCase().includes(q))
+    })
+  })
+
+  const startEdit = () => {
+    const page = selectedPage.value
+    if (!page) return
+    draftTitle.value = page.title
+    draftContent.value = page.content
+    editing.value = true
+  }
+
+  const cancelEdit = () => {
+    editing.value = false
+  }
+
+  const savePage = async () => {
+    const source = selectedSource.value
+    const page = selectedPage.value
+    if (!source || !page) return
+    const content = draftContent.value.trim()
+    if (!content) {
+      error.value = 'Page content cannot be empty'
+      return
+    }
+    isSaving.value = true
+    error.value = null
+    try {
+      await knowledgeService.updatePage(source.id, page.page_id, content, draftTitle.value.trim())
+      await loadSourceContent(source.id, true)
+      editing.value = false
+    } catch (err: unknown) {
+      console.error('Failed to save page:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to save page'
+    } finally {
+      isSaving.value = false
+    }
+  }
+
+  const deletePage = async () => {
+    const source = selectedSource.value
+    const page = selectedPage.value
+    if (!source || !page) return
+    isDeleting.value = true
+    error.value = null
+    try {
+      await knowledgeService.deletePage(source.id, page.page_id)
+      selectedPageId.value = null
+      await loadSourceContent(source.id, true)
+    } catch (err: unknown) {
+      console.error('Failed to delete page:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to delete page'
+    } finally {
+      isDeleting.value = false
+    }
+  }
+
+  const deleteSource = async (source: ExplorerSource) => {
+    isDeleting.value = true
+    error.value = null
+    try {
+      await knowledgeService.deleteKnowledge(source.id)
+      if (selectedSourceId.value === source.id) {
+        selectedSourceId.value = null
+        selectedPageId.value = null
+      }
+      await fetchSources()
+    } catch (err: unknown) {
+      console.error('Failed to delete source:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to delete source'
+    } finally {
+      isDeleting.value = false
+    }
+  }
+
+  const addSource = async (rawUrl: string) => {
+    const url = rawUrl.trim()
+    if (!url) return
+    error.value = null
+    try {
+      await knowledgeService.addUrls(organizationId, [url], mode === 'agent' ? agentId : undefined)
+      await Promise.all([fetchSources(), fetchQueue()])
+    } catch (err: unknown) {
+      console.error('Failed to add source:', err)
+      error.value = err instanceof Error ? err.message : 'Failed to add source'
+      throw err
+    }
+  }
+
+  const refresh = async () => {
+    await Promise.all([fetchSources(), fetchQueue()])
+  }
+
+  const startPolling = () => {
+    if (pollTimer || mode !== 'agent') return
+    pollTimer = setInterval(async () => {
+      await fetchQueue()
+      const active = new Set(
+        queueItems.value
+          .filter((q) => q.status === 'pending' || q.status === 'processing')
+          .map((q) => q.source),
+      )
+      // Reconcile only while a crawl is in flight, or on the tick a crawl just
+      // finished, to avoid needless refetches when the tab sits idle.
+      if (active.size || crawlingNames.size) {
+        await fetchSources(true)
+        // Force-refresh the content of any expanded source that is (or just was)
+        // crawling, so newly-extracted pages appear without a manual re-expand.
+        const touched = new Set<string>([...active, ...crawlingNames])
+        for (const source of sources.value) {
+          if (source.expanded && touched.has(source.name)) {
+            await loadSourceContent(source.id, true)
+          }
+        }
+      }
+      crawlingNames = active
+    }, POLL_INTERVAL_MS)
+  }
+
+  const stopPolling = () => {
+    if (pollTimer) {
+      clearInterval(pollTimer)
+      pollTimer = null
+    }
+  }
+
+  return {
+    // state
+    sources,
+    queueItems,
+    isLoading,
+    error,
+    query,
+    selectedSourceId,
+    selectedPageId,
+    editing,
+    draftTitle,
+    draftContent,
+    isSaving,
+    isDeleting,
+    // computed
+    selectedSource,
+    selectedPage,
+    filteredSources,
+    // helpers for the view
+    sourceStatus,
+    pageRows,
+    // actions
+    fetchSources,
+    fetchQueue,
+    refresh,
+    toggleSource,
+    selectPage,
+    startEdit,
+    cancelEdit,
+    savePage,
+    deletePage,
+    deleteSource,
+    addSource,
+    startPolling,
+    stopPolling,
+  }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -68,6 +68,17 @@ const baseRoutes = [
     },
   },
   {
+    path: '/knowledge',
+    name: 'knowledge',
+    component: () => import('@/views/KnowledgeView.vue'),
+    meta: {
+      requiresAuth: true,
+      layout: 'dashboard',
+      title: 'Knowledge Base',
+      permissions: ['manage_knowledge'],
+    },
+  },
+  {
     path: '/widget/:id',
     name: 'widget',
     component: () => import('@/webclient/WidgetBuilder.vue'),

--- a/frontend/src/services/knowledge.ts
+++ b/frontend/src/services/knowledge.ts
@@ -164,10 +164,11 @@ export const knowledgeService = {
     return response.data
   },
 
-  async addSubpage(knowledgeId: number, subpageName: string, content: string) {
+  async addSubpage(knowledgeId: number, subpageName: string, content: string, url?: string) {
     const response = await api.post(`/knowledge/${knowledgeId}/subpage`, {
       subpage_name: subpageName,
-      content
+      content,
+      ...(url ? { url } : {}),
     })
     return response.data
   },

--- a/frontend/src/services/knowledge.ts
+++ b/frontend/src/services/knowledge.ts
@@ -157,10 +157,28 @@ export const knowledgeService = {
   },
 
   async addSubpage(knowledgeId: number, subpageName: string, content: string) {
-    const response = await api.post(`/knowledge/${knowledgeId}/subpage`, { 
+    const response = await api.post(`/knowledge/${knowledgeId}/subpage`, {
       subpage_name: subpageName,
-      content 
+      content
     })
+    return response.data
+  },
+
+  // Replace a whole sub-page's content and re-embed it. `pageId` is the page's
+  // base id (its URL/name) — encoded for the backend `:path` route param.
+  async updatePage(knowledgeId: number, pageId: string, content: string, title?: string) {
+    const response = await api.put(
+      `/knowledge/${knowledgeId}/page/${encodeURIComponent(pageId)}`,
+      { content, title },
+    )
+    return response.data
+  },
+
+  // Delete an entire sub-page (all of its chunks) from a knowledge source.
+  async deletePage(knowledgeId: number, pageId: string) {
+    const response = await api.delete(
+      `/knowledge/${knowledgeId}/page/${encodeURIComponent(pageId)}`,
+    )
     return response.data
   },
 }

--- a/frontend/src/services/knowledge.ts
+++ b/frontend/src/services/knowledge.ts
@@ -138,6 +138,11 @@ export const knowledgeService = {
     return response.data
   },
 
+  async getOrgQueueItems(orgId: string) {
+    const response = await api.get(`/knowledge/queue/organization/${orgId}`)
+    return response.data
+  },
+
   async deleteQueueItem(queueId: number) {
     const response = await api.delete(`/knowledge/queue/${queueId}`)
     return response.data

--- a/frontend/src/services/knowledge.ts
+++ b/frontend/src/services/knowledge.ts
@@ -59,6 +59,7 @@ export const knowledgeService = {
     urls: string[],
     agentId?: string,
     onProgress?: (progress: number) => void,
+    maxLinks?: number,
   ): Promise<KnowledgeUploadResponse> {
     try {
       let completed = 0
@@ -67,6 +68,8 @@ export const knowledgeService = {
         agent_id: agentId,
         pdf_urls: urls.filter((url) => url.toLowerCase().endsWith('.pdf')),
         websites: urls.filter((url) => !url.toLowerCase().endsWith('.pdf')),
+        // Optional crawl-scope cap for websites (e.g. 1 = "this page only").
+        ...(maxLinks ? { max_links: maxLinks } : {}),
       })
       if (onProgress) {
         const interval = setInterval(() => {
@@ -180,6 +183,23 @@ export const knowledgeService = {
       `/knowledge/${knowledgeId}/page/${encodeURIComponent(pageId)}`,
     )
     return response.data
+  },
+
+  // Create a knowledge source from pasted text; indexed immediately (no crawl).
+  async addText(orgId: string, title: string, content: string, agentId?: string) {
+    try {
+      const response = await api.post('/knowledge/add/text', {
+        org_id: orgId,
+        title,
+        content,
+        agent_id: agentId,
+      })
+      return response.data
+    } catch (error: any) {
+      const errorMessage =
+        error.response?.data?.detail || error.response?.data?.message || 'Failed to add text source'
+      throw new Error(errorMessage)
+    }
   },
 }
 

--- a/frontend/src/services/knowledge.ts
+++ b/frontend/src/services/knowledge.ts
@@ -191,6 +191,22 @@ export const knowledgeService = {
     return response.data
   },
 
+  // Add a sitemap source — the backend discovers and crawls its listed pages.
+  async addSitemap(orgId: string, url: string, agentId?: string): Promise<KnowledgeUploadResponse> {
+    try {
+      const response = await api.post('/knowledge/add/urls', {
+        org_id: orgId,
+        agent_id: agentId,
+        sitemaps: [url],
+      })
+      return response.data
+    } catch (error: any) {
+      const errorMessage =
+        error.response?.data?.detail || error.response?.data?.message || 'Failed to add sitemap'
+      throw new Error(errorMessage)
+    }
+  },
+
   // Create a knowledge source from pasted text; indexed immediately (no crawl).
   async addText(orgId: string, title: string, content: string, agentId?: string) {
     try {

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -75,3 +75,16 @@ export interface KnowledgeContent {
   chunks: KnowledgeContentChunk[]
 }
 
+// A crawled sub-page, reconstructed on the client by grouping the content chunks
+// of a source by their base id (the page URL/name, minus any `_N` chunk suffix).
+export interface KnowledgeSubPage {
+  page_id: string
+  url: string
+  title: string
+  content: string
+  word_count: number
+  chunk_count: number
+  updated_at: string | null
+  chunk_ids: string[]
+}
+

--- a/frontend/src/utils/knowledgePages.ts
+++ b/frontend/src/utils/knowledgePages.ts
@@ -1,0 +1,93 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type { KnowledgeContentChunk, KnowledgeSubPage } from '@/types/knowledge'
+
+/**
+ * Map a chunk id back to its page id by stripping a trailing `_<number>` chunk
+ * suffix (agno splits a page into `<page>_1`, `<page>_2` … chunks).
+ *
+ * Only a numeric suffix is stripped, so real underscores in a page name (e.g.
+ * `getting_started`) are preserved. Mirrors the backend `PAGE_ID_EXPR`
+ * (app/knowledge/page_editor.py) exactly, so the id derived here is the same
+ * `page_id` the backend expects for edit/delete and the `subpage` value it
+ * returns when listing sources — keep the two in sync.
+ */
+export function basePageId(id: string): string {
+  return id.replace(/_\d+$/, '')
+}
+
+function countWords(text: string): number {
+  const trimmed = text.trim()
+  return trimmed ? trimmed.split(/\s+/).length : 0
+}
+
+function laterIso(a: string | null, b: string | null): string | null {
+  if (!a) return b
+  if (!b) return a
+  return a > b ? a : b
+}
+
+/**
+ * Group a source's content chunks into sub-pages. Chunks are concatenated in
+ * their existing order (the backend returns them ordered by `created_at`), and
+ * page-level url/title/updated_at are taken from the chunk metadata.
+ */
+export function groupChunksIntoPages(chunks: KnowledgeContentChunk[]): KnowledgeSubPage[] {
+  const byPage = new Map<string, KnowledgeSubPage>()
+  const order: string[] = []
+
+  for (const chunk of chunks) {
+    const pageId = basePageId(chunk.id)
+    const meta = chunk.metadata || {}
+    const content = chunk.content || ''
+
+    let page = byPage.get(pageId)
+    if (!page) {
+      page = {
+        page_id: pageId,
+        url: typeof meta.url === 'string' && meta.url ? meta.url : pageId,
+        title: typeof meta.title === 'string' && meta.title ? meta.title : titleFromId(pageId),
+        content: '',
+        word_count: 0,
+        chunk_count: 0,
+        updated_at: chunk.created_at ?? null,
+        chunk_ids: [],
+      }
+      byPage.set(pageId, page)
+      order.push(pageId)
+    }
+
+    page.content = page.content ? `${page.content}\n\n${content}` : content
+    page.chunk_count += 1
+    page.chunk_ids.push(chunk.id)
+    page.updated_at = laterIso(page.updated_at, chunk.created_at ?? null)
+  }
+
+  for (const pageId of order) {
+    const page = byPage.get(pageId)!
+    page.word_count = countWords(page.content)
+  }
+
+  return order.map((pageId) => byPage.get(pageId)!)
+}
+
+/** Human-ish title fallback: last non-empty URL/path segment of the page id. */
+export function titleFromId(pageId: string): string {
+  const cleaned = pageId.replace(/[#?].*$/, '').replace(/\/+$/, '')
+  const segment = cleaned.split('/').filter(Boolean).pop()
+  return segment || pageId
+}

--- a/frontend/src/views/KnowledgeView.vue
+++ b/frontend/src/views/KnowledgeView.vue
@@ -1,0 +1,73 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<script setup lang="ts">
+import { computed } from 'vue'
+import DashboardLayout from '@/layouts/DashboardLayout.vue'
+import KnowledgeExplorer from '@/components/knowledge/KnowledgeExplorer.vue'
+import { userService } from '@/services/user'
+
+const organizationId = computed(() => userService.getCurrentUser()?.organization_id ?? '')
+</script>
+
+<template>
+  <DashboardLayout>
+    <div class="knowledge-view">
+      <header class="knowledge-view__header">
+        <h1 class="knowledge-view__title">Knowledge base</h1>
+        <p class="knowledge-view__subtitle">
+          Every page your AI agents learn from. Review and edit the extracted content, add pages of
+          your own, and choose what stays in your knowledge base.
+        </p>
+      </header>
+
+      <KnowledgeExplorer
+        v-if="organizationId"
+        mode="org"
+        :organization-id="organizationId"
+        :show-plan-meters="true"
+      />
+    </div>
+  </DashboardLayout>
+</template>
+
+<style scoped>
+.knowledge-view {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 32px 24px 60px;
+}
+
+.knowledge-view__header {
+  margin-bottom: 24px;
+}
+
+.knowledge-view__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 30px;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  margin: 0 0 8px;
+}
+
+.knowledge-view__subtitle {
+  font-size: 15px;
+  color: var(--muted);
+  margin: 0;
+  max-width: 600px;
+  line-height: 1.55;
+}
+</style>

--- a/frontend/src/views/KnowledgeView.vue
+++ b/frontend/src/views/KnowledgeView.vue
@@ -20,22 +20,21 @@ import KnowledgeExplorer from '@/components/knowledge/KnowledgeExplorer.vue'
 import { userService } from '@/services/user'
 
 const organizationId = computed(() => userService.getCurrentUser()?.organization_id ?? '')
+
+const description =
+  'Every page your AI agents learn from. Review and edit the extracted content, add pages of ' +
+  'your own, and choose what stays in your knowledge base.'
 </script>
 
 <template>
   <DashboardLayout>
     <div class="knowledge-view">
-      <header class="knowledge-view__header">
-        <h1 class="knowledge-view__title">Knowledge base</h1>
-        <p class="knowledge-view__subtitle">
-          Every page your AI agents learn from. Review and edit the extracted content, add pages of
-          your own, and choose what stays in your knowledge base.
-        </p>
-      </header>
-
       <KnowledgeExplorer
         v-if="organizationId"
         mode="org"
+        variant="page"
+        title="Knowledge base"
+        :description="description"
         :organization-id="organizationId"
         :show-plan-meters="true"
       />
@@ -48,26 +47,5 @@ const organizationId = computed(() => userService.getCurrentUser()?.organization
   max-width: 1240px;
   margin: 0 auto;
   padding: 32px 24px 60px;
-}
-
-.knowledge-view__header {
-  margin-bottom: 24px;
-}
-
-.knowledge-view__title {
-  font-family: var(--font-display);
-  font-weight: 700;
-  font-size: 30px;
-  letter-spacing: -0.02em;
-  color: var(--text);
-  margin: 0 0 8px;
-}
-
-.knowledge-view__subtitle {
-  font-size: 15px;
-  color: var(--muted);
-  margin: 0;
-  max-width: 600px;
-  line-height: 1.55;
 }
 </style>


### PR DESCRIPTION
## What & why

Today the Knowledge UI shows only a **flat list of sources** (name / type / “indexed” / Remove). Users can't see the individual sub-pages a crawl produced, can't read or edit the extracted content, and there's **no dedicated place to manage the whole org's knowledge base** — it lives only as a tab inside each agent.

This reframes knowledge around the **pages an agent actually learns from**: a source → sub-page tree with a content reader/editor. Editing a page **re-embeds** it so answers stay current. Delivered on two surfaces from one reusable component:

1. **Agent editor → Knowledge tab** — every crawled sub-page per source; read, edit + re-embed, delete, add sources.
2. **New dedicated `/knowledge` page** (sidebar entry, `manage_knowledge` gated) with plan-usage meters, for managing the whole knowledge base.

## Backend

- **`app/knowledge/page_editor.py`** (new) centralises embed / upsert / delete of sub-pages — dedupes logic previously inlined in `update_chunk_content` and `add_subpage` (all imports at module top).
- **New endpoints** `PUT` / `DELETE /knowledge/{id}/page/{page_id}`. `replace_page` **upserts the new content before deleting old chunks**, so an insert failure can never leave a page empty (no data loss); `upsert` also avoids duplicate-key errors.
- **Page grouping** now strips only a trailing `_<number>` chunk suffix via a shared `PAGE_ID_EXPR`, so pages like `getting_started` are no longer collapsed together. The two source-listing queries reuse the same expression, and the sub-page limit now counts **distinct pages**, not chunks.
- `update_chunk_content` / `delete_chunk` reuse a shared `_require_editable_knowledge` ownership guard.

## Frontend

- **`KnowledgeExplorer`** + `KnowledgeSourceTree` / `KnowledgePageDetail` / `KnowledgePageEditor` / `KnowledgePlanMeters` — one reusable, master-detail component used by both surfaces.
- **`useKnowledgeExplorer`** composable groups chunks into pages (matching the backend rule), lazy-loads content, and polls crawl status live without ever writing content onto a stale source reference.
- Design-token styling only (light + dark); no hardcoded colours.

## Scope notes

- v1 is **delete-only** (the mockup's soft-exclude "In knowledge base" toggle is deferred — it needs a retrieval-path flag).
- "Generate FAQs" is **omitted** (no FAQ feature exists yet).
- `KnowledgeGrid.vue` is retained (still used by the workflow LLM node); the explorer coexists.

## Testing

- Backend: `tests/api/test_knowledge.py` — **25 passed, 1 skipped** (7 new tests covering the page endpoints incl. an ordering test that locks upsert-before-delete). Existing behaviour unchanged.
- Frontend: full unit suite **114 passed**; new `knowledgePages.spec.ts` (8 tests) locks page-id grouping to the backend rule. `vue-tsc` type-check clean.
- Multi-agent code review (correctness + cross-file + frontend wiring) and a security review — all findings addressed; security review found no exploitable issues.

### Manual verification (reviewer)
Open an agent's **Knowledge** tab → add a URL, watch the crawl progress, expand the source, select a page, **Edit → change text → Save** (confirms the `PUT .../page` fires and content updates), delete a page. Then open **/knowledge** from the sidebar and repeat, checking the plan meters. Verify light + dark themes.