### PR TITLE
feat(knowledge): show which agents each source is linked to

### DIFF
--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -28,6 +28,7 @@ from sqlalchemy import text
 from uuid import UUID
 from app.database import get_db
 from app.models.knowledge_to_agent import KnowledgeToAgent
+from app.models.agent import Agent
 from app.models.knowledge import Knowledge
 from app.repositories.knowledge import KnowledgeRepository
 from app.knowledge import page_editor
@@ -879,6 +880,28 @@ async def unlink_knowledge_from_agent(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+def _linked_agents_map(db: Session, knowledge_items) -> dict:
+    """Map knowledge_id -> [{id, name}] of the agents each source is linked to.
+
+    Batched into a single query over the page's sources to avoid N+1 lookups.
+    """
+    ids = [k.id for k in knowledge_items]
+    if not ids:
+        return {}
+    rows = (
+        db.query(KnowledgeToAgent.knowledge_id, Agent.id, Agent.name, Agent.display_name)
+        .join(Agent, Agent.id == KnowledgeToAgent.agent_id)
+        .filter(KnowledgeToAgent.knowledge_id.in_(ids))
+        .all()
+    )
+    result: dict = {}
+    for knowledge_id, agent_id, name, display_name in rows:
+        result.setdefault(knowledge_id, []).append(
+            {"id": str(agent_id), "name": display_name or name}
+        )
+    return result
+
+
 @router.get("/agent/{agent_id}")
 async def get_knowledge_by_agent(
     agent_id: str,
@@ -909,6 +932,7 @@ async def get_knowledge_by_agent(
         )
 
 
+        agents_map = _linked_agents_map(db, knowledge_items)
         result = []
         for k in knowledge_items:
             # Base knowledge data
@@ -916,6 +940,7 @@ async def get_knowledge_by_agent(
                 "id": k.id,
                 "name": k.source,
                 "type": k.source_type.value,
+                "agents": agents_map.get(k.id, []),
                 "pages": []
             }
 
@@ -1126,6 +1151,7 @@ async def get_knowledge_by_organization(
         )
         logger.debug(f"Knowledge items for organization {org_uuid}: {knowledge_items}")
 
+        agents_map = _linked_agents_map(db, knowledge_items)
         result = []
         for k in knowledge_items:
             # Base knowledge data
@@ -1133,6 +1159,7 @@ async def get_knowledge_by_organization(
                 "id": k.id,
                 "name": k.source,
                 "type": k.source_type.value,
+                "agents": agents_map.get(k.id, []),
                 "pages": []
             }
 

--- a/backend/tests/api/test_knowledge.py
+++ b/backend/tests/api/test_knowledge.py
@@ -308,6 +308,10 @@ def test_get_knowledge_by_agent(client: TestClient, test_knowledge, test_agent, 
     assert "knowledge" in data
     assert len(data["knowledge"]) == 1
     assert data["knowledge"][0]["id"] == test_knowledge.id
+    # The source reports which agents it is linked to.
+    agents = data["knowledge"][0]["agents"]
+    assert [a["id"] for a in agents] == [str(test_agent.id)]
+    assert agents[0]["name"] == (test_agent.display_name or test_agent.name)
     assert "pagination" in data
     assert data["pagination"]["page"] == 1
     assert data["pagination"]["page_size"] == 10

--- a/frontend/src/components/knowledge/KnowledgeExplorer.vue
+++ b/frontend/src/components/knowledge/KnowledgeExplorer.vue
@@ -213,6 +213,7 @@ onUnmounted(() => {
           :page="ex.selectedPage.value"
           :source-name="ex.selectedSource.value.name"
           :source-type="ex.selectedSource.value.type"
+          :agents="ex.selectedSource.value.agents"
           :status="ex.sourceStatus(ex.selectedSource.value)"
           :deleting="ex.isDeleting.value"
           @edit="ex.startEdit"

--- a/frontend/src/components/knowledge/KnowledgePageDetail.vue
+++ b/frontend/src/components/knowledge/KnowledgePageDetail.vue
@@ -15,16 +15,20 @@ limitations under the License.
 -->
 <script setup lang="ts">
 import { computed } from 'vue'
-import type { KnowledgeSubPage } from '@/types/knowledge'
+import type { KnowledgeLinkedAgent, KnowledgeSubPage } from '@/types/knowledge'
 import type { SourceStatus } from '@/composables/useKnowledgeExplorer'
 
 const props = defineProps<{
   page: KnowledgeSubPage
   sourceName: string
   sourceType: string
+  agents?: KnowledgeLinkedAgent[]
   status: SourceStatus
   deleting: boolean
 }>()
+
+// First-letter avatar for an agent chip.
+const initial = (name: string) => (name.trim()[0] || '?').toUpperCase()
 
 defineEmits<{
   (e: 'edit'): void
@@ -104,6 +108,14 @@ const updatedLabel = computed(() => {
         <span class="meta__sep"></span>
         <span class="pill" :class="`pill--${status}`">
           <span class="pill__dot"></span>{{ statusText[status] }}
+        </span>
+      </div>
+
+      <div v-if="agents && agents.length" class="usedby">
+        <span class="usedby__label">Used by</span>
+        <span v-for="agent in agents" :key="agent.id" class="agent-chip" :title="agent.name">
+          <span class="agent-chip__avatar">{{ initial(agent.name) }}</span>
+          <span class="agent-chip__name">{{ agent.name }}</span>
         </span>
       </div>
     </div>
@@ -270,6 +282,57 @@ const updatedLabel = computed(() => {
   height: 6px;
   border-radius: 50%;
   background: currentColor;
+}
+
+.usedby {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 14px;
+}
+
+.usedby__label {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted2);
+}
+
+.agent-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px 3px 3px;
+  border-radius: 999px;
+  border: 1px solid var(--o12);
+  background: var(--o05);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text2);
+  max-width: 180px;
+}
+
+.agent-chip__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--teal-bg);
+  color: var(--c-teal);
+  font-size: 10.5px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.agent-chip__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .pill--crawling {

--- a/frontend/src/components/knowledge/KnowledgeSourceTree.vue
+++ b/frontend/src/components/knowledge/KnowledgeSourceTree.vue
@@ -68,6 +68,12 @@ function sourceGlyph(type: string): string {
   if (t.includes('web')) return 'W'
   return 'T'
 }
+
+// First-letter avatar for a linked agent.
+const agentInitial = (name: string) => (name.trim()[0] || '?').toUpperCase()
+
+// Show at most this many agent avatars on a source row; the rest fold into "+N".
+const MAX_AVATARS = 3
 </script>
 
 <template>
@@ -111,6 +117,20 @@ function sourceGlyph(type: string): string {
               </span>
             </span>
           </button>
+          <span
+            v-if="!source.queued && source.agents.length"
+            class="agents"
+            :title="`Used by ${source.agents.map((a) => a.name).join(', ')}`"
+          >
+            <span
+              v-for="agent in source.agents.slice(0, MAX_AVATARS)"
+              :key="agent.id"
+              class="agents__avatar"
+            >{{ agentInitial(agent.name) }}</span>
+            <span v-if="source.agents.length > MAX_AVATARS" class="agents__more">
+              +{{ source.agents.length - MAX_AVATARS }}
+            </span>
+          </span>
           <span class="dot" :class="`dot--${statusOf(source)}`" :title="statusLabel[statusOf(source)]"></span>
           <button
             v-if="!source.queued"
@@ -309,6 +329,38 @@ function sourceGlyph(type: string): string {
 
 .src__count--error {
   color: var(--c-coral);
+}
+
+.agents {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.agents__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--teal-bg);
+  color: var(--c-teal);
+  font-size: 10px;
+  font-weight: 700;
+  border: 1.5px solid var(--surface);
+  margin-left: -6px;
+}
+
+.agents__avatar:first-child {
+  margin-left: 0;
+}
+
+.agents__more {
+  margin-left: 4px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--muted2);
 }
 
 .dot {

--- a/frontend/src/composables/useKnowledgeExplorer.ts
+++ b/frontend/src/composables/useKnowledgeExplorer.ts
@@ -16,7 +16,13 @@ limitations under the License.
 
 import { computed, ref } from 'vue'
 import { toast } from 'vue-sonner'
-import type { KnowledgeItem, KnowledgePage, KnowledgeSubPage, QueueItem } from '@/types/knowledge'
+import type {
+  KnowledgeItem,
+  KnowledgeLinkedAgent,
+  KnowledgePage,
+  KnowledgeSubPage,
+  QueueItem,
+} from '@/types/knowledge'
 import { knowledgeService } from '@/services/knowledge'
 import { basePageId, groupChunksIntoPages, titleFromId } from '@/utils/knowledgePages'
 
@@ -35,6 +41,8 @@ export interface ExplorerSource {
   id: number
   name: string
   type: string
+  // Agents this source is linked to (for the "Used by" chips).
+  agents: KnowledgeLinkedAgent[]
   pageStubs: KnowledgePage[]
   expanded: boolean
   loadingContent: boolean
@@ -104,6 +112,7 @@ export function useKnowledgeExplorer(
     id: item.id,
     name: item.name,
     type: item.type,
+    agents: item.agents || [],
     pageStubs: item.pages || [],
     expanded: false,
     loadingContent: false,
@@ -183,6 +192,7 @@ export function useKnowledgeExplorer(
     id: -item.id,
     name: queueSourceName(item),
     type: queueKind(item.source_type),
+    agents: [],
     pageStubs: [],
     expanded: false,
     loadingContent: false,

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -31,11 +31,18 @@ export interface KnowledgePage {
   updated_at: string | null
 }
 
+// An agent a knowledge source is linked to, as reported by the source list.
+export interface KnowledgeLinkedAgent {
+  id: string
+  name: string
+}
+
 export interface KnowledgeItem {
   id: number
   name: string
   type: string
   pages: KnowledgePage[]
+  agents?: KnowledgeLinkedAgent[]
   error?: string
 }
 


### PR DESCRIPTION
## What & why

The knowledge explorer never showed which agent(s) a source feeds, which made the knowledge tab confusing — you couldn't tell what a given source was actually used for. This surfaces that link.

## Changes

**Backend** (`app/api/knowledge.py`)
- New `_linked_agents_map()` helper: a single `KnowledgeToAgent`→`Agent` join over the page's sources (no N+1), returning `knowledge_id → [{id, name}]` (uses `display_name or name`).
- Both source-list endpoints (`/agent/{id}` and `/organization/{id}`) now include `"agents": [{id, name}]` on each source.
- Test asserts the `agents` field is populated for a linked source.

**Frontend**
- `agents` carried through `KnowledgeItem` → `ExplorerSource` (`toExplorerSource`).
- `KnowledgeSourceTree`: overlapping agent avatars on each source row (up to 3, then `+N`), with a full "Used by …" tooltip.
- `KnowledgePageDetail`: a "Used by" chip row (avatar + name) in the detail header.
- All styling uses design tokens (light + dark).

## Testing
- `pytest tests/api/test_knowledge.py` → 34 passed.
- `vue-tsc` clean; `vitest` → 114 passed.