### PR TITLE
FAQ Manager & public Help Center (auto-generated from knowledge base)

### DIFF
--- a/HELP_CENTER_INFRA.md
+++ b/HELP_CENTER_INFRA.md
@@ -1,0 +1,123 @@
+# Help Center hosting — infrastructure runbook
+
+The public help center is served by the backend itself (host-dispatched SSR —
+see `backend/app/core/help_center_host.py`). This runbook covers the
+deploy-time pieces that live **outside** the repo: DNS, TLS and the host
+nginx on the production VPS. `frontend/nginx.conf` and the docker-compose
+files need **no changes**.
+
+## 1. One-time platform setup
+
+### DNS
+1. Register `chattermate.help` (or set `HELP_CENTER_BASE_DOMAIN` to another
+   zone) and point it at the VPS:
+   - `*.chattermate.help.  A  <VPS_IP>`
+2. Create the CNAME target customers point their own domains at:
+   - `cname.chattermate.chat.  A  <VPS_IP>`
+   (or set `HELP_CENTER_CNAME_TARGET` accordingly)
+3. Backend env (`.env` on the VPS):
+   ```
+   HELP_CENTER_BASE_DOMAIN=chattermate.help
+   HELP_CENTER_CNAME_TARGET=cname.chattermate.chat
+   HELP_CENTER_TARGET_IPS=<VPS_IP>        # accepted for CNAME-flattened records
+   ```
+
+### Wildcard certificate (DNS-01)
+HTTP-01 cannot issue wildcards; use the DNS provider's certbot plugin
+(example for Cloudflare — pick the matching `certbot-dns-*` package):
+```bash
+sudo apt install certbot python3-certbot-dns-cloudflare
+sudo certbot certonly --dns-cloudflare \
+  --dns-cloudflare-credentials /root/.secrets/cf.ini \
+  -d '*.chattermate.help' -d 'chattermate.help'
+```
+Renewal is automatic via the standard certbot timer.
+
+### Host nginx server blocks
+Add to the host nginx (alongside the existing chattermate.chat block).
+`proxy_set_header Host $host` is what makes backend host-dispatch work.
+`<BACKEND_PORT>` is the published port of the backend container (the same
+one the existing API proxy uses).
+
+```nginx
+# {slug}.chattermate.help
+server {
+    listen 443 ssl;
+    server_name *.chattermate.help;
+    ssl_certificate     /etc/letsencrypt/live/chattermate.help/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/chattermate.help/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:<BACKEND_PORT>;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+
+server {
+    listen 80;
+    server_name *.chattermate.help;
+    return 301 https://$host$request_uri;
+}
+```
+
+## 2. Per-customer custom domain (runbook step per domain)
+
+Customers add two records (shown in their FAQ admin UI):
+- `CNAME  help.customer.com  →  cname.chattermate.chat`
+- `TXT    _chattermate.help.customer.com  →  cm-verify=<token>`
+
+After they click **Verify domain** (DNS checks pass, `ssl_status` becomes
+`pending`), issue the certificate on the VPS — HTTP-01 works because the
+CNAME already routes to us:
+
+```bash
+sudo certbot --nginx -d help.customer.com
+```
+
+Add (or let certbot's nginx installer create) a server block identical to the
+wildcard one but with `server_name help.customer.com;` and the new cert
+paths. Reload nginx. The backend's SSL probe (`https://<domain>/healthz`)
+flips `ssl_status` to `active` on the customer's next verify/status check.
+
+> Cloudflare-proxied ("orange cloud") CNAMEs hide the record from DNS lookups
+> and terminate TLS at Cloudflare — customers must grey-cloud (DNS-only) the
+> record for verification, or the CNAME check will fail.
+
+### Automation (later)
+When manual certbot becomes a burden: a host cron that polls a token-guarded
+admin endpoint for verified-but-unprovisioned domains and runs
+`certbot --nginx -d <domain>` — or move edge TLS to Caddy with on-demand TLS
+(`ask` endpoint). Deferred because Caddy would have to own port 443 for the
+whole VPS.
+
+## 3. Verification checklist after deploy
+1. `curl -H "Host: <slug>.chattermate.help" http://127.0.0.1:<BACKEND_PORT>/healthz` → `{"status":"ok"}`
+2. `https://<slug>.chattermate.help` in a browser → published FAQs render, widget loads.
+3. API unaffected: `https://chattermate.chat/api/v1/...` still routes to the SPA/API.
+4. `POST /ask` from the page returns an answer and appears in `help_center_queries`.
+
+## 4. Enterprise (cloud) rollout prerequisite
+
+The feature is gated by the `help_center` plan flag, which lives in the
+**enterprise submodule** (separate repo/PR — required before cloud rollout):
+
+- add `"help_center": True` to PRO and ENTERPRISE in
+  `enterprise/models/plan.py::get_default_features` (FREE/BASE: `False`);
+- backfill existing plan rows' `features` JSON with the same values;
+- extend the message-limit check to add the org's period
+  `help_center_queries` count (`HelpCenterQueryRepository.count_for_period`)
+  to the bot-message count when the org runs on the ChatterMate-hosted model.
+
+Until that PR deploys, cloud orgs see the upgrade lock (`plan_allowed:
+false`); self-hosted/OSS installs are unrestricted immediately.
+
+## 5. Tunables (backend env)
+
+`HELP_CENTER_RESERVED_SLUGS` (labels never claimable as slugs — must mirror
+real infra records on the base domain), `FAQ_MAX_PAGES_PER_SOURCE` (300),
+`FAQ_MAX_BATCH_CHARS` (15000), `FAQ_IMPORT_MAX_PAGE_CHARS` (100000),
+`FAQ_IMPORT_FETCH_TIMEOUT` (30s) — the FAQ_* caps bound LLM spend per
+generation run.

--- a/backend/alembic/versions/add_hc_chat_widget_001_add_chat_widget_enabled.py
+++ b/backend/alembic/versions/add_hc_chat_widget_001_add_chat_widget_enabled.py
@@ -1,0 +1,33 @@
+"""add chat_widget_enabled to help_center_settings
+
+Splits the public help center's two AI surfaces into independent toggles: the
+inline AI quick-summary in search (ai_search_enabled) and the embedded chat
+widget (chat_widget_enabled). Existing rows default to enabled to preserve the
+prior behaviour, where a mapped agent's widget was shown alongside AI search.
+
+Revision ID: add_hc_chat_widget_001
+Revises: f7a1c2d3e4b5
+Create Date: 2026-07-13
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'add_hc_chat_widget_001'
+down_revision = 'f7a1c2d3e4b5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'help_center_settings',
+        sa.Column('chat_widget_enabled', sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    # Drop the server default now that existing rows are backfilled — the model
+    # supplies the default on insert, matching ai_search_enabled.
+    op.alter_column('help_center_settings', 'chat_widget_enabled', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('help_center_settings', 'chat_widget_enabled')

--- a/backend/alembic/versions/add_hc_cta_enabled_001_add_cta_enabled.py
+++ b/backend/alembic/versions/add_hc_cta_enabled_001_add_cta_enabled.py
@@ -1,0 +1,30 @@
+"""add cta_enabled to help_center_settings
+
+Lets the primary button (CTA) in the public help-center header be toggled on/off
+independently of whether its text/URL are filled in. Existing rows default to
+enabled to preserve the prior behaviour (CTA shown when text and URL are set).
+
+Revision ID: add_hc_cta_enabled_001
+Revises: add_hc_chat_widget_001
+Create Date: 2026-07-13
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'add_hc_cta_enabled_001'
+down_revision = 'add_hc_chat_widget_001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'help_center_settings',
+        sa.Column('cta_enabled', sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.alter_column('help_center_settings', 'cta_enabled', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('help_center_settings', 'cta_enabled')

--- a/backend/alembic/versions/add_hc_faq_slug_001_add_faq_slug.py
+++ b/backend/alembic/versions/add_hc_faq_slug_001_add_faq_slug.py
@@ -1,0 +1,61 @@
+"""add slug to faqs for public article-page URLs
+
+FAQs become full help-center articles served at /a/{slug}. Adds a nullable
+per-org-unique slug column, then backfills existing rows from their question
+(deduping collisions with -2, -3, … within each org). New/edited FAQs get their
+slug assigned in the API; this backfill covers everything created before.
+
+Revision ID: add_hc_faq_slug_001
+Revises: add_hc_cta_enabled_001
+Create Date: 2026-07-13
+"""
+import re
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'add_hc_faq_slug_001'
+down_revision = 'add_hc_cta_enabled_001'
+branch_labels = None
+depends_on = None
+
+SLUG_MAX_LENGTH = 80
+_SLUG_CLEAN_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(text: str) -> str:
+    base = _SLUG_CLEAN_RE.sub("-", (text or "").casefold()).strip("-")
+    return base[:SLUG_MAX_LENGTH].strip("-") or "article"
+
+
+def _backfill(conn) -> None:
+    faqs = conn.execute(
+        sa.text("SELECT id, organization_id, question FROM faqs ORDER BY created_at ASC, id ASC")
+    ).fetchall()
+    used: dict = {}  # organization_id -> set(slug)
+    for faq_id, org_id, question in faqs:
+        seen = used.setdefault(org_id, set())
+        base = _slugify(question)
+        candidate = base
+        suffix = 2
+        while candidate in seen:
+            tail = f"-{suffix}"
+            candidate = f"{base[:SLUG_MAX_LENGTH - len(tail)]}{tail}"
+            suffix += 1
+        seen.add(candidate)
+        conn.execute(
+            sa.text("UPDATE faqs SET slug = :slug WHERE id = :id"),
+            {"slug": candidate, "id": faq_id},
+        )
+
+
+def upgrade() -> None:
+    op.add_column('faqs', sa.Column('slug', sa.String(length=80), nullable=True))
+    _backfill(op.get_bind())
+    op.create_index('ix_faqs_org_slug', 'faqs', ['organization_id', 'slug'], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_faqs_org_slug', table_name='faqs')
+    op.drop_column('faqs', 'slug')

--- a/backend/alembic/versions/add_hc_job_meter_001_add_job_metering.py
+++ b/backend/alembic/versions/add_hc_job_meter_001_add_job_metering.py
@@ -1,0 +1,48 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+FAQ generation-job metering + targeting columns:
+- llm_calls / metered: per-job LLM call counter for hosted-model message
+  metering (metered stamped at enqueue from the org's AI config).
+- knowledge_ids: optional explicit source narrowing for GENERATE_ALL jobs.
+- source_file_name: original filename for PDF imports.
+
+Revision ID: add_hc_job_meter_001
+Revises: add_hc_faq_slug_001
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "add_hc_job_meter_001"
+down_revision = "add_hc_faq_slug_001"
+branch_labels = None
+depends_on = None
+
+TABLE = "faq_generation_jobs"
+
+
+def upgrade() -> None:
+    op.add_column(TABLE, sa.Column("llm_calls", sa.Integer(), nullable=False, server_default="0"))
+    op.add_column(TABLE, sa.Column("metered", sa.Boolean(), nullable=False, server_default=sa.text("true")))
+    op.add_column(TABLE, sa.Column("knowledge_ids", sa.JSON(), nullable=True))
+    op.add_column(TABLE, sa.Column("source_file_name", sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column(TABLE, "source_file_name")
+    op.drop_column(TABLE, "knowledge_ids")
+    op.drop_column(TABLE, "metered")
+    op.drop_column(TABLE, "llm_calls")

--- a/backend/alembic/versions/f7a1c2d3e4b5_add_faq_help_center.py
+++ b/backend/alembic/versions/f7a1c2d3e4b5_add_faq_help_center.py
@@ -1,0 +1,172 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""add FAQ + public help center tables
+
+Revision ID: f7a1c2d3e4b5
+Revises: drop_slack_tables_001
+Create Date: 2026-07-12
+
+New feature: AI-generated FAQs reviewed/published by the org and served as a
+public help center on {slug}.chattermate.help or a verified custom domain.
+
+Tables:
+- faq_generation_jobs: async generate/import jobs (worker + UI polling)
+- help_center_settings: per-org branding, slug, agent mapping, custom domain
+- faqs: the question/answer pairs (draft -> published workflow)
+- help_center_queries: public "Ask AI" log for metering/analytics
+
+Status/stage columns are plain strings (mirroring knowledge_queue) so new
+values never need an ALTER TYPE migration.
+
+Also extends the notificationtype enum with FAQ job outcomes. Labels are the
+uppercase member names, matching how the enum was created in
+b365b8447598_initial_version. ALTER TYPE ... ADD VALUE requires PostgreSQL 12+
+to run inside a transaction; added values cannot be removed on downgrade.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'f7a1c2d3e4b5'
+down_revision = 'drop_slack_tables_001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'faq_generation_jobs',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('organization_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('job_type', sa.String(), nullable=False),
+        sa.Column('knowledge_id', sa.Integer(), nullable=True),
+        sa.Column('source_url', sa.String(), nullable=True),
+        sa.Column('status', sa.String(), nullable=False),
+        sa.Column('stage', sa.String(), nullable=False),
+        sa.Column('progress_percentage', sa.Float(), nullable=False),
+        sa.Column('faqs_created', sa.Integer(), nullable=False),
+        sa.Column('error', sa.String(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['organization_id'], ['organizations.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['knowledge_id'], ['knowledge.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_faq_generation_jobs_id'), 'faq_generation_jobs', ['id'])
+    op.create_index(op.f('ix_faq_generation_jobs_organization_id'), 'faq_generation_jobs', ['organization_id'])
+    op.create_index(op.f('ix_faq_generation_jobs_knowledge_id'), 'faq_generation_jobs', ['knowledge_id'])
+    # The worker polls for pending/processing rows forever; keep that lookup
+    # O(active) as terminal rows accumulate.
+    op.create_index(
+        'ix_faq_generation_jobs_active',
+        'faq_generation_jobs',
+        ['status'],
+        postgresql_where=sa.text("status IN ('pending', 'processing')"),
+    )
+
+    op.create_table(
+        'help_center_settings',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('organization_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('enabled', sa.Boolean(), nullable=False),
+        sa.Column('slug', sa.String(length=63), nullable=True),
+        sa.Column('title', sa.String(length=120), nullable=True),
+        sa.Column('description', sa.String(length=300), nullable=True),
+        sa.Column('logo_url', sa.String(), nullable=True),
+        sa.Column('brand_color', sa.String(length=9), nullable=False),
+        sa.Column('header_links', sa.JSON(), nullable=False),
+        sa.Column('cta_text', sa.String(length=40), nullable=True),
+        sa.Column('cta_url', sa.String(), nullable=True),
+        sa.Column('auto_generate', sa.Boolean(), nullable=False),
+        sa.Column('agent_id', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('ai_search_enabled', sa.Boolean(), nullable=False),
+        sa.Column('custom_domain', sa.String(length=255), nullable=True),
+        sa.Column('domain_verification_token', sa.String(length=64), nullable=True),
+        sa.Column('txt_record_verified', sa.Boolean(), nullable=False),
+        sa.Column('cname_record_verified', sa.Boolean(), nullable=False),
+        sa.Column('ssl_status', sa.String(), nullable=False),
+        sa.Column('domain_verified_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['organization_id'], ['organizations.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['agent_id'], ['agents.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('organization_id'),
+        sa.UniqueConstraint('slug'),
+        sa.UniqueConstraint('custom_domain'),
+        sa.CheckConstraint('slug = lower(slug)', name='ck_help_center_slug_lowercase'),
+    )
+    op.create_index(op.f('ix_help_center_settings_slug'), 'help_center_settings', ['slug'])
+    op.create_index(op.f('ix_help_center_settings_custom_domain'), 'help_center_settings', ['custom_domain'])
+
+    op.create_table(
+        'faqs',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('organization_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('question', sa.Text(), nullable=False),
+        sa.Column('answer', sa.Text(), nullable=False),
+        sa.Column('category', sa.String(length=100), nullable=False),
+        sa.Column('status', sa.String(), nullable=False),
+        sa.Column('knowledge_id', sa.Integer(), nullable=True),
+        sa.Column('source_label', sa.String(length=255), nullable=True),
+        sa.Column('generation_job_id', sa.Integer(), nullable=True),
+        sa.Column('created_by', postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column('sort_order', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['organization_id'], ['organizations.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['knowledge_id'], ['knowledge.id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['generation_job_id'], ['faq_generation_jobs.id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['created_by'], ['users.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    # Composite indexes lead with organization_id, so no single-column org index.
+    op.create_index('ix_faqs_org_status', 'faqs', ['organization_id', 'status'])
+    op.create_index('ix_faqs_org_category', 'faqs', ['organization_id', 'category'])
+    # FK indexes so knowledge/job deletions don't scan faqs to enforce SET NULL.
+    op.create_index(op.f('ix_faqs_knowledge_id'), 'faqs', ['knowledge_id'])
+    op.create_index(op.f('ix_faqs_generation_job_id'), 'faqs', ['generation_job_id'])
+
+    op.create_table(
+        'help_center_queries',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('organization_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('query', sa.Text(), nullable=False),
+        sa.Column('answered', sa.Boolean(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['organization_id'], ['organizations.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_help_center_queries_organization_id'), 'help_center_queries', ['organization_id'])
+    op.create_index(op.f('ix_help_center_queries_created_at'), 'help_center_queries', ['created_at'])
+
+    op.execute("ALTER TYPE notificationtype ADD VALUE IF NOT EXISTS 'FAQ_GENERATED'")
+    op.execute("ALTER TYPE notificationtype ADD VALUE IF NOT EXISTS 'FAQ_GENERATION_FAILED'")
+
+
+def downgrade() -> None:
+    # The enum values added in upgrade() cannot be removed; delete the rows
+    # that reference them so the reverted application enum can still load
+    # every remaining notification.
+    op.execute("DELETE FROM notifications WHERE type IN ('FAQ_GENERATED', 'FAQ_GENERATION_FAILED')")
+    op.drop_table('help_center_queries')
+    op.drop_table('faqs')
+    op.drop_table('help_center_settings')
+    op.drop_table('faq_generation_jobs')

--- a/backend/alembic/versions/f7a1c2d3e4b5_add_faq_help_center.py
+++ b/backend/alembic/versions/f7a1c2d3e4b5_add_faq_help_center.py
@@ -80,6 +80,16 @@ def upgrade() -> None:
         ['status'],
         postgresql_where=sa.text("status IN ('pending', 'processing')"),
     )
+    # DB-enforced one-active-job guard per (org, type, source): the API's
+    # check-then-insert would otherwise race on concurrent /generate calls.
+    # COALESCE keeps per-source auto jobs for different sources parallel.
+    op.create_index(
+        'uq_faq_generation_jobs_one_active',
+        'faq_generation_jobs',
+        ['organization_id', 'job_type', sa.text('COALESCE(knowledge_id, -1)')],
+        unique=True,
+        postgresql_where=sa.text("status IN ('pending', 'processing')"),
+    )
 
     op.create_table(
         'help_center_settings',

--- a/backend/app/agents/chat_agent.py
+++ b/backend/app/agents/chat_agent.py
@@ -27,6 +27,11 @@ from app.repositories.session_to_agent import SessionToAgentRepository
 from app.models.session_to_agent import SessionStatus
 from app.models.schemas.chat import ChatResponse,TransferReasonType, EndChatReasonType
 from app.core.config import settings
+from app.agents.structured_output import (
+    build_groq_json_tool,
+    lenient_json_load,
+    salvage_groq_json_error,
+)
 from app.agents.transfer_agent import get_agent_availability_response
 from app.models.notification import Notification
 from app.services.user import send_fcm_notification
@@ -101,80 +106,18 @@ def build_groq_response_tool(capture: dict):
     `capture` is mutated in place with the model's tool-call arguments; the caller reads
     it after `agent.arun()` and builds the ChatResponse from it.
     """
-    from agno.tools.function import Function
-
-    def _record(**kwargs):
-        capture.clear()
-        capture.update(kwargs)
-        return "recorded"
-
-    return Function(
-        name="json",
+    return build_groq_json_tool(
+        capture,
+        _GROQ_JSON_TOOL_SCHEMA,
         description="Return your final structured reply to the visitor. Call this exactly once to end the turn, after any searching.",
-        parameters=_GROQ_JSON_TOOL_SCHEMA,
-        entrypoint=_record,
-        stop_after_tool_call=True,
-        skip_entrypoint_processing=True,
     )
 
-def _lenient_json_load(s: str):
-    """Best-effort parse of a possibly-truncated JSON object. Returns dict or None.
 
-    When Groq truncates a `json` tool call, the trailing field (usually `message`) is
-    cut mid-value. We progressively try closers, then fall back to dropping the last
-    (incomplete) key so the earlier complete fields survive.
-    """
-    s = (s or "").strip()
-    if not s:
-        return None
-    try:
-        return json.loads(s)
-    except json.JSONDecodeError:
-        pass
-    for suffix in ('"}', '}', '"}}', '}}', 'null}'):
-        try:
-            return json.loads(s + suffix)
-        except json.JSONDecodeError:
-            continue
-    last_comma = s.rfind(',')
-    if last_comma != -1:
-        try:
-            return json.loads(s[:last_comma] + '}')
-        except json.JSONDecodeError:
-            pass
-    return None
-
-
-def _salvage_groq_json_error(exc: Exception):
-    """Recover a ChatResponse dict from a Groq `tool_use_failed` error.
-
-    Groq returns the (truncated) tool-call text in `failed_generation`; every field
-    before the truncation point is intact, so the lead/end_chat flags are recoverable
-    even when the message got cut. Returns a dict of arguments or None.
-    """
-    text = getattr(exc, "message", None) or str(exc)
-    if "failed_generation" not in text:
-        return None
-    fg = None
-    try:
-        fg = json.loads(text).get("error", {}).get("failed_generation")
-    except Exception:
-        m = re.search(r'"failed_generation"\s*:\s*"(.*)"\s*\}\s*\}\s*$', text, re.DOTALL)
-        if m:
-            try:
-                # Decode JSON string escapes (\n, \", \uXXXX, non-ASCII) correctly —
-                # unicode_escape would corrupt emoji/accented characters.
-                fg = json.loads('"' + m.group(1) + '"')
-            except Exception:
-                fg = m.group(1)
-    if not fg:
-        return None
-    # fg looks like: {"name": "json", "arguments": {<fields, possibly truncated>}}
-    idx = fg.find('"arguments"')
-    brace = fg.find('{', idx) if idx != -1 else -1
-    if brace == -1:
-        return None
-    return _lenient_json_load(fg[brace:])
+# Shared implementations live in app.agents.structured_output (also used by the
+# FAQ generator); keep the private aliases so existing call sites and tests
+# don't churn.
+_lenient_json_load = lenient_json_load
+_salvage_groq_json_error = salvage_groq_json_error
 
 
 def _build_chat_response_from_capture(capture: dict) -> ChatResponse:

--- a/backend/app/agents/faq_generator.py
+++ b/backend/app/agents/faq_generator.py
@@ -75,6 +75,28 @@ _GROQ_FAQ_INSTRUCTION = (
     "the `json` tool call."
 )
 
+_JSON_ONLY_INSTRUCTION = (
+    "\n\nOUTPUT FORMAT: Respond with ONLY a JSON object of the shape "
+    '{"faqs": [{"question": "...", "answer": "...", "category": "..."}]} '
+    "— no prose, no explanations, no code fences."
+)
+
+
+class _UnparseableOutput(Exception):
+    """Native structured output came back in a shape we can't parse — signals
+    the plain-JSON fallback (distinct from a legitimately empty FAQ list)."""
+
+
+def _first_json_object(text: str) -> dict:
+    """The first {...} object in a text blob (tolerates code fences and prose
+    around it). Raises ValueError when there's no parseable object — surfaces
+    as a batch failure upstream (retry/skip)."""
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end <= start:
+        raise ValueError("no JSON object in model output")
+    return json.loads(text[start : end + 1])
+
 _GENERATE_INSTRUCTIONS = """You turn product documentation into a public help-center FAQ.
 
 Read the CONTENT below and draft frequently-asked questions a customer would realistically ask, each with a clear answer.
@@ -154,7 +176,7 @@ class FAQGeneratorAgent:
         parts.append(f"{content_label}:\n{content}")
         return "\n\n".join(parts)
 
-    async def _extract(self, instructions: str, message: str) -> List[GeneratedFAQ]:
+    def _build_agent(self, instructions: str, tools: list, response_model, structured_outputs: bool):
         from agno.agent import Agent
 
         model = create_model(
@@ -163,7 +185,18 @@ class FAQGeneratorAgent:
             model_name=self.model_name,
             max_tokens=self.max_tokens,
         )
+        return Agent(
+            name="FAQ Generator",
+            model=model,
+            tools=tools,
+            instructions=instructions,
+            markdown=False,
+            response_model=response_model,
+            structured_outputs=structured_outputs,
+            debug_mode=settings.ENVIRONMENT == "development",
+        )
 
+    async def _extract(self, instructions: str, message: str) -> List[GeneratedFAQ]:
         capture: dict = {}
         tools = []
         response_model = FAQExtractionResult
@@ -180,29 +213,46 @@ class FAQGeneratorAgent:
             response_model = None
             structured_outputs = False
 
-        agent = Agent(
-            name="FAQ Generator",
-            model=model,
-            tools=tools,
-            instructions=instructions,
-            markdown=False,
-            response_model=response_model,
-            structured_outputs=structured_outputs,
-            debug_mode=settings.ENVIRONMENT == "development",
-        )
+        agent = self._build_agent(instructions, tools, response_model, structured_outputs)
 
         try:
             response = await agent.arun(message=message, stream=False)
         except Exception as arun_exc:
-            salvaged = salvage_groq_json_error(arun_exc) if self._use_groq_json_tool else None
-            if not salvaged:
-                raise
-            logger.warning("Groq FAQ json tool call unparseable (likely truncated); salvaging fields")
-            return self._validate(salvaged)
+            if self._use_groq_json_tool:
+                salvaged = salvage_groq_json_error(arun_exc)
+                if not salvaged:
+                    raise
+                logger.warning("Groq FAQ json tool call unparseable (likely truncated); salvaging fields")
+                return self._validate(salvaged)
+            # Some providers (Ollama/HuggingFace/Mistral via agno) fail on
+            # native structured outputs — retry once with a plain-JSON prompt.
+            logger.warning(
+                f"Native structured output failed for {self.model_type}/{self.model_name} "
+                f"({arun_exc}); retrying with plain-JSON instruction"
+            )
+            return await self._extract_plain_json(instructions, message)
 
         if self._use_groq_json_tool:
             return self._validate(capture)
-        return self._parse_native(response)
+        try:
+            return self._parse_native(response)
+        except _UnparseableOutput:
+            logger.warning(
+                f"Unparseable structured output from {self.model_type}/{self.model_name}; "
+                "retrying with plain-JSON instruction"
+            )
+            return await self._extract_plain_json(instructions, message)
+
+    async def _extract_plain_json(self, instructions: str, message: str) -> List[GeneratedFAQ]:
+        """Provider-agnostic fallback: no response_model, just a strict
+        respond-only-with-JSON instruction, parsed from the raw text."""
+        agent = self._build_agent(
+            instructions + _JSON_ONLY_INSTRUCTION, tools=[],
+            response_model=None, structured_outputs=False,
+        )
+        response = await agent.arun(message=message, stream=False)
+        content = getattr(response, "content", response)
+        return self._validate(_first_json_object(content if isinstance(content, str) else str(content)))
 
     def _parse_native(self, response) -> List[GeneratedFAQ]:
         content = getattr(response, "content", response)
@@ -212,10 +262,8 @@ class FAQGeneratorAgent:
             try:
                 return self._validate(json.loads(content))
             except (json.JSONDecodeError, TypeError):
-                logger.error("FAQ generator: model returned unparseable text instead of structured output")
-                return []
-        logger.error(f"FAQ generator: unexpected response content type {type(content)}")
-        return []
+                raise _UnparseableOutput("model returned unparseable text instead of structured output")
+        raise _UnparseableOutput(f"unexpected response content type {type(content)}")
 
     def _validate(self, data: dict) -> List[GeneratedFAQ]:
         """Validate model output, dropping malformed entries rather than the

--- a/backend/app/agents/faq_generator.py
+++ b/backend/app/agents/faq_generator.py
@@ -15,12 +15,13 @@ limitations under the License.
 """
 
 import json
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from pydantic import BaseModel, Field, ValidationError
 
 from app.agents.structured_output import (
     build_groq_json_tool,
+    lenient_json_load,
     salvage_groq_json_error,
 )
 from app.core.config import settings
@@ -88,14 +89,17 @@ class _UnparseableOutput(Exception):
 
 
 def _first_json_object(text: str) -> dict:
-    """The first {...} object in a text blob (tolerates code fences and prose
-    around it). Raises ValueError when there's no parseable object — surfaces
-    as a batch failure upstream (retry/skip)."""
+    """The first {...} object in a text blob (tolerates code fences, prose and
+    truncation via the shared lenient parser — the providers that need this
+    fallback are exactly the ones likely to emit imperfect JSON). Raises
+    ValueError when nothing parseable exists — a batch failure upstream."""
     start = text.find("{")
-    end = text.rfind("}")
-    if start == -1 or end <= start:
+    if start == -1:
         raise ValueError("no JSON object in model output")
-    return json.loads(text[start : end + 1])
+    data = lenient_json_load(text[start:])
+    if not isinstance(data, dict):
+        raise ValueError("no JSON object in model output")
+    return data
 
 _GENERATE_INSTRUCTIONS = """You turn product documentation into a public help-center FAQ.
 
@@ -136,6 +140,13 @@ class FAQGeneratorAgent:
         # window (fewer, larger LLM calls on big-context models).
         self.batch_chars, self.max_faqs = faq_batch_chars_for(model_type, model_name)
         self.max_tokens = max(FAQ_MAX_TOKENS, output_tokens_for(self.max_faqs))
+        # Metering hook, fired once per ACTUAL provider call (including the
+        # plain-JSON fallback's second call) — set by the job runner.
+        self.on_llm_call: Optional[Callable[[], None]] = None
+
+    def _count_call(self) -> None:
+        if self.on_llm_call:
+            self.on_llm_call()
 
     async def generate_from_text(
         self,
@@ -216,6 +227,7 @@ class FAQGeneratorAgent:
         agent = self._build_agent(instructions, tools, response_model, structured_outputs)
 
         try:
+            self._count_call()
             response = await agent.arun(message=message, stream=False)
         except Exception as arun_exc:
             if self._use_groq_json_tool:
@@ -250,6 +262,7 @@ class FAQGeneratorAgent:
             instructions + _JSON_ONLY_INSTRUCTION, tools=[],
             response_model=None, structured_outputs=False,
         )
+        self._count_call()
         response = await agent.arun(message=message, stream=False)
         content = getattr(response, "content", response)
         return self._validate(_first_json_object(content if isinstance(content, str) else str(content)))

--- a/backend/app/agents/faq_generator.py
+++ b/backend/app/agents/faq_generator.py
@@ -1,0 +1,232 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, ValidationError
+
+from app.agents.structured_output import (
+    build_groq_json_tool,
+    salvage_groq_json_error,
+)
+from app.core.config import settings
+from app.core.logger import get_logger
+from app.models.schemas.faq import MAX_ANSWER_LENGTH, MAX_QUESTION_LENGTH
+from app.utils.agno_utils import create_model
+
+logger = get_logger(__name__)
+
+# Groq reasoning models spend output tokens before emitting the tool call;
+# match the chat agent's headroom.
+FAQ_MAX_TOKENS = 4000
+MAX_FAQS_PER_BATCH = 15
+
+
+class GeneratedFAQ(BaseModel):
+    question: str = Field(max_length=MAX_QUESTION_LENGTH)
+    answer: str = Field(max_length=MAX_ANSWER_LENGTH)
+    category: str = Field(max_length=100)
+
+
+class FAQExtractionResult(BaseModel):
+    # No max_length here: an over-eager model must not fail response-model
+    # validation for the whole batch — _validate() trims to MAX_FAQS_PER_BATCH.
+    faqs: List[GeneratedFAQ] = Field(default_factory=list)
+
+
+_FAQ_JSON_TOOL_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "faqs": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "question": {"type": "string", "description": "The question, as a customer would ask it."},
+                    "answer": {"type": "string", "description": "A clear, self-contained answer (1-4 sentences)."},
+                    "category": {"type": "string", "description": "Short topic grouping, e.g. 'Getting started', 'Billing'."},
+                },
+                "required": ["question", "answer", "category"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["faqs"],
+    "additionalProperties": False,
+}
+
+_GROQ_FAQ_INSTRUCTION = (
+    "\n\nCRITICAL OUTPUT RULE: You MUST end your turn by calling the `json` tool exactly once "
+    "with the extracted FAQs. Never write the FAQs as plain text — always deliver them through "
+    "the `json` tool call."
+)
+
+_GENERATE_INSTRUCTIONS = """You turn product documentation into a public help-center FAQ.
+
+Read the CONTENT below and draft frequently-asked questions a customer would realistically ask, each with a clear answer.
+
+Rules:
+- Ground every answer strictly in the CONTENT. Never invent facts, prices, limits or URLs that are not present.
+- Write questions the way a customer would phrase them, and answers in second person ("you"), 1-4 sentences, plain language, no markdown headings.
+- Extract between 1 and {max_faqs} FAQs; prefer the most useful ones. If the content contains nothing FAQ-worthy, return an empty list.
+- Assign each FAQ a short category. {category_rule}
+- Do NOT produce any question that duplicates or trivially rephrases one of the EXISTING QUESTIONS listed below."""
+
+_IMPORT_INSTRUCTIONS = """You are migrating an existing FAQ/help-center web page into a structured FAQ list.
+
+Read the PAGE TEXT below and extract every question-and-answer pair that is actually present on the page.
+
+Rules:
+- Preserve the original wording as closely as possible; only trim navigation debris, repeated headings and boilerplate.
+- Only extract real Q&A pairs — skip marketing copy, navigation links and unrelated text.
+- Use the page's own section headings as categories where they exist; otherwise use "General".
+- Extract at most {max_faqs} pairs per call.
+- Do NOT extract any question that duplicates one of the EXISTING QUESTIONS listed below."""
+
+
+class FAQGeneratorAgent:
+    """Stateless one-shot LLM extraction of FAQs from text, using the org's
+    configured model. Groq gets the shared `json`-tool structured-output path;
+    every other provider uses agno's native response_model."""
+
+    def __init__(self, api_key: str, model_name: str, model_type: str):
+        self.model_type = model_type
+        self.model_name = model_name
+        self.api_key = api_key
+        self._use_groq_json_tool = model_type.upper() == "GROQ"
+
+    async def generate_from_text(
+        self,
+        content: str,
+        existing_questions: Optional[List[str]] = None,
+        existing_categories: Optional[List[str]] = None,
+    ) -> List[GeneratedFAQ]:
+        """Draft grounded FAQs from knowledge-base content."""
+        if existing_categories:
+            category_rule = (
+                "Prefer one of the existing categories when it fits: "
+                + ", ".join(existing_categories[:20])
+                + ". Introduce a new category only when none fit."
+            )
+        else:
+            category_rule = 'Good examples: "Getting started", "Billing", "Account & security", "Integrations".'
+        instructions = _GENERATE_INSTRUCTIONS.format(
+            max_faqs=MAX_FAQS_PER_BATCH, category_rule=category_rule
+        )
+        message = self._build_message(instructions, "CONTENT", content, existing_questions)
+        return await self._extract(instructions, message)
+
+    async def extract_from_faq_page(
+        self,
+        content: str,
+        existing_questions: Optional[List[str]] = None,
+    ) -> List[GeneratedFAQ]:
+        """Extract verbatim-ish Q&A pairs from an external FAQ page."""
+        instructions = _IMPORT_INSTRUCTIONS.format(max_faqs=MAX_FAQS_PER_BATCH)
+        message = self._build_message(instructions, "PAGE TEXT", content, existing_questions)
+        return await self._extract(instructions, message)
+
+    @staticmethod
+    def _build_message(instructions: str, content_label: str, content: str, existing_questions: Optional[List[str]]) -> str:
+        parts = []
+        if existing_questions:
+            parts.append("EXISTING QUESTIONS (do not repeat):\n" + "\n".join(f"- {q}" for q in existing_questions))
+        parts.append(f"{content_label}:\n{content}")
+        return "\n\n".join(parts)
+
+    async def _extract(self, instructions: str, message: str) -> List[GeneratedFAQ]:
+        from agno.agent import Agent
+
+        model = create_model(
+            model_type=self.model_type,
+            api_key=self.api_key,
+            model_name=self.model_name,
+            max_tokens=FAQ_MAX_TOKENS,
+        )
+
+        capture: dict = {}
+        tools = []
+        response_model = FAQExtractionResult
+        structured_outputs = True
+        if self._use_groq_json_tool:
+            tools.append(
+                build_groq_json_tool(
+                    capture,
+                    _FAQ_JSON_TOOL_SCHEMA,
+                    description="Return the final extracted FAQ list. Call exactly once.",
+                )
+            )
+            instructions = instructions + _GROQ_FAQ_INSTRUCTION
+            response_model = None
+            structured_outputs = False
+
+        agent = Agent(
+            name="FAQ Generator",
+            model=model,
+            tools=tools,
+            instructions=instructions,
+            markdown=False,
+            response_model=response_model,
+            structured_outputs=structured_outputs,
+            debug_mode=settings.ENVIRONMENT == "development",
+        )
+
+        try:
+            response = await agent.arun(message=message, stream=False)
+        except Exception as arun_exc:
+            salvaged = salvage_groq_json_error(arun_exc) if self._use_groq_json_tool else None
+            if not salvaged:
+                raise
+            logger.warning("Groq FAQ json tool call unparseable (likely truncated); salvaging fields")
+            return self._validate(salvaged)
+
+        if self._use_groq_json_tool:
+            return self._validate(capture)
+        return self._parse_native(response)
+
+    def _parse_native(self, response) -> List[GeneratedFAQ]:
+        content = getattr(response, "content", response)
+        if isinstance(content, FAQExtractionResult):
+            return self._validate(content.model_dump())
+        if isinstance(content, str):
+            try:
+                return self._validate(json.loads(content))
+            except (json.JSONDecodeError, TypeError):
+                logger.error("FAQ generator: model returned unparseable text instead of structured output")
+                return []
+        logger.error(f"FAQ generator: unexpected response content type {type(content)}")
+        return []
+
+    @staticmethod
+    def _validate(data: dict) -> List[GeneratedFAQ]:
+        """Validate model output, dropping malformed entries rather than the
+        whole batch. Truncates over-long fields instead of rejecting them."""
+        raw_items = (data or {}).get("faqs") or []
+        faqs: List[GeneratedFAQ] = []
+        for item in raw_items[:MAX_FAQS_PER_BATCH]:
+            if not isinstance(item, dict):
+                continue
+            question = str(item.get("question") or "").strip()[:MAX_QUESTION_LENGTH]
+            answer = str(item.get("answer") or "").strip()[:MAX_ANSWER_LENGTH]
+            category = str(item.get("category") or "").strip()[:100]
+            if not question or not answer:
+                continue
+            try:
+                faqs.append(GeneratedFAQ(question=question, answer=answer, category=category or "General"))
+            except ValidationError:
+                continue
+        return faqs

--- a/backend/app/agents/faq_generator.py
+++ b/backend/app/agents/faq_generator.py
@@ -27,13 +27,13 @@ from app.core.config import settings
 from app.core.logger import get_logger
 from app.models.schemas.faq import MAX_ANSWER_LENGTH, MAX_QUESTION_LENGTH
 from app.utils.agno_utils import create_model
+from app.utils.model_context import faq_batch_chars_for, output_tokens_for
 
 logger = get_logger(__name__)
 
 # Groq reasoning models spend output tokens before emitting the tool call;
-# match the chat agent's headroom.
+# match the chat agent's headroom. Floor — large batches reserve more.
 FAQ_MAX_TOKENS = 4000
-MAX_FAQS_PER_BATCH = 15
 
 
 class GeneratedFAQ(BaseModel):
@@ -44,7 +44,7 @@ class GeneratedFAQ(BaseModel):
 
 class FAQExtractionResult(BaseModel):
     # No max_length here: an over-eager model must not fail response-model
-    # validation for the whole batch — _validate() trims to MAX_FAQS_PER_BATCH.
+    # validation for the whole batch — _validate() trims to the batch cap.
     faqs: List[GeneratedFAQ] = Field(default_factory=list)
 
 
@@ -110,6 +110,10 @@ class FAQGeneratorAgent:
         self.model_name = model_name
         self.api_key = api_key
         self._use_groq_json_tool = model_type.upper() == "GROQ"
+        # Batch size + FAQ yield scale with the selected model's context
+        # window (fewer, larger LLM calls on big-context models).
+        self.batch_chars, self.max_faqs = faq_batch_chars_for(model_type, model_name)
+        self.max_tokens = max(FAQ_MAX_TOKENS, output_tokens_for(self.max_faqs))
 
     async def generate_from_text(
         self,
@@ -127,7 +131,7 @@ class FAQGeneratorAgent:
         else:
             category_rule = 'Good examples: "Getting started", "Billing", "Account & security", "Integrations".'
         instructions = _GENERATE_INSTRUCTIONS.format(
-            max_faqs=MAX_FAQS_PER_BATCH, category_rule=category_rule
+            max_faqs=self.max_faqs, category_rule=category_rule
         )
         message = self._build_message(instructions, "CONTENT", content, existing_questions)
         return await self._extract(instructions, message)
@@ -138,7 +142,7 @@ class FAQGeneratorAgent:
         existing_questions: Optional[List[str]] = None,
     ) -> List[GeneratedFAQ]:
         """Extract verbatim-ish Q&A pairs from an external FAQ page."""
-        instructions = _IMPORT_INSTRUCTIONS.format(max_faqs=MAX_FAQS_PER_BATCH)
+        instructions = _IMPORT_INSTRUCTIONS.format(max_faqs=self.max_faqs)
         message = self._build_message(instructions, "PAGE TEXT", content, existing_questions)
         return await self._extract(instructions, message)
 
@@ -157,7 +161,7 @@ class FAQGeneratorAgent:
             model_type=self.model_type,
             api_key=self.api_key,
             model_name=self.model_name,
-            max_tokens=FAQ_MAX_TOKENS,
+            max_tokens=self.max_tokens,
         )
 
         capture: dict = {}
@@ -213,13 +217,12 @@ class FAQGeneratorAgent:
         logger.error(f"FAQ generator: unexpected response content type {type(content)}")
         return []
 
-    @staticmethod
-    def _validate(data: dict) -> List[GeneratedFAQ]:
+    def _validate(self, data: dict) -> List[GeneratedFAQ]:
         """Validate model output, dropping malformed entries rather than the
         whole batch. Truncates over-long fields instead of rejecting them."""
         raw_items = (data or {}).get("faqs") or []
         faqs: List[GeneratedFAQ] = []
-        for item in raw_items[:MAX_FAQS_PER_BATCH]:
+        for item in raw_items[: self.max_faqs]:
             if not isinstance(item, dict):
                 continue
             question = str(item.get("question") or "").strip()[:MAX_QUESTION_LENGTH]

--- a/backend/app/agents/faq_generator.py
+++ b/backend/app/agents/faq_generator.py
@@ -57,7 +57,7 @@ _FAQ_JSON_TOOL_SCHEMA = {
                 "type": "object",
                 "properties": {
                     "question": {"type": "string", "description": "The question, as a customer would ask it."},
-                    "answer": {"type": "string", "description": "A clear, self-contained answer (1-4 sentences)."},
+                    "answer": {"type": "string", "description": "A clear, self-contained answer. Simple Markdown allowed (numbered steps, bullet lists, **bold**, links from the content); no headings or images."},
                     "category": {"type": "string", "description": "Short topic grouping, e.g. 'Getting started', 'Billing'."},
                 },
                 "required": ["question", "answer", "category"],
@@ -81,7 +81,8 @@ Read the CONTENT below and draft frequently-asked questions a customer would rea
 
 Rules:
 - Ground every answer strictly in the CONTENT. Never invent facts, prices, limits or URLs that are not present.
-- Write questions the way a customer would phrase them, and answers in second person ("you"), 1-4 sentences, plain language, no markdown headings.
+- Write questions the way a customer would phrase them, and answers in second person ("you"), plain language.
+- Answers may use simple Markdown when it helps: numbered steps, bullet lists, **bold**, and links that appear in the CONTENT. No headings, no images, no invented URLs. Keep short answers to 1-4 sentences.
 - Extract between 1 and {max_faqs} FAQs; prefer the most useful ones. If the content contains nothing FAQ-worthy, return an empty list.
 - Assign each FAQ a short category. {category_rule}
 - Do NOT produce any question that duplicates or trivially rephrases one of the EXISTING QUESTIONS listed below."""
@@ -92,6 +93,7 @@ Read the PAGE TEXT below and extract every question-and-answer pair that is actu
 
 Rules:
 - Preserve the original wording as closely as possible; only trim navigation debris, repeated headings and boilerplate.
+- Preserve the page's list/step structure in answers as Markdown (numbered steps, bullet lists, **bold**, links present in the PAGE TEXT).
 - Only extract real Q&A pairs — skip marketing copy, navigation links and unrelated text.
 - Use the page's own section headings as categories where they exist; otherwise use "General".
 - Extract at most {max_faqs} pairs per call.

--- a/backend/app/agents/structured_output.py
+++ b/backend/app/agents/structured_output.py
@@ -1,0 +1,157 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Groq-safe structured output helpers.
+
+Groq's API rejects response_format (JSON mode) whenever tools are present
+("json mode cannot be combined with tool/function calling"), so agno's
+structured-output path degrades to prompt-only JSON — which GPT-OSS/Llama
+drift away from. GPT-OSS's native structured-output convention on Groq IS a
+tool call named `json`, so callers register a real `json` tool whose
+parameters are the response-model fields, mark it stop_after_tool_call, and
+read the result from the captured arguments. Shared by the chat agent and the
+FAQ generator; other providers keep using agno's native response_model path.
+"""
+
+import json
+import re
+
+from app.core.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def build_groq_json_tool(capture: dict, parameters: dict, description: str):
+    """Return an agno `json` tool that records its call arguments into `capture`.
+
+    `capture` is mutated in place with the model's tool-call arguments; the
+    caller reads it after `agent.arun()` and builds its response model from it.
+    `parameters` is the JSON schema of the expected structured output.
+    """
+    from agno.tools.function import Function
+
+    def _record(**kwargs):
+        capture.clear()
+        capture.update(kwargs)
+        return "recorded"
+
+    return Function(
+        name="json",
+        description=description,
+        parameters=parameters,
+        entrypoint=_record,
+        stop_after_tool_call=True,
+        skip_entrypoint_processing=True,
+    )
+
+
+def _scan_json(s: str):
+    """Single pass over a JSON fragment tracking string state, the stack of
+    open brackets, and the last comma outside any string. The building block
+    for repairing truncated output of ANY shape (nested arrays included), not
+    just flat objects."""
+    stack = []
+    in_string = False
+    escaped = False
+    last_comma = -1
+    for i, ch in enumerate(s):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch in "{[":
+            stack.append(ch)
+        elif ch in "}]":
+            if stack:
+                stack.pop()
+        elif ch == ",":
+            last_comma = i
+    closers = ('"' if in_string else "") + "".join(
+        "}" if opener == "{" else "]" for opener in reversed(stack)
+    )
+    return closers, last_comma
+
+
+def lenient_json_load(s: str):
+    """Best-effort parse of a possibly-truncated JSON object. Returns dict or None.
+
+    When Groq truncates a `json` tool call, the trailing field is cut mid-value.
+    Close any open string/brackets; if the tail is still malformed (e.g. a
+    dangling key), progressively drop the last comma-separated fragment so the
+    earlier complete fields survive. Complete objects followed by trailing
+    wrapper braces parse via raw_decode.
+    """
+    s = (s or "").strip()
+    if not s:
+        return None
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError:
+        pass
+    # Complete value with trailing junk (e.g. the tool-call wrapper's braces).
+    try:
+        obj, _ = json.JSONDecoder().raw_decode(s)
+        if isinstance(obj, dict):
+            return obj
+    except json.JSONDecodeError:
+        pass
+    candidate = s
+    for _ in range(16):
+        closers, last_comma = _scan_json(candidate)
+        try:
+            return json.loads(candidate + closers)
+        except json.JSONDecodeError:
+            pass
+        if last_comma == -1:
+            break
+        candidate = candidate[:last_comma]
+    return None
+
+
+def salvage_groq_json_error(exc: Exception):
+    """Recover structured-output arguments from a Groq `tool_use_failed` error.
+
+    Groq returns the (truncated) tool-call text in `failed_generation`; every
+    field before the truncation point is intact. Returns a dict of arguments
+    or None.
+    """
+    text = getattr(exc, "message", None) or str(exc)
+    if "failed_generation" not in text:
+        return None
+    fg = None
+    try:
+        fg = json.loads(text).get("error", {}).get("failed_generation")
+    except Exception:
+        m = re.search(r'"failed_generation"\s*:\s*"(.*)"\s*\}\s*\}\s*$', text, re.DOTALL)
+        if m:
+            try:
+                # Decode JSON string escapes (\n, \", \uXXXX, non-ASCII) correctly —
+                # unicode_escape would corrupt emoji/accented characters.
+                fg = json.loads('"' + m.group(1) + '"')
+            except Exception:
+                fg = m.group(1)
+    if not fg:
+        return None
+    # fg looks like: {"name": "json", "arguments": {<fields, possibly truncated>}}
+    idx = fg.find('"arguments"')
+    brace = fg.find('{', idx) if idx != -1 else -1
+    if brace == -1:
+        return None
+    return lenient_json_load(fg[brace:])

--- a/backend/app/api/agent.py
+++ b/backend/app/api/agent.py
@@ -36,7 +36,6 @@ from app.core.s3 import upload_file_to_s3, get_s3_signed_url
 from app.core.config import settings
 from pydantic import BaseModel
 from agno.agent import Agent as AgnoAgent
-from agno.models.openai import OpenAIChat
 from app.utils.agno_utils import create_model
 from app.utils.rate_limit import limit_instruction_generation
 

--- a/backend/app/api/help_center/__init__.py
+++ b/backend/app/api/help_center/__init__.py
@@ -21,6 +21,7 @@ joins in the domain-verification unit). Mounted at /api/v1/help-center.
 from fastapi import APIRouter
 
 from app.api.help_center.branding import router as branding_router
+from app.api.help_center.domain import router as domain_router
 from app.api.help_center.faqs import router as faqs_router
 from app.api.help_center.generation import router as generation_router
 
@@ -28,3 +29,4 @@ router = APIRouter()
 router.include_router(branding_router)
 router.include_router(faqs_router)
 router.include_router(generation_router)
+router.include_router(domain_router)

--- a/backend/app/api/help_center/__init__.py
+++ b/backend/app/api/help_center/__init__.py
@@ -1,0 +1,30 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Admin API for the FAQ manager + help center, split by concern
+(settings/branding, FAQ content, generation jobs; the custom-domain router
+joins in the domain-verification unit). Mounted at /api/v1/help-center.
+"""
+
+from fastapi import APIRouter
+
+from app.api.help_center.branding import router as branding_router
+from app.api.help_center.faqs import router as faqs_router
+from app.api.help_center.generation import router as generation_router
+
+router = APIRouter()
+router.include_router(branding_router)
+router.include_router(faqs_router)
+router.include_router(generation_router)

--- a/backend/app/api/help_center/branding.py
+++ b/backend/app/api/help_center/branding.py
@@ -1,0 +1,188 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Help-center settings + branding endpoints (settings get/put, logo upload).
+"""
+
+import io
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from sqlalchemy.orm import Session, selectinload
+
+from app.core.auth import require_permissions
+from app.core.config import settings as app_settings
+from app.database import get_db
+from app.models.agent import Agent
+from app.models.help_center import HelpCenterSettings
+from app.models.schemas.help_center import (
+    DnsRecord,
+    DomainStatusResponse,
+    HelpCenterAgentOption,
+    HelpCenterSettingsResponse,
+    HelpCenterSettingsUpdate,
+)
+from app.models.user import User
+from app.repositories.faq import FAQRepository
+from app.repositories.help_center import HelpCenterRepository
+from app.services.file_storage import resolve_public_url, store_upload
+from app.services.help_center_access import check_help_center_access, help_center_allowed
+from app.services.help_center_settings import get_or_create_settings, live_url
+
+router = APIRouter()
+
+MAX_LOGO_BYTES = 2 * 1024 * 1024
+# Extensions are derived from the VALIDATED content type, never the client
+# filename — a filename-derived extension could store scriptable content
+# (.svg/.html) under the static uploads mount.
+_LOGO_TYPES = {"image/png": ".png", "image/svg+xml": ".svg"}
+# Conservative SVG screen: the logo renders on the public help center, so
+# active content in an uploaded SVG would be stored XSS there.
+_SVG_FORBIDDEN = (b"<script", b"javascript:", b"onload=", b"onerror=", b"onclick=", b"<foreignobject")
+
+
+def domain_status_response(row: HelpCenterSettings) -> DomainStatusResponse:
+    """DNS-records table for the admin UI, shaped from stored state."""
+    records = []
+    if row.custom_domain:
+        records = [
+            DnsRecord(
+                type="CNAME",
+                host=row.custom_domain,
+                value=app_settings.HELP_CENTER_CNAME_TARGET,
+                verified=row.cname_record_verified,
+            ),
+            DnsRecord(
+                type="TXT",
+                host=f"_chattermate.{row.custom_domain}",
+                value=f"cm-verify={row.domain_verification_token}",
+                verified=row.txt_record_verified,
+            ),
+        ]
+    return DomainStatusResponse(
+        custom_domain=row.custom_domain,
+        domain_status=row.domain_status,
+        ssl_status=row.ssl_status,
+        records=records,
+        domain_verified_at=row.domain_verified_at,
+    )
+
+
+async def settings_response(
+    db: Session, row: HelpCenterSettings, organization_id: UUID
+) -> HelpCenterSettingsResponse:
+    agents = (
+        db.query(Agent)
+        .options(selectinload(Agent.widgets))  # avoid a lazy-load query per agent
+        .filter(Agent.organization_id == organization_id)
+        .order_by(Agent.name)
+        .all()
+    )
+    response = HelpCenterSettingsResponse.model_validate(row)
+    response.logo_url = await resolve_public_url(row.logo_url) if row.logo_url else None
+    response.live_url = live_url(row)
+    response.published_count = FAQRepository(db).count_published(organization_id)
+    response.plan_allowed = help_center_allowed(db, organization_id)
+    response.agents = [
+        HelpCenterAgentOption(
+            id=agent.id,
+            name=agent.display_name or agent.name,
+            has_widget=bool(agent.widgets),
+        )
+        for agent in agents
+    ]
+    response.domain = domain_status_response(row)
+    return response
+
+
+@router.get("/settings", response_model=HelpCenterSettingsResponse)
+async def get_settings(
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    """Get-or-create the org's help center settings. Ungated read: the response
+    carries plan_allowed so the UI can render the upgrade lock."""
+    row = get_or_create_settings(db, current_user.organization)
+    return await settings_response(db, row, current_user.organization_id)
+
+
+@router.put("/settings", response_model=HelpCenterSettingsResponse)
+async def update_settings(
+    payload: HelpCenterSettingsUpdate,
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    check_help_center_access(db, current_user.organization_id)
+    row = get_or_create_settings(db, current_user.organization)
+    updates = payload.model_dump(exclude_unset=True)
+    if updates.get("agent_id") is not None:
+        agent = db.query(Agent).filter(
+            Agent.id == updates["agent_id"],
+            Agent.organization_id == current_user.organization_id,
+        ).first()
+        if not agent:
+            raise HTTPException(status_code=404, detail="Agent not found")
+    for field, value in updates.items():
+        setattr(row, field, value)
+    row = HelpCenterRepository(db).update(row)
+    return await settings_response(db, row, current_user.organization_id)
+
+
+@router.post("/logo", response_model=HelpCenterSettingsResponse)
+async def upload_logo(
+    file: UploadFile = File(...),
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    check_help_center_access(db, current_user.organization_id)
+    row = get_or_create_settings(db, current_user.organization)
+
+    content = await file.read()
+    if len(content) > MAX_LOGO_BYTES:
+        raise HTTPException(status_code=400, detail="Logo must be 2 MB or smaller.")
+    if file.content_type not in _LOGO_TYPES:
+        raise HTTPException(status_code=400, detail="Logo must be a PNG or SVG file.")
+    if file.content_type == "image/svg+xml":
+        lowered = content.lower()
+        if any(marker in lowered for marker in _SVG_FORBIDDEN):
+            raise HTTPException(status_code=400, detail="SVG logos must not contain scripts or event handlers.")
+    else:
+        try:
+            from PIL import Image
+            Image.open(io.BytesIO(content)).verify()
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid image file.")
+
+    file_name = f"{uuid4()}{_LOGO_TYPES[file.content_type]}"
+    row.logo_url = await store_upload(
+        content,
+        f"help_center/{current_user.organization_id}",
+        file_name,
+        content_type=file.content_type,
+    )
+    row = HelpCenterRepository(db).update(row)
+    return await settings_response(db, row, current_user.organization_id)
+
+
+@router.delete("/logo", response_model=HelpCenterSettingsResponse)
+async def remove_logo(
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    check_help_center_access(db, current_user.organization_id)
+    row = get_or_create_settings(db, current_user.organization)
+    row.logo_url = None
+    row = HelpCenterRepository(db).update(row)
+    return await settings_response(db, row, current_user.organization_id)

--- a/backend/app/api/help_center/branding.py
+++ b/backend/app/api/help_center/branding.py
@@ -19,11 +19,12 @@ Help-center settings + branding endpoints (settings get/put, logo upload).
 import io
 from uuid import UUID, uuid4
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from sqlalchemy.orm import Session, selectinload
 
 from app.core.auth import require_permissions
 from app.core.config import settings as app_settings
+from app.core.cors import update_cors_middleware
 from app.database import get_db
 from app.models.agent import Agent
 from app.models.help_center import HelpCenterSettings
@@ -121,6 +122,7 @@ async def get_settings(
 @router.put("/settings", response_model=HelpCenterSettingsResponse)
 async def update_settings(
     payload: HelpCenterSettingsUpdate,
+    request: Request,
     current_user: User = Depends(require_permissions("manage_knowledge")),
     db: Session = Depends(get_db),
 ):
@@ -134,9 +136,14 @@ async def update_settings(
         ).first()
         if not agent:
             raise HTTPException(status_code=404, detail="Agent not found")
+    was_enabled = row.enabled
     for field, value in updates.items():
         setattr(row, field, value)
     row = HelpCenterRepository(db).update(row)
+    # Toggling `enabled` changes which {slug}.{base} origins the widget may call,
+    # so refresh the CORS allowlist (and propagate to other workers via Redis).
+    if "enabled" in updates and updates["enabled"] != was_enabled:
+        update_cors_middleware(request.app)
     return await settings_response(db, row, current_user.organization_id)
 
 

--- a/backend/app/api/help_center/domain.py
+++ b/backend/app/api/help_center/domain.py
@@ -19,11 +19,12 @@ inspect status, remove.
 
 import asyncio
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.auth import require_permissions
+from app.core.cors import update_cors_middleware
 from app.database import get_db
 from app.models.schemas.help_center import DomainRequest, DomainStatusResponse
 from app.models.user import User
@@ -73,6 +74,7 @@ async def remove_domain(
 
 @router.post("/domain/verify", response_model=DomainStatusResponse)
 async def verify_domain(
+    request: Request,
     current_user: User = Depends(require_permissions("manage_knowledge")),
     db: Session = Depends(get_db),
 ):
@@ -82,6 +84,9 @@ async def verify_domain(
         raise HTTPException(status_code=400, detail="Set a custom domain first.")
     # DNS + HTTPS probes block; keep them off the event loop.
     row = await asyncio.to_thread(verify_custom_domain, db, row)
+    # Once verified, the custom domain becomes a widget origin — allow it in CORS.
+    if row.domain_verified:
+        update_cors_middleware(request.app)
     return _domain_response(row)
 
 

--- a/backend/app/api/help_center/domain.py
+++ b/backend/app/api/help_center/domain.py
@@ -1,0 +1,96 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Custom-domain lifecycle for the help center: claim, verify (DNS + SSL),
+inspect status, remove.
+"""
+
+import asyncio
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.auth import require_permissions
+from app.database import get_db
+from app.models.schemas.help_center import DomainRequest, DomainStatusResponse
+from app.models.user import User
+from app.services.domain_verification import (
+    clear_custom_domain,
+    set_custom_domain,
+    verify_custom_domain,
+)
+from app.services.help_center_access import check_help_center_access
+from app.services.help_center_settings import get_or_create_settings
+
+router = APIRouter()
+
+
+def _domain_response(row) -> DomainStatusResponse:
+    from app.api.help_center.branding import domain_status_response
+    return domain_status_response(row)
+
+
+@router.post("/domain", response_model=DomainStatusResponse)
+async def set_domain(
+    payload: DomainRequest,
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    check_help_center_access(db, current_user.organization_id)
+    row = get_or_create_settings(db, current_user.organization)
+    try:
+        row = set_custom_domain(db, row, payload.domain)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="That domain is already in use.")
+    return _domain_response(row)
+
+
+@router.delete("/domain", response_model=DomainStatusResponse)
+async def remove_domain(
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    check_help_center_access(db, current_user.organization_id)
+    row = get_or_create_settings(db, current_user.organization)
+    return _domain_response(clear_custom_domain(db, row))
+
+
+@router.post("/domain/verify", response_model=DomainStatusResponse)
+async def verify_domain(
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    check_help_center_access(db, current_user.organization_id)
+    row = get_or_create_settings(db, current_user.organization)
+    if not row.custom_domain:
+        raise HTTPException(status_code=400, detail="Set a custom domain first.")
+    # DNS + HTTPS probes block; keep them off the event loop.
+    row = await asyncio.to_thread(verify_custom_domain, db, row)
+    return _domain_response(row)
+
+
+@router.get("/domain/status", response_model=DomainStatusResponse)
+async def domain_status(
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    """Stored state only — cheap enough for the UI's pending-domain polling.
+    POST /domain/verify is the endpoint that re-runs live DNS checks."""
+    row = get_or_create_settings(db, current_user.organization)
+    return _domain_response(row)

--- a/backend/app/api/help_center/faqs.py
+++ b/backend/app/api/help_center/faqs.py
@@ -1,0 +1,136 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.core.auth import require_permissions
+from app.database import get_db
+from app.models.faq import FAQ, FAQStatus
+from app.models.schemas.faq import (
+    FAQBulkStatusRequest,
+    FAQCreate,
+    FAQListResponse,
+    FAQResponse,
+    FAQUpdate,
+)
+from app.models.schemas.pagination import Pagination
+from app.models.user import User
+from app.repositories.faq import FAQRepository
+from app.services.help_center_access import check_help_center_access
+
+router = APIRouter()
+
+
+def _get_owned_faq(faq_id: UUID, current_user: User, db: Session) -> FAQ:
+    faq = FAQRepository(db).get_by_id(faq_id, current_user.organization_id)
+    # 404 for both missing and cross-org ids (don't reveal existence).
+    if not faq:
+        raise HTTPException(status_code=404, detail="FAQ not found")
+    return faq
+
+
+@router.get("/faqs", response_model=FAQListResponse)
+async def list_faqs(
+    status: Optional[FAQStatus] = Query(default=None),
+    category: Optional[str] = Query(default=None),
+    q: Optional[str] = Query(default=None, max_length=200),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=100, ge=1, le=200),
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    items, total = FAQRepository(db).list_for_org(
+        current_user.organization_id,
+        status=status,
+        category=category,
+        search=q,
+        skip=(page - 1) * page_size,
+        limit=page_size,
+    )
+    return FAQListResponse(
+        faqs=[FAQResponse.model_validate(item) for item in items],
+        pagination=Pagination.build(total=total, page=page, page_size=page_size),
+    )
+
+
+@router.get("/faqs/categories", response_model=List[str])
+async def list_categories(
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    return FAQRepository(db).get_categories(current_user.organization_id)
+
+
+@router.post("/faqs", response_model=FAQResponse, status_code=201)
+async def create_faq(
+    payload: FAQCreate,
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    check_help_center_access(db, current_user.organization_id)
+    faq = FAQ(
+        organization_id=current_user.organization_id,
+        question=payload.question,
+        answer=payload.answer,
+        category=payload.category,
+        status=payload.status,
+        source_label="Added manually",
+        created_by=current_user.id,
+    )
+    return FAQResponse.model_validate(FAQRepository(db).create(faq))
+
+
+@router.put("/faqs/{faq_id}", response_model=FAQResponse)
+async def update_faq(
+    faq_id: UUID,
+    payload: FAQUpdate,
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    check_help_center_access(db, current_user.organization_id)
+    faq = _get_owned_faq(faq_id, current_user, db)
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(faq, field, value)
+    return FAQResponse.model_validate(FAQRepository(db).update(faq))
+
+
+@router.delete("/faqs/{faq_id}", status_code=204)
+async def delete_faq(
+    faq_id: UUID,
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    check_help_center_access(db, current_user.organization_id)
+    faq = _get_owned_faq(faq_id, current_user, db)
+    FAQRepository(db).delete(faq)
+
+
+@router.post("/faqs/bulk-status")
+async def bulk_set_status(
+    payload: FAQBulkStatusRequest,
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    """Publish/unpublish one or many FAQs in a single call."""
+    check_help_center_access(db, current_user.organization_id)
+    updated = FAQRepository(db).bulk_set_status(
+        current_user.organization_id, payload.faq_ids, payload.status
+    )
+    return {"updated": updated}

--- a/backend/app/api/help_center/faqs.py
+++ b/backend/app/api/help_center/faqs.py
@@ -15,13 +15,12 @@ limitations under the License.
 """
 
 from typing import List, Optional
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from sqlalchemy.orm import Session
 
 from app.core.auth import require_permissions
-from app.core.config import settings
 from app.database import get_db
 from app.models.faq import FAQ, FAQStatus
 from app.models.schemas.faq import (
@@ -35,31 +34,15 @@ from app.models.schemas.faq import (
 from app.models.schemas.pagination import Pagination
 from app.models.user import User
 from app.repositories.faq import FAQRepository
-from app.services.file_storage import store_upload
 from app.services.help_center_access import check_help_center_access
+from app.services.help_center_images import (
+    FAQ_IMAGE_TYPES,
+    MAX_FAQ_IMAGE_BYTES,
+    store_article_image,
+)
 from app.services.help_center_settings import generate_faq_slug
 
 router = APIRouter()
-
-# Images embedded in an article's Markdown must resolve to a STABLE, ABSOLUTE URL
-# (they render on the help-center domain, and the reference is stored inline in the
-# answer forever — so no signed/expiring URLs and no host-relative paths).
-MAX_FAQ_IMAGE_BYTES = 5 * 1024 * 1024
-_FAQ_IMAGE_TYPES = {
-    "image/png": ".png",
-    "image/jpeg": ".jpg",
-    "image/gif": ".gif",
-    "image/webp": ".webp",
-}
-
-
-def _absolute_upload_url(stored: str) -> str:
-    """Make a stored upload path absolute. S3 returns an absolute http(s) URL
-    already; local mode returns a path under the /api/v1/uploads mount, which we
-    anchor to the backend's public origin so it loads cross-domain."""
-    if stored.startswith("http"):
-        return stored
-    return f"{settings.BACKEND_URL.rstrip('/')}{stored}"
 
 
 def _get_owned_faq(faq_id: UUID, current_user: User, db: Session) -> FAQ:
@@ -135,16 +118,9 @@ async def upload_faq_image(
     if len(content) > MAX_FAQ_IMAGE_BYTES:
         raise HTTPException(status_code=400, detail="Image must be 5MB or smaller.")
     # Extension comes from the VALIDATED content type, never the client filename.
-    if file.content_type not in _FAQ_IMAGE_TYPES:
+    if file.content_type not in FAQ_IMAGE_TYPES:
         raise HTTPException(status_code=400, detail="Use a PNG, JPEG, GIF or WebP image.")
-    file_name = f"{uuid4()}{_FAQ_IMAGE_TYPES[file.content_type]}"
-    stored = await store_upload(
-        content=content,
-        folder="help_center",
-        file_name=file_name,
-        content_type=file.content_type,
-    )
-    return {"url": _absolute_upload_url(stored)}
+    return {"url": await store_article_image(content, file.content_type)}
 
 
 @router.put("/faqs/{faq_id}", response_model=FAQResponse)

--- a/backend/app/api/help_center/faqs.py
+++ b/backend/app/api/help_center/faqs.py
@@ -25,6 +25,7 @@ from app.core.config import settings
 from app.database import get_db
 from app.models.faq import FAQ, FAQStatus
 from app.models.schemas.faq import (
+    FAQBulkDeleteRequest,
     FAQBulkStatusRequest,
     FAQCreate,
     FAQListResponse,
@@ -187,3 +188,15 @@ async def bulk_set_status(
         current_user.organization_id, payload.faq_ids, payload.status
     )
     return {"updated": updated}
+
+
+@router.post("/faqs/bulk-delete")
+async def bulk_delete(
+    payload: FAQBulkDeleteRequest,
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    """Delete many FAQs in one call (org-scoped; foreign ids are ignored)."""
+    check_help_center_access(db, current_user.organization_id)
+    deleted = FAQRepository(db).bulk_delete(current_user.organization_id, payload.faq_ids)
+    return {"deleted": deleted}

--- a/backend/app/api/help_center/faqs.py
+++ b/backend/app/api/help_center/faqs.py
@@ -15,12 +15,13 @@ limitations under the License.
 """
 
 from typing import List, Optional
-from uuid import UUID
+from uuid import UUID, uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from sqlalchemy.orm import Session
 
 from app.core.auth import require_permissions
+from app.core.config import settings
 from app.database import get_db
 from app.models.faq import FAQ, FAQStatus
 from app.models.schemas.faq import (
@@ -33,9 +34,31 @@ from app.models.schemas.faq import (
 from app.models.schemas.pagination import Pagination
 from app.models.user import User
 from app.repositories.faq import FAQRepository
+from app.services.file_storage import store_upload
 from app.services.help_center_access import check_help_center_access
+from app.services.help_center_settings import generate_faq_slug
 
 router = APIRouter()
+
+# Images embedded in an article's Markdown must resolve to a STABLE, ABSOLUTE URL
+# (they render on the help-center domain, and the reference is stored inline in the
+# answer forever — so no signed/expiring URLs and no host-relative paths).
+MAX_FAQ_IMAGE_BYTES = 5 * 1024 * 1024
+_FAQ_IMAGE_TYPES = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+}
+
+
+def _absolute_upload_url(stored: str) -> str:
+    """Make a stored upload path absolute. S3 returns an absolute http(s) URL
+    already; local mode returns a path under the /api/v1/uploads mount, which we
+    anchor to the backend's public origin so it loads cross-domain."""
+    if stored.startswith("http"):
+        return stored
+    return f"{settings.BACKEND_URL.rstrip('/')}{stored}"
 
 
 def _get_owned_faq(faq_id: UUID, current_user: User, db: Session) -> FAQ:
@@ -91,10 +114,36 @@ async def create_faq(
         answer=payload.answer,
         category=payload.category,
         status=payload.status,
+        slug=generate_faq_slug(db, current_user.organization_id, payload.question),
         source_label="Added manually",
         created_by=current_user.id,
     )
     return FAQResponse.model_validate(FAQRepository(db).create(faq))
+
+
+@router.post("/faqs/image")
+async def upload_faq_image(
+    file: UploadFile = File(...),
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    """Upload an image for embedding in an article's Markdown. Returns a stable
+    absolute URL the editor inserts as ![](url)."""
+    check_help_center_access(db, current_user.organization_id)
+    content = await file.read()
+    if len(content) > MAX_FAQ_IMAGE_BYTES:
+        raise HTTPException(status_code=400, detail="Image must be 5MB or smaller.")
+    # Extension comes from the VALIDATED content type, never the client filename.
+    if file.content_type not in _FAQ_IMAGE_TYPES:
+        raise HTTPException(status_code=400, detail="Use a PNG, JPEG, GIF or WebP image.")
+    file_name = f"{uuid4()}{_FAQ_IMAGE_TYPES[file.content_type]}"
+    stored = await store_upload(
+        content=content,
+        folder="help_center",
+        file_name=file_name,
+        content_type=file.content_type,
+    )
+    return {"url": _absolute_upload_url(stored)}
 
 
 @router.put("/faqs/{faq_id}", response_model=FAQResponse)
@@ -108,6 +157,10 @@ async def update_faq(
     faq = _get_owned_faq(faq_id, current_user, db)
     for field, value in payload.model_dump(exclude_unset=True).items():
         setattr(faq, field, value)
+    # Backfill a slug for legacy/generated FAQs the first time they're edited;
+    # keep an existing slug stable so published article URLs never change.
+    if not faq.slug:
+        faq.slug = generate_faq_slug(db, current_user.organization_id, faq.question)
     return FAQResponse.model_validate(FAQRepository(db).update(faq))
 
 

--- a/backend/app/api/help_center/generation.py
+++ b/backend/app/api/help_center/generation.py
@@ -135,6 +135,10 @@ async def start_generation(
     existing questions). By default only sources without FAQs are read;
     knowledge_ids explicitly targets sources instead."""
     org_id = current_user.organization_id
+    # Plan gate and AI-config checks first: a locked plan must see 403 and a
+    # missing model its setup hint, not source-count errors.
+    check_help_center_access(db, org_id)
+    _require_ai_config(db, org_id)
     knowledge_ids = payload.knowledge_ids if payload else None
     _validate_org_knowledge_ids(db, org_id, knowledge_ids)
     estimate = estimate_generation_calls(db, org_id, knowledge_ids)

--- a/backend/app/api/help_center/generation.py
+++ b/backend/app/api/help_center/generation.py
@@ -24,11 +24,22 @@ from app.core.auth import require_permissions
 from app.database import get_db
 from app.knowledge.url_safety import resolves_to_blocked_host
 from app.models.faq_generation_job import FAQGenerationJob, FAQJobType
-from app.models.schemas.faq import GenerationJobResponse, ImportRequest
+from app.models.knowledge import Knowledge
+from app.models.schemas.faq import (
+    GenerateRequest,
+    GenerationEstimateResponse,
+    GenerationJobResponse,
+    ImportRequest,
+)
 from app.models.user import User
 from app.repositories.ai_config import AIConfigRepository
 from app.repositories.faq_generation_job import FAQGenerationJobRepository
-from app.services.faq_usage import ensure_generation_budget, generation_is_metered
+from app.services.faq_usage import (
+    ensure_generation_budget,
+    estimate_generation_calls,
+    generation_is_metered,
+    remaining_message_credits,
+)
 from app.services.help_center_access import check_help_center_access
 
 router = APIRouter()
@@ -80,14 +91,67 @@ def _enqueue(
         raise HTTPException(status_code=409, detail="A job of this type is already running.")
 
 
-@router.post("/generate", response_model=GenerationJobResponse, status_code=202)
-async def start_generation(
+def _validate_org_knowledge_ids(db: Session, organization_id, knowledge_ids) -> None:
+    if not knowledge_ids:
+        return
+    owned = {
+        row[0]
+        for row in db.query(Knowledge.id)
+        .filter(Knowledge.organization_id == organization_id, Knowledge.id.in_(knowledge_ids))
+        .all()
+    }
+    if set(knowledge_ids) - owned:
+        raise HTTPException(status_code=400, detail="Unknown knowledge source in selection.")
+
+
+@router.get("/generate/estimate", response_model=GenerationEstimateResponse)
+async def generation_estimate(
     current_user: User = Depends(require_permissions("manage_knowledge")),
     db: Session = Depends(get_db),
 ):
-    """Draft FAQs from the whole knowledge base (additive; the worker dedups
-    against existing questions)."""
-    job = _enqueue(db, current_user, FAQJobType.GENERATE_ALL)
+    """Pre-generation numbers for the confirm dialog: new (ungenerated)
+    sources, page count, estimated LLM calls and remaining credits."""
+    org_id = current_user.organization_id
+    check_help_center_access(db, org_id)
+    estimate = estimate_generation_calls(db, org_id)
+    metered = generation_is_metered(db, org_id)
+    return GenerationEstimateResponse(
+        total_sources=estimate.total_sources,
+        new_sources=estimate.new_sources,
+        pages=estimate.pages,
+        estimated_calls=estimate.estimated_calls,
+        metered=metered,
+        remaining_credits=remaining_message_credits(db, org_id) if metered else None,
+    )
+
+
+@router.post("/generate", response_model=GenerationJobResponse, status_code=202)
+async def start_generation(
+    payload: Optional[GenerateRequest] = None,
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    """Draft FAQs from the knowledge base (additive; the worker dedups against
+    existing questions). By default only sources without FAQs are read;
+    knowledge_ids explicitly targets sources instead."""
+    org_id = current_user.organization_id
+    knowledge_ids = payload.knowledge_ids if payload else None
+    _validate_org_knowledge_ids(db, org_id, knowledge_ids)
+    estimate = estimate_generation_calls(db, org_id, knowledge_ids)
+    if estimate.total_sources == 0:
+        raise HTTPException(status_code=400, detail="No knowledge sources to generate from. Add knowledge first.")
+    if estimate.new_sources == 0:
+        raise HTTPException(
+            status_code=409,
+            detail="All knowledge sources already have FAQs. Delete a source's FAQs to regenerate it.",
+        )
+    job = _enqueue(
+        db,
+        current_user,
+        FAQJobType.GENERATE_ALL,
+        estimated_calls=estimate.estimated_calls,
+        knowledge_ids=knowledge_ids,
+    )
     return GenerationJobResponse.model_validate(job)
 
 

--- a/backend/app/api/help_center/generation.py
+++ b/backend/app/api/help_center/generation.py
@@ -22,6 +22,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.auth import require_permissions
+from app.core.config import settings
 from app.core.file_validation import PDF_MAGIC, read_validated, safe_filename
 from app.database import get_db
 from app.knowledge.url_safety import resolves_to_blocked_host
@@ -82,6 +83,13 @@ def _enqueue(
         _require_ai_config(db, org_id)
         ensure_generation_budget(db, org_id, estimated_calls)
     job_repo = FAQGenerationJobRepository(db)
+    # Clear jobs a dead worker left in 'processing' so they don't block this
+    # enqueue (the one-active-per-type guard + partial unique index).
+    job_repo.fail_orphaned_processing(
+        "Worker stopped before the job finished — please try again.",
+        older_than_seconds=settings.FAQ_JOB_STALE_SECONDS,
+        organization_id=org_id,
+    )
     if job_repo.get_active_for_org(org_id, job_type):
         raise HTTPException(status_code=409, detail="A job of this type is already running.")
     try:

--- a/backend/app/api/help_center/generation.py
+++ b/backend/app/api/help_center/generation.py
@@ -62,16 +62,19 @@ def _enqueue(
     current_user: User,
     job_type: FAQJobType,
     estimated_calls: int = MIN_IMPORT_CALL_ESTIMATE,
+    requires_llm: bool = True,
     **fields,
 ) -> FAQGenerationJob:
     """Shared enqueue guard: one active job per type per org (409 on dupes),
     fail fast when no AI model is configured, 402 when a metered run exceeds
     the remaining message credits. Stamps the job's `metered` flag from the
-    org's current AI config."""
+    org's current AI config. requires_llm=False (article import) skips the
+    AI-config and credit checks entirely."""
     org_id = current_user.organization_id
     check_help_center_access(db, org_id)
-    _require_ai_config(db, org_id)
-    ensure_generation_budget(db, org_id, estimated_calls)
+    if requires_llm:
+        _require_ai_config(db, org_id)
+        ensure_generation_budget(db, org_id, estimated_calls)
     job_repo = FAQGenerationJobRepository(db)
     if job_repo.get_active_for_org(org_id, job_type):
         raise HTTPException(status_code=409, detail="A job of this type is already running.")
@@ -81,7 +84,7 @@ def _enqueue(
                 organization_id=org_id,
                 user_id=current_user.id,
                 job_type=job_type.value,
-                metered=generation_is_metered(db, org_id),
+                metered=requires_llm and generation_is_metered(db, org_id),
                 **fields,
             )
         )
@@ -165,12 +168,21 @@ async def start_import(
     current_user: User = Depends(require_permissions("manage_knowledge")),
     db: Session = Depends(get_db),
 ):
-    """Migrate an existing FAQ page: crawl it and draft its Q&A pairs."""
+    """Migrate an existing help center. mode=qa extracts Q&A pairs from the
+    page with the org's model (uses credits); mode=articles crawls the page's
+    linked article pages and imports each one as-is (Markdown, no LLM)."""
     # Early SSRF rejection for immediate feedback; the worker re-validates at
     # fetch time (including every redirect hop).
     if resolves_to_blocked_host(payload.url):
         raise HTTPException(status_code=400, detail="That URL points to a blocked or internal host.")
-    job = _enqueue(db, current_user, FAQJobType.IMPORT_URL, source_url=payload.url)
+    if payload.mode == "articles":
+        # No LLM → no AI-config requirement, no credit checks.
+        job = _enqueue(
+            db, current_user, FAQJobType.IMPORT_ARTICLES,
+            requires_llm=False, source_url=payload.url,
+        )
+    else:
+        job = _enqueue(db, current_user, FAQJobType.IMPORT_URL, source_url=payload.url)
     return GenerationJobResponse.model_validate(job)
 
 

--- a/backend/app/api/help_center/generation.py
+++ b/backend/app/api/help_center/generation.py
@@ -1,0 +1,118 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.auth import require_permissions
+from app.database import get_db
+from app.knowledge.url_safety import resolves_to_blocked_host
+from app.models.faq_generation_job import FAQGenerationJob, FAQJobType
+from app.models.schemas.faq import GenerationJobResponse, ImportRequest
+from app.models.user import User
+from app.repositories.ai_config import AIConfigRepository
+from app.repositories.faq_generation_job import FAQGenerationJobRepository
+from app.services.help_center_access import check_help_center_access
+
+router = APIRouter()
+
+
+def _require_ai_config(db: Session, organization_id) -> None:
+    if not AIConfigRepository(db).get_active_config(organization_id):
+        raise HTTPException(
+            status_code=400,
+            detail="No active AI configuration. Set up an AI model in AI Configuration first.",
+        )
+
+
+def _enqueue(db: Session, current_user: User, job_type: FAQJobType, **fields) -> FAQGenerationJob:
+    """Shared enqueue guard: one active job per type per org (409 on dupes),
+    fail fast when no AI model is configured."""
+    check_help_center_access(db, current_user.organization_id)
+    _require_ai_config(db, current_user.organization_id)
+    job_repo = FAQGenerationJobRepository(db)
+    if job_repo.get_active_for_org(current_user.organization_id, job_type):
+        raise HTTPException(status_code=409, detail="A job of this type is already running.")
+    try:
+        return job_repo.create(
+            FAQGenerationJob(
+                organization_id=current_user.organization_id,
+                user_id=current_user.id,
+                job_type=job_type.value,
+                **fields,
+            )
+        )
+    except IntegrityError:
+        # Concurrent enqueue lost the race against the partial unique index.
+        db.rollback()
+        raise HTTPException(status_code=409, detail="A job of this type is already running.")
+
+
+@router.post("/generate", response_model=GenerationJobResponse, status_code=202)
+async def start_generation(
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    """Draft FAQs from the whole knowledge base (additive; the worker dedups
+    against existing questions)."""
+    job = _enqueue(db, current_user, FAQJobType.GENERATE_ALL)
+    return GenerationJobResponse.model_validate(job)
+
+
+@router.post("/import", response_model=GenerationJobResponse, status_code=202)
+async def start_import(
+    payload: ImportRequest,
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    """Migrate an existing FAQ page: crawl it and draft its Q&A pairs."""
+    # Early SSRF rejection for immediate feedback; the worker re-validates at
+    # fetch time (including every redirect hop).
+    if resolves_to_blocked_host(payload.url):
+        raise HTTPException(status_code=400, detail="That URL points to a blocked or internal host.")
+    job = _enqueue(db, current_user, FAQJobType.IMPORT_URL, source_url=payload.url)
+    return GenerationJobResponse.model_validate(job)
+
+
+@router.get("/jobs", response_model=Optional[GenerationJobResponse])
+async def get_job(
+    active: bool = Query(default=True, description="Active job only; false = most recent job"),
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    """The UI's polling endpoint: the running job if any (active=true), or the
+    most recent job of any status (active=false) for showing the last outcome."""
+    job_repo = FAQGenerationJobRepository(db)
+    if active:
+        job = job_repo.get_active_for_org(current_user.organization_id)
+    else:
+        job = job_repo.get_latest_for_org(current_user.organization_id)
+    return GenerationJobResponse.model_validate(job) if job else None
+
+
+@router.get("/jobs/{job_id}", response_model=GenerationJobResponse)
+async def get_job_by_id(
+    job_id: int,
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    job = FAQGenerationJobRepository(db).get_by_id_for_org(job_id, current_user.organization_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return GenerationJobResponse.model_validate(job)

--- a/backend/app/api/help_center/generation.py
+++ b/backend/app/api/help_center/generation.py
@@ -115,6 +115,10 @@ def _validate_org_knowledge_ids(db: Session, organization_id, knowledge_ids) -> 
 
 @router.get("/generate/estimate", response_model=GenerationEstimateResponse)
 async def generation_estimate(
+    include_pages: bool = Query(
+        default=True,
+        description="False skips the per-source page scan — cheap counts for button labels",
+    ),
     current_user: User = Depends(require_permissions("manage_knowledge")),
     db: Session = Depends(get_db),
 ):
@@ -122,7 +126,7 @@ async def generation_estimate(
     sources, page count, estimated LLM calls and remaining credits."""
     org_id = current_user.organization_id
     check_help_center_access(db, org_id)
-    estimate = estimate_generation_calls(db, org_id)
+    estimate = estimate_generation_calls(db, org_id, count_pages=include_pages)
     metered = generation_is_metered(db, org_id)
     return GenerationEstimateResponse(
         total_sources=estimate.total_sources,

--- a/backend/app/api/help_center/generation.py
+++ b/backend/app/api/help_center/generation.py
@@ -15,12 +15,14 @@ limitations under the License.
 """
 
 from typing import Optional
+from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.core.auth import require_permissions
+from app.core.file_validation import PDF_MAGIC, read_validated, safe_filename
 from app.database import get_db
 from app.knowledge.url_safety import resolves_to_blocked_host
 from app.models.faq_generation_job import FAQGenerationJob, FAQJobType
@@ -47,6 +49,10 @@ router = APIRouter()
 # Budget floor for imports whose call count isn't known up front — blocks only
 # a fully exhausted plan; the per-call metering happens in the worker.
 MIN_IMPORT_CALL_ESTIMATE = 1
+
+MAX_IMPORT_PDF_BYTES = 25 * 1024 * 1024
+# Stored under its own folder so import buffers never mix with article images.
+_PDF_IMPORT_FOLDER = "help_center_imports"
 
 
 def _require_ai_config(db: Session, organization_id) -> None:
@@ -183,6 +189,45 @@ async def start_import(
         )
     else:
         job = _enqueue(db, current_user, FAQJobType.IMPORT_URL, source_url=payload.url)
+    return GenerationJobResponse.model_validate(job)
+
+
+@router.post("/import/pdf", response_model=GenerationJobResponse, status_code=202)
+async def start_pdf_import(
+    file: UploadFile = File(...),
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    """Extract Q&A pairs from an uploaded PDF with the org's model. The file
+    is persisted via shared storage (the worker runs in another container)
+    and deleted after processing."""
+    from app.services.file_storage import store_upload
+
+    content = await read_validated(
+        file,
+        max_size=MAX_IMPORT_PDF_BYTES,
+        allowed_content_types=("application/pdf",),
+        magic_prefix=PDF_MAGIC,
+        label="PDF",
+    )
+    stored = await store_upload(
+        content=content,
+        folder=_PDF_IMPORT_FOLDER,
+        file_name=f"{uuid4().hex}.pdf",
+        content_type="application/pdf",
+    )
+    # safe_filename strips traversal; keep only the readable tail for the label.
+    original = safe_filename(file.filename or "document.pdf").split("_", 1)[-1][:255]
+    try:
+        job = _enqueue(
+            db, current_user, FAQJobType.IMPORT_PDF,
+            source_url=stored, source_file_name=original,
+        )
+    except HTTPException:
+        # Enqueue refused (plan/config/duplicate/budget) — don't leak the buffer.
+        from app.services.file_storage import delete_upload
+        await delete_upload(stored)
+        raise
     return GenerationJobResponse.model_validate(job)
 
 

--- a/backend/app/api/help_center/generation.py
+++ b/backend/app/api/help_center/generation.py
@@ -28,9 +28,14 @@ from app.models.schemas.faq import GenerationJobResponse, ImportRequest
 from app.models.user import User
 from app.repositories.ai_config import AIConfigRepository
 from app.repositories.faq_generation_job import FAQGenerationJobRepository
+from app.services.faq_usage import ensure_generation_budget, generation_is_metered
 from app.services.help_center_access import check_help_center_access
 
 router = APIRouter()
+
+# Budget floor for imports whose call count isn't known up front — blocks only
+# a fully exhausted plan; the per-call metering happens in the worker.
+MIN_IMPORT_CALL_ESTIMATE = 1
 
 
 def _require_ai_config(db: Session, organization_id) -> None:
@@ -41,20 +46,31 @@ def _require_ai_config(db: Session, organization_id) -> None:
         )
 
 
-def _enqueue(db: Session, current_user: User, job_type: FAQJobType, **fields) -> FAQGenerationJob:
+def _enqueue(
+    db: Session,
+    current_user: User,
+    job_type: FAQJobType,
+    estimated_calls: int = MIN_IMPORT_CALL_ESTIMATE,
+    **fields,
+) -> FAQGenerationJob:
     """Shared enqueue guard: one active job per type per org (409 on dupes),
-    fail fast when no AI model is configured."""
-    check_help_center_access(db, current_user.organization_id)
-    _require_ai_config(db, current_user.organization_id)
+    fail fast when no AI model is configured, 402 when a metered run exceeds
+    the remaining message credits. Stamps the job's `metered` flag from the
+    org's current AI config."""
+    org_id = current_user.organization_id
+    check_help_center_access(db, org_id)
+    _require_ai_config(db, org_id)
+    ensure_generation_budget(db, org_id, estimated_calls)
     job_repo = FAQGenerationJobRepository(db)
-    if job_repo.get_active_for_org(current_user.organization_id, job_type):
+    if job_repo.get_active_for_org(org_id, job_type):
         raise HTTPException(status_code=409, detail="A job of this type is already running.")
     try:
         return job_repo.create(
             FAQGenerationJob(
-                organization_id=current_user.organization_id,
+                organization_id=org_id,
                 user_id=current_user.id,
                 job_type=job_type.value,
+                metered=generation_is_metered(db, org_id),
                 **fields,
             )
         )

--- a/backend/app/api/help_center_public.py
+++ b/backend/app/api/help_center_public.py
@@ -15,7 +15,8 @@ limitations under the License.
 
 The public help-center site: a standalone FastAPI app the host-dispatch layer
 routes {slug}.<base-domain> and verified custom domains to. Server-rendered
-Jinja2 HTML for SEO; the only JSON endpoint is the rate-limited "Ask AI".
+Jinja2 HTML for SEO (landing list + per-article pages); the only JSON endpoint
+is the rate-limited "Ask AI".
 """
 
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -26,14 +27,25 @@ from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.database import get_db
+from app.models.faq import FAQ
+from app.models.help_center import HelpCenterSettings
 from app.services.file_storage import resolve_public_url
+from app.services.help_center_content import (
+    excerpt,
+    read_time_label,
+    render_article_html,
+    to_plain_text,
+)
 from app.services.help_center_public import (
     MAX_QUESTION_CHARS,
     answer_question,
     ask_available,
+    category_colors,
     contrast_ink,
+    get_published_article,
     normalize_host,
     published_faq_groups,
+    related_articles,
     resolve_help_center,
     widget_id_for,
 )
@@ -71,8 +83,25 @@ def _resolve_or_404(request: Request, db: Session):
     return row
 
 
+async def _chrome_context(row: HelpCenterSettings) -> dict:
+    """Shared header/footer/widget context used by every rendered page."""
+    return {
+        "row": row,
+        "brand_color": row.brand_color,
+        "brand_ink": contrast_ink(row.brand_color),
+        "logo_url": await resolve_public_url(row.logo_url) if row.logo_url else None,
+        "header_links": row.header_links or [],
+        "widget_id": widget_id_for(row),
+        # The widget LOADER (chattermate.min.js) is served by the frontend, while
+        # the widget APP it pulls in (/assets/widget.js) is served from
+        # VITE_WIDGET_URL by the backend. In prod both resolve to the app domain.
+        "widget_script_url": f"{settings.FRONTEND_URL}/webclient/chattermate.min.js",
+    }
+
+
 def _faq_json_ld(groups) -> dict:
-    """schema.org FAQPage structured data (Google FAQ rich results)."""
+    """schema.org FAQPage structured data (Google FAQ rich results). Uses the
+    plain-text form of the (Markdown) answer."""
     return {
         "@context": "https://schema.org",
         "@type": "FAQPage",
@@ -80,11 +109,23 @@ def _faq_json_ld(groups) -> dict:
             {
                 "@type": "Question",
                 "name": faq.question,
-                "acceptedAnswer": {"@type": "Answer", "text": faq.answer},
+                "acceptedAnswer": {"@type": "Answer", "text": to_plain_text(faq.answer)},
             }
             for _category, faqs in groups
             for faq in faqs
         ],
+    }
+
+
+def _card_view(faq: FAQ) -> dict:
+    """List-card view model: question links to the article, with a plain-text
+    preview and read time computed from the Markdown answer."""
+    return {
+        "question": faq.question,
+        "slug": faq.slug,
+        "preview": excerpt(faq.answer),
+        "read_time": read_time_label(faq.answer),
+        "search_text": f"{faq.question} {faq.answer} {faq.category}".lower(),
     }
 
 
@@ -93,27 +134,85 @@ async def index(request: Request, q: str = "", db: Session = Depends(get_db)):
     row = _resolve_or_404(request, db)
     search = q.strip()[:200] or None
     groups = published_faq_groups(db, row, search=search)
+    colors = category_colors([category for category, _faqs in groups])
+    card_groups = [(category, [_card_view(faq) for faq in faqs]) for category, faqs in groups]
     context = {
-        "faq_json_ld": _faq_json_ld(groups),
+        **await _chrome_context(row),
         "request": request,
-        "row": row,
-        "groups": groups,
+        "groups": card_groups,
+        "colors": colors,
         "search": search or "",
-        "brand_color": row.brand_color,
-        "brand_ink": contrast_ink(row.brand_color),
-        "logo_url": await resolve_public_url(row.logo_url) if row.logo_url else None,
         "title": row.title or f"{row.organization.name} Help Center",
         "description": row.description or f"Answers to common questions about {row.organization.name}.",
-        "canonical_url": live_url(row),
-        "header_links": row.header_links or [],
+        "canonical_url": f"{live_url(row)}/",
+        "og_type": "website",
+        "json_ld": _faq_json_ld(groups) if groups else None,
         "ask_enabled": ask_available(row),
-        "widget_id": widget_id_for(row),
-        # The widget LOADER (chattermate.min.js) is served by the frontend, while
-        # the widget APP it pulls in (/assets/widget.js) is served from
-        # VITE_WIDGET_URL by the backend. In prod both resolve to the app domain.
-        "widget_script_url": f"{settings.FRONTEND_URL}/webclient/chattermate.min.js",
     }
     response = templates.TemplateResponse(request, "help_center/index.html", context)
+    response.headers["Cache-Control"] = PAGE_CACHE_CONTROL
+    return response
+
+
+@public_app.get("/a/{slug}", response_class=HTMLResponse)
+async def article(slug: str, request: Request, db: Session = Depends(get_db)):
+    row = _resolve_or_404(request, db)
+    faq = get_published_article(db, row, slug)
+    if not faq:
+        raise HTTPException(status_code=404, detail="Article not found")
+
+    # All published categories (unfiltered) drive the sidebar + stable colors.
+    all_groups = published_faq_groups(db, row)
+    colors = category_colors([category for category, _faqs in all_groups])
+    default_color = colors.get(faq.category, "#6d5bd0")
+    topics = [
+        {
+            "category": category,
+            "count": len(faqs),
+            "color": colors.get(category, default_color),
+            "active": category == faq.category,
+        }
+        for category, faqs in all_groups
+    ]
+    related = [
+        {
+            "question": rel.question,
+            "slug": rel.slug,
+            "read_time": read_time_label(rel.answer),
+            "color": colors.get(rel.category, default_color),
+        }
+        for rel in related_articles(db, row, faq)
+    ]
+    article_view = {
+        "question": faq.question,
+        "category": faq.category,
+        "color": default_color,
+        "read_time": read_time_label(faq.answer),
+        "body_html": render_article_html(faq.answer),
+        "related": related,
+    }
+    canonical = f"{live_url(row)}/a/{faq.slug}"
+    json_ld = {
+        "@context": "https://schema.org",
+        "@type": "QAPage",
+        "mainEntity": {
+            "@type": "Question",
+            "name": faq.question,
+            "acceptedAnswer": {"@type": "Answer", "text": to_plain_text(faq.answer)},
+        },
+    }
+    context = {
+        **await _chrome_context(row),
+        "request": request,
+        "article": article_view,
+        "topics": topics,
+        "title": f"{faq.question} · {row.organization.name} Help Center",
+        "description": excerpt(faq.answer, 200) or faq.question,
+        "canonical_url": canonical,
+        "og_type": "article",
+        "json_ld": json_ld,
+    }
+    response = templates.TemplateResponse(request, "help_center/article.html", context)
     response.headers["Cache-Control"] = PAGE_CACHE_CONTROL
     return response
 
@@ -138,11 +237,18 @@ async def ask(payload: AskRequest, request: Request, db: Session = Depends(get_d
 @public_app.get("/sitemap.xml")
 async def sitemap(request: Request, db: Session = Depends(get_db)):
     row = _resolve_or_404(request, db)
+    base = live_url(row)
+    groups = published_faq_groups(db, row)
+    urls = [f"  <url><loc>{base}/</loc></url>"]
+    for _category, faqs in groups:
+        for faq in faqs:
+            if faq.slug:
+                urls.append(f"  <url><loc>{base}/a/{faq.slug}</loc></url>")
     xml = (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
-        f"  <url><loc>{live_url(row)}/</loc></url>\n"
-        "</urlset>\n"
+        + "\n".join(urls)
+        + "\n</urlset>\n"
     )
     return Response(content=xml, media_type="application/xml", headers={"Cache-Control": PAGE_CACHE_CONTROL})
 

--- a/backend/app/api/help_center_public.py
+++ b/backend/app/api/help_center_public.py
@@ -1,0 +1,156 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+The public help-center site: a standalone FastAPI app the host-dispatch layer
+routes {slug}.<base-domain> and verified custom domains to. Server-rendered
+Jinja2 HTML for SEO; the only JSON endpoint is the rate-limited "Ask AI".
+"""
+
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse, PlainTextResponse, Response
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.database import get_db
+from app.services.file_storage import resolve_public_url
+from app.services.help_center_public import (
+    MAX_QUESTION_CHARS,
+    answer_question,
+    ask_available,
+    contrast_ink,
+    normalize_host,
+    published_faq_groups,
+    resolve_help_center,
+    widget_id_for,
+)
+from app.services.help_center_settings import live_url
+from app.services.public_rate_limit import allow_request
+
+public_app = FastAPI(title="ChatterMate Help Center", docs_url=None, redoc_url=None, openapi_url=None)
+templates = Jinja2Templates(directory="app/templates")
+
+PAGE_CACHE_CONTROL = "public, max-age=60"
+ASK_LIMIT_PER_MINUTE = 10
+ASK_LIMIT_PER_DAY = 100
+
+
+class AskRequest(BaseModel):
+    question: str = Field(min_length=3, max_length=MAX_QUESTION_CHARS)
+
+
+def _client_ip(request: Request) -> str:
+    """Rate-limit key. Our nginx APPENDS the real client IP to any
+    X-Forwarded-For the client sent, so only the RIGHTMOST entry is
+    trustworthy — keying on the first entry would let attackers rotate fake
+    IPs and bypass the limit."""
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[-1].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _resolve_or_404(request: Request, db: Session):
+    host = normalize_host(request.headers.get("host"))
+    row = resolve_help_center(db, host)
+    if not row:
+        raise HTTPException(status_code=404, detail="Help center not found")
+    return row
+
+
+def _faq_json_ld(groups) -> dict:
+    """schema.org FAQPage structured data (Google FAQ rich results)."""
+    return {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": faq.question,
+                "acceptedAnswer": {"@type": "Answer", "text": faq.answer},
+            }
+            for _category, faqs in groups
+            for faq in faqs
+        ],
+    }
+
+
+@public_app.get("/", response_class=HTMLResponse)
+async def index(request: Request, q: str = "", db: Session = Depends(get_db)):
+    row = _resolve_or_404(request, db)
+    search = q.strip()[:200] or None
+    groups = published_faq_groups(db, row, search=search)
+    context = {
+        "faq_json_ld": _faq_json_ld(groups),
+        "request": request,
+        "row": row,
+        "groups": groups,
+        "search": search or "",
+        "brand_color": row.brand_color,
+        "brand_ink": contrast_ink(row.brand_color),
+        "logo_url": await resolve_public_url(row.logo_url) if row.logo_url else None,
+        "title": row.title or f"{row.organization.name} Help Center",
+        "description": row.description or f"Answers to common questions about {row.organization.name}.",
+        "canonical_url": live_url(row),
+        "header_links": row.header_links or [],
+        "ask_enabled": ask_available(row),
+        "widget_id": widget_id_for(row),
+        "widget_script_url": f"{settings.VITE_WIDGET_URL}/webclient/chattermate.min.js",
+    }
+    response = templates.TemplateResponse(request, "help_center/index.html", context)
+    response.headers["Cache-Control"] = PAGE_CACHE_CONTROL
+    return response
+
+
+@public_app.post("/ask")
+async def ask(payload: AskRequest, request: Request, db: Session = Depends(get_db)):
+    row = _resolve_or_404(request, db)
+    if not ask_available(row):
+        raise HTTPException(status_code=404, detail="AI answers are not enabled")
+    ip = _client_ip(request)
+    if not allow_request(f"ask:{ip}:1m", ASK_LIMIT_PER_MINUTE, 60) or not allow_request(
+        f"ask:{ip}:1d", ASK_LIMIT_PER_DAY, 86400
+    ):
+        raise HTTPException(status_code=429, detail="Too many questions — please try again later.")
+    # answer_question manages its own short sessions around the slow LLM call.
+    answer = await answer_question(row.organization_id, row.agent_id, payload.question)
+    if not answer:
+        raise HTTPException(status_code=503, detail="Could not answer right now — please try again.")
+    return {"answer": answer}
+
+
+@public_app.get("/sitemap.xml")
+async def sitemap(request: Request, db: Session = Depends(get_db)):
+    row = _resolve_or_404(request, db)
+    xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+        f"  <url><loc>{live_url(row)}/</loc></url>\n"
+        "</urlset>\n"
+    )
+    return Response(content=xml, media_type="application/xml", headers={"Cache-Control": PAGE_CACHE_CONTROL})
+
+
+@public_app.get("/robots.txt", response_class=PlainTextResponse)
+async def robots(request: Request, db: Session = Depends(get_db)):
+    row = _resolve_or_404(request, db)
+    return PlainTextResponse(f"User-agent: *\nAllow: /\nSitemap: {live_url(row)}/sitemap.xml\n")
+
+
+@public_app.get("/healthz")
+async def healthz():
+    """Liveness for the SSL-provisioning probe; host-level only, no org data."""
+    return {"status": "ok"}

--- a/backend/app/api/help_center_public.py
+++ b/backend/app/api/help_center_public.py
@@ -108,7 +108,10 @@ async def index(request: Request, q: str = "", db: Session = Depends(get_db)):
         "header_links": row.header_links or [],
         "ask_enabled": ask_available(row),
         "widget_id": widget_id_for(row),
-        "widget_script_url": f"{settings.VITE_WIDGET_URL}/webclient/chattermate.min.js",
+        # The widget LOADER (chattermate.min.js) is served by the frontend, while
+        # the widget APP it pulls in (/assets/widget.js) is served from
+        # VITE_WIDGET_URL by the backend. In prod both resolve to the app domain.
+        "widget_script_url": f"{settings.FRONTEND_URL}/webclient/chattermate.min.js",
     }
     response = templates.TemplateResponse(request, "help_center/index.html", context)
     response.headers["Cache-Control"] = PAGE_CACHE_CONTROL

--- a/backend/app/api/help_center_public.py
+++ b/backend/app/api/help_center_public.py
@@ -119,13 +119,16 @@ def _faq_json_ld(groups) -> dict:
 
 def _card_view(faq: FAQ) -> dict:
     """List-card view model: question links to the article, with a plain-text
-    preview and read time computed from the Markdown answer."""
+    preview and read time computed from the Markdown answer. Search fields are
+    split so the client can rank title hits above body hits, and the body is
+    plain text (raw Markdown would make URLs/syntax searchable noise)."""
     return {
         "question": faq.question,
         "slug": faq.slug,
         "preview": excerpt(faq.answer),
         "read_time": read_time_label(faq.answer),
-        "search_text": f"{faq.question} {faq.answer} {faq.category}".lower(),
+        "search_title": faq.question.lower(),
+        "search_text": f"{to_plain_text(faq.answer)} {faq.category}".lower(),
     }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -124,6 +124,11 @@ class Settings(BaseSettings):
     # Help center (public FAQ site)
     # Base domain serving {slug}.<base> help centers.
     HELP_CENTER_BASE_DOMAIN: str = os.getenv("HELP_CENTER_BASE_DOMAIN", "chattermate.help")
+    # FAQ generation cost caps (per source / per LLM call) and import fetch limits.
+    FAQ_MAX_PAGES_PER_SOURCE: int = int(os.getenv("FAQ_MAX_PAGES_PER_SOURCE", "300"))
+    FAQ_MAX_BATCH_CHARS: int = int(os.getenv("FAQ_MAX_BATCH_CHARS", "15000"))
+    FAQ_IMPORT_MAX_PAGE_CHARS: int = int(os.getenv("FAQ_IMPORT_MAX_PAGE_CHARS", "100000"))
+    FAQ_IMPORT_FETCH_TIMEOUT: int = int(os.getenv("FAQ_IMPORT_FETCH_TIMEOUT", "30"))
     # Subdomain labels reserved for infrastructure — must mirror the DNS/nginx
     # records that exist on the base domain, hence env-configurable.
     HELP_CENTER_RESERVED_SLUGS: frozenset = frozenset(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -157,6 +157,10 @@ class Settings(BaseSettings):
     # and reaped on the next enqueue. Generous — must exceed the slowest single
     # LLM batch / page fetch so a live-but-slow job is never killed.
     FAQ_JOB_STALE_SECONDS: int = int(os.getenv("FAQ_JOB_STALE_SECONDS", "600"))
+    # FAQ generation/import jobs processed concurrently across ALL orgs. Default
+    # 1 = strictly one business at a time (each job does LLM calls + vector-DB
+    # reads); raise for more throughput on a bigger host.
+    MAX_CONCURRENT_FAQ_JOBS: int = int(os.getenv("MAX_CONCURRENT_FAQ_JOBS", "1"))
     # Subdomain labels reserved for infrastructure — must mirror the DNS/nginx
     # records that exist on the base domain, hence env-configurable.
     HELP_CENTER_RESERVED_SLUGS: frozenset = frozenset(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -134,6 +134,11 @@ class Settings(BaseSettings):
     # FAQ generation cost caps (per source / per LLM call) and import fetch limits.
     FAQ_MAX_PAGES_PER_SOURCE: int = int(os.getenv("FAQ_MAX_PAGES_PER_SOURCE", "300"))
     FAQ_MAX_BATCH_CHARS: int = int(os.getenv("FAQ_MAX_BATCH_CHARS", "15000"))
+    # Ceiling for context-window-derived batch sizing (see utils/model_context.py)
+    # — a quality guard for very-large-context models, not a token limit.
+    FAQ_MAX_BATCH_CHARS_CEILING: int = int(os.getenv("FAQ_MAX_BATCH_CHARS_CEILING", "60000"))
+    # Force a context-window size (tokens) for exotic/self-hosted models; 0 = auto.
+    FAQ_CONTEXT_TOKENS_OVERRIDE: int = int(os.getenv("FAQ_CONTEXT_TOKENS_OVERRIDE", "0"))
     FAQ_IMPORT_MAX_PAGE_CHARS: int = int(os.getenv("FAQ_IMPORT_MAX_PAGE_CHARS", "100000"))
     FAQ_IMPORT_FETCH_TIMEOUT: int = int(os.getenv("FAQ_IMPORT_FETCH_TIMEOUT", "30"))
     # Subdomain labels reserved for infrastructure — must mirror the DNS/nginx

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -145,7 +145,9 @@ class Settings(BaseSettings):
     FAQ_IMPORT_MAX_PAGE_CHARS: int = int(os.getenv("FAQ_IMPORT_MAX_PAGE_CHARS", "100000"))
     FAQ_IMPORT_FETCH_TIMEOUT: int = int(os.getenv("FAQ_IMPORT_FETCH_TIMEOUT", "30"))
     # Article-mode import (crawl linked pages, no LLM): crawl and re-host caps.
-    FAQ_ARTICLE_IMPORT_MAX_PAGES: int = int(os.getenv("FAQ_ARTICLE_IMPORT_MAX_PAGES", "50"))
+    # High enough to pull a whole mid-size help center in one pass; a deliberate
+    # one-time migration in a background worker, so slowness is acceptable.
+    FAQ_ARTICLE_IMPORT_MAX_PAGES: int = int(os.getenv("FAQ_ARTICLE_IMPORT_MAX_PAGES", "200"))
     FAQ_ARTICLE_IMPORT_MAX_IMAGES: int = int(os.getenv("FAQ_ARTICLE_IMPORT_MAX_IMAGES", "10"))
     # Category/section listing pages to follow for the full per-category article
     # list (help-center homepages truncate each section to a few articles).

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -144,6 +144,9 @@ class Settings(BaseSettings):
     FAQ_METER_OWN_KEY: bool = os.getenv("FAQ_METER_OWN_KEY", "false").lower() == "true"
     FAQ_IMPORT_MAX_PAGE_CHARS: int = int(os.getenv("FAQ_IMPORT_MAX_PAGE_CHARS", "100000"))
     FAQ_IMPORT_FETCH_TIMEOUT: int = int(os.getenv("FAQ_IMPORT_FETCH_TIMEOUT", "30"))
+    # Article-mode import (crawl linked pages, no LLM): crawl and re-host caps.
+    FAQ_ARTICLE_IMPORT_MAX_PAGES: int = int(os.getenv("FAQ_ARTICLE_IMPORT_MAX_PAGES", "30"))
+    FAQ_ARTICLE_IMPORT_MAX_IMAGES: int = int(os.getenv("FAQ_ARTICLE_IMPORT_MAX_IMAGES", "10"))
     # Subdomain labels reserved for infrastructure — must mirror the DNS/nginx
     # records that exist on the base domain, hence env-configurable.
     HELP_CENTER_RESERVED_SLUGS: frozenset = frozenset(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -150,6 +150,11 @@ class Settings(BaseSettings):
     # Category/section listing pages to follow for the full per-category article
     # list (help-center homepages truncate each section to a few articles).
     FAQ_ARTICLE_IMPORT_MAX_CATEGORIES: int = int(os.getenv("FAQ_ARTICLE_IMPORT_MAX_CATEGORIES", "20"))
+    # A 'processing' FAQ job whose progress hasn't advanced in this long is
+    # treated as dead (worker crashed/killed): excluded from active-job polling
+    # and reaped on the next enqueue. Generous — must exceed the slowest single
+    # LLM batch / page fetch so a live-but-slow job is never killed.
+    FAQ_JOB_STALE_SECONDS: int = int(os.getenv("FAQ_JOB_STALE_SECONDS", "600"))
     # Subdomain labels reserved for infrastructure — must mirror the DNS/nginx
     # records that exist on the base domain, hence env-configurable.
     HELP_CENTER_RESERVED_SLUGS: frozenset = frozenset(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -139,6 +139,9 @@ class Settings(BaseSettings):
     FAQ_MAX_BATCH_CHARS_CEILING: int = int(os.getenv("FAQ_MAX_BATCH_CHARS_CEILING", "60000"))
     # Force a context-window size (tokens) for exotic/self-hosted models; 0 = auto.
     FAQ_CONTEXT_TOKENS_OVERRIDE: int = int(os.getenv("FAQ_CONTEXT_TOKENS_OVERRIDE", "0"))
+    # Meter FAQ generation credits even for orgs on their own API key
+    # (default: hosted CHATTERMATE model only).
+    FAQ_METER_OWN_KEY: bool = os.getenv("FAQ_METER_OWN_KEY", "false").lower() == "true"
     FAQ_IMPORT_MAX_PAGE_CHARS: int = int(os.getenv("FAQ_IMPORT_MAX_PAGE_CHARS", "100000"))
     FAQ_IMPORT_FETCH_TIMEOUT: int = int(os.getenv("FAQ_IMPORT_FETCH_TIMEOUT", "30"))
     # Subdomain labels reserved for infrastructure — must mirror the DNS/nginx

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -145,8 +145,11 @@ class Settings(BaseSettings):
     FAQ_IMPORT_MAX_PAGE_CHARS: int = int(os.getenv("FAQ_IMPORT_MAX_PAGE_CHARS", "100000"))
     FAQ_IMPORT_FETCH_TIMEOUT: int = int(os.getenv("FAQ_IMPORT_FETCH_TIMEOUT", "30"))
     # Article-mode import (crawl linked pages, no LLM): crawl and re-host caps.
-    FAQ_ARTICLE_IMPORT_MAX_PAGES: int = int(os.getenv("FAQ_ARTICLE_IMPORT_MAX_PAGES", "30"))
+    FAQ_ARTICLE_IMPORT_MAX_PAGES: int = int(os.getenv("FAQ_ARTICLE_IMPORT_MAX_PAGES", "50"))
     FAQ_ARTICLE_IMPORT_MAX_IMAGES: int = int(os.getenv("FAQ_ARTICLE_IMPORT_MAX_IMAGES", "10"))
+    # Category/section listing pages to follow for the full per-category article
+    # list (help-center homepages truncate each section to a few articles).
+    FAQ_ARTICLE_IMPORT_MAX_CATEGORIES: int = int(os.getenv("FAQ_ARTICLE_IMPORT_MAX_CATEGORIES", "20"))
     # Subdomain labels reserved for infrastructure — must mirror the DNS/nginx
     # records that exist on the base domain, hence env-configurable.
     HELP_CENTER_RESERVED_SLUGS: frozenset = frozenset(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -126,6 +126,11 @@ class Settings(BaseSettings):
     HELP_CENTER_BASE_DOMAIN: str = os.getenv("HELP_CENTER_BASE_DOMAIN", "chattermate.help")
     # CNAME target customers point their custom help-center domain at.
     HELP_CENTER_CNAME_TARGET: str = os.getenv("HELP_CENTER_CNAME_TARGET", "cname.chattermate.chat")
+    # IPs the CNAME target resolves to — accepted when a provider flattens the
+    # CNAME into A/AAAA records (comma-separated).
+    HELP_CENTER_TARGET_IPS: frozenset = frozenset(
+        ip.strip() for ip in os.getenv("HELP_CENTER_TARGET_IPS", "").split(",") if ip.strip()
+    )
     # FAQ generation cost caps (per source / per LLM call) and import fetch limits.
     FAQ_MAX_PAGES_PER_SOURCE: int = int(os.getenv("FAQ_MAX_PAGES_PER_SOURCE", "300"))
     FAQ_MAX_BATCH_CHARS: int = int(os.getenv("FAQ_MAX_BATCH_CHARS", "15000"))

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -124,6 +124,8 @@ class Settings(BaseSettings):
     # Help center (public FAQ site)
     # Base domain serving {slug}.<base> help centers.
     HELP_CENTER_BASE_DOMAIN: str = os.getenv("HELP_CENTER_BASE_DOMAIN", "chattermate.help")
+    # CNAME target customers point their custom help-center domain at.
+    HELP_CENTER_CNAME_TARGET: str = os.getenv("HELP_CENTER_CNAME_TARGET", "cname.chattermate.chat")
     # FAQ generation cost caps (per source / per LLM call) and import fetch limits.
     FAQ_MAX_PAGES_PER_SOURCE: int = int(os.getenv("FAQ_MAX_PAGES_PER_SOURCE", "300"))
     FAQ_MAX_BATCH_CHARS: int = int(os.getenv("FAQ_MAX_BATCH_CHARS", "15000"))

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -121,6 +121,18 @@ class Settings(BaseSettings):
     KNOWLEDGE_SUMMARY_API_KEY: str = os.getenv("KNOWLEDGE_SUMMARY_API_KEY", "")
     KNOWLEDGE_SUMMARY_MAX_TOKENS: int = int(os.getenv("KNOWLEDGE_SUMMARY_MAX_TOKENS", "4000"))
 
+    # Help center (public FAQ site)
+    # Base domain serving {slug}.<base> help centers.
+    HELP_CENTER_BASE_DOMAIN: str = os.getenv("HELP_CENTER_BASE_DOMAIN", "chattermate.help")
+    # Subdomain labels reserved for infrastructure — must mirror the DNS/nginx
+    # records that exist on the base domain, hence env-configurable.
+    HELP_CENTER_RESERVED_SLUGS: frozenset = frozenset(
+        s.strip() for s in os.getenv(
+            "HELP_CENTER_RESERVED_SLUGS",
+            "www,api,app,help,mail,admin,staging,cname,status",
+        ).split(",") if s.strip()
+    )
+
     # Embedding Model Configuration
     EMBEDDING_MODEL_ID: str = os.getenv("EMBEDDING_MODEL_ID", "sentence-transformers/all-MiniLM-L6-v2")
     EMBEDDING_BATCH_SIZE: int = int(os.getenv("EMBEDDING_BATCH_SIZE", "32"))

--- a/backend/app/core/cors.py
+++ b/backend/app/core/cors.py
@@ -59,6 +59,21 @@ def get_cors_origins() -> Set[str]:
             # Add www subdomain variants
             all_origins.add(f"https://www.{org.domain}")
             all_origins.add(f"http://www.{org.domain}")
+
+        # Help-center hosts embed the org's chat widget, which fetches
+        # /widgets/{id}/data and opens a socket from the public help-center
+        # origin — so those origins must be allowed too. The base-domain
+        # wildcard is also covered by get_cors_origin_regex() for FastAPI, but
+        # python-socketio can't match a regex, so enumerate the live slugs here.
+        from app.repositories.help_center import HelpCenterRepository
+        hc_repo = HelpCenterRepository(db)
+        base = settings.HELP_CENTER_BASE_DOMAIN
+        for slug in hc_repo.list_enabled_slugs():
+            all_origins.add(f"https://{slug}.{base}")
+            all_origins.add(f"http://{slug}.{base}")
+        for domain in hc_repo.list_verified_domains():
+            all_origins.add(f"https://{domain}")
+            all_origins.add(f"http://{domain}")
     except Exception as e:
         logger.error(f"Error fetching organization domains: {e}")
     finally:
@@ -66,6 +81,16 @@ def get_cors_origins() -> Set[str]:
             db.close()
 
     return all_origins
+
+
+@lru_cache(maxsize=1)
+def get_cors_origin_regex() -> str:
+    """Regex allowing every help-center subdomain (`*.{base_domain}`) for the
+    FastAPI CORS middleware, so a new slug works without a cache refresh.
+    Socket.IO can't use this (no regex support) — it relies on the enumerated
+    origins in get_cors_origins()."""
+    base = re.escape(settings.HELP_CENTER_BASE_DOMAIN)
+    return rf"^https?://([a-z0-9-]+\.)?{base}(:\d+)?$"
 
 def refresh_cors_origins() -> None:
     """
@@ -103,10 +128,13 @@ def update_local_cors(app: FastAPI, new_origins: List[str]) -> bool:
         try:
             # Force FastAPI to rebuild the middleware stack
             app.middleware_stack = None
-            # Re-add the middleware with updated origins
+            # Re-add the middleware with updated origins. Keep the help-center
+            # subdomain regex here too, or a rebuild would silently drop the
+            # *.{base_domain} wildcard that the embedded widget relies on.
             app.add_middleware(
                 CORSMiddleware,
                 allow_origins=new_origins,
+                allow_origin_regex=get_cors_origin_regex(),
                 allow_credentials=True,
                 allow_methods=["*"],
                 allow_headers=["*"],

--- a/backend/app/core/cors.py
+++ b/backend/app/core/cors.py
@@ -68,9 +68,15 @@ def get_cors_origins() -> Set[str]:
         from app.repositories.help_center import HelpCenterRepository
         hc_repo = HelpCenterRepository(db)
         base = settings.HELP_CENTER_BASE_DOMAIN
+        # In local dev the help center is reached on a non-standard port (e.g.
+        # :8000), which the browser puts in the Origin header. socket.io matches
+        # origins exactly (no regex), so add that port variant when configured.
+        dev_port = urlparse(settings.APP_BASE_URL).port
         for slug in hc_repo.list_enabled_slugs():
-            all_origins.add(f"https://{slug}.{base}")
-            all_origins.add(f"http://{slug}.{base}")
+            for scheme in ("https", "http"):
+                all_origins.add(f"{scheme}://{slug}.{base}")
+                if dev_port:
+                    all_origins.add(f"{scheme}://{slug}.{base}:{dev_port}")
         for domain in hc_repo.list_verified_domains():
             all_origins.add(f"https://{domain}")
             all_origins.add(f"http://{domain}")

--- a/backend/app/core/help_center_host.py
+++ b/backend/app/core/help_center_host.py
@@ -1,0 +1,127 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Host-based dispatch for the public help center.
+
+Requests whose Host is {slug}.<HELP_CENTER_BASE_DOMAIN> or a DB-verified
+custom domain are routed to the public help-center app; everything else
+passes through to the main API untouched. The Host header is never trusted
+beyond an equality lookup against verified values.
+
+This module is also the single source of truth for host canonicalization and
+slug parsing — the resolver in services/help_center_public imports from here
+so dispatch and resolution can never disagree.
+"""
+
+import asyncio
+import time
+from typing import Optional
+
+from app.core.config import settings
+from app.core.logger import get_logger
+
+logger = get_logger(__name__)
+
+DOMAIN_CACHE_TTL_SECONDS = 60
+
+
+def normalize_host(raw_host: Optional[str]) -> str:
+    return (raw_host or "").split(":")[0].strip().lower().rstrip(".")
+
+
+def slug_for_host(host: str) -> Optional[str]:
+    """The {slug} of {slug}.<HELP_CENTER_BASE_DOMAIN>, if this host is one."""
+    suffix = f".{settings.HELP_CENTER_BASE_DOMAIN}"
+    if host.endswith(suffix):
+        label = host[: -len(suffix)]
+        if label and "." not in label:
+            return label
+    return None
+
+
+class _VerifiedDomainCache:
+    """Snapshot of verified custom domains refreshed in the background, so
+    host dispatch is always a non-blocking set lookup — the middleware fronts
+    EVERY request, and a synchronous DB refresh here would let a slow database
+    stall the whole service. Stale-while-revalidate; fails to an empty set
+    (custom domains temporarily 404; API traffic unaffected)."""
+
+    def __init__(self):
+        self._domains: frozenset = frozenset()
+        self._fetched_at: float = 0.0
+        self._refreshing = False
+
+    def contains(self, host: str) -> bool:
+        if time.monotonic() - self._fetched_at >= DOMAIN_CACHE_TTL_SECONDS and not self._refreshing:
+            self._refreshing = True
+            try:
+                asyncio.get_running_loop().create_task(self._refresh_async())
+            except RuntimeError:
+                # No running loop (sync test context): refresh inline.
+                self._refresh_sync()
+                self._refreshing = False
+        return host in self._domains
+
+    async def _refresh_async(self):
+        try:
+            await asyncio.to_thread(self._refresh_sync)
+        finally:
+            self._refreshing = False
+
+    def _refresh_sync(self):
+        try:
+            from app.database import SessionLocal
+            from app.repositories.help_center import HelpCenterRepository
+
+            with SessionLocal() as db:
+                self._domains = frozenset(HelpCenterRepository(db).list_verified_domains())
+            self._fetched_at = time.monotonic()
+        except Exception as e:
+            # Back off a full TTL rather than re-querying a broken DB per request.
+            self._fetched_at = time.monotonic()
+            logger.error(f"Verified-domain cache refresh failed: {e}")
+
+
+_domain_cache = _VerifiedDomainCache()
+
+
+def _host_from_scope(scope) -> str:
+    for name, value in scope.get("headers") or []:
+        if name == b"host":
+            return normalize_host(value.decode("latin-1"))
+    return ""
+
+
+def is_help_center_host(host: str) -> bool:
+    if not host:
+        return False
+    if slug_for_host(host) is not None:
+        return True
+    return _domain_cache.contains(host)
+
+
+class HelpCenterHostMiddleware:
+    """Pure-ASGI dispatcher installed inside the socketio wrapper: help-center
+    hosts go to the public app, everything else to the main FastAPI app."""
+
+    def __init__(self, app, public_app):
+        self.app = app
+        self.public_app = public_app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http" and is_help_center_host(_host_from_scope(scope)):
+            await self.public_app(scope, receive, send)
+            return
+        await self.app(scope, receive, send)

--- a/backend/app/core/s3.py
+++ b/backend/app/core/s3.py
@@ -198,6 +198,24 @@ async def _save_file_locally(
         logger.error(f"Failed to save file locally: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to save file")
 
+def _key_from_url(s3_url: str) -> str:
+    """Extract the object key from either S3 URL format."""
+    parsed_url = urlparse(s3_url)
+    path_parts = parsed_url.path.strip('/').split('/')
+    if parsed_url.netloc == 's3.amazonaws.com':
+        # Format: https://s3.amazonaws.com/bucket/key
+        return '/'.join(path_parts[1:])
+    # Format: https://bucket.s3.region.amazonaws.com/key
+    return '/'.join(path_parts)
+
+
+async def download_file_from_s3(s3_url: str) -> bytes:
+    """Download an object's bytes (worker-side readback of stored uploads)."""
+    s3_client = get_s3_client()
+    response = s3_client.get_object(Bucket=settings.S3_BUCKET, Key=_key_from_url(s3_url))
+    return response['Body'].read()
+
+
 async def delete_file_from_s3(s3_url: str) -> bool:
     """Delete file from S3 bucket"""
     try:

--- a/backend/app/core/s3.py
+++ b/backend/app/core/s3.py
@@ -210,10 +210,16 @@ def _key_from_url(s3_url: str) -> str:
 
 
 async def download_file_from_s3(s3_url: str) -> bytes:
-    """Download an object's bytes (worker-side readback of stored uploads)."""
-    s3_client = get_s3_client()
-    response = s3_client.get_object(Bucket=settings.S3_BUCKET, Key=_key_from_url(s3_url))
-    return response['Body'].read()
+    """Download an object's bytes (worker-side readback of stored uploads).
+    boto3 is synchronous — offload so the transfer never blocks the event loop."""
+    import asyncio
+
+    def _download() -> bytes:
+        s3_client = get_s3_client()
+        response = s3_client.get_object(Bucket=settings.S3_BUCKET, Key=_key_from_url(s3_url))
+        return response['Body'].read()
+
+    return await asyncio.to_thread(_download)
 
 
 async def delete_file_from_s3(s3_url: str) -> bool:

--- a/backend/app/knowledge/main_content.py
+++ b/backend/app/knowledge/main_content.py
@@ -1,0 +1,77 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Main-content selection heuristics shared by the knowledge crawler (which
+extracts text) and the help-center article importer (which needs the actual
+DOM node to convert to Markdown). Selector priorities mirror
+EnhancedWebsiteReader's extraction strategies.
+"""
+
+import re
+from typing import Optional
+
+from bs4 import BeautifulSoup, Tag
+
+# Tags stripped before any content selection — never useful content.
+STRIP_TAGS = ("script", "style", "noscript", "iframe", "head")
+
+COMMON_CONTENT_CLASSES = (
+    "post-content", "article-content", "entry-content", "page-content", "main-content",
+    "blog-content", "content", "main", "article", "post", "entry", "text", "body",
+)
+
+COMMON_CONTENT_IDS = (
+    "content", "main-content", "post-content", "article-content", "entry-content", "page-content",
+    "blog-content", "main", "article", "post", "entry", "text", "body",
+)
+
+MIN_MAIN_CONTENT_CHARS = 100
+
+
+def _substantial(node: Optional[Tag]) -> bool:
+    return node is not None and len(node.get_text(" ", strip=True)) >= MIN_MAIN_CONTENT_CHARS
+
+
+def select_main_node(soup: BeautifulSoup) -> Optional[Tag]:
+    """The page's main-content element (mutates soup: strips script/style).
+
+    Priority: role="main" → <article>/<main> → common content classes →
+    common content ids → <body>. Returns None only for genuinely empty pages.
+    """
+    for tag in STRIP_TAGS:
+        for element in soup.find_all(tag):
+            element.extract()
+
+    candidate = soup.find(attrs={"role": "main"})
+    if _substantial(candidate):
+        return candidate
+
+    for tag in ("article", "main"):
+        for element in soup.find_all(tag):
+            if _substantial(element):
+                return element
+
+    for class_name in COMMON_CONTENT_CLASSES:
+        for element in soup.find_all(class_=re.compile(class_name, re.IGNORECASE)):
+            if _substantial(element):
+                return element
+
+    for id_name in COMMON_CONTENT_IDS:
+        element = soup.find(id=re.compile(id_name, re.IGNORECASE))
+        if _substantial(element):
+            return element
+
+    body = soup.find("body")
+    return body if _substantial(body) else None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ os.environ.setdefault('TOKENIZERS_PARALLELISM', 'false')
 from fastapi.staticfiles import StaticFiles
 import socketio
 from app.api import chat, organizations, users, ai_setup, knowledge, agent, notification, widget, widget_apps, user_groups, roles, analytics, jira, shopify, workflow, workflow_node, mcp_tool, file_upload, token, lead_capture, people
+from app.api import help_center as help_center_api
 from app.api import channels as channels_api
 from app.api import webhooks as channel_webhooks
 # Import widget_chat to register socket.io event handlers for /widget namespace
@@ -123,6 +124,12 @@ app.include_router(
     users.router,
     prefix=f"{settings.API_V1_STR}/users",
     tags=["users"]
+)
+
+app.include_router(
+    help_center_api.router,
+    prefix=f"{settings.API_V1_STR}/help-center",
+    tags=["help-center"]
 )
 
 app.include_router(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,7 +37,7 @@ from app.core.logger import get_logger
 from contextlib import asynccontextmanager
 import os
 from app.core.socketio import socket_app, configure_socketio, sio
-from app.core.cors import get_cors_origins
+from app.core.cors import get_cors_origins, get_cors_origin_regex
 from app.core.application import app, initialize_cors_listener
 
 # Import models to ensure they're registered with SQLAlchemy
@@ -66,10 +66,13 @@ logger.debug(f"CORS origins: {cors_origins}")
 # Update the FastAPI app to use the lifespan function
 app.router.lifespan_context = lifespan
 
-# Add CORS middleware to FastAPI app
+# Add CORS middleware to FastAPI app. The regex covers every help-center
+# subdomain (*.chattermate.help) so a newly-created slug is allowed without a
+# cache refresh; explicit origins still cover org domains + custom domains.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=list(cors_origins),
+    allow_origin_regex=get_cors_origin_regex(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -281,4 +281,9 @@ app.mount("/api/v1/uploads", StaticFiles(directory="uploads"), name="uploads")
 app.mount("/assets", StaticFiles(directory="assets"), name="assets")
 
 # Create final ASGI app
-app = socketio.ASGIApp(sio, app)
+# Public help center: requests for {slug}.<help domain> / verified custom
+# domains are dispatched to the SSR help-center app before reaching the API.
+from app.api.help_center_public import public_app
+from app.core.help_center_host import HelpCenterHostMiddleware
+
+app = socketio.ASGIApp(sio, HelpCenterHostMiddleware(app, public_app))

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -42,6 +42,13 @@ from app.models.lead_capture import (
 from app.models.channels import (
     ChannelAccount, ChannelType, ChannelConversation, AgentChannelConfig,
 )
+from app.models.faq_generation_job import (
+    FAQGenerationJob, FAQJobType, FAQJobStatus, FAQJobStage,
+)
+from app.models.faq import FAQ, FAQStatus
+from app.models.help_center import (
+    HelpCenterSettings, HelpCenterQuery, DomainStatus, SSLStatus,
+)
 
 
 
@@ -80,4 +87,14 @@ __all__ = [
     "ChannelType",
     "ChannelConversation",
     "AgentChannelConfig",
+    "FAQGenerationJob",
+    "FAQJobType",
+    "FAQJobStatus",
+    "FAQJobStage",
+    "FAQ",
+    "FAQStatus",
+    "HelpCenterSettings",
+    "HelpCenterQuery",
+    "DomainStatus",
+    "SSLStatus",
 ]

--- a/backend/app/models/faq.py
+++ b/backend/app/models/faq.py
@@ -1,0 +1,77 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import enum
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+DEFAULT_FAQ_CATEGORY = "General"
+
+
+class FAQStatus(str, enum.Enum):
+    DRAFT = "draft"
+    PUBLISHED = "published"
+
+
+class FAQ(Base):
+    """A single question/answer pair shown on the org's public help center.
+
+    FAQs are a standalone projection of the knowledge base: generation only
+    reads knowledge content, and editing/deleting FAQs never touches the
+    knowledge tables. Drafts stay private until explicitly published.
+    """
+    __tablename__ = "faqs"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # No single-column index: both composite indexes below lead with org id.
+    organization_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    question = Column(Text, nullable=False)
+    answer = Column(Text, nullable=False)
+    # Free-form category assigned by the LLM grouping step (or the user).
+    category = Column(String(100), nullable=False, default=DEFAULT_FAQ_CATEGORY)
+    # Plain string (values from FAQStatus), like knowledge_queue.status — new
+    # states never need an ALTER TYPE migration.
+    status = Column(String, nullable=False, default=FAQStatus.DRAFT)
+    # Provenance: the knowledge source it was generated from (if any) plus a
+    # human-readable label ("example.com/docs", "Imported from support.x.com",
+    # "Added manually") that survives source deletion.
+    knowledge_id = Column(Integer, ForeignKey("knowledge.id", ondelete="SET NULL"), nullable=True, index=True)
+    source_label = Column(String(255), nullable=True)
+    generation_job_id = Column(
+        Integer, ForeignKey("faq_generation_jobs.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    created_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    sort_order = Column(Integer, nullable=False, default=0)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    organization = relationship("Organization")
+    knowledge = relationship("Knowledge")
+
+    __table_args__ = (
+        Index("ix_faqs_org_status", "organization_id", "status"),
+        Index("ix_faqs_org_category", "organization_id", "category"),
+    )

--- a/backend/app/models/faq.py
+++ b/backend/app/models/faq.py
@@ -49,7 +49,13 @@ class FAQ(Base):
         nullable=False,
     )
     question = Column(Text, nullable=False)
+    # Answer is authored/stored as Markdown; rendered to sanitized HTML on the
+    # public article page (app.services.help_center_content).
     answer = Column(Text, nullable=False)
+    # URL slug for the public article page (/a/{slug}). Assigned once from the
+    # question and kept stable so published article URLs don't churn on edits.
+    # Unique per org (see ix_faqs_org_slug); NULL until assigned.
+    slug = Column(String(80), nullable=True)
     # Free-form category assigned by the LLM grouping step (or the user).
     category = Column(String(100), nullable=False, default=DEFAULT_FAQ_CATEGORY)
     # Plain string (values from FAQStatus), like knowledge_queue.status — new
@@ -74,4 +80,7 @@ class FAQ(Base):
     __table_args__ = (
         Index("ix_faqs_org_status", "organization_id", "status"),
         Index("ix_faqs_org_category", "organization_id", "category"),
+        # Serves the public /a/{slug} lookup and enforces per-org uniqueness.
+        # Multiple NULL slugs coexist (Postgres treats NULLs as distinct).
+        Index("ix_faqs_org_slug", "organization_id", "slug", unique=True),
     )

--- a/backend/app/models/faq_generation_job.py
+++ b/backend/app/models/faq_generation_job.py
@@ -1,0 +1,97 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import enum
+
+from sqlalchemy import Column, DateTime, Float, ForeignKey, Index, Integer, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class FAQJobType(str, enum.Enum):
+    # Generate from every knowledge source in the org (the "Generate" button).
+    GENERATE_ALL = "generate_all"
+    # Generate from one newly processed source (the auto-generation hook).
+    GENERATE_SOURCE = "generate_source"
+    # Extract Q&A pairs from an external FAQ page URL (migration).
+    IMPORT_URL = "import_url"
+
+
+class FAQJobStatus(str, enum.Enum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class FAQJobStage(str, enum.Enum):
+    NOT_STARTED = "not_started"
+    ANALYZING_SOURCES = "analyzing_sources"
+    EXTRACTING = "extracting"
+    DRAFTING = "drafting"
+    GROUPING = "grouping"
+    COMPLETED = "completed"
+
+
+# Statuses that count as "still running" for enqueue guards and UI polling —
+# derived so a future status defaults to "active" rather than silently
+# escaping the duplicate-job guard.
+TERMINAL_FAQ_JOB_STATUSES = {FAQJobStatus.COMPLETED, FAQJobStatus.FAILED}
+ACTIVE_FAQ_JOB_STATUSES = [s.value for s in FAQJobStatus if s not in TERMINAL_FAQ_JOB_STATUSES]
+
+
+class FAQGenerationJob(Base):
+    """Async FAQ generation/import job, processed by the FAQ worker.
+
+    Mirrors the KnowledgeQueue shape (string status/stage + float progress) so
+    the established worker and frontend polling patterns carry over.
+    """
+    __tablename__ = "faq_generation_jobs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    organization_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Nullable: auto-generation jobs may be enqueued without an acting user.
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
+    job_type = Column(String, nullable=False, default=FAQJobType.GENERATE_ALL)
+    # GENERATE_SOURCE: the knowledge source to read. NULL for GENERATE_ALL/
+    # IMPORT_URL. SET NULL (not CASCADE) so deleting a source mid-run doesn't
+    # yank the job row out from under the worker and the UI's polling.
+    knowledge_id = Column(Integer, ForeignKey("knowledge.id", ondelete="SET NULL"), nullable=True, index=True)
+    # IMPORT_URL: the external page to extract from.
+    source_url = Column(String, nullable=True)
+    status = Column(String, nullable=False, default=FAQJobStatus.PENDING)
+    stage = Column(String, nullable=False, default=FAQJobStage.NOT_STARTED)
+    progress_percentage = Column(Float, nullable=False, default=0.0)
+    faqs_created = Column(Integer, nullable=False, default=0)
+    error = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    __table_args__ = (
+        # Partial index keeping the worker's poll O(active rows).
+        Index(
+            "ix_faq_generation_jobs_active",
+            "status",
+            postgresql_where=(status.in_(ACTIVE_FAQ_JOB_STATUSES)),
+        ),
+    )

--- a/backend/app/models/faq_generation_job.py
+++ b/backend/app/models/faq_generation_job.py
@@ -16,9 +16,9 @@ limitations under the License.
 
 import enum
 
-from sqlalchemy import Column, DateTime, Float, ForeignKey, Index, Integer, String
+from sqlalchemy import JSON, Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.sql import func
+from sqlalchemy.sql import expression, func
 
 from app.database import Base
 
@@ -30,6 +30,11 @@ class FAQJobType(str, enum.Enum):
     GENERATE_SOURCE = "generate_source"
     # Extract Q&A pairs from an external FAQ page URL (migration).
     IMPORT_URL = "import_url"
+    # Crawl an external help-center index and import linked articles as-is
+    # (HTML→Markdown, no LLM).
+    IMPORT_ARTICLES = "import_articles"
+    # Extract Q&A pairs from an uploaded PDF.
+    IMPORT_PDF = "import_pdf"
 
 
 class FAQJobStatus(str, enum.Enum):
@@ -77,8 +82,19 @@ class FAQGenerationJob(Base):
     # IMPORT_URL. SET NULL (not CASCADE) so deleting a source mid-run doesn't
     # yank the job row out from under the worker and the UI's polling.
     knowledge_id = Column(Integer, ForeignKey("knowledge.id", ondelete="SET NULL"), nullable=True, index=True)
-    # IMPORT_URL: the external page to extract from.
+    # GENERATE_ALL: optional explicit narrowing to specific knowledge sources
+    # (overrides the default skip-already-generated behaviour).
+    knowledge_ids = Column(JSON, nullable=True)
+    # IMPORT_URL: the external page to extract from. IMPORT_PDF: the stored
+    # upload path/URL the worker reads the file from.
     source_url = Column(String, nullable=True)
+    # IMPORT_PDF: the original client filename, used for source_label.
+    source_file_name = Column(String(255), nullable=True)
+    # LLM calls attempted by this job (retries included) — the usage unit for
+    # hosted-model metering. `metered` is stamped at enqueue time from the
+    # org's AI config so the period sum never depends on later config changes.
+    llm_calls = Column(Integer, nullable=False, default=0, server_default="0")
+    metered = Column(Boolean, nullable=False, default=True, server_default=expression.true())
     status = Column(String, nullable=False, default=FAQJobStatus.PENDING)
     stage = Column(String, nullable=False, default=FAQJobStage.NOT_STARTED)
     progress_percentage = Column(Float, nullable=False, default=0.0)

--- a/backend/app/models/faq_generation_job.py
+++ b/backend/app/models/faq_generation_job.py
@@ -94,4 +94,10 @@ class FAQGenerationJob(Base):
             "status",
             postgresql_where=(status.in_(ACTIVE_FAQ_JOB_STATUSES)),
         ),
+        # NOTE: production also has uq_faq_generation_jobs_one_active — a
+        # UNIQUE partial index on (organization_id, job_type,
+        # COALESCE(knowledge_id, -1)) WHERE status is active, closing the
+        # enqueue check-then-insert race. It lives only in the migration:
+        # declaring it here would create it WITHOUT the partial WHERE on
+        # sqlite (tests), wrongly blocking re-enqueues after completion.
     )

--- a/backend/app/models/help_center.py
+++ b/backend/app/models/help_center.py
@@ -1,0 +1,128 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import enum
+import uuid
+
+from sqlalchemy import Boolean, CheckConstraint, Column, DateTime, ForeignKey, JSON, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+DEFAULT_BRAND_COLOR = "#4338CA"
+DEFAULT_CTA_TEXT = "Contact us"
+
+
+class DomainStatus(str, enum.Enum):
+    UNVERIFIED = "unverified"
+    PENDING = "pending"
+    VERIFIED = "verified"
+
+
+class SSLStatus(str, enum.Enum):
+    NONE = "none"
+    PENDING = "pending"
+    ACTIVE = "active"
+    FAILED = "failed"
+
+
+class HelpCenterSettings(Base):
+    """Per-org public help center configuration (branding, agent mapping,
+    subdomain slug and optional custom domain). One row per organization,
+    created lazily the first time the org opens the FAQ admin page.
+    """
+    __tablename__ = "help_center_settings"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    # Whether the public site is live at {slug}.{HELP_CENTER_BASE_DOMAIN}.
+    enabled = Column(Boolean, nullable=False, default=False)
+    slug = Column(String(63), unique=True, nullable=True, index=True)
+
+    # Branding
+    title = Column(String(120), nullable=True)
+    description = Column(String(300), nullable=True)
+    logo_url = Column(String, nullable=True)
+    brand_color = Column(String(9), nullable=False, default=DEFAULT_BRAND_COLOR)
+    # [{"label": str, "url": str}, ...]
+    header_links = Column(JSON, nullable=False, default=lambda: [])
+    cta_text = Column(String(40), nullable=True, default=DEFAULT_CTA_TEXT)
+    cta_url = Column(String, nullable=True)
+
+    # Draft FAQs are auto-generated when a new knowledge source finishes.
+    auto_generate = Column(Boolean, nullable=False, default=True)
+
+    # AI search: which agent grounds "Ask AI" answers and whose chat widget is
+    # embedded on the public page.
+    agent_id = Column(UUID(as_uuid=True), ForeignKey("agents.id", ondelete="SET NULL"), nullable=True)
+    ai_search_enabled = Column(Boolean, nullable=False, default=True)
+
+    # Custom domain. Verification state is the two per-record booleans; the
+    # aggregate status is derived (see domain_status) so the pieces can never
+    # disagree.
+    custom_domain = Column(String(255), unique=True, nullable=True, index=True)
+    domain_verification_token = Column(String(64), nullable=True)
+    txt_record_verified = Column(Boolean, nullable=False, default=False)
+    cname_record_verified = Column(Boolean, nullable=False, default=False)
+    # Plain string (values from SSLStatus) — an external fact set by the
+    # verification probe, stored like knowledge_queue's string statuses.
+    ssl_status = Column(String, nullable=False, default=SSLStatus.NONE)
+    domain_verified_at = Column(DateTime(timezone=True), nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    organization = relationship("Organization")
+    agent = relationship("Agent")
+
+    __table_args__ = (
+        CheckConstraint("slug = lower(slug)", name="ck_help_center_slug_lowercase"),
+    )
+
+    @property
+    def domain_verified(self) -> bool:
+        return bool(self.custom_domain) and self.txt_record_verified and self.cname_record_verified
+
+    @property
+    def domain_status(self) -> DomainStatus:
+        if not self.custom_domain:
+            return DomainStatus.UNVERIFIED
+        return DomainStatus.VERIFIED if self.domain_verified else DomainStatus.PENDING
+
+
+class HelpCenterQuery(Base):
+    """Log of public "Ask AI" questions — used for per-period metering on
+    hosted models and (later) search analytics. No answer text is stored.
+    """
+    __tablename__ = "help_center_queries"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    query = Column(Text, nullable=False)
+    answered = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), index=True)

--- a/backend/app/models/help_center.py
+++ b/backend/app/models/help_center.py
@@ -68,6 +68,8 @@ class HelpCenterSettings(Base):
     header_links = Column(JSON, nullable=False, default=lambda: [])
     cta_text = Column(String(40), nullable=True, default=DEFAULT_CTA_TEXT)
     cta_url = Column(String, nullable=True)
+    # Whether the primary button (CTA) is shown in the public header.
+    cta_enabled = Column(Boolean, nullable=False, default=True)
 
     # Draft FAQs are auto-generated when a new knowledge source finishes.
     auto_generate = Column(Boolean, nullable=False, default=True)

--- a/backend/app/models/help_center.py
+++ b/backend/app/models/help_center.py
@@ -72,10 +72,13 @@ class HelpCenterSettings(Base):
     # Draft FAQs are auto-generated when a new knowledge source finishes.
     auto_generate = Column(Boolean, nullable=False, default=True)
 
-    # AI search: which agent grounds "Ask AI" answers and whose chat widget is
-    # embedded on the public page.
+    # Which agent grounds "Ask AI" answers and whose chat widget is embedded on
+    # the public page. The two surfaces toggle independently:
+    #   - ai_search_enabled: the inline AI quick-summary answer in search.
+    #   - chat_widget_enabled: the embedded chat widget ("Start a chat").
     agent_id = Column(UUID(as_uuid=True), ForeignKey("agents.id", ondelete="SET NULL"), nullable=True)
     ai_search_enabled = Column(Boolean, nullable=False, default=True)
+    chat_widget_enabled = Column(Boolean, nullable=False, default=True)
 
     # Custom domain. Verification state is the two per-record booleans; the
     # aggregate status is derived (see domain_status) so the pieces can never

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -24,6 +24,8 @@ from sqlalchemy.dialects.postgresql import UUID
 class NotificationType(str, enum.Enum):
     KNOWLEDGE_PROCESSED = "knowledge_processed"
     KNOWLEDGE_FAILED = "knowledge_failed"
+    FAQ_GENERATED = "faq_generated"
+    FAQ_GENERATION_FAILED = "faq_generation_failed"
     SYSTEM = "system"
     CHAT = "chat"
 

--- a/backend/app/models/schemas/faq.py
+++ b/backend/app/models/schemas/faq.py
@@ -1,0 +1,122 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# Reuse the ORM enums so the API contract can never drift from the DB.
+from app.models.faq import DEFAULT_FAQ_CATEGORY, FAQStatus
+from app.models.schemas.pagination import Pagination
+from app.utils.urls import normalize_url
+
+MAX_QUESTION_LENGTH = 300
+MAX_ANSWER_LENGTH = 4000
+MAX_BULK_IDS = 200
+
+
+class FAQBase(BaseModel):
+    question: str = Field(min_length=1, max_length=MAX_QUESTION_LENGTH)
+    answer: str = Field(min_length=1, max_length=MAX_ANSWER_LENGTH)
+    category: str = Field(default=DEFAULT_FAQ_CATEGORY, min_length=1, max_length=100)
+
+    @field_validator("question", "answer", "category")
+    @classmethod
+    def _strip(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be blank")
+        return v
+
+
+class FAQCreate(FAQBase):
+    status: FAQStatus = FAQStatus.DRAFT
+
+
+class FAQUpdate(BaseModel):
+    """Partial update — omitted fields keep their current values (apply with
+    model_dump(exclude_unset=True)), so e.g. a status-only PATCH can't silently
+    reset the category to its default."""
+    question: Optional[str] = Field(default=None, min_length=1, max_length=MAX_QUESTION_LENGTH)
+    answer: Optional[str] = Field(default=None, min_length=1, max_length=MAX_ANSWER_LENGTH)
+    category: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    status: Optional[FAQStatus] = None
+
+    @field_validator("question", "answer", "category")
+    @classmethod
+    def _strip(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be blank")
+        return v
+
+
+class FAQResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    question: str
+    answer: str
+    category: str
+    status: FAQStatus
+    knowledge_id: Optional[int] = None
+    source_label: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+
+class FAQListResponse(BaseModel):
+    faqs: List[FAQResponse]
+    pagination: Pagination
+
+
+class FAQBulkStatusRequest(BaseModel):
+    faq_ids: List[UUID] = Field(min_length=1, max_length=MAX_BULK_IDS)
+    status: FAQStatus
+
+
+class GenerateRequest(BaseModel):
+    """Optional narrowing to specific knowledge sources; empty = all."""
+    knowledge_ids: Optional[List[int]] = None
+
+
+class ImportRequest(BaseModel):
+    url: str = Field(min_length=1, max_length=2048)
+
+    @field_validator("url")
+    @classmethod
+    def _https_url(cls, v: str) -> str:
+        # Scheme-level validation only; the import worker re-checks the URL
+        # against the SSRF guards in app.knowledge.url_safety before fetching.
+        return normalize_url(v, require_https=True)
+
+
+class GenerationJobResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    job_type: str
+    status: str
+    stage: str
+    progress_percentage: float
+    faqs_created: int
+    source_url: Optional[str] = None
+    error: Optional[str] = None
+    created_at: Optional[datetime] = None

--- a/backend/app/models/schemas/faq.py
+++ b/backend/app/models/schemas/faq.py
@@ -94,8 +94,20 @@ class FAQBulkStatusRequest(BaseModel):
 
 
 class GenerateRequest(BaseModel):
-    """Optional narrowing to specific knowledge sources; empty = all."""
-    knowledge_ids: Optional[List[int]] = None
+    """Optional narrowing to specific knowledge sources; empty = new sources
+    only (those without FAQs yet)."""
+    knowledge_ids: Optional[List[int]] = Field(default=None, max_length=MAX_BULK_IDS)
+
+
+class GenerationEstimateResponse(BaseModel):
+    """Confirm-dialog numbers for a generation run. remaining_credits is None
+    when unlimited (OSS, no cap, or org on its own model key)."""
+    total_sources: int
+    new_sources: int
+    pages: int
+    estimated_calls: int
+    metered: bool
+    remaining_credits: Optional[int] = None
 
 
 class ImportRequest(BaseModel):

--- a/backend/app/models/schemas/faq.py
+++ b/backend/app/models/schemas/faq.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Literal, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -26,7 +26,10 @@ from app.models.schemas.pagination import Pagination
 from app.utils.urls import normalize_url
 
 MAX_QUESTION_LENGTH = 300
-MAX_ANSWER_LENGTH = 4000
+# Articles imported as-is (help-center pages with steps/images) routinely run
+# long; the column is TEXT and the public renderer paginates nothing, so the
+# cap only guards against runaway payloads.
+MAX_ANSWER_LENGTH = 20000
 MAX_BULK_IDS = 200
 
 
@@ -116,6 +119,10 @@ class GenerationEstimateResponse(BaseModel):
 
 class ImportRequest(BaseModel):
     url: str = Field(min_length=1, max_length=2048)
+    # qa = single page, LLM extracts Q&A pairs (uses credits).
+    # articles = crawl the page's linked articles and import each as-is
+    #            (HTML -> Markdown, images re-hosted, no LLM).
+    mode: Literal["qa", "articles"] = "qa"
 
     @field_validator("url")
     @classmethod

--- a/backend/app/models/schemas/faq.py
+++ b/backend/app/models/schemas/faq.py
@@ -75,6 +75,7 @@ class FAQResponse(BaseModel):
     question: str
     answer: str
     category: str
+    slug: Optional[str] = None
     status: FAQStatus
     knowledge_id: Optional[int] = None
     source_label: Optional[str] = None

--- a/backend/app/models/schemas/faq.py
+++ b/backend/app/models/schemas/faq.py
@@ -93,6 +93,10 @@ class FAQBulkStatusRequest(BaseModel):
     status: FAQStatus
 
 
+class FAQBulkDeleteRequest(BaseModel):
+    faq_ids: List[UUID] = Field(min_length=1, max_length=MAX_BULK_IDS)
+
+
 class GenerateRequest(BaseModel):
     """Optional narrowing to specific knowledge sources; empty = new sources
     only (those without FAQs yet)."""

--- a/backend/app/models/schemas/help_center.py
+++ b/backend/app/models/schemas/help_center.py
@@ -1,0 +1,146 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import re
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.models.help_center import DomainStatus, SSLStatus
+from app.utils.urls import normalize_url
+
+MAX_HEADER_LINKS = 6
+_HEX_COLOR_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$")
+# RFC 1035-ish hostname: labels of letters/digits/hyphens, at least one dot.
+# The TLD alternation admits punycode labels (xn--...) that IDNA encoding of
+# internationalized domains produces.
+_HOSTNAME_RE = re.compile(
+    r"^(?=.{4,253}$)([a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{2,}|xn--[a-z0-9-]{2,})$"
+)
+
+
+class HeaderLink(BaseModel):
+    label: str = Field(min_length=1, max_length=40)
+    url: str = Field(min_length=1, max_length=2048)
+
+    @field_validator("url")
+    @classmethod
+    def _url(cls, v: str) -> str:
+        # Raises on blank/whitespace input rather than returning None into a
+        # non-optional str field.
+        return normalize_url(v)
+
+
+class HelpCenterSettingsUpdate(BaseModel):
+    enabled: Optional[bool] = None
+    title: Optional[str] = Field(default=None, max_length=120)
+    description: Optional[str] = Field(default=None, max_length=300)
+    brand_color: Optional[str] = None
+    header_links: Optional[List[HeaderLink]] = Field(default=None, max_length=MAX_HEADER_LINKS)
+    cta_text: Optional[str] = Field(default=None, max_length=40)
+    cta_url: Optional[str] = Field(default=None, max_length=2048)
+    auto_generate: Optional[bool] = None
+    agent_id: Optional[UUID] = None
+    ai_search_enabled: Optional[bool] = None
+
+    @field_validator("brand_color")
+    @classmethod
+    def _hex_color(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        v = v.strip()
+        if not _HEX_COLOR_RE.match(v):
+            raise ValueError("brand_color must be a hex color like #4338CA")
+        return v
+
+    @field_validator("cta_url")
+    @classmethod
+    def _cta_url(cls, v: Optional[str]) -> Optional[str]:
+        # Blank clears the CTA link; anything else is normalized.
+        if v is None or not v.strip():
+            return None
+        return normalize_url(v)
+
+
+class HelpCenterAgentOption(BaseModel):
+    """Org agents offered in the AI-search agent selector."""
+    id: UUID
+    name: str
+    has_widget: bool
+
+
+class DnsRecord(BaseModel):
+    """One row of the DNS-records table in the admin UI."""
+    type: str  # CNAME | TXT
+    host: str
+    value: str
+    verified: bool
+
+
+class DomainStatusResponse(BaseModel):
+    custom_domain: Optional[str] = None
+    domain_status: DomainStatus
+    ssl_status: SSLStatus
+    records: List[DnsRecord] = []
+    domain_verified_at: Optional[datetime] = None
+
+
+class HelpCenterSettingsResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    enabled: bool
+    slug: Optional[str] = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    logo_url: Optional[str] = None
+    brand_color: str
+    header_links: List[HeaderLink] = []
+    cta_text: Optional[str] = None
+    cta_url: Optional[str] = None
+    auto_generate: bool
+    agent_id: Optional[UUID] = None
+    ai_search_enabled: bool
+
+    # Enriched by the API layer (not ORM columns):
+    live_url: Optional[str] = None
+    published_count: int = 0
+    plan_allowed: bool = True
+    agents: List[HelpCenterAgentOption] = []
+    domain: Optional[DomainStatusResponse] = None
+
+    @field_validator("header_links", mode="before")
+    @classmethod
+    def _coerce_null_json(cls, v):
+        return v or []
+
+
+class DomainRequest(BaseModel):
+    domain: str = Field(min_length=4, max_length=255)
+
+    @field_validator("domain")
+    @classmethod
+    def _hostname(cls, v: str) -> str:
+        v = v.strip().lower().rstrip(".")
+        v = re.sub(r"^https?://", "", v).split("/")[0]
+        try:
+            v = v.encode("idna").decode("ascii")
+        except UnicodeError as exc:
+            raise ValueError("domain is not a valid hostname") from exc
+        if not _HOSTNAME_RE.match(v):
+            raise ValueError("domain is not a valid hostname")
+        return v

--- a/backend/app/models/schemas/help_center.py
+++ b/backend/app/models/schemas/help_center.py
@@ -54,6 +54,7 @@ class HelpCenterSettingsUpdate(BaseModel):
     header_links: Optional[List[HeaderLink]] = Field(default=None, max_length=MAX_HEADER_LINKS)
     cta_text: Optional[str] = Field(default=None, max_length=40)
     cta_url: Optional[str] = Field(default=None, max_length=2048)
+    cta_enabled: Optional[bool] = None
     auto_generate: Optional[bool] = None
     agent_id: Optional[UUID] = None
     ai_search_enabled: Optional[bool] = None
@@ -113,6 +114,7 @@ class HelpCenterSettingsResponse(BaseModel):
     header_links: List[HeaderLink] = []
     cta_text: Optional[str] = None
     cta_url: Optional[str] = None
+    cta_enabled: bool
     auto_generate: bool
     agent_id: Optional[UUID] = None
     ai_search_enabled: bool

--- a/backend/app/models/schemas/help_center.py
+++ b/backend/app/models/schemas/help_center.py
@@ -57,6 +57,7 @@ class HelpCenterSettingsUpdate(BaseModel):
     auto_generate: Optional[bool] = None
     agent_id: Optional[UUID] = None
     ai_search_enabled: Optional[bool] = None
+    chat_widget_enabled: Optional[bool] = None
 
     @field_validator("brand_color")
     @classmethod
@@ -115,6 +116,7 @@ class HelpCenterSettingsResponse(BaseModel):
     auto_generate: bool
     agent_id: Optional[UUID] = None
     ai_search_enabled: bool
+    chat_widget_enabled: bool
 
     # Enriched by the API layer (not ORM columns):
     live_url: Optional[str] = None

--- a/backend/app/models/schemas/pagination.py
+++ b/backend/app/models/schemas/pagination.py
@@ -1,0 +1,37 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import math
+
+from pydantic import BaseModel
+
+
+class Pagination(BaseModel):
+    """Standard list-endpoint pagination block (shape matches the knowledge
+    API's inline dicts: total / page / page_size / total_pages)."""
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+
+    @classmethod
+    def build(cls, total: int, page: int, page_size: int) -> "Pagination":
+        return cls(
+            total=total,
+            page=page,
+            page_size=page_size,
+            total_pages=max(1, math.ceil(total / page_size)) if total else 0,
+        )

--- a/backend/app/repositories/faq.py
+++ b/backend/app/repositories/faq.py
@@ -171,6 +171,17 @@ class FAQRepository:
         self.db.commit()
         return updated
 
+    def bulk_delete(self, organization_id: UUID, faq_ids: List[UUID]) -> int:
+        """Delete the org's FAQs among faq_ids; returns rows deleted.
+        Org-scoped, so cross-org ids are silently ignored."""
+        deleted = (
+            self._org_query(organization_id)
+            .filter(FAQ.id.in_(faq_ids))
+            .delete(synchronize_session=False)
+        )
+        self.db.commit()
+        return deleted
+
     def count_published(self, organization_id: UUID) -> int:
         return (
             self._org_query(organization_id)

--- a/backend/app/repositories/faq.py
+++ b/backend/app/repositories/faq.py
@@ -110,6 +110,19 @@ class FAQRepository:
         )
         return [row[0] for row in rows]
 
+    def knowledge_ids_with_faqs(self, organization_id: UUID) -> set:
+        """Knowledge sources that already produced FAQs — regenerate skips
+        these unless the caller explicitly targets them. Self-healing: deleting
+        a source's FAQs makes it eligible for generation again."""
+        rows = (
+            self._org_query(organization_id)
+            .with_entities(FAQ.knowledge_id)
+            .filter(FAQ.knowledge_id.isnot(None))
+            .distinct()
+            .all()
+        )
+        return {row[0] for row in rows}
+
     def get_existing_questions(self, organization_id: UUID) -> List[str]:
         """All question strings for the org — the generation dedup baseline."""
         rows = self._org_query(organization_id).with_entities(FAQ.question).all()

--- a/backend/app/repositories/faq.py
+++ b/backend/app/repositories/faq.py
@@ -71,6 +71,35 @@ class FAQRepository:
             query = query.filter(or_(FAQ.question.ilike(pattern), FAQ.answer.ilike(pattern)))
         return query.order_by(FAQ.category.asc(), FAQ.sort_order.asc(), FAQ.created_at.asc()).all()
 
+    def slug_exists(self, organization_id: UUID, slug: str) -> bool:
+        return self.db.query(
+            self._org_query(organization_id).filter(FAQ.slug == slug).exists()
+        ).scalar()
+
+    def get_published_by_slug(self, organization_id: UUID, slug: str) -> Optional[FAQ]:
+        """A single published article by its slug (the public /a/{slug} lookup)."""
+        return (
+            self._org_query(organization_id)
+            .filter(FAQ.slug == slug, FAQ.status == FAQStatus.PUBLISHED)
+            .first()
+        )
+
+    def get_published_related(
+        self, organization_id: UUID, category: str, exclude_id: UUID, limit: int = 4
+    ) -> List[FAQ]:
+        """Other published FAQs in the same category — the article's related list."""
+        return (
+            self._org_query(organization_id)
+            .filter(
+                FAQ.status == FAQStatus.PUBLISHED,
+                FAQ.category == category,
+                FAQ.id != exclude_id,
+            )
+            .order_by(FAQ.sort_order.asc(), FAQ.created_at.asc())
+            .limit(limit)
+            .all()
+        )
+
     def get_categories(self, organization_id: UUID) -> List[str]:
         rows = (
             self._org_query(organization_id)
@@ -98,6 +127,12 @@ class FAQRepository:
         return faq
 
     def bulk_create(self, faqs: List[FAQ]) -> List[FAQ]:
+        # Guarantee every generated/imported FAQ gets a unique article slug (the
+        # single choke point for batch inserts), so publishing one never yields a
+        # broken /a/ link.
+        from app.services.help_center_settings import assign_faq_slugs
+
+        assign_faq_slugs(self.db, faqs)
         self.db.add_all(faqs)
         self.db.commit()
         return faqs

--- a/backend/app/repositories/faq.py
+++ b/backend/app/repositories/faq.py
@@ -1,0 +1,131 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from app.models.faq import FAQ, FAQStatus
+
+
+class FAQRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def _org_query(self, organization_id: UUID):
+        return self.db.query(FAQ).filter(FAQ.organization_id == organization_id)
+
+    def get_by_id(self, faq_id: UUID, organization_id: UUID) -> Optional[FAQ]:
+        """Org-scoped fetch: cross-org ids resolve to None (callers 404)."""
+        return self._org_query(organization_id).filter(FAQ.id == faq_id).first()
+
+    def list_for_org(
+        self,
+        organization_id: UUID,
+        status: Optional[FAQStatus] = None,
+        category: Optional[str] = None,
+        search: Optional[str] = None,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> tuple[List[FAQ], int]:
+        """Filtered, paginated list plus the total matching count."""
+        query = self._org_query(organization_id)
+        if status is not None:
+            query = query.filter(FAQ.status == status)
+        if category:
+            # Exact match: filter values come from get_categories(), and the
+            # (organization_id, category) index only serves equality.
+            query = query.filter(FAQ.category == category)
+        if search:
+            pattern = f"%{search}%"
+            query = query.filter(or_(FAQ.question.ilike(pattern), FAQ.answer.ilike(pattern)))
+        total = query.count()
+        items = (
+            query.order_by(FAQ.category.asc(), FAQ.sort_order.asc(), FAQ.created_at.asc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+        return items, total
+
+    def get_published_for_org(self, organization_id: UUID, search: Optional[str] = None) -> List[FAQ]:
+        """Published FAQs for the public help center, in display order."""
+        query = self._org_query(organization_id).filter(FAQ.status == FAQStatus.PUBLISHED)
+        if search:
+            pattern = f"%{search}%"
+            query = query.filter(or_(FAQ.question.ilike(pattern), FAQ.answer.ilike(pattern)))
+        return query.order_by(FAQ.category.asc(), FAQ.sort_order.asc(), FAQ.created_at.asc()).all()
+
+    def get_categories(self, organization_id: UUID) -> List[str]:
+        rows = (
+            self._org_query(organization_id)
+            .with_entities(FAQ.category)
+            .distinct()
+            .order_by(FAQ.category.asc())
+            .all()
+        )
+        return [row[0] for row in rows]
+
+    def get_existing_questions(self, organization_id: UUID) -> List[str]:
+        """All question strings for the org — the generation dedup baseline."""
+        rows = self._org_query(organization_id).with_entities(FAQ.question).all()
+        return [row[0] for row in rows]
+
+    def exists_for_org(self, organization_id: UUID) -> bool:
+        return self.db.query(
+            self._org_query(organization_id).exists()
+        ).scalar()
+
+    def create(self, faq: FAQ) -> FAQ:
+        self.db.add(faq)
+        self.db.commit()
+        self.db.refresh(faq)
+        return faq
+
+    def bulk_create(self, faqs: List[FAQ]) -> List[FAQ]:
+        self.db.add_all(faqs)
+        self.db.commit()
+        return faqs
+
+    def update(self, faq: FAQ) -> FAQ:
+        self.db.commit()
+        self.db.refresh(faq)
+        return faq
+
+    def delete(self, faq: FAQ) -> None:
+        self.db.delete(faq)
+        self.db.commit()
+
+    def bulk_set_status(
+        self, organization_id: UUID, faq_ids: List[UUID], status: FAQStatus
+    ) -> int:
+        """Set status on the org's FAQs among faq_ids; returns rows changed."""
+        updated = (
+            self._org_query(organization_id)
+            .filter(FAQ.id.in_(faq_ids))
+            .update({FAQ.status: status}, synchronize_session=False)
+        )
+        self.db.commit()
+        return updated
+
+    def count_published(self, organization_id: UUID) -> int:
+        return (
+            self._org_query(organization_id)
+            .filter(FAQ.status == FAQStatus.PUBLISHED)
+            .count()
+        )

--- a/backend/app/repositories/faq.py
+++ b/backend/app/repositories/faq.py
@@ -30,6 +30,22 @@ class FAQRepository:
     def _org_query(self, organization_id: UUID):
         return self.db.query(FAQ).filter(FAQ.organization_id == organization_id)
 
+    @staticmethod
+    def _apply_search(query, search: str):
+        """Tokenized search: every whitespace-separated term must appear in the
+        question, answer or category (any of them). Matching the whole query as
+        one substring made 'close my' miss 'How to close my account'."""
+        for term in search.split():
+            pattern = f"%{term}%"
+            query = query.filter(
+                or_(
+                    FAQ.question.ilike(pattern),
+                    FAQ.answer.ilike(pattern),
+                    FAQ.category.ilike(pattern),
+                )
+            )
+        return query
+
     def get_by_id(self, faq_id: UUID, organization_id: UUID) -> Optional[FAQ]:
         """Org-scoped fetch: cross-org ids resolve to None (callers 404)."""
         return self._org_query(organization_id).filter(FAQ.id == faq_id).first()
@@ -52,8 +68,7 @@ class FAQRepository:
             # (organization_id, category) index only serves equality.
             query = query.filter(FAQ.category == category)
         if search:
-            pattern = f"%{search}%"
-            query = query.filter(or_(FAQ.question.ilike(pattern), FAQ.answer.ilike(pattern)))
+            query = self._apply_search(query, search)
         total = query.count()
         items = (
             query.order_by(FAQ.category.asc(), FAQ.sort_order.asc(), FAQ.created_at.asc())
@@ -67,8 +82,7 @@ class FAQRepository:
         """Published FAQs for the public help center, in display order."""
         query = self._org_query(organization_id).filter(FAQ.status == FAQStatus.PUBLISHED)
         if search:
-            pattern = f"%{search}%"
-            query = query.filter(or_(FAQ.question.ilike(pattern), FAQ.answer.ilike(pattern)))
+            query = self._apply_search(query, search)
         return query.order_by(FAQ.category.asc(), FAQ.sort_order.asc(), FAQ.created_at.asc()).all()
 
     def slug_exists(self, organization_id: UUID, slug: str) -> bool:

--- a/backend/app/repositories/faq_generation_job.py
+++ b/backend/app/repositories/faq_generation_job.py
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 from uuid import UUID
 
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.core.logger import get_logger
 from app.models.faq_generation_job import (
     ACTIVE_FAQ_JOB_STATUSES,
@@ -64,21 +65,32 @@ class FAQGenerationJobRepository:
             .all()
         )
 
-    def fail_orphaned_processing(self, reason: str) -> int:
-        """Mark every job stuck in `processing` as failed — called once at
-        worker startup. The worker is the only writer of `processing`, so on a
-        fresh boot any such row is an orphan left by a previous crash/kill;
-        otherwise it (and the enqueue guard + UI polling) would hang forever."""
-        updated = (
-            self.db.query(FAQGenerationJob)
-            .filter(FAQGenerationJob.status == FAQJobStatus.PROCESSING.value)
-            .update(
-                {
-                    FAQGenerationJob.status: FAQJobStatus.FAILED.value,
-                    FAQGenerationJob.error: reason,
-                },
-                synchronize_session=False,
-            )
+    def fail_orphaned_processing(
+        self,
+        reason: str,
+        older_than_seconds: Optional[int] = None,
+        organization_id: Optional[UUID] = None,
+    ) -> int:
+        """Mark `processing` jobs failed. With no bounds (worker startup): the
+        worker is the only writer of `processing`, so on a fresh boot every such
+        row is an orphan from a previous crash/kill. With `older_than_seconds`
+        (lazy reap on enqueue): only jobs whose progress stopped advancing past
+        the threshold — a worker that died and hasn't restarted. Either way the
+        job (and the enqueue guard + UI polling) would otherwise hang forever."""
+        query = self.db.query(FAQGenerationJob).filter(
+            FAQGenerationJob.status == FAQJobStatus.PROCESSING.value
+        )
+        if organization_id is not None:
+            query = query.filter(FAQGenerationJob.organization_id == organization_id)
+        if older_than_seconds is not None:
+            cutoff = datetime.now(timezone.utc) - timedelta(seconds=older_than_seconds)
+            query = query.filter(FAQGenerationJob.updated_at < cutoff)
+        updated = query.update(
+            {
+                FAQGenerationJob.status: FAQJobStatus.FAILED.value,
+                FAQGenerationJob.error: reason,
+            },
+            synchronize_session=False,
         )
         self.db.commit()
         return updated
@@ -90,10 +102,19 @@ class FAQGenerationJobRepository:
         knowledge_id: Optional[int] = None,
     ) -> Optional[FAQGenerationJob]:
         """Most recent pending/processing job, optionally narrowed by type and
-        source — the enqueue-dedup guard and the UI's polling target."""
+        source — the enqueue-dedup guard and the UI's polling target. A
+        `processing` job whose progress stopped advancing past
+        FAQ_JOB_STALE_SECONDS is treated as dead (excluded), so the UI stops
+        polling even if the worker never restarts to reap it."""
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=settings.FAQ_JOB_STALE_SECONDS)
         query = self.db.query(FAQGenerationJob).filter(
             FAQGenerationJob.organization_id == organization_id,
             FAQGenerationJob.status.in_(ACTIVE_FAQ_JOB_STATUSES),
+            or_(
+                FAQGenerationJob.status != FAQJobStatus.PROCESSING.value,
+                FAQGenerationJob.updated_at.is_(None),
+                FAQGenerationJob.updated_at >= cutoff,
+            ),
         )
         if job_type is not None:
             query = query.filter(FAQGenerationJob.job_type == job_type.value)

--- a/backend/app/repositories/faq_generation_job.py
+++ b/backend/app/repositories/faq_generation_job.py
@@ -64,6 +64,25 @@ class FAQGenerationJobRepository:
             .all()
         )
 
+    def fail_orphaned_processing(self, reason: str) -> int:
+        """Mark every job stuck in `processing` as failed — called once at
+        worker startup. The worker is the only writer of `processing`, so on a
+        fresh boot any such row is an orphan left by a previous crash/kill;
+        otherwise it (and the enqueue guard + UI polling) would hang forever."""
+        updated = (
+            self.db.query(FAQGenerationJob)
+            .filter(FAQGenerationJob.status == FAQJobStatus.PROCESSING.value)
+            .update(
+                {
+                    FAQGenerationJob.status: FAQJobStatus.FAILED.value,
+                    FAQGenerationJob.error: reason,
+                },
+                synchronize_session=False,
+            )
+        )
+        self.db.commit()
+        return updated
+
     def get_active_for_org(
         self,
         organization_id: UUID,

--- a/backend/app/repositories/faq_generation_job.py
+++ b/backend/app/repositories/faq_generation_job.py
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.core.logger import get_logger
@@ -87,6 +89,44 @@ class FAQGenerationJobRepository:
             .order_by(FAQGenerationJob.created_at.desc())
             .first()
         )
+
+    def increment_llm_calls(self, job_id: int, n: int = 1) -> None:
+        """Atomic counter bump — one per attempted LLM call (retries cost too)."""
+        self.db.query(FAQGenerationJob).filter(FAQGenerationJob.id == job_id).update(
+            {FAQGenerationJob.llm_calls: FAQGenerationJob.llm_calls + n},
+            synchronize_session=False,
+        )
+        self.db.commit()
+
+    def count_llm_calls_for_period(
+        self, organization_id: UUID, start_date: datetime, end_date: datetime
+    ) -> int:
+        """Metered LLM calls in a billing period — the hosted-model usage that
+        the enterprise message-limit check adds to the bot-message count."""
+        total = (
+            self.db.query(func.coalesce(func.sum(FAQGenerationJob.llm_calls), 0))
+            .filter(
+                FAQGenerationJob.organization_id == organization_id,
+                FAQGenerationJob.metered.is_(True),
+                FAQGenerationJob.created_at >= start_date,
+                FAQGenerationJob.created_at <= end_date,
+            )
+            .scalar()
+        )
+        return int(total or 0)
+
+    def has_user_initiated_job(self, organization_id: UUID) -> bool:
+        """Whether the org ever explicitly ran generate/import (any status —
+        the attempt is the feature opt-in). GENERATE_SOURCE jobs don't count:
+        only the auto-hook creates those."""
+        return self.db.query(
+            self.db.query(FAQGenerationJob)
+            .filter(
+                FAQGenerationJob.organization_id == organization_id,
+                FAQGenerationJob.job_type != FAQJobType.GENERATE_SOURCE.value,
+            )
+            .exists()
+        ).scalar()
 
     def update_progress(
         self,

--- a/backend/app/repositories/faq_generation_job.py
+++ b/backend/app/repositories/faq_generation_job.py
@@ -1,0 +1,133 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.logger import get_logger
+from app.models.faq_generation_job import (
+    ACTIVE_FAQ_JOB_STATUSES,
+    FAQGenerationJob,
+    FAQJobStage,
+    FAQJobStatus,
+    FAQJobType,
+)
+
+logger = get_logger(__name__)
+
+
+class FAQGenerationJobRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create(self, job: FAQGenerationJob) -> FAQGenerationJob:
+        self.db.add(job)
+        self.db.commit()
+        self.db.refresh(job)
+        return job
+
+    def get_by_id(self, job_id: int) -> Optional[FAQGenerationJob]:
+        return self.db.query(FAQGenerationJob).filter(FAQGenerationJob.id == job_id).first()
+
+    def get_by_id_for_org(self, job_id: int, organization_id: UUID) -> Optional[FAQGenerationJob]:
+        return (
+            self.db.query(FAQGenerationJob)
+            .filter(
+                FAQGenerationJob.id == job_id,
+                FAQGenerationJob.organization_id == organization_id,
+            )
+            .first()
+        )
+
+    def get_pending(self) -> List[FAQGenerationJob]:
+        return (
+            self.db.query(FAQGenerationJob)
+            .filter(FAQGenerationJob.status == FAQJobStatus.PENDING.value)
+            .order_by(FAQGenerationJob.created_at.asc())
+            .all()
+        )
+
+    def get_active_for_org(
+        self,
+        organization_id: UUID,
+        job_type: Optional[FAQJobType] = None,
+        knowledge_id: Optional[int] = None,
+    ) -> Optional[FAQGenerationJob]:
+        """Most recent pending/processing job, optionally narrowed by type and
+        source — the enqueue-dedup guard and the UI's polling target."""
+        query = self.db.query(FAQGenerationJob).filter(
+            FAQGenerationJob.organization_id == organization_id,
+            FAQGenerationJob.status.in_(ACTIVE_FAQ_JOB_STATUSES),
+        )
+        if job_type is not None:
+            query = query.filter(FAQGenerationJob.job_type == job_type.value)
+        if knowledge_id is not None:
+            query = query.filter(FAQGenerationJob.knowledge_id == knowledge_id)
+        return query.order_by(FAQGenerationJob.created_at.desc()).first()
+
+    def get_latest_for_org(self, organization_id: UUID) -> Optional[FAQGenerationJob]:
+        return (
+            self.db.query(FAQGenerationJob)
+            .filter(FAQGenerationJob.organization_id == organization_id)
+            .order_by(FAQGenerationJob.created_at.desc())
+            .first()
+        )
+
+    def update_progress(
+        self,
+        job_id: int,
+        stage: Optional[FAQJobStage] = None,
+        progress_percentage: Optional[float] = None,
+    ) -> bool:
+        """Direct assignment: each job has exactly one sequential writer (the
+        worker), so no monotonicity guard is needed and retries may legitimately
+        move stage/progress backwards."""
+        fields = {}
+        if stage is not None:
+            fields["stage"] = stage.value
+        if progress_percentage is not None:
+            fields["progress_percentage"] = progress_percentage
+        return self._apply(job_id, **fields)
+
+    def mark_processing(self, job_id: int) -> bool:
+        return self._apply(job_id, status=FAQJobStatus.PROCESSING.value)
+
+    def mark_completed(self, job_id: int, faqs_created: int) -> bool:
+        return self._apply(
+            job_id,
+            status=FAQJobStatus.COMPLETED.value,
+            stage=FAQJobStage.COMPLETED.value,
+            progress_percentage=100.0,
+            faqs_created=faqs_created,
+        )
+
+    def mark_failed(self, job_id: int, error: str) -> bool:
+        return self._apply(
+            job_id,
+            status=FAQJobStatus.FAILED.value,
+            error=error[:2000] if error else None,
+        )
+
+    def _apply(self, job_id: int, **fields) -> bool:
+        job = self.get_by_id(job_id)
+        if not job:
+            return False
+        for key, value in fields.items():
+            setattr(job, key, value)
+        self.db.commit()
+        return True

--- a/backend/app/repositories/help_center.py
+++ b/backend/app/repositories/help_center.py
@@ -1,0 +1,116 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models.help_center import HelpCenterQuery, HelpCenterSettings
+
+# Both DNS records verified — the queryable form of the derived
+# HelpCenterSettings.domain_verified property.
+_DOMAIN_VERIFIED = (
+    HelpCenterSettings.txt_record_verified.is_(True)
+    & HelpCenterSettings.cname_record_verified.is_(True)
+)
+
+
+class HelpCenterRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get_by_org(self, organization_id: UUID) -> Optional[HelpCenterSettings]:
+        return (
+            self.db.query(HelpCenterSettings)
+            .filter(HelpCenterSettings.organization_id == organization_id)
+            .first()
+        )
+
+    def get_by_slug(self, slug: str) -> Optional[HelpCenterSettings]:
+        return (
+            self.db.query(HelpCenterSettings)
+            .filter(HelpCenterSettings.slug == slug.lower())
+            .first()
+        )
+
+    def get_by_verified_domain(self, domain: str) -> Optional[HelpCenterSettings]:
+        """Resolve a custom domain — only verified domains ever match, so an
+        unverified claim on someone else's hostname can't hijack serving."""
+        return (
+            self.db.query(HelpCenterSettings)
+            .filter(
+                HelpCenterSettings.custom_domain == domain.lower(),
+                _DOMAIN_VERIFIED,
+            )
+            .first()
+        )
+
+    def list_verified_domains(self) -> List[str]:
+        """All verified custom domains, for the host-dispatch cache."""
+        rows = (
+            self.db.query(HelpCenterSettings.custom_domain)
+            .filter(
+                HelpCenterSettings.custom_domain.isnot(None),
+                _DOMAIN_VERIFIED,
+            )
+            .all()
+        )
+        return [row[0] for row in rows]
+
+    def slug_exists(self, slug: str) -> bool:
+        return self.db.query(
+            self.db.query(HelpCenterSettings)
+            .filter(HelpCenterSettings.slug == slug.lower())
+            .exists()
+        ).scalar()
+
+    def create(self, settings: HelpCenterSettings) -> HelpCenterSettings:
+        self.db.add(settings)
+        self.db.commit()
+        self.db.refresh(settings)
+        return settings
+
+    def update(self, settings: HelpCenterSettings) -> HelpCenterSettings:
+        self.db.commit()
+        self.db.refresh(settings)
+        return settings
+
+
+class HelpCenterQueryRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def log(self, organization_id: UUID, query: str, answered: bool) -> HelpCenterQuery:
+        row = HelpCenterQuery(organization_id=organization_id, query=query, answered=answered)
+        self.db.add(row)
+        self.db.commit()
+        return row
+
+    def count_for_period(self, organization_id: UUID, start: datetime, end: datetime) -> int:
+        """Answered asks in a billing period — feeds the hosted-model metering.
+        Half-open [start, end) so a boundary instant is never billed twice."""
+        return (
+            self.db.query(HelpCenterQuery)
+            .filter(
+                HelpCenterQuery.organization_id == organization_id,
+                HelpCenterQuery.answered.is_(True),
+                HelpCenterQuery.created_at >= start,
+                HelpCenterQuery.created_at < end,
+            )
+            .count()
+        )

--- a/backend/app/repositories/help_center.py
+++ b/backend/app/repositories/help_center.py
@@ -72,6 +72,19 @@ class HelpCenterRepository:
         )
         return [row[0] for row in rows]
 
+    def list_enabled_slugs(self) -> List[str]:
+        """Slugs of enabled help centers — their `{slug}.{base_domain}` origins
+        are added to the CORS allowlist for the embedded widget."""
+        rows = (
+            self.db.query(HelpCenterSettings.slug)
+            .filter(
+                HelpCenterSettings.enabled.is_(True),
+                HelpCenterSettings.slug.isnot(None),
+            )
+            .all()
+        )
+        return [row[0] for row in rows]
+
     def slug_exists(self, slug: str) -> bool:
         return self.db.query(
             self.db.query(HelpCenterSettings)

--- a/backend/app/services/domain_verification.py
+++ b/backend/app/services/domain_verification.py
@@ -1,0 +1,159 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Custom-domain verification for the public help center.
+
+The customer proves control of the domain with a TXT record
+(_chattermate.<domain> = cm-verify=<token>) and routes traffic with a CNAME
+to HELP_CENTER_CNAME_TARGET (A/AAAA records matching HELP_CENTER_TARGET_IPS
+are accepted for providers that flatten CNAMEs). Both must pass before the
+host dispatcher will ever serve the domain. SSL turns active once an HTTPS
+probe against /healthz succeeds with a valid certificate.
+"""
+
+import secrets
+from datetime import datetime, timezone
+
+import httpx
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.logger import get_logger
+from app.models.help_center import HelpCenterSettings, SSLStatus
+from app.repositories.help_center import HelpCenterRepository
+
+logger = get_logger(__name__)
+
+DNS_LIFETIME_SECONDS = 5.0
+SSL_PROBE_TIMEOUT_SECONDS = 10.0
+TXT_RECORD_PREFIX = "_chattermate"
+
+
+def generate_verification_token() -> str:
+    return secrets.token_hex(16)
+
+
+def txt_record_host(domain: str) -> str:
+    return f"{TXT_RECORD_PREFIX}.{domain}"
+
+
+def expected_txt_value(row: HelpCenterSettings) -> str:
+    return f"cm-verify={row.domain_verification_token}"
+
+
+def _resolver():
+    import dns.resolver
+
+    resolver = dns.resolver.Resolver()
+    resolver.lifetime = DNS_LIFETIME_SECONDS
+    return resolver
+
+
+def check_txt_record(row: HelpCenterSettings) -> bool:
+    """True when the verification TXT record is present."""
+    import dns.resolver
+
+    expected = expected_txt_value(row)
+    try:
+        answers = _resolver().resolve(txt_record_host(row.custom_domain), "TXT")
+    except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer, dns.resolver.NoNameservers,
+            dns.resolver.LifetimeTimeout):
+        return False
+    for record in answers:
+        value = b"".join(record.strings).decode("utf-8", errors="replace")
+        if value.strip() == expected:
+            return True
+    return False
+
+
+def check_cname_record(domain: str) -> bool:
+    """True when the domain points at us: CNAME to the target, or (for
+    CNAME-flattening providers) A/AAAA records matching the target IPs."""
+    import dns.resolver
+
+    target = settings.HELP_CENTER_CNAME_TARGET.rstrip(".").lower()
+    try:
+        answers = _resolver().resolve(domain, "CNAME")
+        return any(str(record.target).rstrip(".").lower() == target for record in answers)
+    except (dns.resolver.NXDOMAIN, dns.resolver.NoNameservers, dns.resolver.LifetimeTimeout):
+        return False
+    except dns.resolver.NoAnswer:
+        pass  # no CNAME — fall through to flattened A/AAAA comparison
+    if not settings.HELP_CENTER_TARGET_IPS:
+        return False
+    resolved = set()
+    for rtype in ("A", "AAAA"):
+        try:
+            resolved.update(str(r) for r in _resolver().resolve(domain, rtype))
+        except Exception:
+            continue
+    return bool(resolved) and resolved <= settings.HELP_CENTER_TARGET_IPS
+
+
+def probe_ssl(domain: str) -> bool:
+    """HTTPS reachability with certificate validation — flips ssl_status to
+    ACTIVE once the cert is actually being served for this domain."""
+    try:
+        response = httpx.get(
+            f"https://{domain}/healthz", timeout=SSL_PROBE_TIMEOUT_SECONDS, follow_redirects=False
+        )
+        return response.status_code == 200
+    except httpx.HTTPError as e:
+        logger.info(f"SSL probe for {domain} not ready: {e}")
+        return False
+
+
+def set_custom_domain(db: Session, row: HelpCenterSettings, domain: str) -> HelpCenterSettings:
+    """Claim a (normalized) domain: fresh token, verification state reset."""
+    base_suffix = f".{settings.HELP_CENTER_BASE_DOMAIN}"
+    if domain == settings.HELP_CENTER_BASE_DOMAIN or domain.endswith(base_suffix):
+        raise ValueError(f"{settings.HELP_CENTER_BASE_DOMAIN} subdomains are assigned automatically and cannot be claimed.")
+    row.custom_domain = domain
+    row.domain_verification_token = generate_verification_token()
+    row.txt_record_verified = False
+    row.cname_record_verified = False
+    row.ssl_status = SSLStatus.NONE
+    row.domain_verified_at = None
+    return HelpCenterRepository(db).update(row)
+
+
+def clear_custom_domain(db: Session, row: HelpCenterSettings) -> HelpCenterSettings:
+    row.custom_domain = None
+    row.domain_verification_token = None
+    row.txt_record_verified = False
+    row.cname_record_verified = False
+    row.ssl_status = SSLStatus.NONE
+    row.domain_verified_at = None
+    return HelpCenterRepository(db).update(row)
+
+
+def verify_custom_domain(db: Session, row: HelpCenterSettings) -> HelpCenterSettings:
+    """Run both DNS checks (and the SSL probe once verified) and persist the
+    outcome. Blocking (DNS/HTTP I/O) — callers run it off the event loop."""
+    if not row.custom_domain:
+        raise ValueError("No custom domain configured.")
+    row.txt_record_verified = check_txt_record(row)
+    row.cname_record_verified = check_cname_record(row.custom_domain)
+    if row.domain_verified:
+        if not row.domain_verified_at:
+            row.domain_verified_at = datetime.now(timezone.utc)
+        if row.ssl_status != SSLStatus.ACTIVE.value:
+            row.ssl_status = (
+                SSLStatus.ACTIVE if probe_ssl(row.custom_domain) else SSLStatus.PENDING
+            )
+    else:
+        row.domain_verified_at = None
+        row.ssl_status = SSLStatus.NONE
+    return HelpCenterRepository(db).update(row)

--- a/backend/app/services/faq_article_import.py
+++ b/backend/app/services/faq_article_import.py
@@ -63,6 +63,28 @@ _SKIP_EXTENSIONS = (
 # substrings like "stock-levels" or "autocomplete".
 _TOC_RE = re.compile(r"\b(toc|table-of-contents|on-this-page|breadcrumbs?)\b", re.IGNORECASE)
 
+# Help-center chrome text (platform branding / article metadata) to drop.
+_CHROME_TEXT_RE = re.compile(r"^(made with|powered by)\b|^last updated\b", re.IGNORECASE)
+_CHROME_HREFS = ("chatwoot.com", "chatwoot.help")
+
+# Path markers separating leaf article pages from category/section listings
+# across Chatwoot / Zendesk / Intercom-style help centers. Only /articles/
+# pages hold real content; the listings are followed for their article links.
+_ARTICLE_MARKER = "/articles/"
+_CATEGORY_MARKERS = ("/categories/", "/sections/", "/collections/")
+_HEADING_TAGS = ("h1", "h2", "h3", "h4")
+_LEADING_SYMBOLS_RE = re.compile(r"^[^\w]+", re.UNICODE)
+
+# Homepage section headings that are curated cross-cuts, not real categories —
+# their articles' true category comes from the category listing pages instead.
+_GENERIC_SECTIONS = frozenset({
+    "featured articles", "featured", "popular", "popular articles", "all articles",
+    "browse", "recent articles", "recently updated", "top articles",
+})
+
+# Breadcrumb "back" links whose leading container should be dropped from bodies.
+_BREADCRUMB_ROOTS = frozenset({"home", "all collections", "all categories", "help center", "help centre"})
+
 # Internal scheme marking images collected during conversion, replaced with the
 # re-hosted URL afterwards (conversion is sync; storage is async). The trailing
 # ".img" delimits the index so "…//1.img" is never a prefix of "…//10.img".
@@ -154,40 +176,132 @@ def _fetch_index_soup(client: httpx.Client, url: str) -> Tuple[Optional[Beautifu
     return soup, final_url
 
 
-def discover_article_links(client: httpx.Client, index_url: str, limit: int) -> List[str]:
-    """Same-site article links from the index page, in page order: fragments/
-    queries stripped, binaries and the index itself excluded, links sharing the
-    index's path prefix preferred (most help centers nest articles under it)."""
+def _clean_category(text: str) -> str:
+    """Strip a leading emoji/symbol (Chatwoot section headings are '📞 Help
+    and support') and cap length."""
+    cleaned = _LEADING_SYMBOLS_RE.sub("", (text or "").strip()).strip()
+    return cleaned[:100] or DEFAULT_ARTICLE_CATEGORY
+
+
+def _same_site_href(anchor: Tag, base_url: str, root_domain: str) -> Optional[str]:
+    """Absolute same-site content URL for an anchor, or None if it's off-site,
+    a fragment/query, a bare root, or a binary asset."""
+    href = anchor.get("href")
+    if not href:
+        return None
+    url = urldefrag(urljoin(base_url, href))[0].rstrip("/")
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or parsed.query:
+        return None
+    if parsed.path in ("", "/"):
+        return None
+    if _registrable_domain(parsed.hostname or "") != root_domain:
+        return None
+    if parsed.path.lower().endswith(_SKIP_EXTENSIONS):
+        return None
+    return url
+
+
+def _is_article_url(url: str) -> bool:
+    return _ARTICLE_MARKER in urlparse(url).path.lower()
+
+
+def _is_category_url(url: str) -> bool:
+    path = urlparse(url).path.lower()
+    return any(marker in path for marker in _CATEGORY_MARKERS)
+
+
+def _sectioned_article_links(node: Tag, base_url: str, root_domain: str) -> List[Tuple[str, Optional[str]]]:
+    """Article links in document order, each tagged with the nearest preceding
+    section heading (a help-center homepage's category cards). Headings nested
+    inside a link are article titles, not sections, so they don't reset it."""
+    results: List[Tuple[str, Optional[str]]] = []
+    current: Optional[str] = None
+    for el in node.find_all([*_HEADING_TAGS, "a"]):
+        if el.name in _HEADING_TAGS:
+            if not el.find_parent("a"):
+                cat = _clean_category(el.get_text(" ", strip=True))
+                # Curated cross-cut sections ("Featured Articles") aren't real
+                # categories — leave those articles for the category pages.
+                current = None if cat.lower() in _GENERIC_SECTIONS else cat
+            continue
+        url = _same_site_href(el, base_url, root_domain)
+        if url and _is_article_url(url):
+            results.append((url, current))
+    return results
+
+
+def discover_article_links(
+    client: httpx.Client, index_url: str, limit: int
+) -> List[Tuple[str, Optional[str]]]:
+    """Discover (article_url, category) pairs from a help-center index.
+
+    Standard help centers (Chatwoot/Zendesk/Intercom) nest articles under
+    /articles/ and group them into /categories/ (or /sections//collections/).
+    We tag each article with its homepage section heading, then follow the
+    category listing pages for the full per-category list (homepages truncate
+    each section to a few articles). A non-standard/flat page with no /articles/
+    links falls back to importing every same-site content link.
+    """
     soup, final_url = _fetch_index_soup(client, index_url)
     if soup is None:
         raise ValueError("Could not read that page.")
     root_domain = _registrable_domain(urlparse(final_url).hostname or "")
     index_clean = urldefrag(final_url)[0].rstrip("/")
-    index_path = urlparse(final_url).path.rstrip("/")
+    main = select_main_node(soup) or soup
 
-    preferred: List[str] = []
-    others: List[str] = []
-    seen = set()
-    for anchor in soup.find_all("a", href=True):
-        url = urldefrag(urljoin(final_url, anchor["href"]))[0].rstrip("/")
-        parsed = urlparse(url)
-        if parsed.scheme not in ("http", "https") or parsed.query:
+    ordered: List[str] = []
+    category_of: Dict[str, Optional[str]] = {}
+
+    def record(url: str, category: Optional[str]) -> None:
+        if url == index_clean:
+            return
+        if url not in category_of:
+            category_of[url] = category
+            ordered.append(url)
+        elif category and not category_of[url]:
+            # Upgrade a still-uncategorised article (e.g. seen first under a
+            # generic homepage section) with the category page's real name.
+            category_of[url] = category
+
+    # 1. Homepage article links, tagged by their section heading.
+    for url, category in _sectioned_article_links(main, final_url, root_domain):
+        record(url, category)
+
+    # 2. Follow category/section pages for the complete per-category list.
+    category_links: List[str] = []
+    seen_cat = set()
+    for anchor in main.find_all("a", href=True):
+        url = _same_site_href(anchor, final_url, root_domain)
+        if url and _is_category_url(url) and url not in seen_cat:
+            seen_cat.add(url)
+            category_links.append(url)
+    for cat_url in category_links[: settings.FAQ_ARTICLE_IMPORT_MAX_CATEGORIES]:
+        if len(ordered) >= limit:
+            break
+        cat_soup, cat_final = _fetch_soup(client, cat_url)
+        if cat_soup is None:
             continue
-        # Bare-root links are nav (home/app links), never articles.
-        if parsed.path in ("", "/"):
-            continue
-        if url == index_clean or url in seen:
-            continue
-        if _registrable_domain(parsed.hostname or "") != root_domain:
-            continue
-        if parsed.path.lower().endswith(_SKIP_EXTENSIONS):
-            continue
-        seen.add(url)
-        (preferred if index_path and parsed.path.startswith(index_path + "/") else others).append(url)
-    links = (preferred + others)[:limit]
-    if not links:
+        og_title, doc_title = _head_titles(cat_soup)
+        cat_node = select_main_node(cat_soup) or cat_soup
+        cat_name = _clean_category(_page_title(og_title, doc_title, cat_node, cat_soup))
+        for anchor in cat_node.find_all("a", href=True):
+            url = _same_site_href(anchor, cat_final, root_domain)
+            if url and _is_article_url(url):
+                record(url, cat_name)
+
+    # 3. Fallback: no standard article URLs — import every same-site link,
+    #    resolving each article's category from its own breadcrumb/URL.
+    if not ordered:
+        for anchor in main.find_all("a", href=True):
+            url = _same_site_href(anchor, final_url, root_domain)
+            if url:
+                record(url, None)
+
+    ordered = ordered[:limit]
+    if not ordered:
         raise ValueError("No linked article pages found on that page.")
-    return links
+    return [(url, category_of[url]) for url in ordered]
 
 
 def _head_titles(soup: BeautifulSoup) -> Tuple[str, str]:
@@ -225,13 +339,54 @@ def _category_hint(soup: BeautifulSoup, url: str) -> str:
     return DEFAULT_ARTICLE_CATEGORY
 
 
-def fetch_article(client: httpx.Client, url: str) -> Optional[Article]:
+def _strip_chrome(node: Tag) -> None:
+    """Remove in-article chrome that shouldn't become FAQ content: nav bars,
+    TOCs, footers, help-center platform branding ('Made with Chatwoot') and
+    'Last updated' metadata lines. Best-effort — a detached element mid-loop
+    just skips."""
+    for chrome in node.find_all("nav") + node.find_all("footer"):
+        chrome.decompose()
+    for chrome in node.find_all(class_=_TOC_RE) + node.find_all(id=_TOC_RE):
+        try:
+            chrome.decompose()
+        except Exception:
+            pass
+    # Leading breadcrumb ("Home › …") — a short container whose first link is a
+    # back-to-index link. Chatwoot renders it as a bare div (no nav/class hook).
+    for anchor in node.find_all("a"):
+        if anchor.get_text(strip=True).lower() in _BREADCRUMB_ROOTS:
+            container = anchor.find_parent(["nav", "ol", "ul", "div"])
+            if container and len(container.get_text(" ", strip=True)) <= 80:
+                try:
+                    container.decompose()
+                except Exception:
+                    pass
+            break
+    for anchor in list(node.find_all("a", href=True)):
+        try:
+            href = (anchor.get("href") or "").lower()
+            if any(brand in href for brand in _CHROME_HREFS):
+                (anchor.find_parent(["div", "footer", "section"]) or anchor).decompose()
+        except Exception:
+            pass
+    for el in list(node.find_all(["p", "div", "span", "small", "time"])):
+        try:
+            text = el.get_text(" ", strip=True)
+            if text and len(text) <= 60 and _CHROME_TEXT_RE.search(text):
+                el.decompose()
+        except Exception:
+            pass
+
+
+def fetch_article(
+    client: httpx.Client, url: str, category_override: Optional[str] = None
+) -> Optional[Article]:
     """One article page → title + Markdown body (+ images pending re-host).
-    None when the page can't be read or has no substantial content."""
+    category_override (from the category listing that linked here) wins over the
+    per-page breadcrumb/URL guess. None when the page can't be read or is empty."""
     soup, final_url = _fetch_soup(client, url)
     if soup is None:
         return None
-    category = _category_hint(soup, final_url)
     og_title, doc_title = _head_titles(soup)  # before <head> is stripped below
     node = select_main_node(soup)
     if node is None:
@@ -239,15 +394,12 @@ def fetch_article(client: httpx.Client, url: str) -> Optional[Article]:
     title = _page_title(og_title, doc_title, node, soup)
     if not title:
         return None
+    category = category_override or _category_hint(soup, final_url)
     # The page's own h1 would duplicate the FAQ question.
     first_h1 = node.find("h1")
     if first_h1:
         first_h1.extract()
-    # Strip in-article chrome: nav bars and "On this page" TOCs.
-    for chrome in node.find_all("nav"):
-        chrome.extract()
-    for chrome in node.find_all(class_=_TOC_RE) + node.find_all(id=_TOC_RE):
-        chrome.extract()
+    _strip_chrome(node)
     converter = _ArticleConverter(base_url=final_url, client=client, heading_style="ATX", bullets="-")
     markdown = converter.convert_soup(node).strip()
     if not markdown:
@@ -291,8 +443,8 @@ async def run_article_import_job(db, job: FAQGenerationJob) -> int:
         source_label = f"Imported from {urlparse(job.source_url).netloc}"
 
         rows: List[FAQ] = []
-        for index, link in enumerate(links):
-            article = await asyncio.to_thread(fetch_article, client, link)
+        for index, (link, category) in enumerate(links):
+            article = await asyncio.to_thread(fetch_article, client, link, category)
             job_repo.update_progress(
                 job.id, progress_percentage=10.0 + 78.0 * (index + 1) / len(links)
             )

--- a/backend/app/services/faq_article_import.py
+++ b/backend/app/services/faq_article_import.py
@@ -59,11 +59,14 @@ _SKIP_EXTENSIONS = (
 )
 
 # In-article chrome that shouldn't survive into the imported Markdown.
-_TOC_RE = re.compile("toc|table-of-contents|on-this-page|breadcrumb", re.IGNORECASE)
+# Word-boundary anchored: matches "docs-toc"/"breadcrumbs" but never innocent
+# substrings like "stock-levels" or "autocomplete".
+_TOC_RE = re.compile(r"\b(toc|table-of-contents|on-this-page|breadcrumbs?)\b", re.IGNORECASE)
 
 # Internal scheme marking images collected during conversion, replaced with the
-# re-hosted URL afterwards (conversion is sync; storage is async).
-_IMG_PLACEHOLDER = "cm-pending-image://{index}"
+# re-hosted URL afterwards (conversion is sync; storage is async). The trailing
+# ".img" delimits the index so "…//1.img" is never a prefix of "…//10.img".
+_IMG_PLACEHOLDER = "cm-pending-image://{index}.img"
 
 
 @dataclass
@@ -187,17 +190,25 @@ def discover_article_links(client: httpx.Client, index_url: str, limit: int) -> 
     return links
 
 
-def _page_title(soup: BeautifulSoup, node: Tag) -> str:
+def _head_titles(soup: BeautifulSoup) -> Tuple[str, str]:
+    """(og:title, <title>) — must run BEFORE select_main_node, which strips
+    <head> from the soup."""
     og = soup.find("meta", property="og:title")
-    if og and og.get("content", "").strip():
-        return og["content"].strip()
+    og_title = og["content"].strip() if og and og.get("content", "").strip() else ""
+    doc_title = ""
+    if soup.title and soup.title.get_text(strip=True):
+        # Drop the " | Site Name" tail commonly appended to <title>.
+        doc_title = soup.title.get_text(strip=True).split("|")[0].strip()
+    return og_title, doc_title
+
+
+def _page_title(og_title: str, doc_title: str, node: Tag, soup: BeautifulSoup) -> str:
+    if og_title:
+        return og_title
     h1 = node.find("h1") or soup.find("h1")
     if h1 and h1.get_text(strip=True):
         return h1.get_text(" ", strip=True)
-    if soup.title and soup.title.get_text(strip=True):
-        # Drop the " | Site Name" tail commonly appended to <title>.
-        return soup.title.get_text(strip=True).split("|")[0].strip()
-    return ""
+    return doc_title
 
 
 def _category_hint(soup: BeautifulSoup, url: str) -> str:
@@ -221,10 +232,11 @@ def fetch_article(client: httpx.Client, url: str) -> Optional[Article]:
     if soup is None:
         return None
     category = _category_hint(soup, final_url)
+    og_title, doc_title = _head_titles(soup)  # before <head> is stripped below
     node = select_main_node(soup)
     if node is None:
         return None
-    title = _page_title(soup, node)
+    title = _page_title(og_title, doc_title, node, soup)
     if not title:
         return None
     # The page's own h1 would duplicate the FAQ question.

--- a/backend/app/services/faq_article_import.py
+++ b/backend/app/services/faq_article_import.py
@@ -64,7 +64,14 @@ _SKIP_EXTENSIONS = (
 _TOC_RE = re.compile(r"\b(toc|table-of-contents|on-this-page|breadcrumbs?)\b", re.IGNORECASE)
 
 # Help-center chrome text (platform branding / article metadata) to drop.
-_CHROME_TEXT_RE = re.compile(r"^(made with|powered by)\b|^last updated\b", re.IGNORECASE)
+# Platform-specific so it never strips legitimate prose like "Powered by our
+# AI engine" — only footer branding for known help-center platforms and the
+# "Last updated on …" article-metadata line.
+_CHROME_TEXT_RE = re.compile(
+    r"^last updated on\b"
+    r"|^(made with|powered by)\b.*\b(chatwoot|intercom|zendesk|help ?scout|gitbook|freshdesk|document360)\b",
+    re.IGNORECASE,
+)
 _CHROME_HREFS = ("chatwoot.com", "chatwoot.help")
 
 # Path markers separating leaf article pages from category/section listings
@@ -355,22 +362,27 @@ def _strip_chrome(node: Tag) -> None:
             chrome.decompose()
         except Exception:
             pass
-    # Leading breadcrumb ("Home › …") — a short container whose first link is a
-    # back-to-index link. Chatwoot renders it as a bare div (no nav/class hook).
-    for anchor in node.find_all("a"):
-        if anchor.get_text(strip=True).lower() in _BREADCRUMB_ROOTS:
-            container = anchor.find_parent(["nav", "ol", "ul", "div"])
-            if container and len(container.get_text(" ", strip=True)) <= 80:
-                try:
-                    container.decompose()
-                except Exception:
-                    pass
-            break
+    # Leading breadcrumb ("Home › …"): strip only when the article's FIRST link
+    # is a back-to-index link in a short container. A "Home" link buried in body
+    # prose is never the first anchor, so real content is never removed.
+    first_anchor = node.find("a")
+    if first_anchor and first_anchor.get_text(strip=True).lower() in _BREADCRUMB_ROOTS:
+        container = first_anchor.find_parent(["nav", "ol", "ul", "div"])
+        if container and len(container.get_text(" ", strip=True)) <= 80:
+            try:
+                container.decompose()
+            except Exception:
+                pass
+    # Platform-branding link ("Made with Chatwoot" logo): remove only a SMALL
+    # enclosing block (the footer badge), never a large content div that merely
+    # links out to the platform.
     for anchor in list(node.find_all("a", href=True)):
         try:
             href = (anchor.get("href") or "").lower()
             if any(brand in href for brand in _CHROME_HREFS):
-                (anchor.find_parent(["div", "footer", "section"]) or anchor).decompose()
+                container = anchor.find_parent(["div", "footer", "section"])
+                target = container if container and len(container.get_text(" ", strip=True)) <= 40 else anchor
+                target.decompose()
         except Exception:
             pass
     for el in list(node.find_all(["p", "div", "span", "small", "time"])):

--- a/backend/app/services/faq_article_import.py
+++ b/backend/app/services/faq_article_import.py
@@ -1,0 +1,312 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Article-mode help-center import: crawl the linked article pages of an existing
+help-center/FAQ index and import each one AS-IS — HTML converted straight to
+Markdown (no LLM, no credits), images downloaded and re-hosted on our storage,
+links absolutized. One draft FAQ per article: question = page title, answer =
+the article body in Markdown.
+"""
+
+import asyncio
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urldefrag, urljoin, urlparse
+
+import httpx
+from bs4 import BeautifulSoup, Tag
+from markdownify import MarkdownConverter
+
+from app.core.config import settings
+from app.core.logger import get_logger
+from app.knowledge.main_content import select_main_node
+from app.knowledge.sitemap_parser import _registrable_domain
+from app.knowledge.url_safety import safe_get
+from app.models.faq import FAQ, FAQStatus
+from app.models.faq_generation_job import FAQGenerationJob, FAQJobStage
+from app.models.schemas.faq import MAX_ANSWER_LENGTH, MAX_QUESTION_LENGTH
+from app.repositories.faq import FAQRepository
+from app.repositories.faq_generation_job import FAQGenerationJobRepository
+from app.services.faq_generation import CategoryMerger, insert_draft_rows, normalize_question
+from app.services.faq_import import _FETCH_HEADERS, MIN_STATIC_TEXT_CHARS
+from app.services.help_center_images import (
+    FAQ_IMAGE_TYPES,
+    MAX_FAQ_IMAGE_BYTES,
+    store_article_image,
+)
+
+logger = get_logger(__name__)
+
+DEFAULT_ARTICLE_CATEGORY = "Imported"
+
+# Link targets that can never be article pages.
+_SKIP_EXTENSIONS = (
+    ".pdf", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".zip", ".mp4",
+    ".css", ".js", ".xml", ".ico", ".woff", ".woff2", ".txt", ".json",
+)
+
+# In-article chrome that shouldn't survive into the imported Markdown.
+_TOC_RE = re.compile("toc|table-of-contents|on-this-page|breadcrumb", re.IGNORECASE)
+
+# Internal scheme marking images collected during conversion, replaced with the
+# re-hosted URL afterwards (conversion is sync; storage is async).
+_IMG_PLACEHOLDER = "cm-pending-image://{index}"
+
+
+@dataclass
+class Article:
+    url: str
+    title: str
+    markdown: str
+    category_hint: str
+    # index -> (bytes, content_type) awaiting re-host.
+    pending_images: Dict[int, Tuple[bytes, str]] = field(default_factory=dict)
+
+
+class _ArticleConverter(MarkdownConverter):
+    """HTML→Markdown converter that absolutizes links and swaps images for
+    placeholders after downloading them (SSRF-guarded, size/type-capped)."""
+
+    def __init__(self, base_url: str, client: httpx.Client, **options):
+        super().__init__(**options)
+        self._base_url = base_url
+        self._client = client
+        self.images: Dict[int, Tuple[bytes, str]] = {}
+
+    def convert_a(self, el, text, parent_tags):
+        href = el.get("href")
+        if href:
+            el["href"] = urljoin(self._base_url, href)
+        return super().convert_a(el, text, parent_tags)
+
+    def convert_img(self, el, text, parent_tags):
+        alt = (el.get("alt") or "").strip()
+        src = (el.get("src") or "").strip()
+        if not src or src.startswith("data:"):
+            return alt  # inline/base64 images are stripped by the renderer anyway
+        if len(self.images) >= settings.FAQ_ARTICLE_IMPORT_MAX_IMAGES:
+            return alt
+        image = self._download(urljoin(self._base_url, src))
+        if not image:
+            return alt
+        index = len(self.images)
+        self.images[index] = image
+        return f"![{alt}]({_IMG_PLACEHOLDER.format(index=index)})"
+
+    def _download(self, url: str) -> Optional[Tuple[bytes, str]]:
+        try:
+            response = safe_get(self._client, url)
+            response.raise_for_status()
+            content_type = (response.headers.get("content-type") or "").split(";")[0].strip()
+            if content_type not in FAQ_IMAGE_TYPES or len(response.content) > MAX_FAQ_IMAGE_BYTES:
+                return None
+            return response.content, content_type
+        except Exception as e:
+            logger.warning(f"Article image skipped ({url}): {e}")
+            return None
+
+
+def _fetch_soup(client: httpx.Client, url: str) -> Tuple[Optional[BeautifulSoup], str]:
+    """Static SSRF-guarded fetch → (soup, final hop-validated URL)."""
+    try:
+        response = safe_get(client, url)
+        response.raise_for_status()
+        return BeautifulSoup(response.text, "html.parser"), str(response.url)
+    except httpx.HTTPError as e:
+        logger.warning(f"Article fetch failed for {url}: {e}")
+        return None, url
+
+
+def _fetch_index_soup(client: httpx.Client, url: str) -> Tuple[Optional[BeautifulSoup], str]:
+    """Index fetch with the headless-browser fallback for JS-rendered indexes
+    (article pages themselves are static-only — one browser per crawl, not 30)."""
+    soup, final_url = _fetch_soup(client, url)
+    if soup and len(soup.get_text(" ", strip=True)) >= MIN_STATIC_TEXT_CHARS:
+        return soup, final_url
+    try:
+        from app.knowledge.crawl4ai_fallback import get_crawl4ai_fallback
+
+        fallback = get_crawl4ai_fallback(timeout=settings.FAQ_IMPORT_FETCH_TIMEOUT)
+        if fallback.is_available:
+            html, browser_soup, _ = fallback.fetch_with_browser(final_url)
+            if browser_soup is not None:
+                return browser_soup, final_url
+            if isinstance(html, str) and html:
+                return BeautifulSoup(html, "html.parser"), final_url
+    except Exception as e:
+        logger.warning(f"Article index browser fetch failed for {url}: {e}")
+    return soup, final_url
+
+
+def discover_article_links(client: httpx.Client, index_url: str, limit: int) -> List[str]:
+    """Same-site article links from the index page, in page order: fragments/
+    queries stripped, binaries and the index itself excluded, links sharing the
+    index's path prefix preferred (most help centers nest articles under it)."""
+    soup, final_url = _fetch_index_soup(client, index_url)
+    if soup is None:
+        raise ValueError("Could not read that page.")
+    root_domain = _registrable_domain(urlparse(final_url).hostname or "")
+    index_clean = urldefrag(final_url)[0].rstrip("/")
+    index_path = urlparse(final_url).path.rstrip("/")
+
+    preferred: List[str] = []
+    others: List[str] = []
+    seen = set()
+    for anchor in soup.find_all("a", href=True):
+        url = urldefrag(urljoin(final_url, anchor["href"]))[0].rstrip("/")
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https") or parsed.query:
+            continue
+        # Bare-root links are nav (home/app links), never articles.
+        if parsed.path in ("", "/"):
+            continue
+        if url == index_clean or url in seen:
+            continue
+        if _registrable_domain(parsed.hostname or "") != root_domain:
+            continue
+        if parsed.path.lower().endswith(_SKIP_EXTENSIONS):
+            continue
+        seen.add(url)
+        (preferred if index_path and parsed.path.startswith(index_path + "/") else others).append(url)
+    links = (preferred + others)[:limit]
+    if not links:
+        raise ValueError("No linked article pages found on that page.")
+    return links
+
+
+def _page_title(soup: BeautifulSoup, node: Tag) -> str:
+    og = soup.find("meta", property="og:title")
+    if og and og.get("content", "").strip():
+        return og["content"].strip()
+    h1 = node.find("h1") or soup.find("h1")
+    if h1 and h1.get_text(strip=True):
+        return h1.get_text(" ", strip=True)
+    if soup.title and soup.title.get_text(strip=True):
+        # Drop the " | Site Name" tail commonly appended to <title>.
+        return soup.title.get_text(strip=True).split("|")[0].strip()
+    return ""
+
+
+def _category_hint(soup: BeautifulSoup, url: str) -> str:
+    """Breadcrumb (second-to-last crumb = the article's section) or a URL path
+    segment, else the generic import bucket."""
+    crumbs = soup.select('[aria-label*="readcrumb"] a, nav.breadcrumb a, .breadcrumbs a, .breadcrumb a')
+    texts = [c.get_text(" ", strip=True) for c in crumbs if c.get_text(strip=True)]
+    if len(texts) >= 2:
+        # Last crumb is the page itself; the one before is its section.
+        return texts[-2][:100]
+    segments = [s for s in urlparse(url).path.split("/") if s]
+    if len(segments) >= 2:
+        return segments[-2].replace("-", " ").replace("_", " ").title()[:100]
+    return DEFAULT_ARTICLE_CATEGORY
+
+
+def fetch_article(client: httpx.Client, url: str) -> Optional[Article]:
+    """One article page → title + Markdown body (+ images pending re-host).
+    None when the page can't be read or has no substantial content."""
+    soup, final_url = _fetch_soup(client, url)
+    if soup is None:
+        return None
+    category = _category_hint(soup, final_url)
+    node = select_main_node(soup)
+    if node is None:
+        return None
+    title = _page_title(soup, node)
+    if not title:
+        return None
+    # The page's own h1 would duplicate the FAQ question.
+    first_h1 = node.find("h1")
+    if first_h1:
+        first_h1.extract()
+    # Strip in-article chrome: nav bars and "On this page" TOCs.
+    for chrome in node.find_all("nav"):
+        chrome.extract()
+    for chrome in node.find_all(class_=_TOC_RE) + node.find_all(id=_TOC_RE):
+        chrome.extract()
+    converter = _ArticleConverter(base_url=final_url, client=client, heading_style="ATX", bullets="-")
+    markdown = converter.convert_soup(node).strip()
+    if not markdown:
+        return None
+    return Article(
+        url=final_url,
+        title=title[:MAX_QUESTION_LENGTH],
+        markdown=markdown,
+        category_hint=category,
+        pending_images=converter.images,
+    )
+
+
+async def _rehost_images(article: Article) -> str:
+    markdown = article.markdown
+    for index, (content, content_type) in article.pending_images.items():
+        placeholder = _IMG_PLACEHOLDER.format(index=index)
+        try:
+            markdown = markdown.replace(placeholder, await store_article_image(content, content_type))
+        except Exception as e:
+            logger.warning(f"Article image re-host failed ({article.url}): {e}")
+            markdown = markdown.replace(f"({placeholder})", "()")
+    return markdown
+
+
+async def run_article_import_job(db, job: FAQGenerationJob) -> int:
+    """Execute an IMPORT_ARTICLES job. Returns FAQs created. No LLM involved —
+    articles are imported verbatim as Markdown drafts."""
+    job_repo = FAQGenerationJobRepository(db)
+    job_repo.update_progress(job.id, stage=FAQJobStage.ANALYZING_SOURCES, progress_percentage=5.0)
+
+    client = httpx.Client(timeout=settings.FAQ_IMPORT_FETCH_TIMEOUT, headers=_FETCH_HEADERS)
+    try:
+        links = await asyncio.to_thread(
+            discover_article_links, client, job.source_url, settings.FAQ_ARTICLE_IMPORT_MAX_PAGES
+        )
+        job_repo.update_progress(job.id, stage=FAQJobStage.EXTRACTING, progress_percentage=10.0)
+
+        existing = {normalize_question(q) for q in FAQRepository(db).get_existing_questions(job.organization_id)}
+        categories = CategoryMerger(db, job.organization_id)
+        source_label = f"Imported from {urlparse(job.source_url).netloc}"
+
+        rows: List[FAQ] = []
+        for index, link in enumerate(links):
+            article = await asyncio.to_thread(fetch_article, client, link)
+            job_repo.update_progress(
+                job.id, progress_percentage=10.0 + 78.0 * (index + 1) / len(links)
+            )
+            if not article:
+                continue
+            key = normalize_question(article.title)
+            if not key or key in existing:
+                continue
+            existing.add(key)
+            answer = (await _rehost_images(article))[:MAX_ANSWER_LENGTH]
+            rows.append(
+                FAQ(
+                    organization_id=job.organization_id,
+                    question=article.title,
+                    answer=answer,
+                    category=categories.merge(article.category_hint),
+                    status=FAQStatus.DRAFT,
+                    knowledge_id=None,
+                    source_label=source_label,
+                    generation_job_id=job.id,
+                    created_by=job.user_id,
+                )
+            )
+    finally:
+        client.close()
+
+    if not rows:
+        return 0
+    return insert_draft_rows(db, job, rows)

--- a/backend/app/services/faq_article_import.py
+++ b/backend/app/services/faq_article_import.py
@@ -238,10 +238,12 @@ def discover_article_links(
 
     Standard help centers (Chatwoot/Zendesk/Intercom) nest articles under
     /articles/ and group them into /categories/ (or /sections//collections/).
-    We tag each article with its homepage section heading, then follow the
-    category listing pages for the full per-category list (homepages truncate
-    each section to a few articles). A non-standard/flat page with no /articles/
-    links falls back to importing every same-site content link.
+    We follow the category listing pages FIRST for the complete per-category
+    list (homepages truncate each section to a few articles), so hitting the
+    page cap yields whole categories rather than a thin slice of every one.
+    Homepage section links then fill any remainder (e.g. featured-only
+    articles). A non-standard/flat page with no /articles/ links falls back to
+    importing every same-site content link.
     """
     soup, final_url = _fetch_index_soup(client, index_url)
     if soup is None:
@@ -260,15 +262,12 @@ def discover_article_links(
             category_of[url] = category
             ordered.append(url)
         elif category and not category_of[url]:
-            # Upgrade a still-uncategorised article (e.g. seen first under a
-            # generic homepage section) with the category page's real name.
+            # Upgrade a still-uncategorised article (seen first under a generic
+            # homepage section) with the category page's real name.
             category_of[url] = category
 
-    # 1. Homepage article links, tagged by their section heading.
-    for url, category in _sectioned_article_links(main, final_url, root_domain):
-        record(url, category)
-
-    # 2. Follow category/section pages for the complete per-category list.
+    # 1. Follow category/section listing pages first — the complete per-category
+    #    lists (a homepage shows only ~5 of a category's articles).
     category_links: List[str] = []
     seen_cat = set()
     for anchor in main.find_all("a", href=True):
@@ -289,6 +288,11 @@ def discover_article_links(
             url = _same_site_href(anchor, cat_final, root_domain)
             if url and _is_article_url(url):
                 record(url, cat_name)
+
+    # 2. Homepage section links — fills any remainder (featured-only articles,
+    #    or the index itself being a single category/flat listing page).
+    for url, category in _sectioned_article_links(main, final_url, root_domain):
+        record(url, category)
 
     # 3. Fallback: no standard article URLs — import every same-site link,
     #    resolving each article's category from its own breadcrumb/URL.

--- a/backend/app/services/faq_generation.py
+++ b/backend/app/services/faq_generation.py
@@ -22,6 +22,7 @@ here are shared with the import service (faq_import.py).
 
 import re
 from collections import deque
+from difflib import SequenceMatcher
 from typing import Awaitable, Callable, List, Optional, Tuple, TypeVar
 
 from sqlalchemy import text
@@ -41,9 +42,25 @@ from app.repositories.faq_generation_job import FAQGenerationJobRepository
 
 logger = get_logger(__name__)
 
-# Dedup lists injected into prompts are capped to keep context bounded; the
-# in-Python normalized-set dedup below still covers every existing question.
-MAX_PROMPT_QUESTIONS = 200
+# Dedup lists injected into prompts are a small recent window for intra-run
+# steering only — the in-Python DedupState below (exact + fuzzy) is the real
+# guard covering every existing question, so the prompt stays cheap.
+MAX_PROMPT_QUESTIONS = 30
+
+# Fuzzy-dedup tuning: token-set Jaccard on content words; borderline scores are
+# confirmed with difflib on the normalized strings. Very short questions skip
+# fuzzy matching entirely (too collision-prone).
+FUZZY_JACCARD_DUP = 0.8
+FUZZY_JACCARD_MAYBE = 0.65
+FUZZY_SEQUENCE_DUP = 0.87
+FUZZY_MIN_CONTENT_TOKENS = 3
+
+# Tiny inline stopword set — enough to keep filler words from inflating
+# question similarity, without an NLP dependency.
+_STOPWORDS = frozenset(
+    "a an and are can could do does for from how i in is it my of on or the "
+    "there to we what when where which who why will with you your".split()
+)
 
 # Chunk ids look like 'page', 'page_1', ..., 'page_10' — natural sort (length
 # first) keeps 'page_2' before 'page_10' where plain text ordering would not.
@@ -119,21 +136,65 @@ def pack_batches(items: List[str], max_chars: Optional[int] = None, sep: str = "
     return batches
 
 
+def _content_tokens(normalized: str) -> frozenset:
+    return frozenset(t for t in normalized.split() if t not in _STOPWORDS)
+
+
 class DedupState:
-    """Tracks every question seen (existing + accepted this run): a normalized
-    set for matching, plus a bounded recent-questions window for prompts."""
+    """Tracks every question seen (existing + accepted this run).
+
+    Two layers: an exact normalized-set match, plus fuzzy similarity (token-set
+    Jaccard via an inverted index, difflib confirmation on borderline scores)
+    so rephrasings are caught without shipping the whole question list to the
+    LLM. A bounded recent-questions window is still exposed for prompts."""
 
     def __init__(self, existing_questions: List[str]):
-        self.seen = {normalize_question(q) for q in existing_questions}
+        self.seen: set = set()
+        self._token_index: dict = {}  # content token -> set of seen keys
+        self._key_tokens: dict = {}  # seen key -> its content-token frozenset
         self._recent = deque(existing_questions, maxlen=MAX_PROMPT_QUESTIONS)
+        for q in existing_questions:
+            self._remember(normalize_question(q))
+
+    def _remember(self, key: str) -> None:
+        if not key or key in self.seen:
+            return
+        self.seen.add(key)
+        tokens = _content_tokens(key)
+        self._key_tokens[key] = tokens
+        for token in tokens:
+            self._token_index.setdefault(token, set()).add(key)
+
+    def is_similar(self, key: str) -> bool:
+        """True when key fuzzily matches a seen question. Exact hits are the
+        caller's job (cheap set test); this covers rephrasings."""
+        tokens = _content_tokens(key)
+        if len(tokens) < FUZZY_MIN_CONTENT_TOKENS:
+            return False
+        candidates: set = set()
+        for token in tokens:
+            candidates |= self._token_index.get(token, set())
+        for candidate in candidates:
+            other = self._key_tokens[candidate]
+            union = len(tokens | other)
+            if not union:
+                continue
+            jaccard = len(tokens & other) / union
+            if jaccard >= FUZZY_JACCARD_DUP:
+                return True
+            if jaccard >= FUZZY_JACCARD_MAYBE and (
+                SequenceMatcher(None, key, candidate).ratio() >= FUZZY_SEQUENCE_DUP
+            ):
+                return True
+        return False
 
     def accept_new(self, faqs: List[GeneratedFAQ]) -> List[GeneratedFAQ]:
         accepted = []
         for faq in faqs:
             key = normalize_question(faq.question)
-            if not key or key in self.seen:
+            if not key or key in self.seen or self.is_similar(key):
                 continue
-            self.seen.add(key)
+            self._remember(key)
             self._recent.append(faq.question)
             accepted.append(faq)
         return accepted

--- a/backend/app/services/faq_generation.py
+++ b/backend/app/services/faq_generation.py
@@ -363,8 +363,12 @@ def maybe_enqueue_auto_faq_job(db: Session, queue_item) -> Optional[FAQGeneratio
         org_id = queue_item.organization_id
         settings_row = HelpCenterRepository(db).get_by_org(org_id)
         faq_repo = FAQRepository(db)
-        if not settings_row and not faq_repo.exists_for_org(org_id):
-            return None  # org has never used the feature
+        job_repo_gate = FAQGenerationJobRepository(db)
+        # Adoption gate: auto-generation only after the org explicitly ran a
+        # generate/import (or added an FAQ). A settings row alone is NOT
+        # opt-in — merely opening the admin page creates one.
+        if not job_repo_gate.has_user_initiated_job(org_id) and not faq_repo.exists_for_org(org_id):
+            return None
         if settings_row and not settings_row.auto_generate:
             return None
         if not help_center_allowed(db, org_id):

--- a/backend/app/services/faq_generation.py
+++ b/backend/app/services/faq_generation.py
@@ -281,9 +281,23 @@ async def run_generation_job(db: Session, job: FAQGenerationJob) -> int:
     knowledge_query = db.query(Knowledge).filter(Knowledge.organization_id == job.organization_id)
     if job.job_type == FAQJobType.GENERATE_SOURCE.value:
         knowledge_query = knowledge_query.filter(Knowledge.id == job.knowledge_id)
+    elif job.knowledge_ids:
+        # Explicit selection overrides the skip-already-generated default.
+        knowledge_query = knowledge_query.filter(Knowledge.id.in_(job.knowledge_ids))
     sources = knowledge_query.all()
     if not sources:
         raise ValueError("No knowledge sources to generate from. Add knowledge first.")
+
+    if job.job_type == FAQJobType.GENERATE_ALL.value and not job.knowledge_ids:
+        # Regenerate touches only sources that haven't produced FAQs yet —
+        # deleting a source's FAQs makes it eligible again.
+        generated = FAQRepository(db).knowledge_ids_with_faqs(job.organization_id)
+        sources = [s for s in sources if s.id not in generated]
+        if not sources:
+            raise ValueError(
+                "All knowledge sources already have FAQs. "
+                "Delete a source's FAQs to regenerate it."
+            )
 
     # Stage 2: read stored page text per source. A broken source (missing
     # vector table etc.) is skipped, not fatal — unless nothing is readable.

--- a/backend/app/services/faq_generation.py
+++ b/backend/app/services/faq_generation.py
@@ -82,17 +82,24 @@ class NoAIConfigError(Exception):
     """The org has no active AI configuration to generate with."""
 
 
-def build_generator(db: Session, organization_id) -> FAQGeneratorAgent:
+def build_generator(db: Session, organization_id, job: Optional[FAQGenerationJob] = None) -> FAQGeneratorAgent:
+    """The org's configured extraction agent. When a job is given, every actual
+    provider call (retries and the plain-JSON fallback's second call included)
+    increments the job's llm_calls — the metering source of truth."""
     config = AIConfigRepository(db).get_active_config(organization_id)
     if not config:
         raise NoAIConfigError(
             "No active AI configuration. Set up an AI model in AI Configuration first."
         )
-    return FAQGeneratorAgent(
+    generator = FAQGeneratorAgent(
         api_key=decrypt_api_key(config.encrypted_api_key),
         model_name=config.model_name,
         model_type=config.model_type.value if hasattr(config.model_type, "value") else str(config.model_type),
     )
+    if job is not None:
+        job_repo = FAQGenerationJobRepository(db)
+        generator.on_llm_call = lambda: job_repo.increment_llm_calls(job.id)
+    return generator
 
 
 def load_source_pages(db: Session, knowledge: Knowledge, max_chars: Optional[int] = None) -> List[str]:
@@ -239,9 +246,6 @@ async def draft_batches(
     for index, batch in enumerate(batches):
         faqs = None
         for attempt in range(1 + retries_per_batch):
-            # Counted per attempt (retries cost provider tokens too) — this is
-            # the single metering choke point for generation and LLM imports.
-            job_repo.increment_llm_calls(job.id)
             try:
                 faqs = await extract(batch, dedup)
                 break
@@ -276,7 +280,7 @@ async def run_generation_job(db: Session, job: FAQGenerationJob) -> int:
 
     # Stage 1: resolve sources + model config.
     job_repo.update_progress(job.id, stage=FAQJobStage.ANALYZING_SOURCES, progress_percentage=5.0)
-    generator = build_generator(db, job.organization_id)
+    generator = build_generator(db, job.organization_id, job=job)
 
     knowledge_query = db.query(Knowledge).filter(Knowledge.organization_id == job.organization_id)
     if job.job_type == FAQJobType.GENERATE_SOURCE.value:

--- a/backend/app/services/faq_generation.py
+++ b/backend/app/services/faq_generation.py
@@ -25,6 +25,7 @@ from collections import deque
 from difflib import SequenceMatcher
 from typing import Awaitable, Callable, List, Optional, Tuple, TypeVar
 
+from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -238,6 +239,9 @@ async def draft_batches(
     for index, batch in enumerate(batches):
         faqs = None
         for attempt in range(1 + retries_per_batch):
+            # Counted per attempt (retries cost provider tokens too) — this is
+            # the single metering choke point for generation and LLM imports.
+            job_repo.increment_llm_calls(job.id)
             try:
                 faqs = await extract(batch, dedup)
                 break
@@ -362,12 +366,27 @@ def maybe_enqueue_auto_faq_job(db: Session, queue_item) -> Optional[FAQGeneratio
         job_repo = FAQGenerationJobRepository(db)
         if job_repo.get_active_for_org(org_id, FAQJobType.GENERATE_SOURCE, knowledge_id=knowledge.id):
             return None
+        from app.services.faq_usage import (
+            count_source_pages,
+            ensure_generation_budget,
+            generation_is_metered,
+            PAGES_PER_CALL,
+        )
+        from math import ceil
+
+        try:
+            pages = count_source_pages(db, knowledge)
+            ensure_generation_budget(db, org_id, max(1, ceil((pages or 1) / PAGES_PER_CALL)))
+        except HTTPException:
+            logger.info(f"Auto FAQ generation skipped for org {org_id}: message budget exhausted")
+            return None
         job = job_repo.create(
             FAQGenerationJob(
                 organization_id=org_id,
                 user_id=queue_item.user_id,
                 job_type=FAQJobType.GENERATE_SOURCE.value,
                 knowledge_id=knowledge.id,
+                metered=generation_is_metered(db, org_id),
             )
         )
         logger.info(f"Auto-enqueued FAQ generation job {job.id} for knowledge {knowledge.id}")

--- a/backend/app/services/faq_generation.py
+++ b/backend/app/services/faq_generation.py
@@ -1,0 +1,319 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+FAQ generation pipeline: read the org's stored knowledge text (no re-crawl),
+extract grounded FAQs with the org's configured model, dedup against existing
+questions and insert drafts for review. Additive only — regeneration never
+edits or deletes existing FAQs. The drafting loop and dedup/category helpers
+here are shared with the import service (faq_import.py).
+"""
+
+import re
+from collections import deque
+from typing import Awaitable, Callable, List, Optional, Tuple, TypeVar
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.agents.faq_generator import FAQGeneratorAgent, GeneratedFAQ
+from app.core.config import settings
+from app.core.logger import get_logger
+from app.core.security import decrypt_api_key
+from app.knowledge.page_editor import PAGE_ID_EXPR
+from app.models.faq import FAQ, DEFAULT_FAQ_CATEGORY, FAQStatus
+from app.models.faq_generation_job import FAQGenerationJob, FAQJobStage, FAQJobType
+from app.models.knowledge import Knowledge
+from app.repositories.ai_config import AIConfigRepository
+from app.repositories.faq import FAQRepository
+from app.repositories.faq_generation_job import FAQGenerationJobRepository
+
+logger = get_logger(__name__)
+
+# Dedup lists injected into prompts are capped to keep context bounded; the
+# in-Python normalized-set dedup below still covers every existing question.
+MAX_PROMPT_QUESTIONS = 200
+
+# Chunk ids look like 'page', 'page_1', ..., 'page_10' — natural sort (length
+# first) keeps 'page_2' before 'page_10' where plain text ordering would not.
+_NATURAL_ID_ORDER = "length(id), id"
+
+_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
+
+BatchT = TypeVar("BatchT")
+
+
+def normalize_question(question: str) -> str:
+    """Casefold + strip punctuation/whitespace, so trivial rephrasings of the
+    same question dedup against each other."""
+    return " ".join(_PUNCT_RE.sub(" ", question.casefold()).split())
+
+
+class NoAIConfigError(Exception):
+    """The org has no active AI configuration to generate with."""
+
+
+def build_generator(db: Session, organization_id) -> FAQGeneratorAgent:
+    config = AIConfigRepository(db).get_active_config(organization_id)
+    if not config:
+        raise NoAIConfigError(
+            "No active AI configuration. Set up an AI model in AI Configuration first."
+        )
+    return FAQGeneratorAgent(
+        api_key=decrypt_api_key(config.encrypted_api_key),
+        model_name=config.model_name,
+        model_type=config.model_type.value if hasattr(config.model_type, "value") else str(config.model_type),
+    )
+
+
+def load_source_pages(db: Session, knowledge: Knowledge) -> List[str]:
+    """One string of aggregated text per crawled page/sub-page of a source,
+    read straight from the org's vector table (content is stored alongside the
+    embeddings — no re-crawl needed). Pages kept in crawl order when the cap
+    truncates; chunk text within a page is naturally ordered."""
+    if not knowledge.schema or not knowledge.table_name:
+        # Source rows without a vector table (failed/partial ingestion).
+        return []
+    query = text(
+        f"SELECT {PAGE_ID_EXPR} AS page_id, "
+        f"string_agg(content, E'\n' ORDER BY {_NATURAL_ID_ORDER}) AS body "
+        f'FROM {knowledge.schema}."{knowledge.table_name}" '
+        "WHERE name = :source GROUP BY 1 ORDER BY min(created_at) LIMIT :max_pages"
+    )
+    rows = db.execute(
+        query, {"source": knowledge.source, "max_pages": settings.FAQ_MAX_PAGES_PER_SOURCE}
+    ).fetchall()
+    max_chars = settings.FAQ_MAX_BATCH_CHARS
+    return [row.body[:max_chars] for row in rows if row.body and row.body.strip()]
+
+
+def pack_batches(items: List[str], max_chars: Optional[int] = None, sep: str = "\n\n---\n\n") -> List[str]:
+    """Greedy-pack whole items (pages, lines) into batches of ~max_chars.
+    Oversized single items are truncated to max_chars, never split across
+    batches. Shared by generation (page items) and import (line items)."""
+    max_chars = max_chars or settings.FAQ_MAX_BATCH_CHARS
+    batches: List[str] = []
+    current: List[str] = []
+    size = 0
+    for item in items:
+        item = item[:max_chars]
+        if current and size + len(item) + len(sep) > max_chars:
+            batches.append(sep.join(current))
+            current, size = [], 0
+        current.append(item)
+        size += len(item) + len(sep)
+    if current:
+        batches.append(sep.join(current))
+    return batches
+
+
+class DedupState:
+    """Tracks every question seen (existing + accepted this run): a normalized
+    set for matching, plus a bounded recent-questions window for prompts."""
+
+    def __init__(self, existing_questions: List[str]):
+        self.seen = {normalize_question(q) for q in existing_questions}
+        self._recent = deque(existing_questions, maxlen=MAX_PROMPT_QUESTIONS)
+
+    def accept_new(self, faqs: List[GeneratedFAQ]) -> List[GeneratedFAQ]:
+        accepted = []
+        for faq in faqs:
+            key = normalize_question(faq.question)
+            if not key or key in self.seen:
+                continue
+            self.seen.add(key)
+            self._recent.append(faq.question)
+            accepted.append(faq)
+        return accepted
+
+    @property
+    def for_prompt(self) -> List[str]:
+        return list(self._recent)
+
+
+class CategoryMerger:
+    """Case-insensitive merge of model-emitted categories into the org's
+    existing spellings."""
+
+    def __init__(self, db: Session, organization_id):
+        self._known = {c.casefold(): c for c in FAQRepository(db).get_categories(organization_id)}
+
+    def merge(self, category: str) -> str:
+        cleaned = (category or "").strip() or DEFAULT_FAQ_CATEGORY
+        return self._known.setdefault(cleaned.casefold(), cleaned)
+
+    @property
+    def names(self) -> List[str]:
+        return list(self._known.values())
+
+
+async def draft_batches(
+    db: Session,
+    job: FAQGenerationJob,
+    batches: List[BatchT],
+    extract: Callable[[BatchT, DedupState], Awaitable[List[GeneratedFAQ]]],
+    retries_per_batch: int = 1,
+) -> List[Tuple[BatchT, GeneratedFAQ]]:
+    """Shared DRAFTING stage: run `extract` per batch with retry, dedup as we
+    go, report progress 30→90%. Raises only when every batch failed."""
+    job_repo = FAQGenerationJobRepository(db)
+    job_repo.update_progress(job.id, stage=FAQJobStage.DRAFTING, progress_percentage=30.0)
+    dedup = DedupState(FAQRepository(db).get_existing_questions(job.organization_id))
+
+    accepted: List[Tuple[BatchT, GeneratedFAQ]] = []
+    failures = 0
+    for index, batch in enumerate(batches):
+        faqs = None
+        for attempt in range(1 + retries_per_batch):
+            try:
+                faqs = await extract(batch, dedup)
+                break
+            except Exception as e:
+                logger.warning(f"FAQ batch {index + 1}/{len(batches)} attempt {attempt + 1} failed: {e}")
+        if faqs is None:
+            failures += 1
+        else:
+            accepted.extend((batch, faq) for faq in dedup.accept_new(faqs))
+        job_repo.update_progress(
+            job.id, progress_percentage=30.0 + 60.0 * (index + 1) / len(batches)
+        )
+    if batches and failures == len(batches):
+        raise RuntimeError("FAQ generation failed for every content batch.")
+    return accepted
+
+
+def insert_draft_rows(db: Session, job: FAQGenerationJob, rows: List[FAQ]) -> int:
+    """Shared GROUPING stage tail: bulk-insert the drafted rows."""
+    FAQGenerationJobRepository(db).update_progress(
+        job.id, stage=FAQJobStage.GROUPING, progress_percentage=92.0
+    )
+    if rows:
+        FAQRepository(db).bulk_create(rows)
+    return len(rows)
+
+
+async def run_generation_job(db: Session, job: FAQGenerationJob) -> int:
+    """Execute a GENERATE_ALL / GENERATE_SOURCE job. Returns FAQs created.
+    Status transitions and notifications are the worker's responsibility."""
+    job_repo = FAQGenerationJobRepository(db)
+
+    # Stage 1: resolve sources + model config.
+    job_repo.update_progress(job.id, stage=FAQJobStage.ANALYZING_SOURCES, progress_percentage=5.0)
+    generator = build_generator(db, job.organization_id)
+
+    knowledge_query = db.query(Knowledge).filter(Knowledge.organization_id == job.organization_id)
+    if job.job_type == FAQJobType.GENERATE_SOURCE.value:
+        knowledge_query = knowledge_query.filter(Knowledge.id == job.knowledge_id)
+    sources = knowledge_query.all()
+    if not sources:
+        raise ValueError("No knowledge sources to generate from. Add knowledge first.")
+
+    # Stage 2: read stored page text per source. A broken source (missing
+    # vector table etc.) is skipped, not fatal — unless nothing is readable.
+    job_repo.update_progress(job.id, stage=FAQJobStage.EXTRACTING, progress_percentage=10.0)
+    source_batches: List[Tuple[Knowledge, str]] = []
+    for source in sources:
+        try:
+            pages = load_source_pages(db, source)
+        except Exception as e:
+            logger.warning(f"Skipping unreadable knowledge source {source.id} ({source.source}): {e}")
+            db.rollback()
+            continue
+        for batch in pack_batches(pages):
+            source_batches.append((source, batch))
+    if not source_batches:
+        raise ValueError("The selected knowledge sources contain no readable content.")
+
+    # Stage 3: draft per batch (shared loop).
+    categories = CategoryMerger(db, job.organization_id)
+
+    async def extract(batch: Tuple[Knowledge, str], dedup: DedupState) -> List[GeneratedFAQ]:
+        return await generator.generate_from_text(
+            batch[1],
+            existing_questions=dedup.for_prompt,
+            existing_categories=categories.names,
+        )
+
+    accepted = await draft_batches(db, job, source_batches, extract)
+
+    # Stage 4: group + insert drafts.
+    rows = [
+        FAQ(
+            organization_id=job.organization_id,
+            question=faq.question,
+            answer=faq.answer,
+            category=categories.merge(faq.category),
+            status=FAQStatus.DRAFT,
+            knowledge_id=source.id,
+            source_label=source.source,
+            generation_job_id=job.id,
+            created_by=job.user_id,
+        )
+        for (source, _batch_text), faq in accepted
+    ]
+    return insert_draft_rows(db, job, rows)
+
+
+def maybe_enqueue_auto_faq_job(db: Session, queue_item) -> Optional[FAQGenerationJob]:
+    """Auto-generate draft FAQs when a new knowledge source finishes processing.
+
+    Only fires for orgs that have adopted the feature (a help-center settings
+    row or any FAQ exists), have auto-generate on, are allowed by their plan
+    (cloud), and don't already have an active job for this source. Never raises
+    and always leaves the shared session usable — a hook failure must not fail
+    knowledge processing.
+    """
+    try:
+        from app.repositories.help_center import HelpCenterRepository
+        from app.services.help_center_access import help_center_allowed
+
+        org_id = queue_item.organization_id
+        settings_row = HelpCenterRepository(db).get_by_org(org_id)
+        faq_repo = FAQRepository(db)
+        if not settings_row and not faq_repo.exists_for_org(org_id):
+            return None  # org has never used the feature
+        if settings_row and not settings_row.auto_generate:
+            return None
+        if not help_center_allowed(db, org_id):
+            return None
+        knowledge = (
+            db.query(Knowledge)
+            .filter(Knowledge.organization_id == org_id, Knowledge.source == queue_item.source)
+            .order_by(Knowledge.id.desc())  # deterministic: newest row wins on duplicate sources
+            .first()
+        )
+        if not knowledge:
+            return None
+        job_repo = FAQGenerationJobRepository(db)
+        if job_repo.get_active_for_org(org_id, FAQJobType.GENERATE_SOURCE, knowledge_id=knowledge.id):
+            return None
+        job = job_repo.create(
+            FAQGenerationJob(
+                organization_id=org_id,
+                user_id=queue_item.user_id,
+                job_type=FAQJobType.GENERATE_SOURCE.value,
+                knowledge_id=knowledge.id,
+            )
+        )
+        logger.info(f"Auto-enqueued FAQ generation job {job.id} for knowledge {knowledge.id}")
+        return job
+    except Exception as e:
+        logger.error(f"Auto FAQ enqueue failed (non-fatal): {e}")
+        # A failed flush would otherwise poison the caller's session and turn
+        # an already-successful knowledge run into a FAILED one.
+        try:
+            db.rollback()
+        except Exception:
+            pass
+        return None

--- a/backend/app/services/faq_generation.py
+++ b/backend/app/services/faq_generation.py
@@ -77,11 +77,12 @@ def build_generator(db: Session, organization_id) -> FAQGeneratorAgent:
     )
 
 
-def load_source_pages(db: Session, knowledge: Knowledge) -> List[str]:
+def load_source_pages(db: Session, knowledge: Knowledge, max_chars: Optional[int] = None) -> List[str]:
     """One string of aggregated text per crawled page/sub-page of a source,
     read straight from the org's vector table (content is stored alongside the
     embeddings — no re-crawl needed). Pages kept in crawl order when the cap
-    truncates; chunk text within a page is naturally ordered."""
+    truncates; chunk text within a page is naturally ordered. max_chars caps
+    each page and defaults to the model-agnostic floor."""
     if not knowledge.schema or not knowledge.table_name:
         # Source rows without a vector table (failed/partial ingestion).
         return []
@@ -94,7 +95,7 @@ def load_source_pages(db: Session, knowledge: Knowledge) -> List[str]:
     rows = db.execute(
         query, {"source": knowledge.source, "max_pages": settings.FAQ_MAX_PAGES_PER_SOURCE}
     ).fetchall()
-    max_chars = settings.FAQ_MAX_BATCH_CHARS
+    max_chars = max_chars or settings.FAQ_MAX_BATCH_CHARS
     return [row.body[:max_chars] for row in rows if row.body and row.body.strip()]
 
 
@@ -225,12 +226,14 @@ async def run_generation_job(db: Session, job: FAQGenerationJob) -> int:
     source_batches: List[Tuple[Knowledge, str]] = []
     for source in sources:
         try:
-            pages = load_source_pages(db, source)
+            # Batch size follows the org's model context window — big-context
+            # models get fewer, larger LLM calls.
+            pages = load_source_pages(db, source, max_chars=generator.batch_chars)
         except Exception as e:
             logger.warning(f"Skipping unreadable knowledge source {source.id} ({source.source}): {e}")
             db.rollback()
             continue
-        for batch in pack_batches(pages):
+        for batch in pack_batches(pages, max_chars=generator.batch_chars):
             source_batches.append((source, batch))
     if not source_batches:
         raise ValueError("The selected knowledge sources contain no readable content.")

--- a/backend/app/services/faq_import.py
+++ b/backend/app/services/faq_import.py
@@ -134,7 +134,7 @@ async def run_import_job(db: Session, job: FAQGenerationJob) -> int:
     # replayed against the queue can't reach internal hosts; run in a thread so
     # the slow fetch doesn't block the worker's event loop.
     page_text = await asyncio.to_thread(fetch_page_text, job.source_url)
-    batches = pack_batches(_split_blocks(page_text), sep="\n\n")
+    batches = pack_batches(_split_blocks(page_text), max_chars=generator.batch_chars, sep="\n\n")
 
     async def extract(batch: str, dedup: DedupState):
         return await generator.extract_from_faq_page(batch, existing_questions=dedup.for_prompt)

--- a/backend/app/services/faq_import.py
+++ b/backend/app/services/faq_import.py
@@ -123,9 +123,10 @@ def _split_blocks(text: str) -> List[str]:
     return [block for block in text.split("\n\n") if block.strip()]
 
 
-async def _extract_and_insert(db: Session, job: FAQGenerationJob, text: str, source_label: str) -> int:
+async def _extract_and_insert(
+    db: Session, job: FAQGenerationJob, generator, text: str, source_label: str
+) -> int:
     """Shared LLM tail for URL/PDF imports: batch → extract → dedup → insert."""
-    generator = build_generator(db, job.organization_id)
     batches = pack_batches(_split_blocks(text), max_chars=generator.batch_chars, sep="\n\n")
 
     async def extract(batch: str, dedup: DedupState):
@@ -155,7 +156,9 @@ async def run_import_job(db: Session, job: FAQGenerationJob) -> int:
     """Execute an IMPORT_URL job. Returns FAQs created. Status transitions and
     notifications are the worker's responsibility."""
     job_repo = FAQGenerationJobRepository(db)
+    # ANALYZING = fail fast on a missing model config, before any external I/O.
     job_repo.update_progress(job.id, stage=FAQJobStage.ANALYZING_SOURCES, progress_percentage=5.0)
+    generator = build_generator(db, job.organization_id, job=job)
 
     job_repo.update_progress(job.id, stage=FAQJobStage.EXTRACTING, progress_percentage=15.0)
     # Re-validated at fetch time (not only at the API layer) so a job forged or
@@ -163,7 +166,8 @@ async def run_import_job(db: Session, job: FAQGenerationJob) -> int:
     # the slow fetch doesn't block the worker's event loop.
     page_text = await asyncio.to_thread(fetch_page_text, job.source_url)
     return await _extract_and_insert(
-        db, job, page_text, source_label=f"Imported from {urlparse(job.source_url).netloc}"
+        db, job, generator, page_text,
+        source_label=f"Imported from {urlparse(job.source_url).netloc}",
     )
 
 
@@ -194,17 +198,23 @@ async def run_pdf_import_job(db: Session, job: FAQGenerationJob) -> int:
     from app.services.file_storage import delete_upload, load_upload
 
     job_repo = FAQGenerationJobRepository(db)
+    # Captured before the try: after a DB-originated failure the ORM instance
+    # is expired and reading job attributes from the finally would raise,
+    # masking the real error and leaking the buffer.
+    stored = job.source_url
+    source_label = f"Imported from {job.source_file_name or 'PDF'}"
+    # ANALYZING = fail fast on a missing model config, before file I/O.
     job_repo.update_progress(job.id, stage=FAQJobStage.ANALYZING_SOURCES, progress_percentage=5.0)
 
     try:
-        content = await load_upload(job.source_url)
+        generator = build_generator(db, job.organization_id, job=job)
+        content = await load_upload(stored)
         job_repo.update_progress(job.id, stage=FAQJobStage.EXTRACTING, progress_percentage=15.0)
         text = await asyncio.to_thread(_pdf_to_text, content)
         if not text.strip():
             raise ValueError(
                 "Could not read any text from that PDF (it may be scanned images)."
             )
-        source_label = f"Imported from {job.source_file_name or 'PDF'}"
-        return await _extract_and_insert(db, job, text, source_label=source_label)
+        return await _extract_and_insert(db, job, generator, text, source_label=source_label)
     finally:
-        await delete_upload(job.source_url)
+        await delete_upload(stored)

--- a/backend/app/services/faq_import.py
+++ b/backend/app/services/faq_import.py
@@ -124,17 +124,29 @@ def _split_blocks(text: str) -> List[str]:
 
 
 async def _extract_and_insert(
-    db: Session, job: FAQGenerationJob, generator, text: str, source_label: str
+    db: Session, job: FAQGenerationJob, generator, text: str, source_label: str,
+    mode: str = "extract",
 ) -> int:
-    """Shared LLM tail for URL/PDF imports: batch → extract → dedup → insert."""
-    batches = pack_batches(_split_blocks(text), max_chars=generator.batch_chars, sep="\n\n")
+    """Shared LLM tail for URL/PDF imports: batch → extract → dedup → insert.
 
-    async def extract(batch: str, dedup: DedupState):
-        return await generator.extract_from_faq_page(batch, existing_questions=dedup.for_prompt)
+    mode="extract" migrates a page that already contains Q&A pairs (verbatim).
+    mode="generate" turns free-form documentation (a product guide, manual…)
+    into FAQs — an existing-FAQ extraction prompt would find almost nothing in
+    prose that isn't already a Q&A list."""
+    batches = pack_batches(_split_blocks(text), max_chars=generator.batch_chars, sep="\n\n")
+    categories = CategoryMerger(db, job.organization_id)
+
+    if mode == "generate":
+        async def extract(batch: str, dedup: DedupState):
+            return await generator.generate_from_text(
+                batch, existing_questions=dedup.for_prompt, existing_categories=categories.names
+            )
+    else:
+        async def extract(batch: str, dedup: DedupState):
+            return await generator.extract_from_faq_page(batch, existing_questions=dedup.for_prompt)
 
     accepted = await draft_batches(db, job, batches, extract, retries_per_batch=0)
 
-    categories = CategoryMerger(db, job.organization_id)
     rows = [
         FAQ(
             organization_id=job.organization_id,
@@ -215,6 +227,10 @@ async def run_pdf_import_job(db: Session, job: FAQGenerationJob) -> int:
             raise ValueError(
                 "Could not read any text from that PDF (it may be scanned images)."
             )
-        return await _extract_and_insert(db, job, generator, text, source_label=source_label)
+        # A PDF is usually documentation/marketing prose, not an existing Q&A
+        # list — generate FAQs from it rather than extracting verbatim pairs.
+        return await _extract_and_insert(
+            db, job, generator, text, source_label=source_label, mode="generate"
+        )
     finally:
         await delete_upload(stored)

--- a/backend/app/services/faq_import.py
+++ b/backend/app/services/faq_import.py
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 FAQ page migration: fetch the customer's existing FAQ/help-center page
-(SSRF-guarded), extract its Q&A pairs with the org's model and insert them as
-drafts. Single page only in v1 — linked sub-pages are not followed.
+(SSRF-guarded) or read an uploaded PDF, extract Q&A pairs with the org's model
+and insert them as drafts. URL mode is single page only — for linked article
+pages use the article importer (faq_article_import.py).
 """
 
 import asyncio
+from io import BytesIO
 from typing import List, Optional
 from urllib.parse import urlparse
 
@@ -121,20 +123,10 @@ def _split_blocks(text: str) -> List[str]:
     return [block for block in text.split("\n\n") if block.strip()]
 
 
-async def run_import_job(db: Session, job: FAQGenerationJob) -> int:
-    """Execute an IMPORT_URL job. Returns FAQs created. Status transitions and
-    notifications are the worker's responsibility."""
-    job_repo = FAQGenerationJobRepository(db)
-
-    job_repo.update_progress(job.id, stage=FAQJobStage.ANALYZING_SOURCES, progress_percentage=5.0)
+async def _extract_and_insert(db: Session, job: FAQGenerationJob, text: str, source_label: str) -> int:
+    """Shared LLM tail for URL/PDF imports: batch → extract → dedup → insert."""
     generator = build_generator(db, job.organization_id)
-
-    job_repo.update_progress(job.id, stage=FAQJobStage.EXTRACTING, progress_percentage=15.0)
-    # Re-validated at fetch time (not only at the API layer) so a job forged or
-    # replayed against the queue can't reach internal hosts; run in a thread so
-    # the slow fetch doesn't block the worker's event loop.
-    page_text = await asyncio.to_thread(fetch_page_text, job.source_url)
-    batches = pack_batches(_split_blocks(page_text), max_chars=generator.batch_chars, sep="\n\n")
+    batches = pack_batches(_split_blocks(text), max_chars=generator.batch_chars, sep="\n\n")
 
     async def extract(batch: str, dedup: DedupState):
         return await generator.extract_from_faq_page(batch, existing_questions=dedup.for_prompt)
@@ -142,7 +134,6 @@ async def run_import_job(db: Session, job: FAQGenerationJob) -> int:
     accepted = await draft_batches(db, job, batches, extract, retries_per_batch=0)
 
     categories = CategoryMerger(db, job.organization_id)
-    source_label = f"Imported from {urlparse(job.source_url).netloc}"
     rows = [
         FAQ(
             organization_id=job.organization_id,
@@ -158,3 +149,62 @@ async def run_import_job(db: Session, job: FAQGenerationJob) -> int:
         for _batch, faq in accepted
     ]
     return insert_draft_rows(db, job, rows)
+
+
+async def run_import_job(db: Session, job: FAQGenerationJob) -> int:
+    """Execute an IMPORT_URL job. Returns FAQs created. Status transitions and
+    notifications are the worker's responsibility."""
+    job_repo = FAQGenerationJobRepository(db)
+    job_repo.update_progress(job.id, stage=FAQJobStage.ANALYZING_SOURCES, progress_percentage=5.0)
+
+    job_repo.update_progress(job.id, stage=FAQJobStage.EXTRACTING, progress_percentage=15.0)
+    # Re-validated at fetch time (not only at the API layer) so a job forged or
+    # replayed against the queue can't reach internal hosts; run in a thread so
+    # the slow fetch doesn't block the worker's event loop.
+    page_text = await asyncio.to_thread(fetch_page_text, job.source_url)
+    return await _extract_and_insert(
+        db, job, page_text, source_label=f"Imported from {urlparse(job.source_url).netloc}"
+    )
+
+
+def _pdf_to_text(content: bytes) -> str:
+    """Page-by-page text extraction with pypdf directly — agno's PDFReader
+    chunks/summarizes for the vector KB, which we don't want here. Blank-line
+    separators between pages keep block batching intact."""
+    from pypdf import PdfReader
+
+    reader = PdfReader(BytesIO(content))
+    pages = []
+    for page in reader.pages:
+        try:
+            text = page.extract_text() or ""
+        except Exception as e:  # a single corrupt page shouldn't sink the file
+            logger.warning(f"PDF page extraction failed: {e}")
+            continue
+        if text.strip():
+            pages.append(text.strip())
+    return "\n\n".join(pages)[: settings.FAQ_IMPORT_MAX_PAGE_CHARS]
+
+
+async def run_pdf_import_job(db: Session, job: FAQGenerationJob) -> int:
+    """Execute an IMPORT_PDF job: read the stored upload (job.source_url),
+    extract text and run the shared Q&A extraction. The stored file is
+    best-effort deleted afterwards — it's an import buffer, not a document
+    library."""
+    from app.services.file_storage import delete_upload, load_upload
+
+    job_repo = FAQGenerationJobRepository(db)
+    job_repo.update_progress(job.id, stage=FAQJobStage.ANALYZING_SOURCES, progress_percentage=5.0)
+
+    try:
+        content = await load_upload(job.source_url)
+        job_repo.update_progress(job.id, stage=FAQJobStage.EXTRACTING, progress_percentage=15.0)
+        text = await asyncio.to_thread(_pdf_to_text, content)
+        if not text.strip():
+            raise ValueError(
+                "Could not read any text from that PDF (it may be scanned images)."
+            )
+        source_label = f"Imported from {job.source_file_name or 'PDF'}"
+        return await _extract_and_insert(db, job, text, source_label=source_label)
+    finally:
+        await delete_upload(job.source_url)

--- a/backend/app/services/faq_import.py
+++ b/backend/app/services/faq_import.py
@@ -107,7 +107,7 @@ def _fetch_rendered_text(url: str) -> Optional[str]:
         from app.knowledge.crawl4ai_fallback import get_crawl4ai_fallback
 
         fallback = get_crawl4ai_fallback(timeout=settings.FAQ_IMPORT_FETCH_TIMEOUT)
-        if not fallback.is_available():
+        if not fallback.is_available:
             return None
         _, soup, _ = fallback.fetch_with_browser(url)
         return _soup_to_text(soup) if soup else None

--- a/backend/app/services/faq_import.py
+++ b/backend/app/services/faq_import.py
@@ -1,0 +1,160 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+FAQ page migration: fetch the customer's existing FAQ/help-center page
+(SSRF-guarded), extract its Q&A pairs with the org's model and insert them as
+drafts. Single page only in v1 — linked sub-pages are not followed.
+"""
+
+import asyncio
+from typing import List, Optional
+from urllib.parse import urlparse
+
+import httpx
+from bs4 import BeautifulSoup
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.logger import get_logger
+from app.knowledge.url_safety import guard_url, safe_get
+from app.models.faq import FAQ, FAQStatus
+from app.models.faq_generation_job import FAQGenerationJob, FAQJobStage
+from app.repositories.faq_generation_job import FAQGenerationJobRepository
+from app.services.faq_generation import (
+    CategoryMerger,
+    DedupState,
+    build_generator,
+    draft_batches,
+    insert_draft_rows,
+    pack_batches,
+)
+
+logger = get_logger(__name__)
+
+# Below this, the static HTML likely lacks the real content (JS-rendered page).
+MIN_STATIC_TEXT_CHARS = 500
+# Block-level elements get blank-line separators so a question heading stays
+# attached to its answer text when batches are split on blocks.
+_BLOCK_TAGS = (
+    "p", "div", "section", "article", "li", "h1", "h2", "h3", "h4", "h5", "h6",
+    "dt", "dd", "summary", "details", "tr",
+)
+_BOILERPLATE_TAGS = ("script", "style", "noscript", "nav", "footer", "header", "form")
+
+_FETCH_HEADERS = {"User-Agent": "ChatterMate-FAQ-Import/1.0 (+https://chattermate.chat)"}
+
+
+def _soup_to_text(soup: BeautifulSoup) -> str:
+    """Clean text with one BLANK line between block elements, so downstream
+    blank-line batching keeps each Q&A block intact."""
+    for tag in soup.find_all(_BOILERPLATE_TAGS):
+        tag.decompose()
+    for tag in soup.find_all(_BLOCK_TAGS):
+        tag.append("\n\n")
+    lines = [line.strip() for line in soup.get_text("\n").split("\n")]
+    text = "\n".join(lines)
+    # Collapse 3+ newlines to exactly one blank line.
+    while "\n\n\n" in text:
+        text = text.replace("\n\n\n", "\n\n")
+    return text.strip()
+
+
+def fetch_page_text(url: str) -> str:
+    """Fetch the page and reduce it to clean text. Static fetch first (every
+    redirect hop SSRF-checked by safe_get); crawl4ai's headless browser as a
+    fallback for JS-rendered pages. Blocking — callers run it in a thread."""
+    text = ""
+    final_url = url
+    try:
+        with httpx.Client(timeout=settings.FAQ_IMPORT_FETCH_TIMEOUT, headers=_FETCH_HEADERS) as client:
+            response = safe_get(client, url)
+            response.raise_for_status()
+            # The hop-validated final URL — the browser fallback fetches this,
+            # not the original, so a redirect chain can't smuggle it inward.
+            final_url = str(response.url)
+            text = _soup_to_text(BeautifulSoup(response.text, "html.parser"))
+    except httpx.HTTPError as e:
+        logger.warning(f"FAQ import static fetch failed for {url}: {e}")
+
+    if len(text) < MIN_STATIC_TEXT_CHARS:
+        rendered = _fetch_rendered_text(final_url)
+        if rendered and len(rendered) > len(text):
+            text = rendered
+
+    if not text.strip():
+        raise ValueError("Could not read any text from that page.")
+    return text[: settings.FAQ_IMPORT_MAX_PAGE_CHARS]
+
+
+def _fetch_rendered_text(url: str) -> Optional[str]:
+    """Headless-browser fallback for JS-rendered pages. The URL is re-checked
+    against the SSRF guard, but a browser follows redirects/JS navigation
+    unguarded — same residual exposure as the knowledge crawler's fallback."""
+    try:
+        guard_url(url)
+        from app.knowledge.crawl4ai_fallback import get_crawl4ai_fallback
+
+        fallback = get_crawl4ai_fallback(timeout=settings.FAQ_IMPORT_FETCH_TIMEOUT)
+        if not fallback.is_available():
+            return None
+        _, soup, _ = fallback.fetch_with_browser(url)
+        return _soup_to_text(soup) if soup else None
+    except Exception as e:
+        logger.warning(f"FAQ import browser fetch failed for {url}: {e}")
+        return None
+
+
+def _split_blocks(text: str) -> List[str]:
+    """Blank-line-separated blocks (see _soup_to_text) — the batching unit."""
+    return [block for block in text.split("\n\n") if block.strip()]
+
+
+async def run_import_job(db: Session, job: FAQGenerationJob) -> int:
+    """Execute an IMPORT_URL job. Returns FAQs created. Status transitions and
+    notifications are the worker's responsibility."""
+    job_repo = FAQGenerationJobRepository(db)
+
+    job_repo.update_progress(job.id, stage=FAQJobStage.ANALYZING_SOURCES, progress_percentage=5.0)
+    generator = build_generator(db, job.organization_id)
+
+    job_repo.update_progress(job.id, stage=FAQJobStage.EXTRACTING, progress_percentage=15.0)
+    # Re-validated at fetch time (not only at the API layer) so a job forged or
+    # replayed against the queue can't reach internal hosts; run in a thread so
+    # the slow fetch doesn't block the worker's event loop.
+    page_text = await asyncio.to_thread(fetch_page_text, job.source_url)
+    batches = pack_batches(_split_blocks(page_text), sep="\n\n")
+
+    async def extract(batch: str, dedup: DedupState):
+        return await generator.extract_from_faq_page(batch, existing_questions=dedup.for_prompt)
+
+    accepted = await draft_batches(db, job, batches, extract, retries_per_batch=0)
+
+    categories = CategoryMerger(db, job.organization_id)
+    source_label = f"Imported from {urlparse(job.source_url).netloc}"
+    rows = [
+        FAQ(
+            organization_id=job.organization_id,
+            question=faq.question,
+            answer=faq.answer,
+            category=categories.merge(faq.category),
+            status=FAQStatus.DRAFT,
+            knowledge_id=None,
+            source_label=source_label,
+            generation_job_id=job.id,
+            created_by=job.user_id,
+        )
+        for _batch, faq in accepted
+    ]
+    return insert_draft_rows(db, job, rows)

--- a/backend/app/services/faq_usage.py
+++ b/backend/app/services/faq_usage.py
@@ -93,11 +93,19 @@ def count_source_pages(db: Session, knowledge: Knowledge) -> Optional[int]:
 
 
 def estimate_generation_calls(
-    db: Session, organization_id: UUID, knowledge_ids: Optional[List[int]] = None
+    db: Session,
+    organization_id: UUID,
+    knowledge_ids: Optional[List[int]] = None,
+    count_pages: bool = True,
 ) -> GenerationEstimate:
     """Confirm-dialog numbers for a GENERATE_ALL run: which sources it would
     read (new-only unless explicitly targeted) and roughly how many LLM calls
-    that costs. Unreadable sources count as one call each."""
+    that costs. Unreadable sources count as one call each.
+
+    count_pages=False skips the per-source page COUNT over the vector tables
+    (two cheap queries instead of N aggregate scans) — for surfaces that only
+    need the source counts, like the Generate button label. estimated_calls
+    is then a 1-per-source lower bound."""
     query = db.query(Knowledge).filter(Knowledge.organization_id == organization_id)
     if knowledge_ids:
         query = query.filter(Knowledge.id.in_(knowledge_ids))
@@ -105,6 +113,14 @@ def estimate_generation_calls(
 
     generated = FAQRepository(db).knowledge_ids_with_faqs(organization_id)
     targets = sources if knowledge_ids else [s for s in sources if s.id not in generated]
+
+    if not count_pages:
+        return GenerationEstimate(
+            total_sources=len(sources),
+            new_sources=len(targets),
+            pages=0,
+            estimated_calls=len(targets),
+        )
 
     pages = 0
     estimated_calls = 0

--- a/backend/app/services/faq_usage.py
+++ b/backend/app/services/faq_usage.py
@@ -1,0 +1,152 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+FAQ generation usage/credits: estimate how many LLM calls a run will make,
+decide whether those calls are metered (hosted model), and enforce the org's
+message budget before enqueueing. OSS/self-hosted (no enterprise module) is
+never metered and never blocked.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import List, Optional
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.logger import get_logger
+from app.knowledge.page_editor import PAGE_ID_EXPR
+from app.models.knowledge import Knowledge
+from app.repositories.ai_config import AIConfigRepository
+from app.repositories.faq import FAQRepository
+
+logger = get_logger(__name__)
+
+# Rough pages-per-LLM-call heuristic for the confirm-dialog estimate (matches
+# today's floor batch of ~3 average pages). An estimate, not billing.
+PAGES_PER_CALL = 3
+
+# Model type whose provider costs land on the platform, hence metered.
+HOSTED_MODEL_TYPE = "CHATTERMATE"
+
+OVER_BUDGET_MESSAGE = (
+    "Not enough message credits left in your plan for this generation "
+    "(~{estimated} needed, {remaining} remaining). Upgrade your plan or "
+    "switch to your own AI model key."
+)
+
+
+@dataclass
+class GenerationEstimate:
+    total_sources: int
+    new_sources: int
+    pages: int
+    estimated_calls: int
+
+
+def generation_is_metered(db: Session, organization_id: UUID) -> bool:
+    """Generation costs credits only on the hosted model — own-key orgs pay
+    their provider directly. FAQ_METER_OWN_KEY flips to always-meter."""
+    if settings.FAQ_METER_OWN_KEY:
+        return True
+    config = AIConfigRepository(db).get_active_config(organization_id)
+    if not config:
+        return False
+    model_type = config.model_type.value if hasattr(config.model_type, "value") else str(config.model_type)
+    return model_type.upper() == HOSTED_MODEL_TYPE
+
+
+def count_source_pages(db: Session, knowledge: Knowledge) -> Optional[int]:
+    """Distinct stored pages for a source, capped like generation itself.
+    None when the vector table is missing/unreadable."""
+    if not knowledge.schema or not knowledge.table_name:
+        return None
+    query = text(
+        f"SELECT COUNT(*) FROM (SELECT {PAGE_ID_EXPR} "
+        f'FROM {knowledge.schema}."{knowledge.table_name}" '
+        "WHERE name = :source GROUP BY 1 LIMIT :max_pages) pages"
+    )
+    try:
+        count = db.execute(
+            query, {"source": knowledge.source, "max_pages": settings.FAQ_MAX_PAGES_PER_SOURCE}
+        ).scalar()
+        return int(count or 0)
+    except Exception as e:
+        logger.warning(f"Page count failed for knowledge {knowledge.id}: {e}")
+        db.rollback()
+        return None
+
+
+def estimate_generation_calls(
+    db: Session, organization_id: UUID, knowledge_ids: Optional[List[int]] = None
+) -> GenerationEstimate:
+    """Confirm-dialog numbers for a GENERATE_ALL run: which sources it would
+    read (new-only unless explicitly targeted) and roughly how many LLM calls
+    that costs. Unreadable sources count as one call each."""
+    query = db.query(Knowledge).filter(Knowledge.organization_id == organization_id)
+    if knowledge_ids:
+        query = query.filter(Knowledge.id.in_(knowledge_ids))
+    sources = query.all()
+
+    generated = FAQRepository(db).knowledge_ids_with_faqs(organization_id)
+    targets = sources if knowledge_ids else [s for s in sources if s.id not in generated]
+
+    pages = 0
+    estimated_calls = 0
+    for source in targets:
+        source_pages = count_source_pages(db, source)
+        if source_pages is None:
+            estimated_calls += 1
+            continue
+        pages += source_pages
+        estimated_calls += max(1, math.ceil(source_pages / PAGES_PER_CALL)) if source_pages else 0
+    return GenerationEstimate(
+        total_sources=len(sources),
+        new_sources=len(targets),
+        pages=pages,
+        estimated_calls=estimated_calls,
+    )
+
+
+def remaining_message_credits(db: Session, organization_id: UUID) -> Optional[int]:
+    """Credits left in the billing period, or None when unlimited (no
+    enterprise module, no subscription cap, or the check errored — fail open,
+    matching check_message_limit's posture)."""
+    try:
+        from app.enterprise.services.message_limit import get_remaining_messages
+    except ImportError:
+        return None
+    try:
+        return get_remaining_messages(db, organization_id)
+    except Exception as e:
+        logger.error(f"Remaining-credit check failed for org {organization_id}: {e}")
+        return None
+
+
+def ensure_generation_budget(db: Session, organization_id: UUID, estimated_calls: int) -> None:
+    """402 when a metered run would exceed the org's remaining credits."""
+    if estimated_calls <= 0 or not generation_is_metered(db, organization_id):
+        return
+    remaining = remaining_message_credits(db, organization_id)
+    if remaining is None:
+        return
+    if estimated_calls > remaining:
+        raise HTTPException(
+            status_code=402,
+            detail=OVER_BUDGET_MESSAGE.format(estimated=estimated_calls, remaining=remaining),
+        )

--- a/backend/app/services/feature_gate.py
+++ b/backend/app/services/feature_gate.py
@@ -1,0 +1,66 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Generic plan-feature gating.
+
+Cloud (enterprise module installed): a feature is available when the org has
+an accessible subscription whose plan carries the feature flag. OSS/community
+deployments are always unrestricted. This generalizes the per-feature gates
+copied across the API layer (lead_capture, mcp_tool, workflow, ...) — new
+features should gate through here instead of minting another copy.
+"""
+
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.logger import get_logger
+
+try:
+    from app.enterprise.repositories.plan import PlanRepository
+    from app.enterprise.services.feature_access import require_accessible_subscription
+    HAS_ENTERPRISE = True
+except ImportError:
+    HAS_ENTERPRISE = False
+
+logger = get_logger(__name__)
+
+
+def feature_allowed(db: Session, organization_id: UUID, feature: str) -> bool:
+    """Non-raising check. Any gating-lookup failure fails CLOSED (feature
+    hidden) rather than surfacing a 500 — used by public/unauthenticated
+    surfaces and background hooks."""
+    if not HAS_ENTERPRISE:
+        return True
+    try:
+        subscription = require_accessible_subscription(db, organization_id)
+        return PlanRepository(db).check_feature_availability(str(subscription.plan_id), feature)
+    except HTTPException:
+        return False
+    except Exception as e:
+        logger.error(f"Feature gate check '{feature}' failed for org {organization_id}: {e}")
+        return False
+
+
+def check_feature_access(db: Session, organization_id: UUID, feature: str, upgrade_message: str) -> None:
+    """Raising check for authenticated admin endpoints: 403 with the feature's
+    upgrade message when the plan lacks the flag (subscription-level errors
+    propagate from the enterprise module)."""
+    if not HAS_ENTERPRISE:
+        return
+    subscription = require_accessible_subscription(db, organization_id)
+    if not PlanRepository(db).check_feature_availability(str(subscription.plan_id), feature):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=upgrade_message)

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -1,0 +1,48 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Storage backend shim shared by upload endpoints: S3 when configured, else the
+local uploads/ directory (served by the /api/v1/uploads static mount).
+"""
+
+import os
+
+import aiofiles
+
+from app.core.config import settings
+
+
+async def store_upload(content: bytes, folder: str, file_name: str, content_type: str) -> str:
+    """Persist bytes and return the URL to store. S3 mode returns the raw S3
+    URL (sign with resolve_public_url before handing to clients); local mode
+    returns the path under the /api/v1/uploads static mount."""
+    if settings.S3_FILE_STORAGE:
+        from app.core.s3 import upload_file_to_s3
+        return await upload_file_to_s3(content, folder, file_name, content_type=content_type)
+    upload_dir = os.path.join("uploads", folder)
+    os.makedirs(upload_dir, exist_ok=True)
+    async with aiofiles.open(os.path.join(upload_dir, file_name), "wb") as f:
+        await f.write(content)
+    # The uploads/ directory is static-mounted at {API_V1_STR}/uploads.
+    return f"{settings.API_V1_STR}/uploads/{folder}/{file_name}"
+
+
+async def resolve_public_url(stored_url: str) -> str:
+    """Client-facing URL for a stored upload: signed for private S3 objects,
+    verbatim otherwise."""
+    if stored_url and settings.S3_FILE_STORAGE and stored_url.startswith("http"):
+        from app.core.s3 import get_s3_signed_url
+        return await get_s3_signed_url(stored_url)
+    return stored_url

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -39,6 +39,34 @@ async def store_upload(content: bytes, folder: str, file_name: str, content_type
     return f"{settings.API_V1_STR}/uploads/{folder}/{file_name}"
 
 
+async def load_upload(stored: str) -> bytes:
+    """Read back a previously stored upload by the URL/path store_upload
+    returned. Used by workers running in a different container than the API
+    (shared local uploads mount or S3)."""
+    if stored.startswith("http"):
+        from app.core.s3 import download_file_from_s3
+        return await download_file_from_s3(stored)
+    # `{API_V1_STR}/uploads/...` → local `uploads/...`
+    marker = f"{settings.API_V1_STR}/uploads/"
+    relative = stored.split(marker, 1)[1] if marker in stored else stored.lstrip("/")
+    async with aiofiles.open(os.path.join("uploads", relative), "rb") as f:
+        return await f.read()
+
+
+async def delete_upload(stored: str) -> None:
+    """Best-effort removal of a stored upload (temp import files)."""
+    try:
+        if stored.startswith("http"):
+            from app.core.s3 import delete_file_from_s3
+            await delete_file_from_s3(stored)
+            return
+        marker = f"{settings.API_V1_STR}/uploads/"
+        relative = stored.split(marker, 1)[1] if marker in stored else stored.lstrip("/")
+        os.remove(os.path.join("uploads", relative))
+    except Exception:
+        pass
+
+
 async def resolve_public_url(stored_url: str) -> str:
     """Client-facing URL for a stored upload: signed for private S3 objects,
     verbatim otherwise."""

--- a/backend/app/services/help_center_access.py
+++ b/backend/app/services/help_center_access.py
@@ -1,0 +1,42 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Help-center plan gating: Pro-only on cloud, unrestricted for OSS/self-hosted.
+Thin wrappers over the generic feature gate.
+"""
+
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.services.feature_gate import check_feature_access, feature_allowed
+
+HELP_CENTER_FEATURE = "help_center"
+
+UPGRADE_MESSAGE = (
+    "The Help Center is not available in your current plan. "
+    "Please upgrade to Pro to access this feature."
+)
+
+
+def help_center_allowed(db: Session, organization_id: UUID) -> bool:
+    """Non-raising check — used by the public site (which 404s instead of
+    403ing) and the auto-generation hook. Fails closed on gating errors."""
+    return feature_allowed(db, organization_id, HELP_CENTER_FEATURE)
+
+
+def check_help_center_access(db: Session, organization_id: UUID) -> None:
+    """Raising check for admin endpoints (403 with the upgrade message)."""
+    check_feature_access(db, organization_id, HELP_CENTER_FEATURE, UPGRADE_MESSAGE)

--- a/backend/app/services/help_center_content.py
+++ b/backend/app/services/help_center_content.py
@@ -1,0 +1,98 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+FAQ answers are authored and stored as Markdown so a single Text column can hold
+rich help-center articles (headings, images, links, ordered steps, callouts).
+This module turns that Markdown into HTML for the public page, and into plain
+text for previews, meta descriptions and FAQPage structured data.
+
+Security: the rendered HTML is dropped onto the *public* help center, so an org
+admin's Markdown is untrusted input for visitors. Everything is run through an
+nh3 (ammonia) allowlist clean — the template must mark this output `| safe`, so
+this is the ONLY place org content is ever trusted as HTML.
+"""
+
+import re
+
+import markdown as _markdown
+import nh3
+from bs4 import BeautifulSoup
+
+# `extra` enables tables/fenced code/etc; `sane_lists` fixes mixed list quirks;
+# `nl2br` treats single newlines as <br> so plain-text FAQ answers (the common
+# case) keep their line breaks without the author needing blank lines.
+_MD_EXTENSIONS = ["extra", "sane_lists", "nl2br"]
+
+# Allowlist of tags a help-center article may contain. Anything else (script,
+# style, iframe, form, event handlers, …) is stripped by nh3.
+_ALLOWED_TAGS = {
+    "p", "br", "hr", "h1", "h2", "h3", "h4", "h5", "h6",
+    "strong", "b", "em", "i", "u", "s", "del", "code", "pre", "blockquote",
+    "ul", "ol", "li", "a", "img",
+    "table", "thead", "tbody", "tr", "th", "td",
+    "figure", "figcaption", "span",
+}
+_ALLOWED_ATTRS = {
+    "a": {"href", "title"},
+    "img": {"src", "alt", "title"},
+}
+# Block javascript:/data: URLs; images and links may only point at real hosts.
+_URL_SCHEMES = {"http", "https", "mailto"}
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def render_article_html(text: str) -> str:
+    """Markdown -> sanitized HTML for the public article body. Safe to render
+    with Jinja's `| safe` because nh3 strips every tag/attr/scheme off-allowlist
+    and rewrites link rel to neutralise tab-nabbing."""
+    if not text or not text.strip():
+        return ""
+    raw = _markdown.markdown(text, extensions=_MD_EXTENSIONS, output_format="html")
+    return nh3.clean(
+        raw,
+        tags=_ALLOWED_TAGS,
+        attributes=_ALLOWED_ATTRS,
+        url_schemes=_URL_SCHEMES,
+        link_rel="noopener noreferrer nofollow",
+    )
+
+
+def to_plain_text(text: str) -> str:
+    """Strip Markdown/HTML to a single line of readable text (previews, meta
+    descriptions, JSON-LD answer text)."""
+    if not text or not text.strip():
+        return ""
+    html = _markdown.markdown(text, extensions=_MD_EXTENSIONS, output_format="html")
+    plain = BeautifulSoup(html, "html.parser").get_text(" ")
+    return _WHITESPACE_RE.sub(" ", plain).strip()
+
+
+def excerpt(text: str, length: int = 150) -> str:
+    """A short one-line preview of an answer, cut on a word boundary."""
+    plain = to_plain_text(text)
+    if len(plain) <= length:
+        return plain
+    return plain[:length].rsplit(" ", 1)[0].rstrip() + "…"
+
+
+def read_time_minutes(text: str) -> int:
+    """Estimated read time in whole minutes (>= 1), ~200 words/min."""
+    words = len(to_plain_text(text).split())
+    return max(1, round(words / 200))
+
+
+def read_time_label(text: str) -> str:
+    return f"{read_time_minutes(text)} min read"

--- a/backend/app/services/help_center_images.py
+++ b/backend/app/services/help_center_images.py
@@ -1,0 +1,53 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Help-center article images. Images embedded in an article's Markdown must
+resolve to a STABLE, ABSOLUTE URL (they render on the help-center domain, and
+the reference is stored inline in the answer forever — so no signed/expiring
+URLs and no host-relative paths). Shared by the admin upload endpoint and the
+article importer's re-hosting path.
+"""
+
+from uuid import uuid4
+
+from app.core.config import settings
+from app.services.file_storage import store_upload
+
+MAX_FAQ_IMAGE_BYTES = 5 * 1024 * 1024
+FAQ_IMAGE_TYPES = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+}
+_UPLOAD_FOLDER = "help_center"
+
+
+def absolute_upload_url(stored: str) -> str:
+    """Make a stored upload path absolute. S3 returns an absolute http(s) URL
+    already; local mode returns a path under the /api/v1/uploads mount, which we
+    anchor to the backend's public origin so it loads cross-domain."""
+    if stored.startswith("http"):
+        return stored
+    return f"{settings.BACKEND_URL.rstrip('/')}{stored}"
+
+
+async def store_article_image(content: bytes, content_type: str) -> str:
+    """Persist validated image bytes and return the stable absolute URL.
+    Caller is responsible for size/content-type validation against
+    MAX_FAQ_IMAGE_BYTES / FAQ_IMAGE_TYPES."""
+    file_name = f"{uuid4()}{FAQ_IMAGE_TYPES[content_type]}"
+    stored = await store_upload(content, folder=_UPLOAD_FOLDER, file_name=file_name, content_type=content_type)
+    return absolute_upload_url(stored)

--- a/backend/app/services/help_center_public.py
+++ b/backend/app/services/help_center_public.py
@@ -1,0 +1,184 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Public help-center domain logic: resolve the Host header to an org's
+published help center, group its FAQs, and answer "Ask AI" questions grounded
+in the mapped agent's knowledge. No admin auth here — everything must stay
+read-only against published data.
+"""
+
+import asyncio
+from typing import List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.core.help_center_host import normalize_host, slug_for_host  # noqa: F401 — canonical host helpers re-exported for the public app
+from app.core.logger import get_logger
+from app.database import SessionLocal
+from app.models.faq import FAQ
+from app.models.help_center import HelpCenterSettings
+from app.repositories.faq import FAQRepository
+from app.repositories.help_center import HelpCenterQueryRepository, HelpCenterRepository
+from app.services.help_center_access import help_center_allowed
+
+logger = get_logger(__name__)
+
+MAX_QUESTION_CHARS = 500
+ANSWER_MAX_TOKENS = 600
+_ASK_FAQ_CONTEXT_LIMIT = 5
+# Unauthenticated LLM calls are expensive: bound how many run at once per
+# worker so /ask can't drain the DB pool or the provider budget.
+_ask_concurrency = asyncio.Semaphore(4)
+
+_ASK_INSTRUCTIONS = """You answer a customer's question on a public help center.
+
+Use ONLY the CONTEXT below (knowledge excerpts and published FAQs). If the
+context doesn't contain the answer, say you don't know and suggest contacting
+support — never invent facts, prices or URLs. Answer in 1-4 short sentences of
+plain text (no markdown), in a friendly second-person voice."""
+
+
+def resolve_help_center(db: Session, host: str) -> Optional[HelpCenterSettings]:
+    """Host header → enabled help center row, or None (renders as 404).
+    Custom domains only match once verified; plan lapses hide the site."""
+    repo = HelpCenterRepository(db)
+    slug = slug_for_host(host)
+    if slug:
+        row = repo.get_by_slug(slug)
+    else:
+        row = repo.get_by_verified_domain(host)
+    if not row or not row.enabled:
+        return None
+    if not help_center_allowed(db, row.organization_id):
+        return None
+    return row
+
+
+def published_faq_groups(
+    db: Session, row: HelpCenterSettings, search: Optional[str] = None
+) -> List[Tuple[str, List[FAQ]]]:
+    """Published FAQs grouped by category, in display order."""
+    faqs = FAQRepository(db).get_published_for_org(row.organization_id, search=search)
+    groups: dict = {}
+    for faq in faqs:
+        groups.setdefault(faq.category, []).append(faq)
+    return list(groups.items())
+
+
+def contrast_ink(hex_color: str) -> str:
+    """Dark or light text over the brand color (WCAG relative luminance)."""
+    try:
+        value = hex_color.lstrip("#")
+        if len(value) == 3:
+            value = "".join(ch * 2 for ch in value)
+        r, g, b = (int(value[i:i + 2], 16) / 255 for i in (0, 2, 4))
+
+        def linear(c: float) -> float:
+            return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+        luminance = 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b)
+        return "#12131A" if luminance > 0.45 else "#FFFFFF"
+    except (ValueError, IndexError):
+        return "#FFFFFF"
+
+
+def widget_id_for(row: HelpCenterSettings) -> Optional[str]:
+    """The chat widget embedded on the page: the mapped agent's widget."""
+    if not (row.ai_search_enabled and row.agent and row.agent.widgets):
+        return None
+    return row.agent.widgets[0].id
+
+
+def ask_available(row: HelpCenterSettings) -> bool:
+    return bool(row.ai_search_enabled and row.agent_id)
+
+
+def _rank_faqs_by_overlap(faqs: List[FAQ], question: str, limit: int) -> List[FAQ]:
+    """Word-overlap ranking: a natural-language question almost never matches
+    an FAQ as a whole-string ILIKE, so score by shared words instead."""
+    words = {w for w in question.casefold().split() if len(w) > 3}
+    if not words:
+        return faqs[:limit]
+    scored = sorted(
+        faqs,
+        key=lambda f: -len(words & set(f"{f.question} {f.answer}".casefold().split())),
+    )
+    return scored[:limit]
+
+
+async def answer_question(organization_id, agent_id, question: str) -> Optional[str]:
+    """One-shot grounded answer from the mapped agent's knowledge + published
+    FAQs. Returns None when no confident answer could be produced. Writes the
+    ask-log row (metering/analytics); never touches chat history or the KB.
+
+    Uses its own short-lived DB sessions on either side of the slow LLM await —
+    holding a pooled connection through a 5-30s model call would let this
+    unauthenticated endpoint drain the pool for the whole backend.
+    """
+    from agno.agent import Agent
+
+    from app.core.security import decrypt_api_key
+    from app.repositories.ai_config import AIConfigRepository
+    from app.utils.agno_utils import create_model
+
+    question = question.strip()[:MAX_QUESTION_CHARS]
+
+    async with _ask_concurrency:
+        with SessionLocal() as db:
+            config = AIConfigRepository(db).get_active_config(organization_id)
+            if not config:
+                return None
+            model_type = config.model_type.value if hasattr(config.model_type, "value") else str(config.model_type)
+            model_name = config.model_name
+            api_key = decrypt_api_key(config.encrypted_api_key)
+            published = FAQRepository(db).get_published_for_org(organization_id)
+        faq_context = "\n\n".join(
+            f"Q: {faq.question}\nA: {faq.answer}"
+            for faq in _rank_faqs_by_overlap(published, question, _ASK_FAQ_CONTEXT_LIMIT)
+        )
+
+        # Vector retrieval scoped to the mapped agent's sources. Constructed
+        # inside the thread: the tool's __init__ does sync DB work.
+        def _search() -> str:
+            from app.tools.knowledge_search_byagent import KnowledgeSearchByAgent
+            tool = KnowledgeSearchByAgent(agent_id=str(agent_id), org_id=organization_id)
+            return tool.search_knowledge_base(question)
+
+        knowledge_context = await asyncio.to_thread(_search)
+
+        model = create_model(
+            model_type=model_type, api_key=api_key, model_name=model_name, max_tokens=ANSWER_MAX_TOKENS
+        )
+        agent = Agent(name="Help Center Answers", model=model, instructions=_ASK_INSTRUCTIONS, markdown=False)
+        answered = False
+        answer = None
+        try:
+            response = await agent.arun(
+                message=f"CONTEXT:\n{knowledge_context}\n\nPUBLISHED FAQS:\n{faq_context}\n\nQUESTION: {question}",
+                stream=False,
+            )
+            content = getattr(response, "content", None)
+            if isinstance(content, str) and content.strip():
+                answer = content.strip()
+                answered = True
+        except Exception as e:
+            logger.error(f"Help center ask failed for org {organization_id}: {e}")
+        finally:
+            try:
+                with SessionLocal() as log_db:
+                    HelpCenterQueryRepository(log_db).log(organization_id, question, answered=answered)
+            except Exception as log_err:
+                logger.error(f"Help center ask log failed: {log_err}")
+    return answer

--- a/backend/app/services/help_center_public.py
+++ b/backend/app/services/help_center_public.py
@@ -74,6 +74,14 @@ def resolve_help_center(db: Session, host: str) -> Optional[HelpCenterSettings]:
     return row
 
 
+# Topic accent colors, applied by category display order (matches the index and
+# article templates). Kept here so list cards, sidebar topics, the article tag
+# and related cards all resolve the SAME color for a given category.
+CATEGORY_PALETTE = [
+    "#6d5bd0", "#0e8c8c", "#cf5b38", "#2a6fdb", "#1f8a5b", "#b0468a", "#c98a1e", "#3a6f8f",
+]
+
+
 def published_faq_groups(
     db: Session, row: HelpCenterSettings, search: Optional[str] = None
 ) -> List[Tuple[str, List[FAQ]]]:
@@ -83,6 +91,23 @@ def published_faq_groups(
     for faq in faqs:
         groups.setdefault(faq.category, []).append(faq)
     return list(groups.items())
+
+
+def category_colors(categories) -> dict:
+    """category name -> accent hex, by display order."""
+    return {c: CATEGORY_PALETTE[i % len(CATEGORY_PALETTE)] for i, c in enumerate(categories)}
+
+
+def get_published_article(db: Session, row: HelpCenterSettings, slug: str) -> Optional[FAQ]:
+    """A single published FAQ by slug for the /a/{slug} article page."""
+    return FAQRepository(db).get_published_by_slug(row.organization_id, slug)
+
+
+def related_articles(db: Session, row: HelpCenterSettings, faq: FAQ, limit: int = 4) -> List[FAQ]:
+    """Other published FAQs in the same category — the article's related list."""
+    return FAQRepository(db).get_published_related(
+        row.organization_id, faq.category, faq.id, limit=limit
+    )
 
 
 def contrast_ink(hex_color: str) -> str:

--- a/backend/app/services/help_center_public.py
+++ b/backend/app/services/help_center_public.py
@@ -103,8 +103,9 @@ def contrast_ink(hex_color: str) -> str:
 
 
 def widget_id_for(row: HelpCenterSettings) -> Optional[str]:
-    """The chat widget embedded on the page: the mapped agent's widget."""
-    if not (row.ai_search_enabled and row.agent and row.agent.widgets):
+    """The chat widget embedded on the page: the mapped agent's widget. Gated by
+    its own toggle, independent of the AI quick-summary in search."""
+    if not (row.chat_widget_enabled and row.agent and row.agent.widgets):
         return None
     return row.agent.widgets[0].id
 

--- a/backend/app/services/help_center_public.py
+++ b/backend/app/services/help_center_public.py
@@ -37,17 +37,25 @@ logger = get_logger(__name__)
 
 MAX_QUESTION_CHARS = 500
 ANSWER_MAX_TOKENS = 600
-_ASK_FAQ_CONTEXT_LIMIT = 5
 # Unauthenticated LLM calls are expensive: bound how many run at once per
 # worker so /ask can't drain the DB pool or the provider budget.
 _ask_concurrency = asyncio.Semaphore(4)
 
-_ASK_INSTRUCTIONS = """You answer a customer's question on a public help center.
+_ASK_INSTRUCTIONS = """You are the support assistant on a company's public help center. A visitor has asked a question.
 
-Use ONLY the CONTEXT below (knowledge excerpts and published FAQs). If the
-context doesn't contain the answer, say you don't know and suggest contacting
-support — never invent facts, prices or URLs. Answer in 1-4 short sentences of
-plain text (no markdown), in a friendly second-person voice."""
+You have tools to look up the answer:
+- search_faqs: search the published help-center FAQs.
+- search_knowledge_base: search the company's wider knowledge base (only available when the help center is mapped to an agent).
+
+ALWAYS use the tools before answering — start with search_faqs, and also try
+search_knowledge_base for anything the FAQs don't cover. You may call a tool more
+than once with different wording if the first result isn't relevant.
+
+Answer ONLY from what the tools return. When they surface a relevant answer, reply
+in 1-4 short sentences of plain text (no markdown), in a friendly second-person
+voice. If, after genuinely searching, you find nothing relevant, briefly say you
+couldn't find that in the help center and suggest starting a chat or contacting
+support. Never invent facts, prices, policies, or URLs."""
 
 
 def resolve_help_center(db: Session, host: str) -> Optional[HelpCenterSettings]:
@@ -105,33 +113,19 @@ def ask_available(row: HelpCenterSettings) -> bool:
     return bool(row.ai_search_enabled and row.agent_id)
 
 
-def _rank_faqs_by_overlap(faqs: List[FAQ], question: str, limit: int) -> List[FAQ]:
-    """Word-overlap ranking: a natural-language question almost never matches
-    an FAQ as a whole-string ILIKE, so score by shared words instead."""
-    words = {w for w in question.casefold().split() if len(w) > 3}
-    if not words:
-        return faqs[:limit]
-    scored = sorted(
-        faqs,
-        key=lambda f: -len(words & set(f"{f.question} {f.answer}".casefold().split())),
-    )
-    return scored[:limit]
-
-
 async def answer_question(organization_id, agent_id, question: str) -> Optional[str]:
-    """One-shot grounded answer from the mapped agent's knowledge + published
-    FAQs. Returns None when no confident answer could be produced. Writes the
-    ask-log row (metering/analytics); never touches chat history or the KB.
+    """Grounded answer for a public help-center question. The agent is given
+    FAQ + knowledge search tools and decides what to look up, so it can find and
+    combine answers instead of relying on a single pre-stuffed context. Returns
+    None when no confident answer could be produced. Writes the ask-log row
+    (metering/analytics); never touches chat history or the KB.
 
-    Uses its own short-lived DB sessions on either side of the slow LLM await —
-    holding a pooled connection through a 5-30s model call would let this
-    unauthenticated endpoint drain the pool for the whole backend.
+    The whole tool-using run happens in a worker thread: the tools do synchronous
+    DB work, and holding a pooled connection through a multi-second model call
+    would let this unauthenticated endpoint drain the pool for the backend.
     """
-    from agno.agent import Agent
-
     from app.core.security import decrypt_api_key
     from app.repositories.ai_config import AIConfigRepository
-    from app.utils.agno_utils import create_model
 
     question = question.strip()[:MAX_QUESTION_CHARS]
 
@@ -143,42 +137,40 @@ async def answer_question(organization_id, agent_id, question: str) -> Optional[
             model_type = config.model_type.value if hasattr(config.model_type, "value") else str(config.model_type)
             model_name = config.model_name
             api_key = decrypt_api_key(config.encrypted_api_key)
-            published = FAQRepository(db).get_published_for_org(organization_id)
-        faq_context = "\n\n".join(
-            f"Q: {faq.question}\nA: {faq.answer}"
-            for faq in _rank_faqs_by_overlap(published, question, _ASK_FAQ_CONTEXT_LIMIT)
-        )
 
-        # Vector retrieval scoped to the mapped agent's sources. Constructed
-        # inside the thread: the tool's __init__ does sync DB work.
-        def _search() -> str:
+        def _run() -> Optional[str]:
+            from agno.agent import Agent
+
+            from app.tools.faq_search import FAQSearchTool
             from app.tools.knowledge_search_byagent import KnowledgeSearchByAgent
-            tool = KnowledgeSearchByAgent(agent_id=str(agent_id), org_id=organization_id)
-            return tool.search_knowledge_base(question)
+            from app.utils.agno_utils import create_model
 
-        knowledge_context = await asyncio.to_thread(_search)
+            tools = [FAQSearchTool(organization_id=organization_id)]
+            if agent_id:
+                tools.append(KnowledgeSearchByAgent(agent_id=str(agent_id), org_id=organization_id))
+            model = create_model(
+                model_type=model_type, api_key=api_key, model_name=model_name, max_tokens=ANSWER_MAX_TOKENS
+            )
+            agent = Agent(
+                name="Help Center Answers",
+                model=model,
+                tools=tools,
+                instructions=_ASK_INSTRUCTIONS,
+                markdown=False,
+            )
+            response = agent.run(message=f"Visitor's question: {question}", stream=False)
+            content = getattr(response, "content", None)
+            return content.strip() if isinstance(content, str) and content.strip() else None
 
-        model = create_model(
-            model_type=model_type, api_key=api_key, model_name=model_name, max_tokens=ANSWER_MAX_TOKENS
-        )
-        agent = Agent(name="Help Center Answers", model=model, instructions=_ASK_INSTRUCTIONS, markdown=False)
-        answered = False
         answer = None
         try:
-            response = await agent.arun(
-                message=f"CONTEXT:\n{knowledge_context}\n\nPUBLISHED FAQS:\n{faq_context}\n\nQUESTION: {question}",
-                stream=False,
-            )
-            content = getattr(response, "content", None)
-            if isinstance(content, str) and content.strip():
-                answer = content.strip()
-                answered = True
+            answer = await asyncio.to_thread(_run)
         except Exception as e:
             logger.error(f"Help center ask failed for org {organization_id}: {e}")
         finally:
             try:
                 with SessionLocal() as log_db:
-                    HelpCenterQueryRepository(log_db).log(organization_id, question, answered=answered)
+                    HelpCenterQueryRepository(log_db).log(organization_id, question, answered=bool(answer))
             except Exception as log_err:
                 logger.error(f"Help center ask log failed: {log_err}")
     return answer

--- a/backend/app/services/help_center_settings.py
+++ b/backend/app/services/help_center_settings.py
@@ -1,0 +1,102 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Help-center settings lifecycle: lazy get-or-create (which is also the
+"org has adopted the feature" marker), slug generation and the agent
+auto-default for AI search.
+"""
+
+import re
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.logger import get_logger
+from app.models.agent import Agent
+from app.models.help_center import HelpCenterSettings
+from app.models.knowledge_to_agent import KnowledgeToAgent
+from app.repositories.help_center import HelpCenterRepository
+
+logger = get_logger(__name__)
+
+SLUG_MAX_LENGTH = 63
+_SLUG_CLEAN_RE = re.compile(r"[^a-z0-9]+")
+
+
+def slugify_org_name(name: str) -> str:
+    slug = _SLUG_CLEAN_RE.sub("-", (name or "").casefold()).strip("-")
+    return slug[:SLUG_MAX_LENGTH].strip("-") or "help"
+
+
+def generate_unique_slug(db: Session, name: str) -> str:
+    """Slug from the org name; reserved labels and collisions get -2, -3, …"""
+    repo = HelpCenterRepository(db)
+    base = slugify_org_name(name)
+    if base in settings.HELP_CENTER_RESERVED_SLUGS:
+        base = f"{base}-help"[:SLUG_MAX_LENGTH]
+    candidate = base
+    suffix = 2
+    while repo.slug_exists(candidate) or candidate in settings.HELP_CENTER_RESERVED_SLUGS:
+        tail = f"-{suffix}"
+        candidate = f"{base[:SLUG_MAX_LENGTH - len(tail)]}{tail}"
+        suffix += 1
+    return candidate
+
+
+def default_agent_id(db: Session, organization_id: UUID) -> Optional[UUID]:
+    """The org's only active agent; else the first agent with linked knowledge;
+    else None (user picks manually)."""
+    active_agents = (
+        db.query(Agent)
+        .filter(Agent.organization_id == organization_id, Agent.is_active.is_(True))
+        .order_by(Agent.id)
+        .all()
+    )
+    if len(active_agents) == 1:
+        return active_agents[0].id
+    with_knowledge = (
+        db.query(Agent)
+        .join(KnowledgeToAgent, KnowledgeToAgent.agent_id == Agent.id)
+        .filter(Agent.organization_id == organization_id)
+        .order_by(Agent.id)
+        .first()
+    )
+    return with_knowledge.id if with_knowledge else None
+
+
+def get_or_create_settings(db: Session, organization) -> HelpCenterSettings:
+    """Fetch the org's help-center settings, creating the row (slug + agent
+    auto-default) on first access."""
+    repo = HelpCenterRepository(db)
+    row = repo.get_by_org(organization.id)
+    if row:
+        return row
+    row = HelpCenterSettings(
+        organization_id=organization.id,
+        slug=generate_unique_slug(db, organization.name),
+        agent_id=default_agent_id(db, organization.id),
+    )
+    created = repo.create(row)
+    logger.info(f"Created help center settings for org {organization.id} (slug={created.slug})")
+    return created
+
+
+def live_url(row: HelpCenterSettings) -> str:
+    """The public URL the help center is (or will be) served at."""
+    if row.domain_verified:
+        return f"https://{row.custom_domain}"
+    return f"https://{row.slug}.{settings.HELP_CENTER_BASE_DOMAIN}"

--- a/backend/app/services/help_center_settings.py
+++ b/backend/app/services/help_center_settings.py
@@ -37,9 +37,57 @@ SLUG_MAX_LENGTH = 63
 _SLUG_CLEAN_RE = re.compile(r"[^a-z0-9]+")
 
 
+FAQ_SLUG_MAX_LENGTH = 80
+
+
 def slugify_org_name(name: str) -> str:
     slug = _SLUG_CLEAN_RE.sub("-", (name or "").casefold()).strip("-")
     return slug[:SLUG_MAX_LENGTH].strip("-") or "help"
+
+
+def _faq_base_slug(question: str) -> str:
+    base = _SLUG_CLEAN_RE.sub("-", (question or "").casefold()).strip("-")
+    return base[:FAQ_SLUG_MAX_LENGTH].strip("-") or "article"
+
+
+def _dedupe_slug(base: str, is_taken) -> str:
+    """First free slug from `base`, appending -2, -3, … while is_taken(candidate)."""
+    candidate = base
+    suffix = 2
+    while is_taken(candidate):
+        tail = f"-{suffix}"
+        candidate = f"{base[:FAQ_SLUG_MAX_LENGTH - len(tail)]}{tail}"
+        suffix += 1
+    return candidate
+
+
+def generate_faq_slug(db: Session, organization_id: UUID, question: str) -> str:
+    """A per-org-unique URL slug from an FAQ question. Collisions get -2, -3, …
+    Assigned once at creation and kept stable afterwards so article URLs persist."""
+    from app.repositories.faq import FAQRepository
+
+    repo = FAQRepository(db)
+    return _dedupe_slug(_faq_base_slug(question), lambda c: repo.slug_exists(organization_id, c))
+
+
+def assign_faq_slugs(db: Session, faqs) -> None:
+    """Give every FAQ in a batch a unique slug in place, deduping against both the
+    DB and the other rows in the same batch. Rows that already have a slug are
+    left untouched (and reserved so batch-mates don't collide with them)."""
+    from app.repositories.faq import FAQRepository
+
+    repo = FAQRepository(db)
+    taken: set = set()
+    for faq in faqs:
+        if faq.slug:
+            taken.add(faq.slug)
+            continue
+        slug = _dedupe_slug(
+            _faq_base_slug(faq.question),
+            lambda c: c in taken or repo.slug_exists(faq.organization_id, c),
+        )
+        faq.slug = slug
+        taken.add(slug)
 
 
 def generate_unique_slug(db: Session, name: str) -> str:

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1,0 +1,59 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.logger import get_logger
+from app.models.notification import Notification, NotificationType
+from app.services.user import send_fcm_notification
+
+logger = get_logger(__name__)
+
+
+async def notify_user(
+    db: Session,
+    user_id,
+    type_: NotificationType,
+    title: str,
+    message: str,
+    metadata: Optional[dict] = None,
+) -> None:
+    """Persist an in-app notification and send its FCM push.
+
+    Never raises and no-ops without a user (background jobs may have none) —
+    a notification failure must not fail the work it reports on.
+    """
+    if not user_id:
+        return
+    try:
+        notification = Notification(
+            user_id=user_id,
+            type=type_,
+            title=title,
+            message=message,
+            notification_metadata=metadata,
+        )
+        db.add(notification)
+        db.commit()
+        await send_fcm_notification(user_id, notification, db)
+    except Exception as e:
+        logger.error(f"Error sending notification '{title}' to user {user_id}: {e}")
+        try:
+            db.rollback()
+        except Exception:
+            pass

--- a/backend/app/services/public_rate_limit.py
+++ b/backend/app/services/public_rate_limit.py
@@ -1,0 +1,70 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Fixed-window per-key rate limiting for public unauthenticated endpoints.
+Redis-backed when available (shared across workers, like the socket rate
+limiter); per-process in-memory fallback otherwise.
+"""
+
+import time
+from threading import Lock
+
+from app.core.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Prune expired windows once the fallback map exceeds this many keys, so
+# attacker-rotated keys can't grow memory without bound.
+_LOCAL_PRUNE_THRESHOLD = 10_000
+
+_local_counts: dict = {}  # key -> (count, window_start, window_seconds)
+_local_lock = Lock()
+
+
+def _redis_client():
+    try:
+        from app.services.socket_rate_limit import redis_client
+        return redis_client
+    except Exception:
+        return None
+
+
+def allow_request(key: str, limit: int, window_seconds: int) -> bool:
+    """True if `key` may make another request in the current fixed window."""
+    client = _redis_client()
+    if client:
+        try:
+            redis_key = f"public_rl:{key}:{window_seconds}"
+            # SET NX EX guarantees the key always carries a TTL before any
+            # INCR — an INCR-then-EXPIRE pair could leave an immortal counter
+            # if the EXPIRE step was lost.
+            client.set(redis_key, 0, nx=True, ex=window_seconds)
+            return client.incr(redis_key) <= limit
+        except Exception as e:
+            logger.warning(f"Redis rate limit failed, using local fallback: {e}")
+    now = time.monotonic()
+    with _local_lock:
+        if len(_local_counts) > _LOCAL_PRUNE_THRESHOLD:
+            expired = [
+                k for k, (_, start, window) in _local_counts.items()
+                if now - start >= window
+            ]
+            for k in expired:
+                del _local_counts[k]
+        count, window_start, _ = _local_counts.get(key, (0, now, window_seconds))
+        if now - window_start >= window_seconds:
+            count, window_start = 0, now
+        _local_counts[key] = (count + 1, window_start, window_seconds)
+        return count + 1 <= limit

--- a/backend/app/templates/help_center/article.html
+++ b/backend/app/templates/help_center/article.html
@@ -1,0 +1,124 @@
+{#
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+A single help-center article: breadcrumb, rich Markdown body, "Was this helpful?"
+feedback, and related articles. `article.body_html` is the ONLY value rendered
+`| safe` — it is pre-sanitized to an HTML allowlist by help_center_content;
+every other value stays autoescaped.
+#}{% extends "help_center/base.html" %}
+
+{% block body %}
+  <div class="hc-body">
+
+    <!-- ---- SIDEBAR ---- -->
+    <aside class="hc-aside">
+      {% if topics %}
+      <div class="hc-aside-label">BROWSE TOPICS</div>
+      <div class="hc-topics">
+        {% for topic in topics %}
+        <a class="hc-topic{% if topic.active %} active{% endif %}" href="/?topic={{ topic.category | urlencode }}" style="--ic: {{ topic.color }};">
+          <span class="hc-topic-icon">
+            <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path></svg>
+          </span>
+          <span class="hc-topic-name">{{ topic.category }}</span>
+          <span class="hc-topic-count">{{ topic.count }}</span>
+        </a>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% if widget_id %}
+      <div class="hc-help-card">
+        <h3>Can't find it?</h3>
+        <p>Ask our assistant — it answers instantly and can bring in a human.</p>
+        <button class="hc-cta-btn" type="button" data-chat style="padding: 9px 14px; font-size: 13px; border-radius: 10px; background: var(--brand); color: var(--brand-ink);">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z"></path></svg>
+          Start a chat
+        </button>
+      </div>
+      {% endif %}
+    </aside>
+
+    <!-- ---- ARTICLE ---- -->
+    <main class="hc-main">
+      <article class="hc-article" style="--ic: {{ article.color }};">
+        <a class="hc-back" href="/?topic={{ article.category | urlencode }}">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"></path></svg>
+          All {{ article.category }} articles
+        </a>
+        <div class="hc-article-meta">
+          <span class="hc-article-tag">{{ article.category }}</span>
+          <span class="hc-article-time">{{ article.read_time }}</span>
+        </div>
+        <h1>{{ article.question }}</h1>
+        <div class="hc-article-card">
+          <div class="hc-article-body">{{ article.body_html | safe }}</div>
+          <div class="hc-feedback" data-feedback>
+            <span class="hc-feedback-q">Was this helpful?</span>
+            <button class="hc-vote" type="button" data-vote="yes">
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 11v9H4a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1z"></path><path d="M7 11l4-8a2 2 0 0 1 3 1.8V9h4.5a2 2 0 0 1 2 2.4l-1.4 7A2 2 0 0 1 17 20H7"></path></svg>
+              Yes
+            </button>
+            <button class="hc-vote" type="button" data-vote="no">
+              <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 13V4h3a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1z"></path><path d="M17 13l-4 8a2 2 0 0 1-3-1.8V15H5.5a2 2 0 0 1-2-2.4l1.4-7A2 2 0 0 1 7 4h10"></path></svg>
+              No
+            </button>
+            <span class="hc-thanks" hidden>Thanks for the feedback!</span>
+          </div>
+        </div>
+
+        {% if article.related %}
+        <div class="hc-related">
+          <div class="hc-related-label">RELATED ARTICLES</div>
+          <div class="hc-related-grid">
+            {% for r in article.related %}
+            <a class="hc-related-card" href="/a/{{ r.slug }}" style="--ic: {{ r.color }};">
+              <span class="hc-related-top">
+                <span class="hc-related-icon">
+                  <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path></svg>
+                </span>
+                <span style="color:#c4c8d2; display:flex;"><svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7M17 7H8M17 7v9"></path></svg></span>
+              </span>
+              <span class="hc-related-q">{{ r.question }}</span>
+              <span class="hc-related-time">
+                <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v5h5"></path><path d="M6 3h9l5 5v13H6z"></path></svg>
+                {{ r.read_time }}
+              </span>
+            </a>
+            {% endfor %}
+          </div>
+        </div>
+        {% endif %}
+      </article>
+    </main>
+  </div>
+{% endblock %}
+
+{% block page_scripts %}
+  <script>
+  (function () {
+    // per-article feedback (client-only acknowledgement)
+    var fb = document.querySelector('[data-feedback]');
+    if (!fb) return;
+    fb.addEventListener('click', function (e) {
+      var btn = e.target.closest('[data-vote]');
+      if (!btn) return;
+      fb.querySelectorAll('.hc-vote').forEach(function (v) { v.classList.remove('on-yes', 'on-no'); });
+      btn.classList.add(btn.getAttribute('data-vote') === 'yes' ? 'on-yes' : 'on-no');
+      var thanks = fb.querySelector('.hc-thanks');
+      if (thanks) thanks.hidden = false;
+    });
+  })();
+  </script>
+{% endblock %}

--- a/backend/app/templates/help_center/base.html
+++ b/backend/app/templates/help_center/base.html
@@ -1,0 +1,337 @@
+{#
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Shared chrome for the public help center (list page + article page): head/meta,
+all CSS, header, contact CTA, footer, and the chat-widget embed. Pages fill the
+`hero`, `body` and `page_scripts` blocks.
+
+Every org/FAQ value is escaped by Jinja2 autoescaping. The ONE exception is the
+article body, which is pre-sanitized to an HTML allowlist by
+app.services.help_center_content and rendered with `| safe`; never mark any other
+org content safe. Colors: only `--brand`/`--brand-ink` come from the server
+(validated hex); every other tone is derived in CSS via color-mix.
+#}<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ title }}</title>
+  <meta name="description" content="{{ description }}">
+  <link rel="canonical" href="{{ canonical_url }}">
+  <meta property="og:title" content="{{ title }}">
+  <meta property="og:description" content="{{ description }}">
+  <meta property="og:type" content="{{ og_type | default('website') }}">
+  <meta property="og:url" content="{{ canonical_url }}">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&family=Instrument+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --brand: {{ brand_color }};
+      --brand-ink: {{ brand_ink }};
+      --brand-tint: color-mix(in srgb, var(--brand) 9%, #fff);
+      --brand-soft: color-mix(in srgb, var(--brand) 30%, #fff);
+      --brand-line: color-mix(in srgb, var(--brand) 40%, #fff);
+      --hero-bg: linear-gradient(180deg, color-mix(in srgb, var(--brand) 10%, #fff), #f5f6f9 80%);
+      --hero-glow: radial-gradient(ellipse, color-mix(in srgb, var(--brand) 12%, transparent), transparent 68%);
+      --cta-bg: linear-gradient(120deg, var(--brand), color-mix(in srgb, var(--brand) 78%, #fff));
+      --cta-sub: color-mix(in srgb, var(--brand-ink) 72%, transparent);
+      --sans: 'Instrument Sans', system-ui, -apple-system, sans-serif;
+      --display: 'Sora', var(--sans);
+      --mono: 'JetBrains Mono', ui-monospace, monospace;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; background: #f5f6f9; }
+    body { color: #1a1b25; font-family: var(--sans); -webkit-font-smoothing: antialiased; min-height: 100vh; }
+    a { color: var(--brand); }
+    ::selection { background: var(--brand-soft); color: #1a1b25; }
+    @keyframes hc-rise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+    @keyframes hc-blink { 0%, 100% { opacity: .3; } 50% { opacity: 1; } }
+    @keyframes hc-shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+
+    /* ---------- header ---------- */
+    .hc-header { background: #fff; border-bottom: 1px solid #ececf2; position: sticky; top: 0; z-index: 40; }
+    .hc-header-in { max-width: 1120px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 15px 28px; }
+    .hc-brand { display: flex; align-items: center; gap: 11px; text-decoration: none; color: inherit; min-width: 0; }
+    .hc-mark { width: 30px; height: 30px; border-radius: 9px; background: var(--brand); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+    .hc-mark span { width: 12px; height: 12px; border-radius: 3px; background: var(--brand-ink); transform: rotate(45deg); }
+    .hc-logo { height: 30px; width: auto; display: block; flex-shrink: 0; }
+    .hc-name { font-family: var(--display); font-weight: 700; font-size: 19px; letter-spacing: -.02em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .hc-kicker { font-size: 14px; color: #8a90a0; font-weight: 500; padding-left: 12px; border-left: 1px solid #e4e6ec; white-space: nowrap; }
+    .hc-nav { display: flex; align-items: center; gap: 20px; font-size: 14.5px; flex-shrink: 0; }
+    .hc-nav a { color: #5a6172; text-decoration: none; }
+    .hc-nav a:hover { color: #1a1b25; }
+    .hc-nav a.cta { padding: 9px 17px; background: var(--brand); color: var(--brand-ink); border-radius: 10px; font-weight: 600; }
+
+    /* ---------- hero ---------- */
+    .hc-hero { position: relative; overflow: hidden; background: var(--hero-bg); padding: 58px 28px 46px; }
+    .hc-hero-glow { position: absolute; top: -90px; left: 50%; transform: translateX(-50%); width: 640px; height: 340px; max-width: 100%; background: var(--hero-glow); pointer-events: none; }
+    .hc-hero-in { position: relative; max-width: 720px; margin: 0 auto; text-align: center; }
+    .hc-hero h1 { font-family: var(--display); font-weight: 700; font-size: 38px; line-height: 1.1; letter-spacing: -.03em; margin: 0 0 12px; }
+    .hc-hero p.lead { font-size: 16.5px; color: #5a6172; margin: 0 0 26px; }
+    .hc-searchbar { display: flex; align-items: center; gap: 12px; background: #fff; border: 1px solid #e4e6ec; border-radius: 15px; padding: 6px 6px 6px 18px; box-shadow: 0 12px 34px rgba(40, 36, 90, .08); max-width: 600px; margin: 0 auto; }
+    .hc-searchbar svg { flex-shrink: 0; }
+    .hc-searchbar input { flex: 1; min-width: 0; background: transparent; border: none; outline: none; font-size: 16px; color: #1a1b25; font-family: var(--sans); padding: 12px 0; }
+    .hc-searchbar input::placeholder { color: #9aa0ad; }
+    .hc-clear { flex-shrink: 0; width: 34px; height: 34px; border-radius: 9px; background: #f1f2f6; border: none; color: #8a90a0; cursor: pointer; font-size: 14px; display: none; }
+    .hc-popular { display: flex; align-items: center; justify-content: center; gap: 9px; margin-top: 18px; font-size: 13.5px; color: #8a90a0; flex-wrap: wrap; }
+    .hc-chip { padding: 5px 12px; background: #fff; border: 1px solid #e4e6ec; border-radius: 999px; font-size: 13px; color: #4a5163; cursor: pointer; font-family: var(--sans); text-decoration: none; }
+    .hc-chip:hover { border-color: var(--brand-soft); }
+
+    /* ---------- body layout ---------- */
+    .hc-body { max-width: 1120px; margin: 0 auto; padding: 40px 28px 20px; display: grid; grid-template-columns: 250px 1fr; gap: 36px; align-items: start; }
+    .hc-aside { position: sticky; top: 82px; }
+    .hc-aside-label { font-family: var(--mono); font-size: 11px; letter-spacing: .09em; color: #9aa0ad; padding: 0 6px; margin-bottom: 12px; }
+    .hc-topics { display: flex; flex-direction: column; gap: 4px; }
+    .hc-topic { display: flex; align-items: center; gap: 11px; width: 100%; padding: 9px 10px; border-radius: 12px; cursor: pointer; font-family: var(--sans); border: 1px solid transparent; background: transparent; color: #4a5163; transition: background .15s; text-decoration: none; text-align: left; }
+    .hc-topic:hover { background: #fff; }
+    .hc-topic.active { border-color: var(--brand-soft); background: var(--brand-tint); color: #1a1b25; }
+    .hc-topic-icon { width: 30px; height: 30px; flex-shrink: 0; border-radius: 9px; display: flex; align-items: center; justify-content: center; background: color-mix(in srgb, var(--ic) 12%, #fff); color: var(--ic); }
+    .hc-topic-name { flex: 1; min-width: 0; text-align: left; font-size: 14.5px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .hc-topic.active .hc-topic-name { font-weight: 600; }
+    .hc-topic-count { flex-shrink: 0; font-family: var(--mono); font-size: 12px; color: #b4b9c4; }
+    .hc-topic.active .hc-topic-count { color: var(--brand); }
+    .hc-help-card { margin-top: 22px; padding: 18px; background: #fff; border: 1px solid #ececf2; border-radius: 16px; box-shadow: 0 2px 10px rgba(40, 36, 90, .04); }
+    .hc-help-card h3 { font-family: var(--display); font-weight: 600; font-size: 14.5px; margin: 0 0 5px; }
+    .hc-help-card p { font-size: 13px; color: #8a90a0; line-height: 1.5; margin: 0 0 13px; }
+
+    .hc-main { min-width: 0; }
+
+    /* ---------- AI answer ---------- */
+    .hc-ai-wrap { margin-bottom: 24px; }
+    .hc-ask-btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 18px; background: #fff; border: 1px solid var(--brand-soft); color: var(--brand); border-radius: 12px; font-size: 14px; font-weight: 600; cursor: pointer; font-family: var(--sans); }
+    .hc-ask-btn:hover { background: var(--brand-tint); }
+    .hc-ai { background: #fff; border: 1px solid var(--brand-soft); border-radius: 18px; padding: 22px 24px; box-shadow: 0 12px 34px rgba(40, 36, 90, .06); animation: hc-rise .3s ease; }
+    .hc-ai-head { display: flex; align-items: center; gap: 10px; margin-bottom: 13px; flex-wrap: wrap; }
+    .hc-badge { display: inline-flex; align-items: center; gap: 7px; padding: 5px 11px; background: var(--brand-tint); border: 1px solid var(--brand-soft); border-radius: 999px; font-family: var(--mono); font-size: 11px; font-weight: 500; color: var(--brand); letter-spacing: .04em; }
+    .hc-dots { display: inline-flex; gap: 3px; }
+    .hc-dots span { width: 4px; height: 4px; border-radius: 50%; background: var(--brand); animation: hc-blink 1s ease-in-out infinite; }
+    .hc-dots span:nth-child(2) { animation-delay: .18s; }
+    .hc-dots span:nth-child(3) { animation-delay: .36s; }
+    .hc-ai-note { font-size: 12px; color: #9aa0ad; }
+    .hc-ai-answer { font-size: 16px; line-height: 1.65; color: #2a303e; margin: 0; white-space: pre-line; }
+    .hc-ai-foot { display: flex; align-items: center; justify-content: flex-end; gap: 16px; flex-wrap: wrap; padding-top: 14px; margin-top: 14px; border-top: 1px solid #f1f2f6; }
+    .hc-skeleton { display: flex; flex-direction: column; gap: 9px; }
+    .hc-skeleton span { height: 12px; border-radius: 6px; background: linear-gradient(90deg, #eef0f4, #f6f7f9, #eef0f4); background-size: 200% 100%; animation: hc-shimmer 1.3s linear infinite; }
+
+    /* ---------- content header ---------- */
+    .hc-head { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; }
+    .hc-head-icon { width: 38px; height: 38px; flex-shrink: 0; border-radius: 11px; display: flex; align-items: center; justify-content: center; background: color-mix(in srgb, var(--ic) 12%, #fff); color: var(--ic); }
+    .hc-head h2 { font-family: var(--display); font-weight: 600; font-size: 22px; letter-spacing: -.02em; margin: 0; }
+    .hc-head-sub { font-size: 13.5px; color: #8a90a0; margin-top: 2px; }
+
+    /* ---------- FAQ list (link cards) ---------- */
+    .hc-list { display: flex; flex-direction: column; gap: 10px; }
+    .hc-card { display: flex; align-items: center; justify-content: space-between; gap: 16px; background: #fff; border: 1px solid #ececf2; border-radius: 14px; padding: 16px 20px; text-decoration: none; box-shadow: 0 1px 5px rgba(40, 36, 90, .03); transition: border-color .18s, transform .18s; }
+    .hc-card:hover { border-color: var(--brand-soft); transform: translateY(-1px); }
+    .hc-card-main { min-width: 0; flex: 1; }
+    .hc-tag { display: none; font-family: var(--mono); font-size: 10.5px; padding: 3px 8px; border-radius: 6px; background: color-mix(in srgb, var(--ic) 12%, #fff); color: var(--ic); margin-bottom: 8px; }
+    .hc-qtext { display: block; font-size: 15.5px; font-weight: 600; color: #1a1b25; line-height: 1.4; }
+    .hc-preview { display: block; font-size: 13.5px; color: #8a90a0; line-height: 1.5; margin-top: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .hc-card-meta { flex-shrink: 0; display: flex; align-items: center; gap: 12px; }
+    .hc-read { font-size: 12px; color: #b4b9c4; white-space: nowrap; }
+    .hc-chev { color: #8a90a0; display: flex; }
+
+    .hc-empty { text-align: center; padding: 56px 20px; background: #fff; border: 1px solid #ececf2; border-radius: 18px; }
+    .hc-empty-icon { width: 52px; height: 52px; margin: 0 auto 18px; border-radius: 14px; background: #f5f6f9; border: 1px solid #ececf2; display: flex; align-items: center; justify-content: center; color: #9aa0ad; }
+    .hc-empty h3 { font-family: var(--display); font-weight: 600; font-size: 19px; margin: 0 0 8px; }
+    .hc-empty p { font-size: 15px; color: #8a90a0; margin: 0 0 20px; }
+
+    /* ---------- article page ---------- */
+    .hc-back { display: inline-flex; align-items: center; gap: 7px; margin-bottom: 20px; text-decoration: none; font-family: var(--sans); font-size: 13.5px; color: #8a90a0; }
+    .hc-back:hover { color: #4a5163; }
+    .hc-article-meta { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; flex-wrap: wrap; }
+    .hc-article-tag { font-family: var(--mono); font-size: 11px; padding: 4px 10px; border-radius: 7px; background: color-mix(in srgb, var(--ic) 12%, #fff); color: var(--ic); }
+    .hc-article-time { font-size: 13px; color: #9aa0ad; }
+    .hc-article h1 { font-family: var(--display); font-weight: 700; font-size: 30px; line-height: 1.2; letter-spacing: -.025em; margin: 0 0 22px; }
+    .hc-article-card { background: #fff; border: 1px solid #ececf2; border-radius: 18px; padding: 30px 32px; box-shadow: 0 2px 12px rgba(40, 36, 90, .04); }
+
+    /* rendered Markdown body */
+    .hc-article-body { font-size: 15.5px; color: #3a4152; line-height: 1.72; }
+    .hc-article-body > :first-child { margin-top: 0; }
+    .hc-article-body > :last-child { margin-bottom: 0; }
+    .hc-article-body p { margin: 0 0 16px; }
+    .hc-article-body h1, .hc-article-body h2, .hc-article-body h3, .hc-article-body h4 { font-family: var(--display); font-weight: 600; letter-spacing: -.015em; color: #1a1b25; margin: 28px 0 12px; line-height: 1.3; }
+    .hc-article-body h1 { font-size: 22px; }
+    .hc-article-body h2 { font-size: 19px; }
+    .hc-article-body h3 { font-size: 16.5px; }
+    .hc-article-body h4 { font-size: 15px; }
+    .hc-article-body a { color: var(--brand); font-weight: 600; text-decoration: none; }
+    .hc-article-body a:hover { text-decoration: underline; }
+    .hc-article-body img { max-width: 100%; height: auto; display: block; border-radius: 14px; border: 1px solid #ececf2; margin: 8px 0 22px; }
+    .hc-article-body ul, .hc-article-body ol { margin: 6px 0 22px; padding-left: 24px; }
+    .hc-article-body li { margin-bottom: 8px; }
+    .hc-article-body blockquote { margin: 6px 0 22px; padding: 14px 18px; background: var(--brand-tint); border: 1px solid var(--brand-soft); border-left: 3px solid var(--brand); border-radius: 12px; color: #3a4152; }
+    .hc-article-body blockquote p { margin: 0; }
+    .hc-article-body code { font-family: var(--mono); font-size: 13px; background: #f1f2f6; border-radius: 5px; padding: 1px 6px; }
+    .hc-article-body pre { background: #f1f2f6; border-radius: 12px; padding: 14px 16px; overflow-x: auto; margin: 6px 0 22px; }
+    .hc-article-body pre code { background: none; padding: 0; }
+    .hc-article-body table { border-collapse: collapse; width: 100%; margin: 6px 0 22px; font-size: 14px; }
+    .hc-article-body th, .hc-article-body td { border: 1px solid #ececf2; padding: 8px 11px; text-align: left; }
+    .hc-article-body th { background: #f5f6f9; font-weight: 600; }
+    .hc-article-body hr { border: none; border-top: 1px solid #ececf2; margin: 24px 0; }
+
+    .hc-feedback { display: flex; align-items: center; gap: 14px; margin-top: 10px; padding-top: 20px; border-top: 1px solid #f1f2f6; flex-wrap: wrap; }
+    .hc-feedback-q { font-size: 13.5px; color: #8a90a0; }
+    .hc-vote { display: inline-flex; align-items: center; gap: 6px; padding: 7px 13px; border-radius: 9px; font-size: 13px; cursor: pointer; font-family: var(--sans); background: #f5f6f9; border: 1px solid #e4e6ec; color: #4a5163; }
+    .hc-vote.on-yes { background: var(--brand-tint); border-color: var(--brand-soft); color: var(--brand); }
+    .hc-vote.on-no { background: #fdecea; border-color: #f3c6be; color: #cf5b38; }
+    .hc-thanks { font-size: 12.5px; color: var(--brand); font-weight: 600; }
+
+    /* related articles */
+    .hc-related { margin-top: 34px; }
+    .hc-related-label { font-family: var(--mono); font-size: 11px; letter-spacing: .09em; color: #9aa0ad; margin-bottom: 14px; }
+    .hc-related-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+    .hc-related-card { display: flex; flex-direction: column; gap: 14px; height: 100%; padding: 18px; background: #fff; border: 1px solid #ececf2; border-radius: 15px; text-decoration: none; box-shadow: 0 1px 5px rgba(40, 36, 90, .03); transition: border-color .18s, transform .18s, box-shadow .18s; }
+    .hc-related-card:hover { border-color: var(--brand-soft); transform: translateY(-2px); box-shadow: 0 12px 26px rgba(40, 36, 90, .08); }
+    .hc-related-top { display: flex; align-items: center; justify-content: space-between; }
+    .hc-related-icon { width: 34px; height: 34px; border-radius: 10px; background: color-mix(in srgb, var(--ic) 12%, #fff); color: var(--ic); display: flex; align-items: center; justify-content: center; }
+    .hc-related-q { display: block; font-family: var(--display); font-size: 15px; font-weight: 600; color: #1a1b25; line-height: 1.35; letter-spacing: -.01em; }
+    .hc-related-time { display: inline-flex; align-items: center; gap: 6px; margin-top: auto; font-size: 12.5px; color: #9aa0ad; }
+
+    /* ---------- contact CTA ---------- */
+    .hc-cta-shell { max-width: 1120px; margin: 0 auto; padding: 0 28px; }
+    .hc-cta { margin: 24px 0 56px; background: var(--cta-bg); border-radius: 24px; padding: 44px; display: flex; align-items: center; justify-content: space-between; gap: 30px; flex-wrap: wrap; color: var(--brand-ink); scroll-margin-top: 90px; }
+    .hc-cta h2 { font-family: var(--display); font-weight: 700; font-size: 26px; letter-spacing: -.02em; margin: 0 0 8px; }
+    .hc-cta p { font-size: 16px; color: var(--cta-sub); margin: 0; max-width: 440px; line-height: 1.55; }
+    .hc-cta-btn { display: inline-flex; align-items: center; gap: 10px; padding: 15px 26px; background: var(--brand-ink); color: var(--brand); border: none; border-radius: 13px; font-size: 15.5px; font-weight: 600; cursor: pointer; font-family: var(--sans); white-space: nowrap; text-decoration: none; }
+
+    /* ---------- footer ---------- */
+    .hc-footer { border-top: 1px solid #ececf2; background: #fff; }
+    .hc-footer-in { max-width: 1120px; margin: 0 auto; padding: 30px 28px; display: flex; align-items: center; justify-content: space-between; gap: 24px; flex-wrap: wrap; }
+    .hc-footer-org { display: flex; align-items: center; gap: 11px; }
+    .hc-footer-org .hc-mark { width: 26px; height: 26px; border-radius: 8px; }
+    .hc-footer-org .hc-mark span { width: 10px; height: 10px; }
+    .hc-footer-org .hc-name { font-size: 15px; }
+    .hc-powered { display: inline-flex; align-items: center; gap: 8px; text-decoration: none; padding: 7px 13px; border: 1px solid #ececf2; border-radius: 999px; font-size: 12.5px; color: #8a90a0; }
+    .hc-powered strong { display: inline-flex; align-items: center; gap: 6px; color: #1a1b25; font-weight: 600; }
+    .hc-cm-mark { width: 15px; height: 15px; border-radius: 5px 5px 5px 1px; background: #c9f24e; display: inline-flex; align-items: center; justify-content: center; gap: 1.5px; }
+    .hc-cm-mark i { width: 2px; height: 2px; border-radius: 50%; background: #0b0c10; }
+
+    /* progressive enhancement: only hide things once JS takes over */
+    .js .hc-tag { display: none; }
+
+    @media (max-width: 860px) {
+      .hc-body { grid-template-columns: 1fr; gap: 24px; }
+      .hc-aside { position: static; }
+      .hc-topics { flex-direction: row; flex-wrap: wrap; }
+      .hc-topic { width: auto; }
+      .hc-hero h1 { font-size: 30px; }
+      .hc-cta { padding: 30px; }
+      .hc-article-card { padding: 24px 20px; }
+      .hc-related-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+  {% block extra_head %}{% endblock %}
+</head>
+<body>
+  <!-- ============ HEADER ============ -->
+  <header class="hc-header">
+    <div class="hc-header-in">
+      <a class="hc-brand" href="/">
+        {% if logo_url %}
+          <img class="hc-logo" src="{{ logo_url }}" alt="{{ row.organization.name }} logo">
+        {% else %}
+          <span class="hc-mark"><span></span></span>
+        {% endif %}
+        <span class="hc-name">{{ row.organization.name }}</span>
+        <span class="hc-kicker">Help Center</span>
+      </a>
+      <nav class="hc-nav">
+        {% for link in header_links %}<a href="{{ link.url }}" rel="noopener">{{ link.label }}</a>{% endfor %}
+        {% if row.cta_enabled and row.cta_text and row.cta_url %}<a class="cta" href="{{ row.cta_url }}" rel="noopener">{{ row.cta_text }}</a>{% endif %}
+      </nav>
+    </div>
+  </header>
+
+  {% block hero %}{% endblock %}
+
+  {% block body %}{% endblock %}
+
+  <!-- ============ CONTACT CTA ============ -->
+  {% set cta_shown = row.cta_enabled and row.cta_text and row.cta_url %}
+  {% if widget_id or cta_shown %}
+  <div class="hc-cta-shell">
+    <section class="hc-cta" id="contact">
+      <div>
+        <h2>Still need a hand?</h2>
+        <p>{% if widget_id %}Our support assistant answers instantly, any time of day — and connects you to a human whenever you need one.{% else %}Reach out and our team will get back to you.{% endif %}</p>
+      </div>
+      {% if widget_id %}
+      <button class="hc-cta-btn" type="button" data-chat>
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z"></path></svg>
+        Start a chat
+      </button>
+      {% elif cta_shown %}
+      <a class="hc-cta-btn" href="{{ row.cta_url }}" rel="noopener">{{ row.cta_text }}</a>
+      {% endif %}
+    </section>
+  </div>
+  {% endif %}
+
+  <!-- ============ FOOTER ============ -->
+  <footer class="hc-footer">
+    <div class="hc-footer-in">
+      <div class="hc-footer-org">
+        <span class="hc-mark"><span></span></span>
+        <span class="hc-name">{{ row.organization.name }}</span>
+      </div>
+      <a class="hc-powered" href="https://chattermate.chat" target="_blank" rel="noopener">
+        <span>Powered by</span>
+        <strong><span class="hc-cm-mark"><i></i><i></i><i></i></span> ChatterMate</strong>
+      </a>
+    </div>
+  </footer>
+
+  {% if json_ld %}
+  <script type="application/ld+json">{{ json_ld | tojson }}</script>
+  {% endif %}
+
+  <!-- open the real embedded ChatterMate widget -->
+  <script>
+  (function () {
+    // The widget script is async and builds its launcher (#chattermate-button)
+    // a moment after load, so a click can land before it exists — poll briefly
+    // and click as soon as it appears instead of silently doing nothing.
+    function openChat() {
+      var tries = 0;
+      (function attempt() {
+        var btn = document.getElementById('chattermate-button');
+        if (btn) { btn.click(); return; }
+        if (tries++ < 40) { setTimeout(attempt, 150); return; }  // ~6s
+        if (window.console) console.warn('[ChatterMate] chat widget is not available on this page.');
+      })();
+    }
+    [].slice.call(document.querySelectorAll('[data-chat]')).forEach(function (b) {
+      b.addEventListener('click', openChat);
+    });
+  })();
+  </script>
+
+  {% block page_scripts %}{% endblock %}
+
+  {% if widget_id %}
+  <script>
+    window.chattermateId = {{ widget_id | tojson }};
+    (function () {
+      var s = document.createElement('script');
+      s.src = {{ widget_script_url | tojson }};
+      s.async = true;
+      document.body.appendChild(s);
+    })();
+  </script>
+  {% endif %}
+</body>
+</html>

--- a/backend/app/templates/help_center/base.html
+++ b/backend/app/templates/help_center/base.html
@@ -53,6 +53,9 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
       --mono: 'JetBrains Mono', ui-monospace, monospace;
     }
     * { box-sizing: border-box; }
+    /* Author display rules (e.g. .hc-card { display:flex }) otherwise beat the UA
+       [hidden] rule, so the hidden attribute must win explicitly for JS toggling. */
+    [hidden] { display: none !important; }
     html, body { margin: 0; padding: 0; background: #f5f6f9; }
     body { color: #1a1b25; font-family: var(--sans); -webkit-font-smoothing: antialiased; min-height: 100vh; }
     a { color: var(--brand); }

--- a/backend/app/templates/help_center/index.html
+++ b/backend/app/templates/help_center/index.html
@@ -515,9 +515,17 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
     });
 
     // ----- open the real embedded ChatterMate widget -----
+    // The widget script is async and builds its launcher (#chattermate-button)
+    // a moment after load, so a click can land before it exists — poll briefly
+    // and click as soon as it appears instead of silently doing nothing.
     function openChat() {
-      var btn = document.getElementById('chattermate-button');
-      if (btn) btn.click();
+      var tries = 0;
+      (function attempt() {
+        var btn = document.getElementById('chattermate-button');
+        if (btn) { btn.click(); return; }
+        if (tries++ < 40) { setTimeout(attempt, 150); return; }  // ~6s
+        if (window.console) console.warn('[ChatterMate] chat widget is not available on this page.');
+      })();
     }
     [].slice.call(document.querySelectorAll('[data-chat]')).forEach(function (b) {
       b.addEventListener('click', openChat);

--- a/backend/app/templates/help_center/index.html
+++ b/backend/app/templates/help_center/index.html
@@ -1,0 +1,162 @@
+{#
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Public help center page. Every org value is escaped by Jinja2 autoescaping;
+never mark org content safe. The only JS is the optional Ask-AI fetch and the
+chat-widget embed.
+#}<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ title }}</title>
+  <meta name="description" content="{{ description }}">
+  <link rel="canonical" href="{{ canonical_url }}/">
+  <meta property="og:title" content="{{ title }}">
+  <meta property="og:description" content="{{ description }}">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="{{ canonical_url }}/">
+  <style>
+    :root { --brand: {{ brand_color }}; --brand-ink: {{ brand_ink }}; }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif; color: #1a1b25; background: #fff; }
+    a { color: inherit; }
+    .header { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 24px; border-bottom: 1px solid #ececf2; }
+    .header .org { display: flex; align-items: center; gap: 10px; font-weight: 700; font-size: 17px; }
+    .header .org img { height: 32px; width: auto; display: block; }
+    .header nav { display: flex; align-items: center; gap: 18px; font-size: 14px; }
+    .header nav a { color: #5a6172; text-decoration: none; }
+    .header nav a.cta { background: var(--brand); color: var(--brand-ink); padding: 9px 16px; border-radius: 9px; font-weight: 600; }
+    .hero { padding: 48px 24px 40px; text-align: center; background: linear-gradient(180deg, color-mix(in srgb, var(--brand) 10%, #fff), #fff 90%); }
+    .hero h1 { margin: 0 0 20px; font-size: 30px; letter-spacing: -0.02em; }
+    .search { display: flex; gap: 8px; max-width: 560px; margin: 0 auto; }
+    .search input { flex: 1; padding: 13px 16px; font-size: 15px; border: 1px solid #e4e6ec; border-radius: 11px; outline: none; }
+    .search input:focus { border-color: var(--brand); }
+    .search button { padding: 13px 22px; font-size: 15px; font-weight: 600; border: none; border-radius: 11px; background: var(--brand); color: var(--brand-ink); cursor: pointer; }
+    .ask { max-width: 720px; margin: 0 auto; padding: 0 24px; }
+    .ask-card { display: none; margin-top: 18px; padding: 16px 18px; border: 1px solid #e4e6ec; border-radius: 12px; background: #fafafc; text-align: left; font-size: 15px; line-height: 1.55; }
+    .ask-card.loading { color: #7a8190; }
+    .ask-btn { margin-top: 14px; background: none; border: 1px solid var(--brand); color: var(--brand); padding: 9px 18px; border-radius: 9px; font-size: 14px; font-weight: 600; cursor: pointer; }
+    .content { max-width: 760px; margin: 0 auto; padding: 24px 24px 80px; }
+    .category { margin-top: 34px; }
+    .category h2 { font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; color: #7a8190; border-bottom: 1px solid #ececf2; padding-bottom: 10px; }
+    details { border-bottom: 1px solid #f1f2f6; }
+    summary { cursor: pointer; padding: 16px 4px; font-size: 16px; font-weight: 600; list-style: none; display: flex; justify-content: space-between; align-items: center; }
+    summary::-webkit-details-marker { display: none; }
+    summary::after { content: "+"; color: var(--brand); font-size: 20px; font-weight: 400; }
+    details[open] summary::after { content: "\2212"; }
+    .answer { padding: 0 4px 18px; color: #4a5060; font-size: 15px; line-height: 1.6; white-space: pre-line; }
+    .empty { text-align: center; color: #7a8190; padding: 60px 0; }
+    .footer { text-align: center; padding: 28px; color: #9aa0ad; font-size: 13px; border-top: 1px solid #ececf2; }
+    .footer a { color: #7a8190; text-decoration: none; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <header class="header">
+    <div class="org">
+      {% if logo_url %}<img src="{{ logo_url }}" alt="{{ row.organization.name }} logo">{% endif %}
+      <span>{{ row.organization.name }}</span>
+    </div>
+    <nav>
+      {% for link in header_links %}<a href="{{ link.url }}" rel="noopener">{{ link.label }}</a>{% endfor %}
+      {% if row.cta_text and row.cta_url %}<a class="cta" href="{{ row.cta_url }}" rel="noopener">{{ row.cta_text }}</a>{% endif %}
+    </nav>
+  </header>
+
+  <section class="hero">
+    <h1>How can we help?</h1>
+    <form class="search" method="get" action="/">
+      <input type="search" name="q" value="{{ search }}" placeholder="Search for answers…" maxlength="200">
+      <button type="submit">Search</button>
+    </form>
+    {% if ask_enabled %}
+    <div class="ask">
+      <button class="ask-btn" id="ask-btn" type="button">✦ Ask AI</button>
+      <div class="ask-card" id="ask-card"></div>
+    </div>
+    {% endif %}
+  </section>
+
+  <main class="content">
+    {% if search %}<p>Results for “{{ search }}” — <a href="/">clear</a></p>{% endif %}
+    {% for category, faqs in groups %}
+    <section class="category">
+      <h2>{{ category }}</h2>
+      {% for faq in faqs %}
+      <details{% if search %} open{% endif %}>
+        <summary>{{ faq.question }}</summary>
+        <div class="answer">{{ faq.answer }}</div>
+      </details>
+      {% endfor %}
+    </section>
+    {% else %}
+    <p class="empty">{% if search %}No answers matched your search.{% else %}No published FAQs yet — check back soon.{% endif %}</p>
+    {% endfor %}
+  </main>
+
+  <footer class="footer">
+    Powered by <a href="https://chattermate.chat" rel="noopener">ChatterMate</a>
+  </footer>
+
+  {% if groups %}
+  <script type="application/ld+json">{{ faq_json_ld | tojson }}</script>
+  {% endif %}
+
+  {% if ask_enabled %}
+  <script>
+    (function () {
+      var btn = document.getElementById('ask-btn');
+      var card = document.getElementById('ask-card');
+      var input = document.querySelector('.search input');
+      btn.addEventListener('click', function () {
+        var question = (input.value || '').trim();
+        if (question.length < 3) { input.focus(); return; }
+        card.style.display = 'block';
+        card.className = 'ask-card loading';
+        card.textContent = 'Thinking…';
+        fetch('/ask', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ question: question })
+        }).then(function (r) {
+          if (!r.ok) throw new Error(r.status);
+          return r.json();
+        }).then(function (data) {
+          card.className = 'ask-card';
+          card.textContent = data.answer;
+        }).catch(function (err) {
+          card.className = 'ask-card';
+          card.textContent = String(err.message) === '429'
+            ? 'Too many questions — please try again in a minute.'
+            : 'Sorry, I could not answer that right now.';
+        });
+      });
+    })();
+  </script>
+  {% endif %}
+
+  {% if widget_id %}
+  <script>
+    window.chattermateId = {{ widget_id | tojson }};
+    (function () {
+      var s = document.createElement('script');
+      s.src = {{ widget_script_url | tojson }};
+      s.async = true;
+      document.body.appendChild(s);
+    })();
+  </script>
+  {% endif %}
+</body>
+</html>

--- a/backend/app/templates/help_center/index.html
+++ b/backend/app/templates/help_center/index.html
@@ -128,7 +128,8 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
         {% for category, faqs in groups %}
           {% for faq in faqs %}
           <a class="hc-card" href="/a/{{ faq.slug }}" data-category="{{ category }}"
-             data-search="{{ faq.search_text }}" style="--ic: {{ colors[category] }};">
+             data-title="{{ faq.search_title }}" data-search="{{ faq.search_text }}"
+             style="--ic: {{ colors[category] }};">
             <span class="hc-card-main">
               <span class="hc-tag">{{ category }}</span>
               <span class="hc-qtext">{{ faq.question }}</span>
@@ -171,6 +172,9 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
     var clearBtn = document.getElementById('hc-clear');
     var topics = [].slice.call(document.querySelectorAll('.hc-topic'));
     var cards = [].slice.call(document.querySelectorAll('.hc-card'));
+    var list = document.getElementById('hc-list');
+    // Search reorders cards by relevance; browsing restores document order.
+    var originalOrder = cards.slice();
     var head = document.getElementById('hc-head');
     var headIcon = document.getElementById('hc-head-icon');
     var headTitle = document.getElementById('hc-head-title');
@@ -189,9 +193,14 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
       var b = document.getElementById('hc-ask-btn'); if (b) b.hidden = false;
     }
 
+    function restoreOrder() {
+      originalOrder.forEach(function (card) { list.appendChild(card); });
+    }
+
     // ----- browse a single category -----
     function browse(cat) {
       activeCat = cat;
+      restoreOrder();
       var count = 0;
       cards.forEach(function (card) {
         var show = card.getAttribute('data-category') === cat;
@@ -211,19 +220,58 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
     }
 
     // ----- search across all categories -----
+    // Token-based relevance search: every query term must match somewhere
+    // (word-prefix or substring), title hits outrank body hits, and results
+    // are re-ordered by score — so "close my" finds "How to close my account".
+    function termScore(term, title, titleWords, body) {
+      var best = 0;
+      for (var i = 0; i < titleWords.length; i++) {
+        if (titleWords[i] === term) return 8;                 // exact title word
+        if (titleWords[i].indexOf(term) === 0) best = 5;      // title word prefix
+      }
+      if (!best && title.indexOf(term) !== -1) best = 3;      // inside a title word
+      if (!best) {
+        if (body.indexOf(' ' + term) !== -1 || body.indexOf(term) === 0) best = 2; // body word start
+        else if (body.indexOf(term) !== -1) best = 1;         // anywhere in body
+      }
+      return best;
+    }
+
+    // Partial-match semantics: a card qualifies when ANY term matches, but
+    // cards matching MORE terms always rank above cards matching fewer —
+    // so "close my" still surfaces "How to close your Atoa account" (no
+    // literal "my") below any article containing both words.
+    function cardScore(card, terms) {
+      var title = card.getAttribute('data-title') || '';
+      var body = card.getAttribute('data-search') || '';
+      var titleWords = title.split(/\s+/);
+      var matched = 0;
+      var total = 0;
+      for (var i = 0; i < terms.length; i++) {
+        var s = termScore(terms[i], title, titleWords, body);
+        if (s) { matched++; total += s; }
+      }
+      // Matched-term count dominates; per-term quality breaks ties.
+      return matched ? matched * 100 + total : 0;
+    }
+
     function search(raw) {
       var q = (raw || '').trim().toLowerCase();
       clearBtn.style.display = q ? 'block' : 'none';
       if (!q) { if (activeCat) browse(activeCat); return; }
       topics.forEach(function (x) { x.classList.remove('active'); });
-      var count = 0;
+      var terms = q.split(/\s+/);
+      var matches = [];
       cards.forEach(function (card) {
-        var hit = card.getAttribute('data-search').indexOf(q) !== -1;
-        card.hidden = !hit;
+        var score = cardScore(card, terms);
+        card.hidden = !score;
         var tag = card.querySelector('.hc-tag');
-        if (tag) tag.style.display = hit ? 'inline-block' : '';
-        if (hit) count++;
+        if (tag) tag.style.display = score ? 'inline-block' : '';
+        if (score) matches.push({ card: card, score: score });
       });
+      matches.sort(function (a, b) { return b.score - a.score; });
+      matches.forEach(function (m) { list.appendChild(m.card); });
+      var count = matches.length;
       if (head) {
         head.hidden = false;
         headIcon.style.setProperty('--ic', topics.length ? topics[0].getAttribute('data-color') : 'var(--brand)');

--- a/backend/app/templates/help_center/index.html
+++ b/backend/app/templates/help_center/index.html
@@ -13,9 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-Public help center page. Every org value is escaped by Jinja2 autoescaping;
-never mark org content safe. The only JS is the optional Ask-AI fetch and the
-chat-widget embed.
+Public help center page. Every org/FAQ value is escaped by Jinja2 autoescaping;
+never mark org content safe. The page is fully server-rendered for SEO — the JS
+below is progressive enhancement only (topic filtering, client-side search, the
+optional Ask-AI fetch). The chat is the real embedded ChatterMate widget, whose
+own launcher (#chattermate-button) the "Start a chat" buttons click.
+
+Colors: only `--brand`/`--brand-ink` come from the server (validated hex); every
+other brand tone is derived in CSS via color-mix, so no computed colors leak in.
 #}<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -28,122 +33,533 @@ chat-widget embed.
   <meta property="og:description" content="{{ description }}">
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ canonical_url }}/">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&family=Instrument+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
   <style>
-    :root { --brand: {{ brand_color }}; --brand-ink: {{ brand_ink }}; }
+    :root {
+      --brand: {{ brand_color }};
+      --brand-ink: {{ brand_ink }};
+      --brand-tint: color-mix(in srgb, var(--brand) 9%, #fff);
+      --brand-soft: color-mix(in srgb, var(--brand) 30%, #fff);
+      --brand-line: color-mix(in srgb, var(--brand) 40%, #fff);
+      --hero-bg: linear-gradient(180deg, color-mix(in srgb, var(--brand) 10%, #fff), #f5f6f9 80%);
+      --hero-glow: radial-gradient(ellipse, color-mix(in srgb, var(--brand) 12%, transparent), transparent 68%);
+      --cta-bg: linear-gradient(120deg, var(--brand), color-mix(in srgb, var(--brand) 78%, #fff));
+      --cta-sub: color-mix(in srgb, var(--brand-ink) 72%, transparent);
+      --sans: 'Instrument Sans', system-ui, -apple-system, sans-serif;
+      --display: 'Sora', var(--sans);
+      --mono: 'JetBrains Mono', ui-monospace, monospace;
+    }
     * { box-sizing: border-box; }
-    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif; color: #1a1b25; background: #fff; }
-    a { color: inherit; }
-    .header { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 14px 24px; border-bottom: 1px solid #ececf2; }
-    .header .org { display: flex; align-items: center; gap: 10px; font-weight: 700; font-size: 17px; }
-    .header .org img { height: 32px; width: auto; display: block; }
-    .header nav { display: flex; align-items: center; gap: 18px; font-size: 14px; }
-    .header nav a { color: #5a6172; text-decoration: none; }
-    .header nav a.cta { background: var(--brand); color: var(--brand-ink); padding: 9px 16px; border-radius: 9px; font-weight: 600; }
-    .hero { padding: 48px 24px 40px; text-align: center; background: linear-gradient(180deg, color-mix(in srgb, var(--brand) 10%, #fff), #fff 90%); }
-    .hero h1 { margin: 0 0 20px; font-size: 30px; letter-spacing: -0.02em; }
-    .search { display: flex; gap: 8px; max-width: 560px; margin: 0 auto; }
-    .search input { flex: 1; padding: 13px 16px; font-size: 15px; border: 1px solid #e4e6ec; border-radius: 11px; outline: none; }
-    .search input:focus { border-color: var(--brand); }
-    .search button { padding: 13px 22px; font-size: 15px; font-weight: 600; border: none; border-radius: 11px; background: var(--brand); color: var(--brand-ink); cursor: pointer; }
-    .ask { max-width: 720px; margin: 0 auto; padding: 0 24px; }
-    .ask-card { display: none; margin-top: 18px; padding: 16px 18px; border: 1px solid #e4e6ec; border-radius: 12px; background: #fafafc; text-align: left; font-size: 15px; line-height: 1.55; }
-    .ask-card.loading { color: #7a8190; }
-    .ask-btn { margin-top: 14px; background: none; border: 1px solid var(--brand); color: var(--brand); padding: 9px 18px; border-radius: 9px; font-size: 14px; font-weight: 600; cursor: pointer; }
-    .content { max-width: 760px; margin: 0 auto; padding: 24px 24px 80px; }
-    .category { margin-top: 34px; }
-    .category h2 { font-size: 13px; letter-spacing: 0.08em; text-transform: uppercase; color: #7a8190; border-bottom: 1px solid #ececf2; padding-bottom: 10px; }
-    details { border-bottom: 1px solid #f1f2f6; }
-    summary { cursor: pointer; padding: 16px 4px; font-size: 16px; font-weight: 600; list-style: none; display: flex; justify-content: space-between; align-items: center; }
-    summary::-webkit-details-marker { display: none; }
-    summary::after { content: "+"; color: var(--brand); font-size: 20px; font-weight: 400; }
-    details[open] summary::after { content: "\2212"; }
-    .answer { padding: 0 4px 18px; color: #4a5060; font-size: 15px; line-height: 1.6; white-space: pre-line; }
-    .empty { text-align: center; color: #7a8190; padding: 60px 0; }
-    .footer { text-align: center; padding: 28px; color: #9aa0ad; font-size: 13px; border-top: 1px solid #ececf2; }
-    .footer a { color: #7a8190; text-decoration: none; font-weight: 600; }
+    html, body { margin: 0; padding: 0; background: #f5f6f9; }
+    body { color: #1a1b25; font-family: var(--sans); -webkit-font-smoothing: antialiased; min-height: 100vh; }
+    a { color: var(--brand); }
+    ::selection { background: var(--brand-soft); color: #1a1b25; }
+    @keyframes hc-rise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+    @keyframes hc-blink { 0%, 100% { opacity: .3; } 50% { opacity: 1; } }
+    @keyframes hc-shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+
+    /* ---------- header ---------- */
+    .hc-header { background: #fff; border-bottom: 1px solid #ececf2; position: sticky; top: 0; z-index: 40; }
+    .hc-header-in { max-width: 1120px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 15px 28px; }
+    .hc-brand { display: flex; align-items: center; gap: 11px; text-decoration: none; color: inherit; min-width: 0; }
+    .hc-mark { width: 30px; height: 30px; border-radius: 9px; background: var(--brand); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+    .hc-mark span { width: 12px; height: 12px; border-radius: 3px; background: var(--brand-ink); transform: rotate(45deg); }
+    .hc-logo { height: 30px; width: auto; display: block; flex-shrink: 0; }
+    .hc-name { font-family: var(--display); font-weight: 700; font-size: 19px; letter-spacing: -.02em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .hc-kicker { font-size: 14px; color: #8a90a0; font-weight: 500; padding-left: 12px; border-left: 1px solid #e4e6ec; white-space: nowrap; }
+    .hc-nav { display: flex; align-items: center; gap: 20px; font-size: 14.5px; flex-shrink: 0; }
+    .hc-nav a { color: #5a6172; text-decoration: none; }
+    .hc-nav a:hover { color: #1a1b25; }
+    .hc-nav a.cta { padding: 9px 17px; background: var(--brand); color: var(--brand-ink); border-radius: 10px; font-weight: 600; }
+
+    /* ---------- hero ---------- */
+    .hc-hero { position: relative; overflow: hidden; background: var(--hero-bg); padding: 58px 28px 46px; }
+    .hc-hero-glow { position: absolute; top: -90px; left: 50%; transform: translateX(-50%); width: 640px; height: 340px; max-width: 100%; background: var(--hero-glow); pointer-events: none; }
+    .hc-hero-in { position: relative; max-width: 720px; margin: 0 auto; text-align: center; }
+    .hc-hero h1 { font-family: var(--display); font-weight: 700; font-size: 38px; line-height: 1.1; letter-spacing: -.03em; margin: 0 0 12px; }
+    .hc-hero p.lead { font-size: 16.5px; color: #5a6172; margin: 0 0 26px; }
+    .hc-searchbar { display: flex; align-items: center; gap: 12px; background: #fff; border: 1px solid #e4e6ec; border-radius: 15px; padding: 6px 6px 6px 18px; box-shadow: 0 12px 34px rgba(40, 36, 90, .08); max-width: 600px; margin: 0 auto; }
+    .hc-searchbar svg { flex-shrink: 0; }
+    .hc-searchbar input { flex: 1; min-width: 0; background: transparent; border: none; outline: none; font-size: 16px; color: #1a1b25; font-family: var(--sans); padding: 12px 0; }
+    .hc-searchbar input::placeholder { color: #9aa0ad; }
+    .hc-clear { flex-shrink: 0; width: 34px; height: 34px; border-radius: 9px; background: #f1f2f6; border: none; color: #8a90a0; cursor: pointer; font-size: 14px; display: none; }
+    .hc-popular { display: flex; align-items: center; justify-content: center; gap: 9px; margin-top: 18px; font-size: 13.5px; color: #8a90a0; flex-wrap: wrap; }
+    .hc-chip { padding: 5px 12px; background: #fff; border: 1px solid #e4e6ec; border-radius: 999px; font-size: 13px; color: #4a5163; cursor: pointer; font-family: var(--sans); }
+    .hc-chip:hover { border-color: var(--brand-soft); }
+
+    /* ---------- body layout ---------- */
+    .hc-body { max-width: 1120px; margin: 0 auto; padding: 40px 28px 20px; display: grid; grid-template-columns: 250px 1fr; gap: 36px; align-items: start; }
+    .hc-aside { position: sticky; top: 82px; }
+    .hc-aside-label { font-family: var(--mono); font-size: 11px; letter-spacing: .09em; color: #9aa0ad; padding: 0 6px; margin-bottom: 12px; }
+    .hc-topics { display: flex; flex-direction: column; gap: 4px; }
+    .hc-topic { display: flex; align-items: center; gap: 11px; width: 100%; padding: 9px 10px; border-radius: 12px; cursor: pointer; font-family: var(--sans); border: 1px solid transparent; background: transparent; color: #4a5163; transition: background .15s; }
+    .hc-topic:hover { background: #fff; }
+    .hc-topic.active { border-color: var(--brand-soft); background: var(--brand-tint); color: #1a1b25; }
+    .hc-topic-icon { width: 30px; height: 30px; flex-shrink: 0; border-radius: 9px; display: flex; align-items: center; justify-content: center; background: color-mix(in srgb, var(--ic) 12%, #fff); color: var(--ic); }
+    .hc-topic-name { flex: 1; min-width: 0; text-align: left; font-size: 14.5px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .hc-topic.active .hc-topic-name { font-weight: 600; }
+    .hc-topic-count { flex-shrink: 0; font-family: var(--mono); font-size: 12px; color: #b4b9c4; }
+    .hc-topic.active .hc-topic-count { color: var(--brand); }
+    .hc-help-card { margin-top: 22px; padding: 18px; background: #fff; border: 1px solid #ececf2; border-radius: 16px; box-shadow: 0 2px 10px rgba(40, 36, 90, .04); }
+    .hc-help-card h3 { font-family: var(--display); font-weight: 600; font-size: 14.5px; margin: 0 0 5px; }
+    .hc-help-card p { font-size: 13px; color: #8a90a0; line-height: 1.5; margin: 0 0 13px; }
+
+    .hc-main { min-width: 0; }
+
+    /* ---------- AI answer ---------- */
+    .hc-ai-wrap { margin-bottom: 24px; }
+    .hc-ask-btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 18px; background: #fff; border: 1px solid var(--brand-soft); color: var(--brand); border-radius: 12px; font-size: 14px; font-weight: 600; cursor: pointer; font-family: var(--sans); }
+    .hc-ask-btn:hover { background: var(--brand-tint); }
+    .hc-ai { background: #fff; border: 1px solid var(--brand-soft); border-radius: 18px; padding: 22px 24px; box-shadow: 0 12px 34px rgba(40, 36, 90, .06); animation: hc-rise .3s ease; }
+    .hc-ai-head { display: flex; align-items: center; gap: 10px; margin-bottom: 13px; flex-wrap: wrap; }
+    .hc-badge { display: inline-flex; align-items: center; gap: 7px; padding: 5px 11px; background: var(--brand-tint); border: 1px solid var(--brand-soft); border-radius: 999px; font-family: var(--mono); font-size: 11px; font-weight: 500; color: var(--brand); letter-spacing: .04em; }
+    .hc-dots { display: inline-flex; gap: 3px; }
+    .hc-dots span { width: 4px; height: 4px; border-radius: 50%; background: var(--brand); animation: hc-blink 1s ease-in-out infinite; }
+    .hc-dots span:nth-child(2) { animation-delay: .18s; }
+    .hc-dots span:nth-child(3) { animation-delay: .36s; }
+    .hc-ai-note { font-size: 12px; color: #9aa0ad; }
+    .hc-ai-answer { font-size: 16px; line-height: 1.65; color: #2a303e; margin: 0; white-space: pre-line; }
+    .hc-ai-foot { display: flex; align-items: center; justify-content: flex-end; gap: 16px; flex-wrap: wrap; padding-top: 14px; margin-top: 14px; border-top: 1px solid #f1f2f6; }
+    .hc-skeleton { display: flex; flex-direction: column; gap: 9px; }
+    .hc-skeleton span { height: 12px; border-radius: 6px; background: linear-gradient(90deg, #eef0f4, #f6f7f9, #eef0f4); background-size: 200% 100%; animation: hc-shimmer 1.3s linear infinite; }
+
+    /* ---------- content header ---------- */
+    .hc-head { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; }
+    .hc-head-icon { width: 38px; height: 38px; flex-shrink: 0; border-radius: 11px; display: flex; align-items: center; justify-content: center; background: color-mix(in srgb, var(--ic) 12%, #fff); color: var(--ic); }
+    .hc-head h2 { font-family: var(--display); font-weight: 600; font-size: 22px; letter-spacing: -.02em; margin: 0; }
+    .hc-head-sub { font-size: 13.5px; color: #8a90a0; margin-top: 2px; }
+
+    /* ---------- FAQ list ---------- */
+    .hc-list { display: flex; flex-direction: column; gap: 10px; }
+    .hc-card { background: #fff; border: 1px solid #ececf2; border-radius: 14px; overflow: hidden; box-shadow: 0 1px 5px rgba(40, 36, 90, .03); }
+    .hc-card[open] { border-color: var(--brand-line); }
+    .hc-q { display: flex; align-items: center; justify-content: space-between; gap: 16px; width: 100%; padding: 17px 20px; background: none; border: none; cursor: pointer; text-align: left; font-family: var(--sans); list-style: none; }
+    .hc-q::-webkit-details-marker { display: none; }
+    .hc-q-label { display: flex; align-items: center; gap: 11px; min-width: 0; }
+    .hc-tag { flex-shrink: 0; font-family: var(--mono); font-size: 10.5px; padding: 3px 8px; border-radius: 6px; background: color-mix(in srgb, var(--ic) 12%, #fff); color: var(--ic); display: none; }
+    .hc-qtext { font-size: 15.5px; font-weight: 600; color: #1a1b25; line-height: 1.4; }
+    .hc-chev { flex-shrink: 0; display: flex; transition: transform .2s ease; color: #8a90a0; }
+    .hc-card[open] .hc-chev { transform: rotate(180deg); }
+    .hc-a { padding: 0 20px 20px; font-size: 14.5px; color: #5a6172; line-height: 1.65; border-top: 1px solid #f1f2f6; }
+    .hc-a-text { padding-top: 15px; white-space: pre-line; }
+    .hc-feedback { display: flex; align-items: center; gap: 14px; margin-top: 16px; padding-top: 14px; border-top: 1px solid #f5f6f9; }
+    .hc-feedback-q { font-size: 13px; color: #9aa0ad; }
+    .hc-vote { display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; border-radius: 9px; font-size: 13px; cursor: pointer; font-family: var(--sans); background: #f5f6f9; border: 1px solid #e4e6ec; color: #4a5163; }
+    .hc-vote.on-yes { background: var(--brand-tint); border-color: var(--brand-soft); color: var(--brand); }
+    .hc-vote.on-no { background: #fdecea; border-color: #f3c6be; color: #cf5b38; }
+    .hc-thanks { font-size: 12.5px; color: var(--brand); font-weight: 600; }
+
+    .hc-empty { text-align: center; padding: 56px 20px; background: #fff; border: 1px solid #ececf2; border-radius: 18px; }
+    .hc-empty-icon { width: 52px; height: 52px; margin: 0 auto 18px; border-radius: 14px; background: #f5f6f9; border: 1px solid #ececf2; display: flex; align-items: center; justify-content: center; color: #9aa0ad; }
+    .hc-empty h3 { font-family: var(--display); font-weight: 600; font-size: 19px; margin: 0 0 8px; }
+    .hc-empty p { font-size: 15px; color: #8a90a0; margin: 0 0 20px; }
+
+    /* ---------- contact CTA ---------- */
+    .hc-cta-shell { max-width: 1120px; margin: 0 auto; padding: 0 28px; }
+    .hc-cta { margin: 24px 0 56px; background: var(--cta-bg); border-radius: 24px; padding: 44px; display: flex; align-items: center; justify-content: space-between; gap: 30px; flex-wrap: wrap; color: var(--brand-ink); }
+    .hc-cta h2 { font-family: var(--display); font-weight: 700; font-size: 26px; letter-spacing: -.02em; margin: 0 0 8px; }
+    .hc-cta p { font-size: 16px; color: var(--cta-sub); margin: 0; max-width: 440px; line-height: 1.55; }
+    .hc-cta-btn { display: inline-flex; align-items: center; gap: 10px; padding: 15px 26px; background: var(--brand-ink); color: var(--brand); border: none; border-radius: 13px; font-size: 15.5px; font-weight: 600; cursor: pointer; font-family: var(--sans); white-space: nowrap; text-decoration: none; }
+
+    /* ---------- footer ---------- */
+    .hc-footer { border-top: 1px solid #ececf2; background: #fff; }
+    .hc-footer-in { max-width: 1120px; margin: 0 auto; padding: 30px 28px; display: flex; align-items: center; justify-content: space-between; gap: 24px; flex-wrap: wrap; }
+    .hc-footer-org { display: flex; align-items: center; gap: 11px; }
+    .hc-footer-org .hc-mark { width: 26px; height: 26px; border-radius: 8px; }
+    .hc-footer-org .hc-mark span { width: 10px; height: 10px; }
+    .hc-footer-org .hc-name { font-size: 15px; }
+    .hc-footer-year { font-size: 13.5px; color: #9aa0ad; }
+    .hc-powered { display: inline-flex; align-items: center; gap: 8px; text-decoration: none; padding: 7px 13px; border: 1px solid #ececf2; border-radius: 999px; font-size: 12.5px; color: #8a90a0; }
+    .hc-powered strong { display: inline-flex; align-items: center; gap: 6px; color: #1a1b25; font-weight: 600; }
+    .hc-cm-mark { width: 15px; height: 15px; border-radius: 5px 5px 5px 1px; background: #c9f24e; display: inline-flex; align-items: center; justify-content: center; gap: 1.5px; }
+    .hc-cm-mark i { width: 2px; height: 2px; border-radius: 50%; background: #0b0c10; }
+
+    /* progressive enhancement: only hide things once JS takes over */
+    .js .hc-tag { display: none; }
+
+    @media (max-width: 860px) {
+      .hc-body { grid-template-columns: 1fr; gap: 24px; }
+      .hc-aside { position: static; }
+      .hc-topics { flex-direction: row; flex-wrap: wrap; }
+      .hc-topic { width: auto; }
+      .hc-hero h1 { font-size: 30px; }
+      .hc-cta { padding: 30px; }
+    }
   </style>
 </head>
 <body>
-  <header class="header">
-    <div class="org">
-      {% if logo_url %}<img src="{{ logo_url }}" alt="{{ row.organization.name }} logo">{% endif %}
-      <span>{{ row.organization.name }}</span>
+  {% set palette = ['#6d5bd0', '#0e8c8c', '#cf5b38', '#2a6fdb', '#1f8a5b', '#b0468a', '#c98a1e', '#3a6f8f'] %}
+  {% set first_cat = groups[0][0] if groups else '' %}
+
+  <!-- ============ HEADER ============ -->
+  <header class="hc-header">
+    <div class="hc-header-in">
+      <a class="hc-brand" href="#top">
+        {% if logo_url %}
+          <img class="hc-logo" src="{{ logo_url }}" alt="{{ row.organization.name }} logo">
+        {% else %}
+          <span class="hc-mark"><span></span></span>
+        {% endif %}
+        <span class="hc-name">{{ row.organization.name }}</span>
+        <span class="hc-kicker">Help Center</span>
+      </a>
+      <nav class="hc-nav">
+        {% for link in header_links %}<a href="{{ link.url }}" rel="noopener">{{ link.label }}</a>{% endfor %}
+        {% if row.cta_text and row.cta_url %}<a class="cta" href="{{ row.cta_url }}" rel="noopener">{{ row.cta_text }}</a>{% endif %}
+      </nav>
     </div>
-    <nav>
-      {% for link in header_links %}<a href="{{ link.url }}" rel="noopener">{{ link.label }}</a>{% endfor %}
-      {% if row.cta_text and row.cta_url %}<a class="cta" href="{{ row.cta_url }}" rel="noopener">{{ row.cta_text }}</a>{% endif %}
-    </nav>
   </header>
 
-  <section class="hero">
-    <h1>How can we help?</h1>
-    <form class="search" method="get" action="/">
-      <input type="search" name="q" value="{{ search }}" placeholder="Search for answers…" maxlength="200">
-      <button type="submit">Search</button>
-    </form>
-    {% if ask_enabled %}
-    <div class="ask">
-      <button class="ask-btn" id="ask-btn" type="button">✦ Ask AI</button>
-      <div class="ask-card" id="ask-card"></div>
+  <!-- ============ HERO / SEARCH ============ -->
+  <section class="hc-hero" id="top">
+    <div class="hc-hero-glow"></div>
+    <div class="hc-hero-in">
+      <h1>How can we help?</h1>
+      <p class="lead">Search our knowledge base, or pick a topic to browse.</p>
+      <form class="hc-searchbar" method="get" action="/" role="search" onsubmit="return false;">
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="#9aa0ad" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+        <input id="hc-search" type="search" name="q" value="{{ search }}" placeholder="Search for answers…" maxlength="200" autocomplete="off">
+        <button class="hc-clear" id="hc-clear" type="button" aria-label="Clear search">✕</button>
+      </form>
+      {% if groups %}
+      <div class="hc-popular">
+        <span>Popular:</span>
+        {% for category, faqs in groups[:4] %}
+        <button class="hc-chip" type="button" data-jump="{{ category }}">{{ category }}</button>
+        {% endfor %}
+      </div>
+      {% endif %}
     </div>
-    {% endif %}
   </section>
 
-  <main class="content">
-    {% if search %}<p>Results for “{{ search }}” — <a href="/">clear</a></p>{% endif %}
-    {% for category, faqs in groups %}
-    <section class="category">
-      <h2>{{ category }}</h2>
-      {% for faq in faqs %}
-      <details{% if search %} open{% endif %}>
-        <summary>{{ faq.question }}</summary>
-        <div class="answer">{{ faq.answer }}</div>
-      </details>
-      {% endfor %}
-    </section>
-    {% else %}
-    <p class="empty">{% if search %}No answers matched your search.{% else %}No published FAQs yet — check back soon.{% endif %}</p>
-    {% endfor %}
-  </main>
+  <!-- ============ BODY : SIDEBAR + CONTENT ============ -->
+  <div class="hc-body">
 
-  <footer class="footer">
-    Powered by <a href="https://chattermate.chat" rel="noopener">ChatterMate</a>
+    <!-- ---- SIDEBAR ---- -->
+    <aside class="hc-aside">
+      {% if groups %}
+      <div class="hc-aside-label">BROWSE TOPICS</div>
+      <div class="hc-topics">
+        {% for category, faqs in groups %}
+        <button class="hc-topic{% if loop.first %} active{% endif %}" type="button"
+                data-category="{{ category }}" data-count="{{ faqs | length }}"
+                data-color="{{ palette[loop.index0 % (palette | length)] }}"
+                style="--ic: {{ palette[loop.index0 % (palette | length)] }};">
+          <span class="hc-topic-icon">
+            <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path></svg>
+          </span>
+          <span class="hc-topic-name">{{ category }}</span>
+          <span class="hc-topic-count">{{ faqs | length }}</span>
+        </button>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% if widget_id %}
+      <div class="hc-help-card">
+        <h3>Can't find it?</h3>
+        <p>Ask our assistant — it answers instantly and can bring in a human.</p>
+        <button class="hc-cta-btn" type="button" data-chat style="padding: 9px 14px; font-size: 13px; border-radius: 10px; background: var(--brand); color: var(--brand-ink);">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z"></path></svg>
+          Start a chat
+        </button>
+      </div>
+      {% endif %}
+    </aside>
+
+    <!-- ---- CONTENT ---- -->
+    <main class="hc-main">
+
+      {% if ask_enabled %}
+      <div class="hc-ai-wrap" id="hc-ai-wrap" hidden>
+        <button class="hc-ask-btn" id="hc-ask-btn" type="button">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.9 4.7L18.5 9l-4.6 1.3L12 15l-1.9-4.7L5.5 9l4.6-1.3z"></path></svg>
+          <span id="hc-ask-label">Ask AI for an answer</span>
+        </button>
+        <div class="hc-ai" id="hc-ai-loading" hidden>
+          <div class="hc-ai-head">
+            <span class="hc-badge"><span class="hc-dots"><span></span><span></span><span></span></span> GENERATING ANSWER</span>
+            <span class="hc-ai-note">Reading the knowledge base…</span>
+          </div>
+          <div class="hc-skeleton"><span style="width:96%"></span><span style="width:88%"></span><span style="width:64%"></span></div>
+        </div>
+        <div class="hc-ai" id="hc-ai-card" hidden>
+          <div class="hc-ai-head">
+            <span class="hc-badge">
+              <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.9 4.7L18.5 9l-4.6 1.3L12 15l-1.9-4.7L5.5 9l4.6-1.3z"></path></svg>
+              AI ANSWER
+            </span>
+            <span class="hc-ai-note">Grounded in this help center · answers may not be perfect</span>
+          </div>
+          <p class="hc-ai-answer" id="hc-ai-answer"></p>
+          {% if widget_id %}
+          <div class="hc-ai-foot">
+            <button class="hc-cta-btn" type="button" data-chat style="padding: 9px 15px; font-size: 13.5px; border-radius: 10px; background: var(--brand); color: var(--brand-ink);">
+              <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z"></path></svg>
+              Ask a follow-up in chat
+            </button>
+          </div>
+          {% endif %}
+        </div>
+      </div>
+      {% endif %}
+
+      <div class="hc-head" id="hc-head"{% if not groups %} hidden{% endif %}>
+        <div class="hc-head-icon" id="hc-head-icon" style="--ic: {{ palette[0] }};">
+          <svg viewBox="0 0 24 24" width="19" height="19" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path></svg>
+        </div>
+        <div style="min-width:0;">
+          <h2 id="hc-head-title">{{ first_cat }}</h2>
+          <div class="hc-head-sub" id="hc-head-sub">{% if groups %}{{ groups[0][1] | length }} {{ 'article' if groups[0][1] | length == 1 else 'articles' }}{% endif %}</div>
+        </div>
+      </div>
+
+      <div class="hc-list" id="hc-list">
+        {% for category, faqs in groups %}
+          {% set cat_color = palette[loop.index0 % (palette | length)] %}
+          {% for faq in faqs %}
+          <details class="hc-card" data-category="{{ category }}"
+                   data-search="{{ (faq.question ~ ' ' ~ faq.answer ~ ' ' ~ category) | lower }}"
+                   style="--ic: {{ cat_color }};"{% if search %} open{% endif %}>
+            <summary class="hc-q">
+              <span class="hc-q-label">
+                <span class="hc-tag">{{ category }}</span>
+                <span class="hc-qtext">{{ faq.question }}</span>
+              </span>
+              <span class="hc-chev">
+                <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"></path></svg>
+              </span>
+            </summary>
+            <div class="hc-a">
+              <div class="hc-a-text">{{ faq.answer }}</div>
+              <div class="hc-feedback" data-feedback>
+                <span class="hc-feedback-q">Was this helpful?</span>
+                <button class="hc-vote" type="button" data-vote="yes">
+                  <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 11v9H4a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1z"></path><path d="M7 11l4-8a2 2 0 0 1 3 1.8V9h4.5a2 2 0 0 1 2 2.4l-1.4 7A2 2 0 0 1 17 20H7"></path></svg>
+                  Yes
+                </button>
+                <button class="hc-vote" type="button" data-vote="no">
+                  <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 13V4h3a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1z"></path><path d="M17 13l-4 8a2 2 0 0 1-3-1.8V15H5.5a2 2 0 0 1-2-2.4l1.4-7A2 2 0 0 1 7 4h10"></path></svg>
+                  No
+                </button>
+                <span class="hc-thanks" hidden>Thanks for the feedback!</span>
+              </div>
+            </div>
+          </details>
+          {% endfor %}
+        {% endfor %}
+      </div>
+
+      <div class="hc-empty" id="hc-empty"{% if groups %} hidden{% endif %}>
+        <div class="hc-empty-icon">
+          <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+        </div>
+        <h3 id="hc-empty-title">{% if groups %}No results{% else %}No published FAQs yet{% endif %}</h3>
+        <p id="hc-empty-sub">{% if groups %}Try a different search{% if widget_id %}, or chat with us — our assistant can help right away{% endif %}.{% else %}Check back soon.{% endif %}</p>
+        {% if widget_id %}
+        <button class="hc-cta-btn" type="button" data-chat style="background: var(--brand); color: var(--brand-ink);">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z"></path></svg>
+          Ask a question
+        </button>
+        {% endif %}
+      </div>
+    </main>
+  </div>
+
+  <!-- ============ CONTACT CTA ============ -->
+  {% if widget_id or (row.cta_text and row.cta_url) %}
+  <div class="hc-cta-shell">
+    <section class="hc-cta" id="contact">
+      <div>
+        <h2>Still need a hand?</h2>
+        <p>{% if widget_id %}Our support assistant answers instantly, any time of day — and connects you to a human whenever you need one.{% else %}Reach out and our team will get back to you.{% endif %}</p>
+      </div>
+      {% if widget_id %}
+      <button class="hc-cta-btn" type="button" data-chat>
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z"></path></svg>
+        Start a chat
+      </button>
+      {% else %}
+      <a class="hc-cta-btn" href="{{ row.cta_url }}" rel="noopener">{{ row.cta_text }}</a>
+      {% endif %}
+    </section>
+  </div>
+  {% endif %}
+
+  <!-- ============ FOOTER ============ -->
+  <footer class="hc-footer">
+    <div class="hc-footer-in">
+      <div class="hc-footer-org">
+        <span class="hc-mark"><span></span></span>
+        <span class="hc-name">{{ row.organization.name }}</span>
+      </div>
+      <a class="hc-powered" href="https://chattermate.chat" target="_blank" rel="noopener">
+        <span>Powered by</span>
+        <strong><span class="hc-cm-mark"><i></i><i></i><i></i></span> ChatterMate</strong>
+      </a>
+    </div>
   </footer>
 
   {% if groups %}
   <script type="application/ld+json">{{ faq_json_ld | tojson }}</script>
   {% endif %}
 
+  <script>
+  (function () {
+    var main = document.querySelector('.hc-main');
+    document.body.classList.add('js');
+
+    var input = document.getElementById('hc-search');
+    var clearBtn = document.getElementById('hc-clear');
+    var topics = [].slice.call(document.querySelectorAll('.hc-topic'));
+    var cards = [].slice.call(document.querySelectorAll('.hc-card'));
+    var head = document.getElementById('hc-head');
+    var headIcon = document.getElementById('hc-head-icon');
+    var headTitle = document.getElementById('hc-head-title');
+    var headSub = document.getElementById('hc-head-sub');
+    var empty = document.getElementById('hc-empty');
+    var emptyTitle = document.getElementById('hc-empty-title');
+    var emptySub = document.getElementById('hc-empty-sub');
+    var aiWrap = document.getElementById('hc-ai-wrap');
+    var activeCat = topics.length ? topics[0].getAttribute('data-category') : null;
+
+    function articles(n) { return n + ' ' + (n === 1 ? 'article' : 'articles'); }
+    function resetAi() {
+      if (!aiWrap) return;
+      aiWrap.hidden = true;
+      var c = document.getElementById('hc-ai-card'); if (c) c.hidden = true;
+      var l = document.getElementById('hc-ai-loading'); if (l) l.hidden = true;
+      var b = document.getElementById('hc-ask-btn'); if (b) b.hidden = false;
+    }
+
+    // ----- browse a single category -----
+    function browse(cat) {
+      activeCat = cat;
+      var count = 0;
+      cards.forEach(function (card) {
+        var show = card.getAttribute('data-category') === cat;
+        card.hidden = !show;
+        card.open = false;
+        if (show) count++;
+      });
+      var t = topics.filter(function (x) { return x.getAttribute('data-category') === cat; })[0];
+      topics.forEach(function (x) { x.classList.toggle('active', x === t); });
+      if (t && head) {
+        head.hidden = false;
+        headIcon.style.setProperty('--ic', t.getAttribute('data-color'));
+        headTitle.textContent = cat;
+        headSub.textContent = articles(count);
+      }
+      if (empty) empty.hidden = true;
+      resetAi();
+    }
+
+    // ----- search across all categories -----
+    function search(raw) {
+      var q = (raw || '').trim().toLowerCase();
+      clearBtn.style.display = q ? 'block' : 'none';
+      if (!q) { if (activeCat) browse(activeCat); return; }
+      topics.forEach(function (x) { x.classList.remove('active'); });
+      var count = 0;
+      cards.forEach(function (card) {
+        var hit = card.getAttribute('data-search').indexOf(q) !== -1;
+        card.hidden = !hit;
+        card.open = false;
+        var tag = card.querySelector('.hc-tag');
+        if (tag) tag.style.display = hit ? 'inline' : '';
+        if (hit) count++;
+      });
+      if (head) {
+        head.hidden = false;
+        headIcon.style.setProperty('--ic', topics.length ? topics[0].getAttribute('data-color') : 'var(--brand)');
+        headTitle.textContent = 'Search results';
+        headSub.textContent = count + (count === 1 ? ' answer' : ' answers') + ' for “' + raw.trim() + '”';
+      }
+      if (empty) {
+        empty.hidden = count > 0;
+        emptyTitle.textContent = 'No results for “' + raw.trim() + '”';
+      }
+      if (aiWrap) {
+        resetAi();
+        aiWrap.hidden = false;
+        var label = document.getElementById('hc-ask-label');
+        if (label) label.textContent = 'Ask AI: “' + raw.trim() + '”';
+      }
+    }
+
+    if (input) {
+      input.addEventListener('input', function () { search(input.value); });
+      // A crawler-friendly GET form is the no-JS fallback; with JS we filter live.
+      if (input.value) search(input.value); else if (activeCat) browse(activeCat);
+    }
+    if (clearBtn) clearBtn.addEventListener('click', function () { input.value = ''; input.focus(); search(''); });
+
+    topics.forEach(function (t) {
+      t.addEventListener('click', function () { input.value = ''; search(''); browse(t.getAttribute('data-category')); });
+    });
+    [].slice.call(document.querySelectorAll('[data-jump]')).forEach(function (chip) {
+      chip.addEventListener('click', function () { input.value = ''; search(''); browse(chip.getAttribute('data-jump')); window.scrollTo({ top: 0, behavior: 'smooth' }); });
+    });
+
+    // ----- per-FAQ feedback (client-only acknowledgement) -----
+    [].slice.call(document.querySelectorAll('[data-feedback]')).forEach(function (fb) {
+      fb.addEventListener('click', function (e) {
+        var btn = e.target.closest('[data-vote]');
+        if (!btn) return;
+        fb.querySelectorAll('.hc-vote').forEach(function (v) { v.classList.remove('on-yes', 'on-no'); });
+        btn.classList.add(btn.getAttribute('data-vote') === 'yes' ? 'on-yes' : 'on-no');
+        var thanks = fb.querySelector('.hc-thanks');
+        if (thanks) thanks.hidden = false;
+      });
+    });
+
+    // ----- open the real embedded ChatterMate widget -----
+    function openChat() {
+      var btn = document.getElementById('chattermate-button');
+      if (btn) btn.click();
+    }
+    [].slice.call(document.querySelectorAll('[data-chat]')).forEach(function (b) {
+      b.addEventListener('click', openChat);
+    });
+  })();
+  </script>
+
   {% if ask_enabled %}
   <script>
-    (function () {
-      var btn = document.getElementById('ask-btn');
-      var card = document.getElementById('ask-card');
-      var input = document.querySelector('.search input');
-      btn.addEventListener('click', function () {
-        var question = (input.value || '').trim();
-        if (question.length < 3) { input.focus(); return; }
-        card.style.display = 'block';
-        card.className = 'ask-card loading';
-        card.textContent = 'Thinking…';
-        fetch('/ask', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ question: question })
-        }).then(function (r) {
-          if (!r.ok) throw new Error(r.status);
-          return r.json();
-        }).then(function (data) {
-          card.className = 'ask-card';
-          card.textContent = data.answer;
-        }).catch(function (err) {
-          card.className = 'ask-card';
-          card.textContent = String(err.message) === '429'
-            ? 'Too many questions — please try again in a minute.'
-            : 'Sorry, I could not answer that right now.';
-        });
+  (function () {
+    var askBtn = document.getElementById('hc-ask-btn');
+    var input = document.getElementById('hc-search');
+    var loading = document.getElementById('hc-ai-loading');
+    var card = document.getElementById('hc-ai-card');
+    var answerEl = document.getElementById('hc-ai-answer');
+    if (!askBtn) return;
+    askBtn.addEventListener('click', function () {
+      var question = (input.value || '').trim();
+      if (question.length < 3) { input.focus(); return; }
+      askBtn.hidden = true;
+      card.hidden = true;
+      loading.hidden = false;
+      fetch('/ask', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question: question })
+      }).then(function (r) {
+        if (!r.ok) throw new Error(r.status);
+        return r.json();
+      }).then(function (data) {
+        loading.hidden = true;
+        answerEl.textContent = data.answer;   // text only — never innerHTML
+        card.hidden = false;
+      }).catch(function (err) {
+        loading.hidden = true;
+        answerEl.textContent = String(err.message) === '429'
+          ? 'Too many questions — please try again in a minute.'
+          : 'Sorry, I could not answer that right now.';
+        card.hidden = false;
       });
-    })();
+    });
+  })();
   </script>
   {% endif %}
 

--- a/backend/app/templates/help_center/index.html
+++ b/backend/app/templates/help_center/index.html
@@ -13,206 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-Public help center page. Every org/FAQ value is escaped by Jinja2 autoescaping;
-never mark org content safe. The page is fully server-rendered for SEO — the JS
-below is progressive enhancement only (topic filtering, client-side search, the
-optional Ask-AI fetch). The chat is the real embedded ChatterMate widget, whose
-own launcher (#chattermate-button) the "Start a chat" buttons click.
+Help-center landing: hero + search, topic sidebar, and a list of FAQ cards that
+link to their article pages (/a/{slug}). Fully server-rendered for SEO; the JS is
+progressive enhancement only (topic filtering, client-side search, optional
+Ask-AI fetch). Card previews/read-times are computed server-side.
+#}{% extends "help_center/base.html" %}
 
-Colors: only `--brand`/`--brand-ink` come from the server (validated hex); every
-other brand tone is derived in CSS via color-mix, so no computed colors leak in.
-#}<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ title }}</title>
-  <meta name="description" content="{{ description }}">
-  <link rel="canonical" href="{{ canonical_url }}/">
-  <meta property="og:title" content="{{ title }}">
-  <meta property="og:description" content="{{ description }}">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="{{ canonical_url }}/">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&family=Instrument+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <style>
-    :root {
-      --brand: {{ brand_color }};
-      --brand-ink: {{ brand_ink }};
-      --brand-tint: color-mix(in srgb, var(--brand) 9%, #fff);
-      --brand-soft: color-mix(in srgb, var(--brand) 30%, #fff);
-      --brand-line: color-mix(in srgb, var(--brand) 40%, #fff);
-      --hero-bg: linear-gradient(180deg, color-mix(in srgb, var(--brand) 10%, #fff), #f5f6f9 80%);
-      --hero-glow: radial-gradient(ellipse, color-mix(in srgb, var(--brand) 12%, transparent), transparent 68%);
-      --cta-bg: linear-gradient(120deg, var(--brand), color-mix(in srgb, var(--brand) 78%, #fff));
-      --cta-sub: color-mix(in srgb, var(--brand-ink) 72%, transparent);
-      --sans: 'Instrument Sans', system-ui, -apple-system, sans-serif;
-      --display: 'Sora', var(--sans);
-      --mono: 'JetBrains Mono', ui-monospace, monospace;
-    }
-    * { box-sizing: border-box; }
-    html, body { margin: 0; padding: 0; background: #f5f6f9; }
-    body { color: #1a1b25; font-family: var(--sans); -webkit-font-smoothing: antialiased; min-height: 100vh; }
-    a { color: var(--brand); }
-    ::selection { background: var(--brand-soft); color: #1a1b25; }
-    @keyframes hc-rise { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
-    @keyframes hc-blink { 0%, 100% { opacity: .3; } 50% { opacity: 1; } }
-    @keyframes hc-shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
-
-    /* ---------- header ---------- */
-    .hc-header { background: #fff; border-bottom: 1px solid #ececf2; position: sticky; top: 0; z-index: 40; }
-    .hc-header-in { max-width: 1120px; margin: 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 15px 28px; }
-    .hc-brand { display: flex; align-items: center; gap: 11px; text-decoration: none; color: inherit; min-width: 0; }
-    .hc-mark { width: 30px; height: 30px; border-radius: 9px; background: var(--brand); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
-    .hc-mark span { width: 12px; height: 12px; border-radius: 3px; background: var(--brand-ink); transform: rotate(45deg); }
-    .hc-logo { height: 30px; width: auto; display: block; flex-shrink: 0; }
-    .hc-name { font-family: var(--display); font-weight: 700; font-size: 19px; letter-spacing: -.02em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .hc-kicker { font-size: 14px; color: #8a90a0; font-weight: 500; padding-left: 12px; border-left: 1px solid #e4e6ec; white-space: nowrap; }
-    .hc-nav { display: flex; align-items: center; gap: 20px; font-size: 14.5px; flex-shrink: 0; }
-    .hc-nav a { color: #5a6172; text-decoration: none; }
-    .hc-nav a:hover { color: #1a1b25; }
-    .hc-nav a.cta { padding: 9px 17px; background: var(--brand); color: var(--brand-ink); border-radius: 10px; font-weight: 600; }
-
-    /* ---------- hero ---------- */
-    .hc-hero { position: relative; overflow: hidden; background: var(--hero-bg); padding: 58px 28px 46px; }
-    .hc-hero-glow { position: absolute; top: -90px; left: 50%; transform: translateX(-50%); width: 640px; height: 340px; max-width: 100%; background: var(--hero-glow); pointer-events: none; }
-    .hc-hero-in { position: relative; max-width: 720px; margin: 0 auto; text-align: center; }
-    .hc-hero h1 { font-family: var(--display); font-weight: 700; font-size: 38px; line-height: 1.1; letter-spacing: -.03em; margin: 0 0 12px; }
-    .hc-hero p.lead { font-size: 16.5px; color: #5a6172; margin: 0 0 26px; }
-    .hc-searchbar { display: flex; align-items: center; gap: 12px; background: #fff; border: 1px solid #e4e6ec; border-radius: 15px; padding: 6px 6px 6px 18px; box-shadow: 0 12px 34px rgba(40, 36, 90, .08); max-width: 600px; margin: 0 auto; }
-    .hc-searchbar svg { flex-shrink: 0; }
-    .hc-searchbar input { flex: 1; min-width: 0; background: transparent; border: none; outline: none; font-size: 16px; color: #1a1b25; font-family: var(--sans); padding: 12px 0; }
-    .hc-searchbar input::placeholder { color: #9aa0ad; }
-    .hc-clear { flex-shrink: 0; width: 34px; height: 34px; border-radius: 9px; background: #f1f2f6; border: none; color: #8a90a0; cursor: pointer; font-size: 14px; display: none; }
-    .hc-popular { display: flex; align-items: center; justify-content: center; gap: 9px; margin-top: 18px; font-size: 13.5px; color: #8a90a0; flex-wrap: wrap; }
-    .hc-chip { padding: 5px 12px; background: #fff; border: 1px solid #e4e6ec; border-radius: 999px; font-size: 13px; color: #4a5163; cursor: pointer; font-family: var(--sans); }
-    .hc-chip:hover { border-color: var(--brand-soft); }
-
-    /* ---------- body layout ---------- */
-    .hc-body { max-width: 1120px; margin: 0 auto; padding: 40px 28px 20px; display: grid; grid-template-columns: 250px 1fr; gap: 36px; align-items: start; }
-    .hc-aside { position: sticky; top: 82px; }
-    .hc-aside-label { font-family: var(--mono); font-size: 11px; letter-spacing: .09em; color: #9aa0ad; padding: 0 6px; margin-bottom: 12px; }
-    .hc-topics { display: flex; flex-direction: column; gap: 4px; }
-    .hc-topic { display: flex; align-items: center; gap: 11px; width: 100%; padding: 9px 10px; border-radius: 12px; cursor: pointer; font-family: var(--sans); border: 1px solid transparent; background: transparent; color: #4a5163; transition: background .15s; }
-    .hc-topic:hover { background: #fff; }
-    .hc-topic.active { border-color: var(--brand-soft); background: var(--brand-tint); color: #1a1b25; }
-    .hc-topic-icon { width: 30px; height: 30px; flex-shrink: 0; border-radius: 9px; display: flex; align-items: center; justify-content: center; background: color-mix(in srgb, var(--ic) 12%, #fff); color: var(--ic); }
-    .hc-topic-name { flex: 1; min-width: 0; text-align: left; font-size: 14.5px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .hc-topic.active .hc-topic-name { font-weight: 600; }
-    .hc-topic-count { flex-shrink: 0; font-family: var(--mono); font-size: 12px; color: #b4b9c4; }
-    .hc-topic.active .hc-topic-count { color: var(--brand); }
-    .hc-help-card { margin-top: 22px; padding: 18px; background: #fff; border: 1px solid #ececf2; border-radius: 16px; box-shadow: 0 2px 10px rgba(40, 36, 90, .04); }
-    .hc-help-card h3 { font-family: var(--display); font-weight: 600; font-size: 14.5px; margin: 0 0 5px; }
-    .hc-help-card p { font-size: 13px; color: #8a90a0; line-height: 1.5; margin: 0 0 13px; }
-
-    .hc-main { min-width: 0; }
-
-    /* ---------- AI answer ---------- */
-    .hc-ai-wrap { margin-bottom: 24px; }
-    .hc-ask-btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 18px; background: #fff; border: 1px solid var(--brand-soft); color: var(--brand); border-radius: 12px; font-size: 14px; font-weight: 600; cursor: pointer; font-family: var(--sans); }
-    .hc-ask-btn:hover { background: var(--brand-tint); }
-    .hc-ai { background: #fff; border: 1px solid var(--brand-soft); border-radius: 18px; padding: 22px 24px; box-shadow: 0 12px 34px rgba(40, 36, 90, .06); animation: hc-rise .3s ease; }
-    .hc-ai-head { display: flex; align-items: center; gap: 10px; margin-bottom: 13px; flex-wrap: wrap; }
-    .hc-badge { display: inline-flex; align-items: center; gap: 7px; padding: 5px 11px; background: var(--brand-tint); border: 1px solid var(--brand-soft); border-radius: 999px; font-family: var(--mono); font-size: 11px; font-weight: 500; color: var(--brand); letter-spacing: .04em; }
-    .hc-dots { display: inline-flex; gap: 3px; }
-    .hc-dots span { width: 4px; height: 4px; border-radius: 50%; background: var(--brand); animation: hc-blink 1s ease-in-out infinite; }
-    .hc-dots span:nth-child(2) { animation-delay: .18s; }
-    .hc-dots span:nth-child(3) { animation-delay: .36s; }
-    .hc-ai-note { font-size: 12px; color: #9aa0ad; }
-    .hc-ai-answer { font-size: 16px; line-height: 1.65; color: #2a303e; margin: 0; white-space: pre-line; }
-    .hc-ai-foot { display: flex; align-items: center; justify-content: flex-end; gap: 16px; flex-wrap: wrap; padding-top: 14px; margin-top: 14px; border-top: 1px solid #f1f2f6; }
-    .hc-skeleton { display: flex; flex-direction: column; gap: 9px; }
-    .hc-skeleton span { height: 12px; border-radius: 6px; background: linear-gradient(90deg, #eef0f4, #f6f7f9, #eef0f4); background-size: 200% 100%; animation: hc-shimmer 1.3s linear infinite; }
-
-    /* ---------- content header ---------- */
-    .hc-head { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; }
-    .hc-head-icon { width: 38px; height: 38px; flex-shrink: 0; border-radius: 11px; display: flex; align-items: center; justify-content: center; background: color-mix(in srgb, var(--ic) 12%, #fff); color: var(--ic); }
-    .hc-head h2 { font-family: var(--display); font-weight: 600; font-size: 22px; letter-spacing: -.02em; margin: 0; }
-    .hc-head-sub { font-size: 13.5px; color: #8a90a0; margin-top: 2px; }
-
-    /* ---------- FAQ list ---------- */
-    .hc-list { display: flex; flex-direction: column; gap: 10px; }
-    .hc-card { background: #fff; border: 1px solid #ececf2; border-radius: 14px; overflow: hidden; box-shadow: 0 1px 5px rgba(40, 36, 90, .03); }
-    .hc-card[open] { border-color: var(--brand-line); }
-    .hc-q { display: flex; align-items: center; justify-content: space-between; gap: 16px; width: 100%; padding: 17px 20px; background: none; border: none; cursor: pointer; text-align: left; font-family: var(--sans); list-style: none; }
-    .hc-q::-webkit-details-marker { display: none; }
-    .hc-q-label { display: flex; align-items: center; gap: 11px; min-width: 0; }
-    .hc-tag { flex-shrink: 0; font-family: var(--mono); font-size: 10.5px; padding: 3px 8px; border-radius: 6px; background: color-mix(in srgb, var(--ic) 12%, #fff); color: var(--ic); display: none; }
-    .hc-qtext { font-size: 15.5px; font-weight: 600; color: #1a1b25; line-height: 1.4; }
-    .hc-chev { flex-shrink: 0; display: flex; transition: transform .2s ease; color: #8a90a0; }
-    .hc-card[open] .hc-chev { transform: rotate(180deg); }
-    .hc-a { padding: 0 20px 20px; font-size: 14.5px; color: #5a6172; line-height: 1.65; border-top: 1px solid #f1f2f6; }
-    .hc-a-text { padding-top: 15px; white-space: pre-line; }
-    .hc-feedback { display: flex; align-items: center; gap: 14px; margin-top: 16px; padding-top: 14px; border-top: 1px solid #f5f6f9; }
-    .hc-feedback-q { font-size: 13px; color: #9aa0ad; }
-    .hc-vote { display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px; border-radius: 9px; font-size: 13px; cursor: pointer; font-family: var(--sans); background: #f5f6f9; border: 1px solid #e4e6ec; color: #4a5163; }
-    .hc-vote.on-yes { background: var(--brand-tint); border-color: var(--brand-soft); color: var(--brand); }
-    .hc-vote.on-no { background: #fdecea; border-color: #f3c6be; color: #cf5b38; }
-    .hc-thanks { font-size: 12.5px; color: var(--brand); font-weight: 600; }
-
-    .hc-empty { text-align: center; padding: 56px 20px; background: #fff; border: 1px solid #ececf2; border-radius: 18px; }
-    .hc-empty-icon { width: 52px; height: 52px; margin: 0 auto 18px; border-radius: 14px; background: #f5f6f9; border: 1px solid #ececf2; display: flex; align-items: center; justify-content: center; color: #9aa0ad; }
-    .hc-empty h3 { font-family: var(--display); font-weight: 600; font-size: 19px; margin: 0 0 8px; }
-    .hc-empty p { font-size: 15px; color: #8a90a0; margin: 0 0 20px; }
-
-    /* ---------- contact CTA ---------- */
-    .hc-cta-shell { max-width: 1120px; margin: 0 auto; padding: 0 28px; }
-    .hc-cta { margin: 24px 0 56px; background: var(--cta-bg); border-radius: 24px; padding: 44px; display: flex; align-items: center; justify-content: space-between; gap: 30px; flex-wrap: wrap; color: var(--brand-ink); }
-    .hc-cta h2 { font-family: var(--display); font-weight: 700; font-size: 26px; letter-spacing: -.02em; margin: 0 0 8px; }
-    .hc-cta p { font-size: 16px; color: var(--cta-sub); margin: 0; max-width: 440px; line-height: 1.55; }
-    .hc-cta-btn { display: inline-flex; align-items: center; gap: 10px; padding: 15px 26px; background: var(--brand-ink); color: var(--brand); border: none; border-radius: 13px; font-size: 15.5px; font-weight: 600; cursor: pointer; font-family: var(--sans); white-space: nowrap; text-decoration: none; }
-
-    /* ---------- footer ---------- */
-    .hc-footer { border-top: 1px solid #ececf2; background: #fff; }
-    .hc-footer-in { max-width: 1120px; margin: 0 auto; padding: 30px 28px; display: flex; align-items: center; justify-content: space-between; gap: 24px; flex-wrap: wrap; }
-    .hc-footer-org { display: flex; align-items: center; gap: 11px; }
-    .hc-footer-org .hc-mark { width: 26px; height: 26px; border-radius: 8px; }
-    .hc-footer-org .hc-mark span { width: 10px; height: 10px; }
-    .hc-footer-org .hc-name { font-size: 15px; }
-    .hc-footer-year { font-size: 13.5px; color: #9aa0ad; }
-    .hc-powered { display: inline-flex; align-items: center; gap: 8px; text-decoration: none; padding: 7px 13px; border: 1px solid #ececf2; border-radius: 999px; font-size: 12.5px; color: #8a90a0; }
-    .hc-powered strong { display: inline-flex; align-items: center; gap: 6px; color: #1a1b25; font-weight: 600; }
-    .hc-cm-mark { width: 15px; height: 15px; border-radius: 5px 5px 5px 1px; background: #c9f24e; display: inline-flex; align-items: center; justify-content: center; gap: 1.5px; }
-    .hc-cm-mark i { width: 2px; height: 2px; border-radius: 50%; background: #0b0c10; }
-
-    /* progressive enhancement: only hide things once JS takes over */
-    .js .hc-tag { display: none; }
-
-    @media (max-width: 860px) {
-      .hc-body { grid-template-columns: 1fr; gap: 24px; }
-      .hc-aside { position: static; }
-      .hc-topics { flex-direction: row; flex-wrap: wrap; }
-      .hc-topic { width: auto; }
-      .hc-hero h1 { font-size: 30px; }
-      .hc-cta { padding: 30px; }
-    }
-  </style>
-</head>
-<body>
-  {% set palette = ['#6d5bd0', '#0e8c8c', '#cf5b38', '#2a6fdb', '#1f8a5b', '#b0468a', '#c98a1e', '#3a6f8f'] %}
-  {% set first_cat = groups[0][0] if groups else '' %}
-
-  <!-- ============ HEADER ============ -->
-  <header class="hc-header">
-    <div class="hc-header-in">
-      <a class="hc-brand" href="#top">
-        {% if logo_url %}
-          <img class="hc-logo" src="{{ logo_url }}" alt="{{ row.organization.name }} logo">
-        {% else %}
-          <span class="hc-mark"><span></span></span>
-        {% endif %}
-        <span class="hc-name">{{ row.organization.name }}</span>
-        <span class="hc-kicker">Help Center</span>
-      </a>
-      <nav class="hc-nav">
-        {% for link in header_links %}<a href="{{ link.url }}" rel="noopener">{{ link.label }}</a>{% endfor %}
-        {% if row.cta_enabled and row.cta_text and row.cta_url %}<a class="cta" href="{{ row.cta_url }}" rel="noopener">{{ row.cta_text }}</a>{% endif %}
-      </nav>
-    </div>
-  </header>
-
-  <!-- ============ HERO / SEARCH ============ -->
+{% block hero %}
   <section class="hc-hero" id="top">
     <div class="hc-hero-glow"></div>
     <div class="hc-hero-in">
@@ -233,8 +40,10 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
       {% endif %}
     </div>
   </section>
+{% endblock %}
 
-  <!-- ============ BODY : SIDEBAR + CONTENT ============ -->
+{% block body %}
+  {% set first_cat = groups[0][0] if groups else '' %}
   <div class="hc-body">
 
     <!-- ---- SIDEBAR ---- -->
@@ -245,8 +54,8 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
         {% for category, faqs in groups %}
         <button class="hc-topic{% if loop.first %} active{% endif %}" type="button"
                 data-category="{{ category }}" data-count="{{ faqs | length }}"
-                data-color="{{ palette[loop.index0 % (palette | length)] }}"
-                style="--ic: {{ palette[loop.index0 % (palette | length)] }};">
+                data-color="{{ colors[category] }}"
+                style="--ic: {{ colors[category] }};">
           <span class="hc-topic-icon">
             <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path></svg>
           </span>
@@ -306,7 +115,7 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
       {% endif %}
 
       <div class="hc-head" id="hc-head"{% if not groups %} hidden{% endif %}>
-        <div class="hc-head-icon" id="hc-head-icon" style="--ic: {{ palette[0] }};">
+        <div class="hc-head-icon" id="hc-head-icon" style="--ic: {{ colors[first_cat] if first_cat else '#6d5bd0' }};">
           <svg viewBox="0 0 24 24" width="19" height="19" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path></svg>
         </div>
         <div style="min-width:0;">
@@ -317,36 +126,21 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
 
       <div class="hc-list" id="hc-list">
         {% for category, faqs in groups %}
-          {% set cat_color = palette[loop.index0 % (palette | length)] %}
           {% for faq in faqs %}
-          <details class="hc-card" data-category="{{ category }}"
-                   data-search="{{ (faq.question ~ ' ' ~ faq.answer ~ ' ' ~ category) | lower }}"
-                   style="--ic: {{ cat_color }};"{% if search %} open{% endif %}>
-            <summary class="hc-q">
-              <span class="hc-q-label">
-                <span class="hc-tag">{{ category }}</span>
-                <span class="hc-qtext">{{ faq.question }}</span>
-              </span>
+          <a class="hc-card" href="/a/{{ faq.slug }}" data-category="{{ category }}"
+             data-search="{{ faq.search_text }}" style="--ic: {{ colors[category] }};">
+            <span class="hc-card-main">
+              <span class="hc-tag">{{ category }}</span>
+              <span class="hc-qtext">{{ faq.question }}</span>
+              <span class="hc-preview">{{ faq.preview }}</span>
+            </span>
+            <span class="hc-card-meta">
+              <span class="hc-read">{{ faq.read_time }}</span>
               <span class="hc-chev">
-                <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"></path></svg>
+                <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"></path></svg>
               </span>
-            </summary>
-            <div class="hc-a">
-              <div class="hc-a-text">{{ faq.answer }}</div>
-              <div class="hc-feedback" data-feedback>
-                <span class="hc-feedback-q">Was this helpful?</span>
-                <button class="hc-vote" type="button" data-vote="yes">
-                  <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 11v9H4a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1z"></path><path d="M7 11l4-8a2 2 0 0 1 3 1.8V9h4.5a2 2 0 0 1 2 2.4l-1.4 7A2 2 0 0 1 17 20H7"></path></svg>
-                  Yes
-                </button>
-                <button class="hc-vote" type="button" data-vote="no">
-                  <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 13V4h3a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1z"></path><path d="M17 13l-4 8a2 2 0 0 1-3-1.8V15H5.5a2 2 0 0 1-2-2.4l1.4-7A2 2 0 0 1 7 4h10"></path></svg>
-                  No
-                </button>
-                <span class="hc-thanks" hidden>Thanks for the feedback!</span>
-              </div>
-            </div>
-          </details>
+            </span>
+          </a>
           {% endfor %}
         {% endfor %}
       </div>
@@ -366,49 +160,11 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
       </div>
     </main>
   </div>
+{% endblock %}
 
-  <!-- ============ CONTACT CTA ============ -->
-  {% set cta_shown = row.cta_enabled and row.cta_text and row.cta_url %}
-  {% if widget_id or cta_shown %}
-  <div class="hc-cta-shell">
-    <section class="hc-cta" id="contact">
-      <div>
-        <h2>Still need a hand?</h2>
-        <p>{% if widget_id %}Our support assistant answers instantly, any time of day — and connects you to a human whenever you need one.{% else %}Reach out and our team will get back to you.{% endif %}</p>
-      </div>
-      {% if widget_id %}
-      <button class="hc-cta-btn" type="button" data-chat>
-        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z"></path></svg>
-        Start a chat
-      </button>
-      {% elif cta_shown %}
-      <a class="hc-cta-btn" href="{{ row.cta_url }}" rel="noopener">{{ row.cta_text }}</a>
-      {% endif %}
-    </section>
-  </div>
-  {% endif %}
-
-  <!-- ============ FOOTER ============ -->
-  <footer class="hc-footer">
-    <div class="hc-footer-in">
-      <div class="hc-footer-org">
-        <span class="hc-mark"><span></span></span>
-        <span class="hc-name">{{ row.organization.name }}</span>
-      </div>
-      <a class="hc-powered" href="https://chattermate.chat" target="_blank" rel="noopener">
-        <span>Powered by</span>
-        <strong><span class="hc-cm-mark"><i></i><i></i><i></i></span> ChatterMate</strong>
-      </a>
-    </div>
-  </footer>
-
-  {% if groups %}
-  <script type="application/ld+json">{{ faq_json_ld | tojson }}</script>
-  {% endif %}
-
+{% block page_scripts %}
   <script>
   (function () {
-    var main = document.querySelector('.hc-main');
     document.body.classList.add('js');
 
     var input = document.getElementById('hc-search');
@@ -421,7 +177,6 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
     var headSub = document.getElementById('hc-head-sub');
     var empty = document.getElementById('hc-empty');
     var emptyTitle = document.getElementById('hc-empty-title');
-    var emptySub = document.getElementById('hc-empty-sub');
     var aiWrap = document.getElementById('hc-ai-wrap');
     var activeCat = topics.length ? topics[0].getAttribute('data-category') : null;
 
@@ -441,7 +196,6 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
       cards.forEach(function (card) {
         var show = card.getAttribute('data-category') === cat;
         card.hidden = !show;
-        card.open = false;
         if (show) count++;
       });
       var t = topics.filter(function (x) { return x.getAttribute('data-category') === cat; })[0];
@@ -466,9 +220,8 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
       cards.forEach(function (card) {
         var hit = card.getAttribute('data-search').indexOf(q) !== -1;
         card.hidden = !hit;
-        card.open = false;
         var tag = card.querySelector('.hc-tag');
-        if (tag) tag.style.display = hit ? 'inline' : '';
+        if (tag) tag.style.display = hit ? 'inline-block' : '';
         if (hit) count++;
       });
       if (head) {
@@ -489,10 +242,15 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
       }
     }
 
+    // Honor ?topic=… so links from an article page land on the right category.
+    var params = new URLSearchParams(window.location.search);
+    var wantTopic = params.get('topic');
+
     if (input) {
       input.addEventListener('input', function () { search(input.value); });
-      // A crawler-friendly GET form is the no-JS fallback; with JS we filter live.
-      if (input.value) search(input.value); else if (activeCat) browse(activeCat);
+      if (input.value) search(input.value);
+      else if (wantTopic && topics.some(function (t) { return t.getAttribute('data-category') === wantTopic; })) browse(wantTopic);
+      else if (activeCat) browse(activeCat);
     }
     if (clearBtn) clearBtn.addEventListener('click', function () { input.value = ''; input.focus(); search(''); });
 
@@ -501,35 +259,6 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
     });
     [].slice.call(document.querySelectorAll('[data-jump]')).forEach(function (chip) {
       chip.addEventListener('click', function () { input.value = ''; search(''); browse(chip.getAttribute('data-jump')); window.scrollTo({ top: 0, behavior: 'smooth' }); });
-    });
-
-    // ----- per-FAQ feedback (client-only acknowledgement) -----
-    [].slice.call(document.querySelectorAll('[data-feedback]')).forEach(function (fb) {
-      fb.addEventListener('click', function (e) {
-        var btn = e.target.closest('[data-vote]');
-        if (!btn) return;
-        fb.querySelectorAll('.hc-vote').forEach(function (v) { v.classList.remove('on-yes', 'on-no'); });
-        btn.classList.add(btn.getAttribute('data-vote') === 'yes' ? 'on-yes' : 'on-no');
-        var thanks = fb.querySelector('.hc-thanks');
-        if (thanks) thanks.hidden = false;
-      });
-    });
-
-    // ----- open the real embedded ChatterMate widget -----
-    // The widget script is async and builds its launcher (#chattermate-button)
-    // a moment after load, so a click can land before it exists — poll briefly
-    // and click as soon as it appears instead of silently doing nothing.
-    function openChat() {
-      var tries = 0;
-      (function attempt() {
-        var btn = document.getElementById('chattermate-button');
-        if (btn) { btn.click(); return; }
-        if (tries++ < 40) { setTimeout(attempt, 150); return; }  // ~6s
-        if (window.console) console.warn('[ChatterMate] chat widget is not available on this page.');
-      })();
-    }
-    [].slice.call(document.querySelectorAll('[data-chat]')).forEach(function (b) {
-      b.addEventListener('click', openChat);
     });
   })();
   </script>
@@ -571,17 +300,4 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
   })();
   </script>
   {% endif %}
-
-  {% if widget_id %}
-  <script>
-    window.chattermateId = {{ widget_id | tojson }};
-    (function () {
-      var s = document.createElement('script');
-      s.src = {{ widget_script_url | tojson }};
-      s.async = true;
-      document.body.appendChild(s);
-    })();
-  </script>
-  {% endif %}
-</body>
-</html>
+{% endblock %}

--- a/backend/app/templates/help_center/index.html
+++ b/backend/app/templates/help_center/index.html
@@ -99,7 +99,6 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
               <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l1.9 4.7L18.5 9l-4.6 1.3L12 15l-1.9-4.7L5.5 9l4.6-1.3z"></path></svg>
               AI ANSWER
             </span>
-            <span class="hc-ai-note">Grounded in this help center · answers may not be perfect</span>
           </div>
           <p class="hc-ai-answer" id="hc-ai-answer"></p>
           {% if widget_id %}

--- a/backend/app/templates/help_center/index.html
+++ b/backend/app/templates/help_center/index.html
@@ -207,7 +207,7 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
       </a>
       <nav class="hc-nav">
         {% for link in header_links %}<a href="{{ link.url }}" rel="noopener">{{ link.label }}</a>{% endfor %}
-        {% if row.cta_text and row.cta_url %}<a class="cta" href="{{ row.cta_url }}" rel="noopener">{{ row.cta_text }}</a>{% endif %}
+        {% if row.cta_enabled and row.cta_text and row.cta_url %}<a class="cta" href="{{ row.cta_url }}" rel="noopener">{{ row.cta_text }}</a>{% endif %}
       </nav>
     </div>
   </header>
@@ -368,7 +368,8 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
   </div>
 
   <!-- ============ CONTACT CTA ============ -->
-  {% if widget_id or (row.cta_text and row.cta_url) %}
+  {% set cta_shown = row.cta_enabled and row.cta_text and row.cta_url %}
+  {% if widget_id or cta_shown %}
   <div class="hc-cta-shell">
     <section class="hc-cta" id="contact">
       <div>
@@ -380,7 +381,7 @@ other brand tone is derived in CSS via color-mix, so no computed colors leak in.
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.5 8.5 0 0 1-12.3 7.6L3 21l1.9-5.7A8.5 8.5 0 1 1 21 11.5z"></path></svg>
         Start a chat
       </button>
-      {% else %}
+      {% elif cta_shown %}
       <a class="hc-cta-btn" href="{{ row.cta_url }}" rel="noopener">{{ row.cta_text }}</a>
       {% endif %}
     </section>

--- a/backend/app/tools/faq_search.py
+++ b/backend/app/tools/faq_search.py
@@ -1,0 +1,71 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import List
+from uuid import UUID
+
+from agno.tools import Toolkit
+from agno.utils.log import logger
+
+from app.database import SessionLocal
+from app.models.faq import FAQ
+from app.repositories.faq import FAQRepository
+
+# Word-overlap ranking beats a whole-string ILIKE here: a visitor's
+# natural-language question rarely appears verbatim in an FAQ, but shares
+# meaningful words with the right one.
+_MIN_WORD_LEN = 3
+_MAX_RESULTS = 5
+
+
+class FAQSearchTool(Toolkit):
+    """Lets the help-center answer agent search the org's PUBLISHED FAQs.
+    Read-only and org-scoped — never exposes drafts or other orgs' content."""
+
+    def __init__(self, organization_id: UUID):
+        super().__init__(name="faq_search")
+        self.organization_id = organization_id
+        self.register(self.search_faqs)
+
+    def search_faqs(self, query: str) -> str:
+        """Search this help center's published FAQs for a question.
+
+        Args:
+            query: What the visitor wants to know.
+        """
+        try:
+            with SessionLocal() as db:
+                faqs = FAQRepository(db).get_published_for_org(self.organization_id)
+                ranked = _rank(faqs, query)
+                if not ranked:
+                    return "No published FAQs matched that question."
+                return "\n\n".join(f"Q: {faq.question}\nA: {faq.answer}" for faq in ranked)
+        except Exception as e:
+            logger.error(f"FAQ search failed: {e}")
+            return "Error searching the FAQs."
+
+
+def _rank(faqs: List[FAQ], query: str) -> List[FAQ]:
+    words = {w for w in query.casefold().split() if len(w) > _MIN_WORD_LEN}
+    if not words:
+        return faqs[:_MAX_RESULTS]
+    scored = [
+        (len(words & set(f"{faq.question} {faq.answer}".casefold().split())), faq)
+        for faq in faqs
+    ]
+    scored = [(score, faq) for score, faq in scored if score > 0]
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    return [faq for _score, faq in scored[:_MAX_RESULTS]]

--- a/backend/app/tools/knowledge_search_byagent.py
+++ b/backend/app/tools/knowledge_search_byagent.py
@@ -21,13 +21,10 @@ from app.database import SessionLocal
 from app.core.config import settings
 from app.repositories.knowledge_to_agent import KnowledgeToAgentRepository
 from app.repositories.knowledge import KnowledgeRepository
-from app.repositories.ai_config import AIConfigRepository
-from app.core.security import decrypt_api_key
 from agno.knowledge.agent import AgentKnowledge
 from agno.vectordb.pgvector import PgVector, SearchType
 from agno.embedder.fastembed import FastEmbedEmbedder
 from uuid import UUID
-import os
 
 class KnowledgeSearchByAgent(Toolkit):
     def __init__(self, agent_id: str, org_id: UUID, source: str = None):
@@ -41,14 +38,12 @@ class KnowledgeSearchByAgent(Toolkit):
         # Structured citations for the most recent turn: list of {"name", "type"}.
         # Read (and reset) by the chat agent after each run to attach to the response.
         self.collected_sources: List[Dict[str, str]] = []
-        
-        # Get API key from AI config - use context manager for database session
-        with SessionLocal() as db:
-            ai_config_repo = AIConfigRepository(db)
-            ai_config = ai_config_repo.get_active_config(org_id)
-            if ai_config and ai_config.encrypted_api_key:
-                os.environ['OPENAI_API_KEY'] = decrypt_api_key(ai_config.encrypted_api_key)
-        
+
+        # NOTE: this used to export the org's key as OPENAI_API_KEY for agno's
+        # old default OpenAI embedder. Search now uses the local FastEmbed
+        # embedder and every model gets its key explicitly, so the env write
+        # was dead — and a cross-tenant race (concurrent orgs overwrote each
+        # other's key in process-global state).
         self.agent_knowledge = None
         self.register(self.search_knowledge_base)
 

--- a/backend/app/utils/model_context.py
+++ b/backend/app/utils/model_context.py
@@ -1,0 +1,114 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Curated context-window lookup for the org-configurable chat models, used to
+size FAQ-generation batches to the selected model instead of a fixed constant.
+Deliberately a small hand-maintained table (kept conservative) rather than a
+dependency on litellm's model map; unknown models fall back to a per-provider
+floor, and FAQ_CONTEXT_TOKENS_OVERRIDE forces a value for anything exotic.
+"""
+
+from app.core.config import settings
+
+# Conservative floors when the model name is unrecognised. Keys match
+# AIModelType values, uppercased.
+_PROVIDER_DEFAULT_TOKENS = {
+    "OPENAI": 16_000,
+    "CHATTERMATE": 128_000,
+    "ANTHROPIC": 200_000,
+    "DEEPSEEK": 64_000,
+    "GOOGLE": 32_000,
+    "GOOGLEVERTEX": 32_000,
+    "GROQ": 8_000,
+    "MISTRAL": 32_000,
+    "HUGGINGFACE": 8_000,
+    "OLLAMA": 8_000,
+    "XAI": 128_000,
+}
+_FALLBACK_TOKENS = 8_000
+
+# Lowercase model-name prefixes; the longest matching prefix wins so
+# "gpt-4o" beats "gpt-4" and "mistral-large" beats "mistral".
+_MODEL_PREFIX_TOKENS = {
+    "gpt-5": 400_000,
+    "gpt-4.1": 1_000_000,
+    "gpt-4o": 128_000,
+    "gpt-4-turbo": 128_000,
+    "gpt-4": 8_000,
+    "gpt-3.5": 16_000,
+    "o1": 200_000,
+    "o3": 200_000,
+    "o4": 200_000,
+    "claude": 200_000,
+    "gemini": 1_000_000,
+    "deepseek": 64_000,
+    "llama-3.1": 128_000,
+    "llama-3.2": 128_000,
+    "llama-3.3": 128_000,
+    "llama-4": 128_000,
+    "mixtral": 32_000,
+    "mistral-large": 128_000,
+    "mistral": 32_000,
+    "grok": 128_000,
+    "qwen": 32_000,
+    "kimi": 128_000,
+}
+
+# Batch-size math. CHARS_PER_TOKEN is conservative for English prose (~4);
+# SAFETY absorbs tokenizer variance and the packed-batch separators.
+_PROMPT_OVERHEAD_TOKENS = 2_500  # instructions + existing-questions block
+_OUTPUT_TOKENS_PER_FAQ = 120
+_OUTPUT_TOKENS_BASE = 500
+_CHARS_PER_TOKEN = 3.5
+_SAFETY = 0.8
+_MIN_FAQS_PER_BATCH = 15
+_MAX_FAQS_PER_BATCH = 40
+_CHARS_PER_FAQ = 3_000  # scale FAQ yield with batch size so density stays flat
+
+
+def context_tokens_for(model_type: str, model_name: str) -> int:
+    """Best-known context window (tokens) for the configured model."""
+    if settings.FAQ_CONTEXT_TOKENS_OVERRIDE > 0:
+        return settings.FAQ_CONTEXT_TOKENS_OVERRIDE
+    name = (model_name or "").casefold()
+    best = None
+    for prefix, tokens in _MODEL_PREFIX_TOKENS.items():
+        if name.startswith(prefix) and (best is None or len(prefix) > best[0]):
+            best = (len(prefix), tokens)
+    if best:
+        return best[1]
+    return _PROVIDER_DEFAULT_TOKENS.get((model_type or "").upper(), _FALLBACK_TOKENS)
+
+
+def output_tokens_for(max_faqs: int) -> int:
+    """Output reserve for a structured batch of up to max_faqs FAQs."""
+    return max_faqs * _OUTPUT_TOKENS_PER_FAQ + _OUTPUT_TOKENS_BASE
+
+
+def faq_batch_chars_for(model_type: str, model_name: str) -> tuple[int, int]:
+    """(batch_chars, max_faqs) for FAQ extraction with this model.
+
+    batch_chars is floored at FAQ_MAX_BATCH_CHARS (today's behaviour for
+    small-context models) and ceilinged at FAQ_MAX_BATCH_CHARS_CEILING — a
+    quality guard, not a token limit: grounded extraction degrades on very
+    long contexts. max_faqs scales with the batch so bigger batches don't
+    reduce total FAQ yield.
+    """
+    context = context_tokens_for(model_type, model_name)
+    usable = context - _PROMPT_OVERHEAD_TOKENS - output_tokens_for(_MAX_FAQS_PER_BATCH)
+    raw_chars = int(usable * _CHARS_PER_TOKEN * _SAFETY)
+    batch_chars = max(settings.FAQ_MAX_BATCH_CHARS, min(raw_chars, settings.FAQ_MAX_BATCH_CHARS_CEILING))
+    max_faqs = max(_MIN_FAQS_PER_BATCH, min(batch_chars // _CHARS_PER_FAQ, _MAX_FAQS_PER_BATCH))
+    return batch_chars, max_faqs

--- a/backend/app/utils/urls.py
+++ b/backend/app/utils/urls.py
@@ -1,0 +1,40 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import re
+
+# Any scheme prefix, matched case-insensitively so "HTTP://" can't sneak past
+# scheme checks or get a second scheme prepended.
+_SCHEME_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9+.-]*)://")
+
+
+def normalize_url(value: str, require_https: bool = False) -> str:
+    """Normalize a user-supplied URL: default the scheme to https and lowercase
+    an existing scheme. Raises ValueError for blank input, non-http(s) schemes,
+    and — when require_https is set — plain http URLs.
+    """
+    value = value.strip()
+    if not value:
+        raise ValueError("URL must not be blank")
+    match = _SCHEME_RE.match(value)
+    if match:
+        scheme = match.group(1).lower()
+        if scheme not in ("http", "https"):
+            raise ValueError("URL must use http or https")
+        if require_https and scheme != "https":
+            raise ValueError("URL must use https")
+        return f"{scheme}://{value[match.end():]}"
+    return f"https://{value}"

--- a/backend/app/workers/faq_processor.py
+++ b/backend/app/workers/faq_processor.py
@@ -27,7 +27,7 @@ from app.models.notification import NotificationType
 from app.repositories.faq_generation_job import FAQGenerationJobRepository
 from app.services.faq_article_import import run_article_import_job
 from app.services.faq_generation import run_generation_job
-from app.services.faq_import import run_import_job
+from app.services.faq_import import run_import_job, run_pdf_import_job
 from app.services.notifications import notify_user
 
 logger = get_logger(__name__)
@@ -50,6 +50,8 @@ async def process_faq_job(job_id: int):
                 created = await run_import_job(db, job)
             elif job.job_type == FAQJobType.IMPORT_ARTICLES.value:
                 created = await run_article_import_job(db, job)
+            elif job.job_type == FAQJobType.IMPORT_PDF.value:
+                created = await run_pdf_import_job(db, job)
             else:
                 created = await run_generation_job(db, job)
             job_repo.mark_completed(job.id, faqs_created=created)

--- a/backend/app/workers/faq_processor.py
+++ b/backend/app/workers/faq_processor.py
@@ -25,6 +25,7 @@ from app.core.logger import get_logger
 from app.models.faq_generation_job import FAQJobType
 from app.models.notification import NotificationType
 from app.repositories.faq_generation_job import FAQGenerationJobRepository
+from app.services.faq_article_import import run_article_import_job
 from app.services.faq_generation import run_generation_job
 from app.services.faq_import import run_import_job
 from app.services.notifications import notify_user
@@ -47,6 +48,8 @@ async def process_faq_job(job_id: int):
             job_repo.mark_processing(job.id)
             if job.job_type == FAQJobType.IMPORT_URL.value:
                 created = await run_import_job(db, job)
+            elif job.job_type == FAQJobType.IMPORT_ARTICLES.value:
+                created = await run_article_import_job(db, job)
             else:
                 created = await run_generation_job(db, job)
             job_repo.mark_completed(job.id, faqs_created=created)

--- a/backend/app/workers/faq_processor.py
+++ b/backend/app/workers/faq_processor.py
@@ -44,25 +44,38 @@ async def process_faq_job(job_id: int):
         if not job:
             logger.error(f"FAQ job {job_id} not found")
             return
+        # Captured before the try: after a DB failure + rollback the ORM
+        # instance is expired and attribute access could raise or re-query.
+        job_type = job.job_type
+        is_import = job_type in (
+            FAQJobType.IMPORT_URL.value,
+            FAQJobType.IMPORT_ARTICLES.value,
+            FAQJobType.IMPORT_PDF.value,
+        )
         try:
             job_repo.mark_processing(job.id)
-            if job.job_type == FAQJobType.IMPORT_URL.value:
+            if job_type == FAQJobType.IMPORT_URL.value:
                 created = await run_import_job(db, job)
-            elif job.job_type == FAQJobType.IMPORT_ARTICLES.value:
+            elif job_type == FAQJobType.IMPORT_ARTICLES.value:
                 created = await run_article_import_job(db, job)
-            elif job.job_type == FAQJobType.IMPORT_PDF.value:
+            elif job_type == FAQJobType.IMPORT_PDF.value:
                 created = await run_pdf_import_job(db, job)
             else:
                 created = await run_generation_job(db, job)
             job_repo.mark_completed(job.id, faqs_created=created)
+            if created:
+                body = f"{created} draft FAQ{'s' if created != 1 else ''} added — review and publish them in Help center."
+            elif is_import:
+                body = "Nothing new was imported — the pages were unreadable or duplicated existing FAQs."
+            else:
+                body = "No new FAQs were found — your existing FAQs already cover this content."
             await notify_user(
                 db,
                 job.user_id,
                 NotificationType.FAQ_GENERATED,
-                "Draft FAQs ready for review",
-                f"{created} draft FAQ{'s' if created != 1 else ''} added — review and publish them in FAQ & Help Center."
-                if created
-                else "No new FAQs were found — your existing FAQs already cover this content.",
+                "Imported drafts ready for review" if is_import and created else
+                ("Import finished" if is_import else "Draft FAQs ready for review"),
+                body,
                 metadata={"faq_job_id": job.id},
             )
         except Exception as e:
@@ -78,7 +91,7 @@ async def process_faq_job(job_id: int):
                 db,
                 job.user_id,
                 NotificationType.FAQ_GENERATION_FAILED,
-                "FAQ generation failed",
+                "FAQ import failed" if is_import else "FAQ generation failed",
                 str(e),
                 metadata={"faq_job_id": job.id},
             )

--- a/backend/app/workers/faq_processor.py
+++ b/backend/app/workers/faq_processor.py
@@ -112,9 +112,26 @@ async def run_faq_processor():
     await asyncio.gather(*[process_with_semaphore(job_id) for job_id in pending_ids])
 
 
+def reap_orphaned_jobs() -> None:
+    """Fail jobs left in `processing` by a previous crash/kill. Runs once at
+    startup: this worker is the only writer of `processing`, so on a fresh boot
+    any such row is orphaned — otherwise it hangs the enqueue guard (one active
+    job per type) and the UI's active-job polling forever."""
+    try:
+        with SessionLocal() as db:
+            reaped = FAQGenerationJobRepository(db).fail_orphaned_processing(
+                "Worker restarted before the job finished — please try again."
+            )
+        if reaped:
+            logger.warning(f"Reaped {reaped} orphaned FAQ job(s) left in 'processing' on startup")
+    except Exception as e:
+        logger.error(f"FAQ orphan reap failed (non-fatal): {e}")
+
+
 async def run_faq_processor_loop(poll_interval: int = POLL_INTERVAL_SECONDS):
     """Forever-loop wrapper — run as an independent task next to the knowledge
     loop so a long FAQ job never delays knowledge ingestion."""
+    reap_orphaned_jobs()
     while True:
         try:
             await run_faq_processor()

--- a/backend/app/workers/faq_processor.py
+++ b/backend/app/workers/faq_processor.py
@@ -97,8 +97,23 @@ async def process_faq_job(job_id: int):
             )
 
 
+_reaped_orphans = False
+
+
+def _reap_orphans_once() -> None:
+    """Reap orphaned `processing` jobs the first time the processor runs in
+    this process — covers both worker entrypoints (the loop wrapper here and
+    run_knowledge_processor's per-iteration call) without reaping every tick."""
+    global _reaped_orphans
+    if _reaped_orphans:
+        return
+    _reaped_orphans = True
+    reap_orphaned_jobs()
+
+
 async def run_faq_processor():
     """Single pass: process every pending FAQ job (bounded concurrency)."""
+    _reap_orphans_once()
     with SessionLocal() as db:
         pending_ids = [job.id for job in FAQGenerationJobRepository(db).get_pending()]
     if not pending_ids:
@@ -130,8 +145,8 @@ def reap_orphaned_jobs() -> None:
 
 async def run_faq_processor_loop(poll_interval: int = POLL_INTERVAL_SECONDS):
     """Forever-loop wrapper — run as an independent task next to the knowledge
-    loop so a long FAQ job never delays knowledge ingestion."""
-    reap_orphaned_jobs()
+    loop so a long FAQ job never delays knowledge ingestion. run_faq_processor
+    reaps orphans on its first call, so no explicit reap is needed here."""
     while True:
         try:
             await run_faq_processor()

--- a/backend/app/workers/faq_processor.py
+++ b/backend/app/workers/faq_processor.py
@@ -1,0 +1,110 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+FAQ generation/import worker. Runs as an independent loop inside the
+knowledge_processor container; `python -m app.workers.faq_processor` also
+works as a standalone service if it ever needs its own container.
+"""
+
+import asyncio
+
+from app.database import SessionLocal
+from app.core.logger import get_logger
+from app.models.faq_generation_job import FAQJobType
+from app.models.notification import NotificationType
+from app.repositories.faq_generation_job import FAQGenerationJobRepository
+from app.services.faq_generation import run_generation_job
+from app.services.faq_import import run_import_job
+from app.services.notifications import notify_user
+
+logger = get_logger(__name__)
+
+MAX_CONCURRENT_FAQ_JOBS = 2
+POLL_INTERVAL_SECONDS = 60
+
+
+async def process_faq_job(job_id: int):
+    """Run one job to a terminal state, with notifications."""
+    with SessionLocal() as db:
+        job_repo = FAQGenerationJobRepository(db)
+        job = job_repo.get_by_id(job_id)
+        if not job:
+            logger.error(f"FAQ job {job_id} not found")
+            return
+        try:
+            job_repo.mark_processing(job.id)
+            if job.job_type == FAQJobType.IMPORT_URL.value:
+                created = await run_import_job(db, job)
+            else:
+                created = await run_generation_job(db, job)
+            job_repo.mark_completed(job.id, faqs_created=created)
+            await notify_user(
+                db,
+                job.user_id,
+                NotificationType.FAQ_GENERATED,
+                "Draft FAQs ready for review",
+                f"{created} draft FAQ{'s' if created != 1 else ''} added — review and publish them in FAQ & Help Center."
+                if created
+                else "No new FAQs were found — your existing FAQs already cover this content.",
+                metadata={"faq_job_id": job.id},
+            )
+        except Exception as e:
+            logger.error(f"FAQ job {job_id} failed: {e}")
+            # A DB-originated failure leaves the session aborted; roll back so
+            # mark_failed and the notification can still be persisted.
+            try:
+                db.rollback()
+            except Exception:
+                pass
+            job_repo.mark_failed(job.id, str(e))
+            await notify_user(
+                db,
+                job.user_id,
+                NotificationType.FAQ_GENERATION_FAILED,
+                "FAQ generation failed",
+                str(e),
+                metadata={"faq_job_id": job.id},
+            )
+
+
+async def run_faq_processor():
+    """Single pass: process every pending FAQ job (bounded concurrency)."""
+    with SessionLocal() as db:
+        pending_ids = [job.id for job in FAQGenerationJobRepository(db).get_pending()]
+    if not pending_ids:
+        return
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_FAQ_JOBS)
+
+    async def process_with_semaphore(job_id: int):
+        async with semaphore:
+            await process_faq_job(job_id)
+
+    await asyncio.gather(*[process_with_semaphore(job_id) for job_id in pending_ids])
+
+
+async def run_faq_processor_loop(poll_interval: int = POLL_INTERVAL_SECONDS):
+    """Forever-loop wrapper — run as an independent task next to the knowledge
+    loop so a long FAQ job never delays knowledge ingestion."""
+    while True:
+        try:
+            await run_faq_processor()
+        except Exception as e:
+            logger.error(f"Error in FAQ processor loop: {e}")
+        await asyncio.sleep(poll_interval)
+
+
+if __name__ == "__main__":
+    logger.info("Starting FAQ processor service")
+    asyncio.run(run_faq_processor_loop())

--- a/backend/app/workers/faq_processor.py
+++ b/backend/app/workers/faq_processor.py
@@ -21,6 +21,7 @@ works as a standalone service if it ever needs its own container.
 import asyncio
 
 from app.database import SessionLocal
+from app.core.config import settings
 from app.core.logger import get_logger
 from app.models.faq_generation_job import FAQJobType
 from app.models.notification import NotificationType
@@ -32,7 +33,6 @@ from app.services.notifications import notify_user
 
 logger = get_logger(__name__)
 
-MAX_CONCURRENT_FAQ_JOBS = 2
 POLL_INTERVAL_SECONDS = 60
 
 
@@ -118,7 +118,7 @@ async def run_faq_processor():
         pending_ids = [job.id for job in FAQGenerationJobRepository(db).get_pending()]
     if not pending_ids:
         return
-    semaphore = asyncio.Semaphore(MAX_CONCURRENT_FAQ_JOBS)
+    semaphore = asyncio.Semaphore(max(1, settings.MAX_CONCURRENT_FAQ_JOBS))
 
     async def process_with_semaphore(job_id: int):
         async with semaphore:

--- a/backend/app/workers/knowledge_processor.py
+++ b/backend/app/workers/knowledge_processor.py
@@ -100,13 +100,24 @@ async def process_queue_item(queue_item_id: int):
                     type=NotificationType.KNOWLEDGE_PROCESSED,
                     title="Knowledge Processing Complete",
                     message=f"Successfully processed {user_friendly_name}",
-                    metadata={"queue_id": queue_item.id}
+                    # The column is notification_metadata; the old metadata=
+                    # kwarg silently shadowed Base.metadata and stored nothing.
+                    notification_metadata={"queue_id": queue_item.id}
                 )
                 db.add(notification)
                 db.commit()
 
                 # Send FCM notification
                 await send_fcm_notification(queue_item.user_id, notification, db)
+
+                # Auto-draft FAQs from the new source for orgs using the help
+                # center. Fully non-fatal — even an import failure of the FAQ
+                # stack must not flip an already-successful run to FAILED.
+                try:
+                    from app.services.faq_generation import maybe_enqueue_auto_faq_job
+                    maybe_enqueue_auto_faq_job(db, queue_item)
+                except Exception as faq_hook_err:
+                    logger.error(f"Auto FAQ hook unavailable (non-fatal): {faq_hook_err}")
 
             queue_item.status = QueueStatus.COMPLETED
             db.commit()
@@ -125,7 +136,7 @@ async def process_queue_item(queue_item_id: int):
                     type=NotificationType.KNOWLEDGE_FAILED,
                     title="Knowledge Processing Failed",
                     message=f"Failed to process {user_friendly_name}: {str(e)}",
-                    metadata={"queue_id": queue_item.id}
+                    notification_metadata={"queue_id": queue_item.id}
                 )
                 db.add(notification)
                 db.commit()
@@ -187,9 +198,22 @@ if __name__ == "__main__":
                 logger.info("Knowledge processor completed, sleeping for 60 seconds")
             except Exception as e:
                 logger.error(f"Error in knowledge processor loop: {str(e)}")
-            
+
             # Sleep for 60 seconds before next run
             await asyncio.sleep(60)
+
+    async def main():
+        """Knowledge and FAQ loops run as independent tasks in this container:
+        a long FAQ generation job never delays knowledge ingestion, and an
+        import failure of the FAQ stack only disables the FAQ half."""
+        tasks = [processor_loop()]
+        try:
+            from app.workers.faq_processor import run_faq_processor_loop
+            tasks.append(run_faq_processor_loop())
+        except Exception as e:
+            logger.error(f"FAQ processor unavailable, running knowledge only: {e}")
+        await asyncio.gather(*tasks)
+
+    # Run both loops
+    asyncio.run(main())
     
-    # Run the processor loop
-    asyncio.run(processor_loop())

--- a/backend/app/workers/run_knowledge_processor.py
+++ b/backend/app/workers/run_knowledge_processor.py
@@ -63,6 +63,14 @@ async def run_processor_loop():
                 logger.info(f"Worker {WORKER_ID}: Iteration {iteration} - Processing completed successfully")
             except Exception as e:
                 logger.error(f"Worker {WORKER_ID}: Iteration {iteration} - Error in knowledge processor: {str(e)}")
+
+            # FAQ generation jobs ride the same loop in this entrypoint too, so
+            # both worker entrypoints drain the FAQ queue.
+            try:
+                from app.workers.faq_processor import run_faq_processor
+                await run_faq_processor()
+            except Exception as e:
+                logger.error(f"Worker {WORKER_ID}: Iteration {iteration} - Error in FAQ processor: {str(e)}")
             
             # Calculate how long the processing took
             elapsed = asyncio.get_event_loop().time() - start_time

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -69,6 +69,11 @@ firebase_admin
 beautifulsoup4
 aiofiles
 
+# help-center article rendering: FAQ answers are authored/stored as Markdown and
+# rendered to sanitized HTML on the public page (markdown -> nh3 allowlist clean).
+markdown
+nh3
+
 gunicorn
 
 redis

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -73,6 +73,9 @@ aiofiles
 # rendered to sanitized HTML on the public page (markdown -> nh3 allowlist clean).
 markdown
 nh3
+# help-center article import: crawled help pages are converted HTML -> Markdown
+# (subclassed converter re-hosts images and absolutizes links inline).
+markdownify
 
 gunicorn
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -105,3 +105,7 @@ httpx
 pyOpenSSL==26.0.0
 cryptography==46.0.3
 crawl4ai>=0.7.0
+
+# Help center (public SSR templates + custom-domain DNS verification)
+jinja2
+dnspython

--- a/backend/tests/agent/test_chat_agent.py
+++ b/backend/tests/agent/test_chat_agent.py
@@ -198,11 +198,9 @@ def mock_db_session(db):
 async def test_chat_agent_initialization(test_organization_id, test_agent, mock_db_session):
     """Test ChatAgent initialization"""
     # Mock the AI config repository and use MockAgentStorage
-    with patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo, \
-         patch('app.agents.chat_agent.AgentShopifyConfigRepository') as mock_shopify_config_repo, \
+    with patch('app.agents.chat_agent.AgentShopifyConfigRepository') as mock_shopify_config_repo, \
          patch('app.agents.chat_agent.JiraRepository') as mock_jira_repo, \
          patch('app.agents.chat_agent.PostgresAgentStorage', return_value=MockAgentStorage()):
-        mock_ai_config_repo.return_value.get_active_config.return_value = None
         mock_shopify_config_repo.return_value.get_agent_shopify_config.return_value = None
         
         # Create a proper AgentWithJiraConfig mock
@@ -251,11 +249,9 @@ async def test_chat_agent_initialization(test_organization_id, test_agent, mock_
 async def test_chat_agent_get_response(test_organization_id, test_agent, test_user, mock_db_session):
     """Test ChatAgent get_response method"""
     # Mock the AI config repository and use MockAgentStorage
-    with patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo, \
-         patch('app.agents.chat_agent.AgentShopifyConfigRepository') as mock_shopify_config_repo, \
+    with patch('app.agents.chat_agent.AgentShopifyConfigRepository') as mock_shopify_config_repo, \
          patch('app.agents.chat_agent.JiraRepository') as mock_jira_repo, \
          patch('app.agents.chat_agent.PostgresAgentStorage', return_value=MockAgentStorage()):
-        mock_ai_config_repo.return_value.get_active_config.return_value = None
         mock_shopify_config_repo.return_value.get_agent_shopify_config.return_value = None
         
         # Create a proper AgentWithJiraConfig mock
@@ -336,11 +332,9 @@ async def test_chat_agent_api_key_validation():
 async def test_chat_agent_error_handling(test_organization_id, test_agent, test_user, mock_db_session):
     """Test ChatAgent error handling"""
     # Mock the AI config repository and use MockAgentStorage
-    with patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo, \
-         patch('app.agents.chat_agent.AgentShopifyConfigRepository') as mock_shopify_config_repo, \
+    with patch('app.agents.chat_agent.AgentShopifyConfigRepository') as mock_shopify_config_repo, \
          patch('app.agents.chat_agent.JiraRepository') as mock_jira_repo, \
          patch('app.agents.chat_agent.PostgresAgentStorage', return_value=MockAgentStorage()):
-        mock_ai_config_repo.return_value.get_active_config.return_value = None
         mock_shopify_config_repo.return_value.get_agent_shopify_config.return_value = None
         
         # Create a proper AgentWithJiraConfig mock

--- a/backend/tests/agents/test_chat_agent_end_chat.py
+++ b/backend/tests/agents/test_chat_agent_end_chat.py
@@ -54,8 +54,6 @@ def chat_agent(mock_agent_data, mock_db):
     mock_ai_config.encrypted_api_key = "test-key"
     
     # Mock AI config repository
-    mock_ai_config_repo = Mock()
-    mock_ai_config_repo.get_active_config.return_value = mock_ai_config
     
     # Mock knowledge search tool
     mock_knowledge_tool = Mock()
@@ -69,9 +67,7 @@ def chat_agent(mock_agent_data, mock_db):
     
     with patch('app.agents.chat_agent.get_db') as mock_get_db, \
          patch('app.agents.chat_agent.JiraRepository') as mock_jira_repo, \
-         patch('app.tools.knowledge_search_byagent.AIConfigRepository', return_value=mock_ai_config_repo), \
          patch('app.tools.knowledge_search_byagent.KnowledgeSearchByAgent', return_value=mock_knowledge_tool), \
-         patch('app.tools.knowledge_search_byagent.decrypt_api_key', return_value="decrypted-test-key"), \
          patch('app.agents.chat_agent.PostgresAgentStorage', return_value=mock_storage), \
          patch('app.agents.chat_agent.settings.DATABASE_URL', "mock://test"), \
          patch.dict('os.environ', mock_env, clear=True):

--- a/backend/tests/agents/test_faq_generator.py
+++ b/backend/tests/agents/test_faq_generator.py
@@ -25,7 +25,6 @@ from app.agents.faq_generator import (
     FAQExtractionResult,
     FAQGeneratorAgent,
     GeneratedFAQ,
-    MAX_FAQS_PER_BATCH,
 )
 from app.models.schemas.faq import MAX_QUESTION_LENGTH
 
@@ -44,7 +43,7 @@ def test_validate_drops_malformed_and_truncates():
             {"question": "Q" * (MAX_QUESTION_LENGTH + 50), "answer": "A", "category": ""},  # over-long + no category
         ]
     }
-    faqs = FAQGeneratorAgent._validate(data)
+    faqs = _agent()._validate(data)
     assert len(faqs) == 2
     assert faqs[0].category == "Getting started"
     assert len(faqs[1].question) == MAX_QUESTION_LENGTH
@@ -52,15 +51,26 @@ def test_validate_drops_malformed_and_truncates():
 
 
 def test_validate_caps_batch_size():
+    agent = _agent()
     items = [
-        {"question": f"Q{i}", "answer": "A", "category": "C"} for i in range(MAX_FAQS_PER_BATCH + 10)
+        {"question": f"Q{i}", "answer": "A", "category": "C"} for i in range(agent.max_faqs + 10)
     ]
-    assert len(FAQGeneratorAgent._validate({"faqs": items})) == MAX_FAQS_PER_BATCH
+    assert len(agent._validate({"faqs": items})) == agent.max_faqs
 
 
 def test_validate_handles_empty_and_none():
-    assert FAQGeneratorAgent._validate({}) == []
-    assert FAQGeneratorAgent._validate({"faqs": None}) == []
+    assert _agent()._validate({}) == []
+    assert _agent()._validate({"faqs": None}) == []
+
+
+def test_batch_sizing_follows_model_context():
+    """A big-context model gets larger batches (and a bigger FAQ cap) than a
+    small-context one — the whole point of context-aware batching."""
+    small = FAQGeneratorAgent(api_key="k", model_name="llama3-8b-8192", model_type="GROQ")
+    big = FAQGeneratorAgent(api_key="k", model_name="claude-sonnet-5", model_type="ANTHROPIC")
+    assert big.batch_chars > small.batch_chars
+    assert big.max_faqs >= small.max_faqs
+    assert big.max_tokens >= small.max_tokens >= 4000
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agents/test_faq_generator.py
+++ b/backend/tests/agents/test_faq_generator.py
@@ -203,6 +203,30 @@ async def test_plain_json_fallback_on_structured_output_failure():
 
 
 @pytest.mark.asyncio
+async def test_metering_hook_counts_fallback_call_too():
+    """on_llm_call fires once per ACTUAL provider call — the fallback's second
+    call must be billed, not hidden inside one 'attempt'."""
+    calls = []
+    fallback_response = MagicMock()
+    fallback_response.content = '{"faqs": []}'
+
+    def fake_agent(**kwargs):
+        agent = MagicMock()
+        if len(calls) == 0:
+            agent.arun = AsyncMock(side_effect=ValueError("no structured outputs"))
+        else:
+            agent.arun = AsyncMock(return_value=fallback_response)
+        return agent
+
+    with patch("app.agents.faq_generator.create_model", return_value=MagicMock()), \
+         patch("agno.agent.Agent", side_effect=fake_agent):
+        agent = _agent("OLLAMA")
+        agent.on_llm_call = lambda: calls.append(1)
+        await agent.generate_from_text("docs")
+    assert len(calls) == 2  # native attempt + plain-JSON fallback
+
+
+@pytest.mark.asyncio
 async def test_plain_json_fallback_on_unparseable_native_text():
     """Native call 'succeeds' but returns prose instead of the model — fall
     back rather than silently dropping the batch."""

--- a/backend/tests/agents/test_faq_generator.py
+++ b/backend/tests/agents/test_faq_generator.py
@@ -162,12 +162,65 @@ async def test_groq_salvage_truncated_mid_array():
 
 
 @pytest.mark.asyncio
-async def test_non_groq_errors_reraise():
+async def test_non_groq_hard_errors_still_reraise():
+    """Provider down: the plain-JSON fallback fails the same way → propagate."""
     with patch("app.agents.faq_generator.create_model", return_value=MagicMock()), \
          patch("agno.agent.Agent") as MockAgent:
         MockAgent.return_value.arun = AsyncMock(side_effect=RuntimeError("provider down"))
         with pytest.raises(RuntimeError):
             await _agent("OPENAI").generate_from_text("docs")
+    assert MockAgent.call_count == 2  # native attempt + fallback attempt
+
+
+@pytest.mark.asyncio
+async def test_plain_json_fallback_on_structured_output_failure():
+    """Providers without native structured outputs: first attempt raises, the
+    plain-JSON retry parses the raw text (fences and prose tolerated)."""
+    fallback_response = MagicMock()
+    fallback_response.content = (
+        'Sure! ```json\n{"faqs": [{"question": "How do I export data?", '
+        '"answer": "From Settings.", "category": "Data"}]}\n```'
+    )
+    attempts = []
+
+    def fake_agent(**kwargs):
+        agent = MagicMock()
+        if not attempts:
+            attempts.append("native")
+            agent.arun = AsyncMock(side_effect=ValueError("structured_outputs unsupported"))
+        else:
+            attempts.append("fallback")
+            assert "ONLY a JSON object" in kwargs["instructions"]
+            assert kwargs["response_model"] is None
+            agent.arun = AsyncMock(return_value=fallback_response)
+        return agent
+
+    with patch("app.agents.faq_generator.create_model", return_value=MagicMock()), \
+         patch("agno.agent.Agent", side_effect=fake_agent):
+        faqs = await _agent("OLLAMA").generate_from_text("docs")
+    assert attempts == ["native", "fallback"]
+    assert [f.question for f in faqs] == ["How do I export data?"]
+
+
+@pytest.mark.asyncio
+async def test_plain_json_fallback_on_unparseable_native_text():
+    """Native call 'succeeds' but returns prose instead of the model — fall
+    back rather than silently dropping the batch."""
+    bad_native = MagicMock()
+    bad_native.content = "Here are some FAQs I found: 1) How..."
+    good_fallback = MagicMock()
+    good_fallback.content = '{"faqs": [{"question": "Q?", "answer": "A.", "category": "C"}]}'
+    responses = [bad_native, good_fallback]
+
+    def fake_agent(**kwargs):
+        agent = MagicMock()
+        agent.arun = AsyncMock(return_value=responses.pop(0))
+        return agent
+
+    with patch("app.agents.faq_generator.create_model", return_value=MagicMock()), \
+         patch("agno.agent.Agent", side_effect=fake_agent):
+        faqs = await _agent("MISTRAL").generate_from_text("docs")
+    assert [f.question for f in faqs] == ["Q?"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agents/test_faq_generator.py
+++ b/backend/tests/agents/test_faq_generator.py
@@ -1,0 +1,180 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Tests for the FAQ generator agent: structured-output parsing on both provider
+paths (native response_model and the Groq json tool), output validation, and
+prompt assembly (dedup list + category steering).
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.agents.faq_generator import (
+    FAQExtractionResult,
+    FAQGeneratorAgent,
+    GeneratedFAQ,
+    MAX_FAQS_PER_BATCH,
+)
+from app.models.schemas.faq import MAX_QUESTION_LENGTH
+
+
+def _agent(model_type: str = "OPENAI") -> FAQGeneratorAgent:
+    return FAQGeneratorAgent(api_key="k", model_name="m", model_type=model_type)
+
+
+def test_validate_drops_malformed_and_truncates():
+    data = {
+        "faqs": [
+            {"question": "How do I sign up?", "answer": "Use your work email.", "category": "Getting started"},
+            {"question": "", "answer": "orphan answer", "category": "X"},          # blank question
+            {"question": "No answer?", "answer": "", "category": "X"},             # blank answer
+            "not-a-dict",
+            {"question": "Q" * (MAX_QUESTION_LENGTH + 50), "answer": "A", "category": ""},  # over-long + no category
+        ]
+    }
+    faqs = FAQGeneratorAgent._validate(data)
+    assert len(faqs) == 2
+    assert faqs[0].category == "Getting started"
+    assert len(faqs[1].question) == MAX_QUESTION_LENGTH
+    assert faqs[1].category == "General"
+
+
+def test_validate_caps_batch_size():
+    items = [
+        {"question": f"Q{i}", "answer": "A", "category": "C"} for i in range(MAX_FAQS_PER_BATCH + 10)
+    ]
+    assert len(FAQGeneratorAgent._validate({"faqs": items})) == MAX_FAQS_PER_BATCH
+
+
+def test_validate_handles_empty_and_none():
+    assert FAQGeneratorAgent._validate({}) == []
+    assert FAQGeneratorAgent._validate({"faqs": None}) == []
+
+
+@pytest.mark.asyncio
+async def test_native_path_returns_validated_faqs():
+    """Non-Groq providers: agno returns FAQExtractionResult via response_model."""
+    result = FAQExtractionResult(
+        faqs=[GeneratedFAQ(question="How does billing work?", answer="Per seat.", category="Billing")]
+    )
+    response = MagicMock()
+    response.content = result
+    with patch("app.agents.faq_generator.create_model", return_value=MagicMock()), \
+         patch("agno.agent.Agent") as MockAgent:
+        MockAgent.return_value.arun = AsyncMock(return_value=response)
+        faqs = await _agent("OPENAI").generate_from_text("Billing docs...")
+    assert [f.question for f in faqs] == ["How does billing work?"]
+    # Native path must configure structured outputs, not the json tool.
+    kwargs = MockAgent.call_args.kwargs
+    assert kwargs["response_model"] is FAQExtractionResult
+    assert kwargs["structured_outputs"] is True
+    assert kwargs["tools"] == []
+
+
+@pytest.mark.asyncio
+async def test_groq_path_reads_capture_from_json_tool():
+    """Groq: the json tool records arguments into the capture dict."""
+    captured_tools = {}
+
+    def fake_agent(**kwargs):
+        captured_tools["tools"] = kwargs["tools"]
+        agent = MagicMock()
+
+        async def arun(message, stream):
+            # Simulate the model calling the registered `json` tool.
+            kwargs["tools"][0].entrypoint(
+                faqs=[{"question": "Is data encrypted?", "answer": "Yes, AES-256.", "category": "Security"}]
+            )
+            return MagicMock(content="tool called")
+
+        agent.arun = arun
+        return agent
+
+    with patch("app.agents.faq_generator.create_model", return_value=MagicMock()), \
+         patch("agno.agent.Agent", side_effect=fake_agent) as MockAgent:
+        faqs = await _agent("GROQ").generate_from_text("Security docs...")
+
+    assert [f.category for f in faqs] == ["Security"]
+    kwargs = MockAgent.call_args.kwargs
+    assert kwargs["response_model"] is None
+    assert kwargs["structured_outputs"] is False
+    assert len(captured_tools["tools"]) == 1
+    assert captured_tools["tools"][0].name == "json"
+
+
+async def _salvage(failed_generation: str):
+    """Run the Groq path against an arun() failure carrying failed_generation."""
+    import json as _json
+
+    exc = Exception(_json.dumps({"error": {"failed_generation": failed_generation}}))
+    with patch("app.agents.faq_generator.create_model", return_value=MagicMock()), \
+         patch("agno.agent.Agent") as MockAgent:
+        MockAgent.return_value.arun = AsyncMock(side_effect=exc)
+        return await _agent("GROQ").generate_from_text("Account docs...")
+
+
+@pytest.mark.asyncio
+async def test_groq_salvage_complete_tool_call():
+    """A complete tool call inside failed_generation (rejected for another
+    reason) parses despite the trailing wrapper braces."""
+    faqs = await _salvage(
+        '{"name": "json", "arguments": {"faqs": [{"question": "How do I reset my password?", '
+        '"answer": "Use the forgot-password link.", "category": "Account"}]}}'
+    )
+    assert [f.question for f in faqs] == ["How do I reset my password?"]
+
+
+@pytest.mark.asyncio
+async def test_groq_salvage_truncated_mid_array():
+    """Truncation mid-answer inside the faqs ARRAY still yields every pair up
+    to the cut (needs bracket-aware repair, not flat closers). The final,
+    partially-cut answer survives as a reviewable draft — same policy as the
+    chat agent's truncated messages."""
+    faqs = await _salvage(
+        '{"name": "json", "arguments": {"faqs": ['
+        '{"question": "How do I reset my password?", "answer": "Use the forgot-password link.", "category": "Account"}, '
+        '{"question": "Can I invite my team?", "answer": "Yes — go to Settings and se'
+    )
+    assert [f.question for f in faqs] == ["How do I reset my password?", "Can I invite my team?"]
+    assert faqs[1].answer.endswith("and se")  # truncated tail kept for review
+
+
+@pytest.mark.asyncio
+async def test_non_groq_errors_reraise():
+    with patch("app.agents.faq_generator.create_model", return_value=MagicMock()), \
+         patch("agno.agent.Agent") as MockAgent:
+        MockAgent.return_value.arun = AsyncMock(side_effect=RuntimeError("provider down"))
+        with pytest.raises(RuntimeError):
+            await _agent("OPENAI").generate_from_text("docs")
+
+
+@pytest.mark.asyncio
+async def test_prompt_includes_dedup_and_categories():
+    response = MagicMock()
+    response.content = FAQExtractionResult(faqs=[])
+    with patch("app.agents.faq_generator.create_model", return_value=MagicMock()), \
+         patch("agno.agent.Agent") as MockAgent:
+        arun = AsyncMock(return_value=response)
+        MockAgent.return_value.arun = arun
+        await _agent("OPENAI").generate_from_text(
+            "content body",
+            existing_questions=["How do I sign up?"],
+            existing_categories=["Billing"],
+        )
+    message = arun.call_args.kwargs["message"]
+    instructions = MockAgent.call_args.kwargs["instructions"]
+    assert "How do I sign up?" in message
+    assert "content body" in message
+    assert "Billing" in instructions

--- a/backend/tests/api/test_help_center_api.py
+++ b/backend/tests/api/test_help_center_api.py
@@ -34,6 +34,22 @@ from app.repositories.faq import FAQRepository
 BASE = "/api/v1/help-center"
 
 
+@pytest.fixture(autouse=True)
+def _open_plan_gate(request):
+    """Env-independent plan gating: local dev has the enterprise module (test
+    org has no subscription → everything 403s), CI/OSS doesn't. These tests
+    target the help-center endpoints, not the gate — the plan-gating tests
+    below opt out via the `real_plan_gate` marker to exercise it for real."""
+    if request.node.get_closest_marker("real_plan_gate"):
+        yield
+        return
+    # Patch the names bound inside help_center_access (import-time binding —
+    # patching feature_gate itself would not reach them).
+    with patch("app.services.help_center_access.feature_allowed", return_value=True), \
+         patch("app.services.help_center_access.check_feature_access", return_value=None):
+        yield
+
+
 @pytest.fixture
 def client(db, test_user):
     # The shared test_role lacks manage_knowledge, which every help-center
@@ -147,13 +163,45 @@ def test_bulk_status_publish(client, db, test_organization):
     assert r.json()["updated"] == 3
 
 
+def test_bulk_delete_is_org_scoped(client, db, test_organization):
+    from app.models.organization import Organization
+    mine = [str(_create_faq(db, test_organization.id, question=f"D{i}?").id) for i in range(2)]
+    other_org = Organization(name="Other2", domain="other2.com", timezone="UTC")
+    db.add(other_org)
+    db.commit()
+    foreign = _create_faq(db, other_org.id)
+
+    r = client.post(f"{BASE}/faqs/bulk-delete", json={"faq_ids": mine + [str(foreign.id)]})
+    assert r.status_code == 200
+    assert r.json()["deleted"] == 2  # foreign id silently ignored
+    assert client.get(f"{BASE}/faqs").json()["pagination"]["total"] == 0
+    db.expire_all()
+    assert db.get(FAQ, foreign.id) is not None  # other org untouched
+
+
 # ---------- generation / import ----------
 
 def test_generate_requires_ai_config(client):
     assert client.post(f"{BASE}/generate").status_code == 400
 
 
-def test_generate_enqueues_and_409s_on_duplicate(client, test_ai_config):
+def _create_knowledge(db, org_id, source="docs.example.com"):
+    from app.models.knowledge import Knowledge, SourceType
+    knowledge = Knowledge(
+        source=source, source_type=SourceType.WEBSITE,
+        schema="ai", table_name="d_test", organization_id=org_id,
+    )
+    db.add(knowledge)
+    db.commit()
+    return knowledge
+
+
+def test_generate_requires_knowledge_sources(client, test_ai_config):
+    assert client.post(f"{BASE}/generate").status_code == 400
+
+
+def test_generate_enqueues_and_409s_on_duplicate(client, db, test_organization, test_ai_config):
+    _create_knowledge(db, test_organization.id)
     first = client.post(f"{BASE}/generate")
     assert first.status_code == 202
     assert first.json()["status"] == "pending"
@@ -161,6 +209,26 @@ def test_generate_enqueues_and_409s_on_duplicate(client, test_ai_config):
     # Polling returns the active job.
     active = client.get(f"{BASE}/jobs")
     assert active.json()["id"] == first.json()["id"]
+
+
+def test_generate_409s_when_all_sources_generated(client, db, test_organization, test_ai_config):
+    knowledge = _create_knowledge(db, test_organization.id)
+    _create_faq(db, test_organization.id, knowledge_id=knowledge.id)
+    r = client.post(f"{BASE}/generate")
+    assert r.status_code == 409
+    assert "already have FAQs" in r.json()["detail"]
+
+
+def test_generate_estimate_reports_new_sources(client, db, test_organization, test_ai_config):
+    generated = _create_knowledge(db, test_organization.id, "done.example.com")
+    _create_faq(db, test_organization.id, knowledge_id=generated.id)
+    _create_knowledge(db, test_organization.id, "new.example.com")
+    r = client.get(f"{BASE}/generate/estimate")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total_sources"] == 2
+    assert body["new_sources"] == 1
+    assert body["estimated_calls"] >= 1
 
 
 def test_import_rejects_internal_hosts(client, test_ai_config):
@@ -197,6 +265,7 @@ def _cloud_gate(feature_available: bool):
     )
 
 
+@pytest.mark.real_plan_gate
 def test_cloud_free_plan_gets_403_on_writes(client, test_ai_config):
     p1, p2, p3 = _cloud_gate(feature_available=False)
     with p1, p2, p3:
@@ -208,6 +277,7 @@ def test_cloud_free_plan_gets_403_on_writes(client, test_ai_config):
         assert settings_response.json()["plan_allowed"] is False
 
 
+@pytest.mark.real_plan_gate
 def test_cloud_pro_plan_allowed(client, test_ai_config):
     p1, p2, p3 = _cloud_gate(feature_available=True)
     with p1, p2, p3:

--- a/backend/tests/api/test_help_center_api.py
+++ b/backend/tests/api/test_help_center_api.py
@@ -1,0 +1,215 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Help-center admin API tests: settings get-or-create + slug, FAQ CRUD and
+publish flow, generation/import job enqueueing (409/400 guards, SSRF),
+and plan gating in simulated cloud mode.
+"""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main  # noqa: F401 — ensures routers are registered on the FastAPI app
+from app.core.application import app
+from app.core.auth import get_current_user, require_permissions
+from app.database import get_db
+from app.models.faq import FAQ, FAQStatus
+from app.repositories.faq import FAQRepository
+
+BASE = "/api/v1/help-center"
+
+
+@pytest.fixture
+def client(db, test_user):
+    # The shared test_role lacks manage_knowledge, which every help-center
+    # endpoint requires.
+    from app.models.permission import Permission
+    perm = Permission(name="manage_knowledge")
+    db.add(perm)
+    test_user.role.permissions.append(perm)
+    db.commit()
+
+    async def override_user():
+        return test_user
+
+    def override_db():
+        yield db
+
+    # NOTE: overriding require_permissions itself would be a no-op (FastAPI
+    # keys overrides on the closure it returns) — the real permission check
+    # runs against test_user's role, which now has manage_knowledge.
+    app.dependency_overrides[get_current_user] = override_user
+    app.dependency_overrides[get_db] = override_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def _create_faq(db, org_id, **kwargs):
+    defaults = dict(question="How do I sign up?", answer="With your email.", category="Getting started")
+    defaults.update(kwargs)
+    return FAQRepository(db).create(FAQ(organization_id=org_id, **defaults))
+
+
+# ---------- settings ----------
+
+def test_settings_get_or_create_assigns_slug_and_defaults(client, test_agent):
+    r = client.get(f"{BASE}/settings")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["slug"] == "test-organization"
+    assert body["live_url"].startswith("https://test-organization.")
+    assert body["plan_allowed"] is True  # OSS mode: never locked
+    assert body["auto_generate"] is True
+    assert body["ai_search_enabled"] is True
+    assert [a["name"] for a in body["agents"]] == ["Test Agent"]
+    # Second call returns the same row (no duplicate creation).
+    assert client.get(f"{BASE}/settings").json()["slug"] == "test-organization"
+
+
+def test_settings_update_branding(client):
+    client.get(f"{BASE}/settings")
+    r = client.put(f"{BASE}/settings", json={
+        "brand_color": "#0E8C8C",
+        "header_links": [{"label": "Product", "url": "example.com"}],
+        "cta_text": "Sign in",
+        "cta_url": "app.example.com",
+        "enabled": True,
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["brand_color"] == "#0E8C8C"
+    assert body["header_links"] == [{"label": "Product", "url": "https://example.com"}]
+    assert body["cta_url"] == "https://app.example.com"
+    assert body["enabled"] is True
+
+
+def test_settings_update_rejects_bad_color_and_cross_org_agent(client):
+    assert client.put(f"{BASE}/settings", json={"brand_color": "red"}).status_code == 422
+    assert client.put(f"{BASE}/settings", json={"agent_id": str(uuid4())}).status_code == 404
+
+
+# ---------- FAQ CRUD ----------
+
+def test_faq_crud_flow(client, db, test_organization):
+    created = client.post(f"{BASE}/faqs", json={
+        "question": "What does it cost?", "answer": "From $19.", "category": "Billing",
+    })
+    assert created.status_code == 201
+    faq_id = created.json()["id"]
+    assert created.json()["status"] == "draft"
+    assert created.json()["source_label"] == "Added manually"
+
+    # Partial update must not reset omitted fields (category keeps Billing).
+    updated = client.put(f"{BASE}/faqs/{faq_id}", json={"status": "published"})
+    assert updated.status_code == 200
+    assert updated.json()["status"] == "published"
+    assert updated.json()["category"] == "Billing"
+
+    listing = client.get(f"{BASE}/faqs", params={"status": "published"})
+    assert listing.status_code == 200
+    assert listing.json()["pagination"]["total"] == 1
+
+    assert client.get(f"{BASE}/faqs/categories").json() == ["Billing"]
+
+    assert client.delete(f"{BASE}/faqs/{faq_id}").status_code == 204
+    assert client.get(f"{BASE}/faqs").json()["pagination"]["total"] == 0
+
+
+def test_faq_cross_org_is_404(client, db):
+    from app.models.organization import Organization
+    other_org = Organization(name="Other", domain="other.com", timezone="UTC")
+    db.add(other_org)
+    db.commit()
+    foreign = _create_faq(db, other_org.id)
+    assert client.put(f"{BASE}/faqs/{foreign.id}", json={"status": "published"}).status_code == 404
+    assert client.delete(f"{BASE}/faqs/{foreign.id}").status_code == 404
+
+
+def test_bulk_status_publish(client, db, test_organization):
+    ids = [str(_create_faq(db, test_organization.id, question=f"Q{i}?").id) for i in range(3)]
+    r = client.post(f"{BASE}/faqs/bulk-status", json={"faq_ids": ids, "status": "published"})
+    assert r.status_code == 200
+    assert r.json()["updated"] == 3
+
+
+# ---------- generation / import ----------
+
+def test_generate_requires_ai_config(client):
+    assert client.post(f"{BASE}/generate").status_code == 400
+
+
+def test_generate_enqueues_and_409s_on_duplicate(client, test_ai_config):
+    first = client.post(f"{BASE}/generate")
+    assert first.status_code == 202
+    assert first.json()["status"] == "pending"
+    assert client.post(f"{BASE}/generate").status_code == 409
+    # Polling returns the active job.
+    active = client.get(f"{BASE}/jobs")
+    assert active.json()["id"] == first.json()["id"]
+
+
+def test_import_rejects_internal_hosts(client, test_ai_config):
+    with patch("app.api.help_center.generation.resolves_to_blocked_host", return_value=True):
+        assert client.post(f"{BASE}/import", json={"url": "https://internal.host/faq"}).status_code == 400
+
+
+def test_import_enqueues_with_source_url(client, test_ai_config):
+    with patch("app.api.help_center.generation.resolves_to_blocked_host", return_value=False):
+        r = client.post(f"{BASE}/import", json={"url": "support.example.com/faq"})
+    assert r.status_code == 202
+    assert r.json()["source_url"] == "https://support.example.com/faq"
+    assert r.json()["job_type"] == "import_url"
+
+
+def test_job_by_id_cross_org_404(client):
+    assert client.get(f"{BASE}/jobs/999999").status_code == 404
+
+
+# ---------- plan gating (simulated cloud) ----------
+
+def _cloud_gate(feature_available: bool):
+    """Simulate the enterprise module being present with a plan whose
+    help_center flag is `feature_available`."""
+    subscription = MagicMock(plan_id=uuid4())
+    plan_repo = MagicMock()
+    plan_repo.check_feature_availability.return_value = feature_available
+    return (
+        patch("app.services.feature_gate.HAS_ENTERPRISE", True),
+        patch("app.services.feature_gate.require_accessible_subscription",
+              return_value=subscription, create=True),
+        patch("app.services.feature_gate.PlanRepository",
+              return_value=plan_repo, create=True),
+    )
+
+
+def test_cloud_free_plan_gets_403_on_writes(client, test_ai_config):
+    p1, p2, p3 = _cloud_gate(feature_available=False)
+    with p1, p2, p3:
+        assert client.post(f"{BASE}/faqs", json={"question": "Q?", "answer": "A."}).status_code == 403
+        assert client.post(f"{BASE}/generate").status_code == 403
+        # Ungated read still works and reports the lock.
+        settings_response = client.get(f"{BASE}/settings")
+        assert settings_response.status_code == 200
+        assert settings_response.json()["plan_allowed"] is False
+
+
+def test_cloud_pro_plan_allowed(client, test_ai_config):
+    p1, p2, p3 = _cloud_gate(feature_available=True)
+    with p1, p2, p3:
+        assert client.post(f"{BASE}/faqs", json={"question": "Q?", "answer": "A."}).status_code == 201
+        assert client.get(f"{BASE}/settings").json()["plan_allowed"] is True

--- a/backend/tests/api/test_help_center_public.py
+++ b/backend/tests/api/test_help_center_public.py
@@ -1,0 +1,185 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Public help-center tests: host resolution, published-only rendering with
+escaping and JSON-LD, plan/enabled gating (404s), Ask AI guards, host
+dispatch routing.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.help_center_public import public_app
+from app.core.help_center_host import is_help_center_host
+from app.database import get_db
+from app.models.faq import FAQ, FAQStatus
+from app.models.help_center import HelpCenterSettings
+from app.repositories.faq import FAQRepository
+from app.services.help_center_public import contrast_ink, resolve_help_center, slug_for_host
+
+HOST = "test-org.chattermate.help"
+
+
+@pytest.fixture
+def client(db):
+    def override_db():
+        yield db
+
+    public_app.dependency_overrides[get_db] = override_db
+    yield TestClient(public_app)
+    public_app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def help_center(db, test_organization):
+    row = HelpCenterSettings(
+        organization_id=test_organization.id,
+        slug="test-org",
+        enabled=True,
+        brand_color="#4338CA",
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _publish_faq(db, org_id, question="How do I sign up?", answer="Use your <b>email</b>.", category="Getting started"):
+    return FAQRepository(db).create(FAQ(
+        organization_id=org_id, question=question, answer=answer,
+        category=category, status=FAQStatus.PUBLISHED,
+    ))
+
+
+# ---------- helpers ----------
+
+def test_slug_for_host():
+    assert slug_for_host("acme.chattermate.help") == "acme"
+    assert slug_for_host("a.b.chattermate.help") is None
+    assert slug_for_host("chattermate.help") is None
+    assert slug_for_host("help.acme.com") is None
+
+
+def test_contrast_ink():
+    assert contrast_ink("#FFFFFF") == "#12131A"
+    assert contrast_ink("#0B0C10") == "#FFFFFF"
+    assert contrast_ink("not-a-color") == "#FFFFFF"
+
+
+# ---------- rendering ----------
+
+def test_page_renders_published_only_and_escapes(client, db, test_organization, help_center):
+    _publish_faq(db, test_organization.id)
+    FAQRepository(db).create(FAQ(
+        organization_id=test_organization.id, question="Secret draft?",
+        answer="Hidden.", category="Getting started", status=FAQStatus.DRAFT,
+    ))
+    r = client.get("/", headers={"host": HOST})
+    assert r.status_code == 200
+    assert "How do I sign up?" in r.text
+    assert "Secret draft?" not in r.text
+    # Org content is escaped, never raw HTML.
+    assert "<b>email</b>" not in r.text
+    assert "&lt;b&gt;email&lt;/b&gt;" in r.text
+    # SEO artifacts.
+    assert 'application/ld+json' in r.text and "FAQPage" in r.text
+    assert f'<link rel="canonical" href="https://{HOST}/">' in r.text
+    assert r.headers["cache-control"] == "public, max-age=60"
+
+
+def test_search_filters_results(client, db, test_organization, help_center):
+    _publish_faq(db, test_organization.id, question="How does billing work?", answer="Per seat.")
+    _publish_faq(db, test_organization.id, question="Is data encrypted?", answer="Yes.")
+    r = client.get("/", params={"q": "billing"}, headers={"host": HOST})
+    assert "How does billing work?" in r.text
+    assert "Is data encrypted?" not in r.text
+
+
+def test_disabled_or_unknown_hosts_404(client, db, test_organization, help_center):
+    assert client.get("/", headers={"host": "nope.chattermate.help"}).status_code == 404
+    help_center.enabled = False
+    db.commit()
+    assert client.get("/", headers={"host": HOST}).status_code == 404
+
+
+def test_lapsed_plan_hides_site(client, db, test_organization, help_center):
+    with patch("app.services.help_center_public.help_center_allowed", return_value=False):
+        assert client.get("/", headers={"host": HOST}).status_code == 404
+
+
+def test_sitemap_and_robots(client, db, test_organization, help_center):
+    sitemap = client.get("/sitemap.xml", headers={"host": HOST})
+    assert sitemap.status_code == 200 and f"https://{HOST}/" in sitemap.text
+    robots = client.get("/robots.txt", headers={"host": HOST})
+    assert "Sitemap:" in robots.text
+
+
+# ---------- ask ----------
+
+def test_ask_disabled_404(client, db, test_organization, help_center):
+    help_center.ai_search_enabled = False
+    db.commit()
+    r = client.post("/ask", json={"question": "How do I sign up?"}, headers={"host": HOST})
+    assert r.status_code == 404
+
+
+def test_ask_answers_and_rate_limits(client, db, test_organization, help_center, test_agent):
+    help_center.agent_id = test_agent.id
+    db.commit()
+    with patch("app.api.help_center_public.answer_question", new=AsyncMock(return_value="From your dashboard.")):
+        ok = client.post("/ask", json={"question": "Where do I log in?"}, headers={"host": HOST})
+        assert ok.status_code == 200
+        assert ok.json()["answer"] == "From your dashboard."
+    with patch("app.api.help_center_public.allow_request", return_value=False):
+        limited = client.post("/ask", json={"question": "again?"}, headers={"host": HOST})
+        assert limited.status_code == 429
+
+
+def test_ask_unanswerable_503(client, db, test_organization, help_center, test_agent):
+    help_center.agent_id = test_agent.id
+    db.commit()
+    with patch("app.api.help_center_public.answer_question", new=AsyncMock(return_value=None)):
+        r = client.post("/ask", json={"question": "Where do I log in?"}, headers={"host": HOST})
+        assert r.status_code == 503
+
+
+# ---------- host dispatch ----------
+
+def test_is_help_center_host_matches_subdomains_only():
+    assert is_help_center_host("acme.chattermate.help") is True
+    assert is_help_center_host("chattermate.help") is False
+    assert is_help_center_host("api.chattermate.chat") is False
+    assert is_help_center_host("") is False
+
+
+def test_is_help_center_host_checks_verified_domain_cache():
+    with patch("app.core.help_center_host._domain_cache") as cache:
+        cache.contains.return_value = True
+        assert is_help_center_host("help.customer.com") is True
+        cache.contains.assert_called_once_with("help.customer.com")
+
+
+def test_resolve_help_center_via_verified_domain(db, test_organization, help_center):
+    help_center.custom_domain = "help.customer.com"
+    help_center.txt_record_verified = True
+    help_center.cname_record_verified = True
+    db.commit()
+    assert resolve_help_center(db, "help.customer.com").id == help_center.id
+    # Unverified custom domains never resolve.
+    help_center.txt_record_verified = False
+    db.commit()
+    assert resolve_help_center(db, "help.customer.com") is None

--- a/backend/tests/services/test_domain_verification.py
+++ b/backend/tests/services/test_domain_verification.py
@@ -33,6 +33,16 @@ from app.services import domain_verification as dv
 BASE = "/api/v1/help-center"
 
 
+@pytest.fixture(autouse=True)
+def _open_plan_gate():
+    """Env-independent plan gating: local dev has the enterprise module (test
+    org has no subscription → 403s), CI/OSS doesn't. These tests target the
+    domain endpoints, not the gate."""
+    with patch("app.services.help_center_access.feature_allowed", return_value=True), \
+         patch("app.services.help_center_access.check_feature_access", return_value=None):
+        yield
+
+
 @pytest.fixture
 def row(db, test_organization):
     settings_row = HelpCenterSettings(organization_id=test_organization.id, slug="test-org")

--- a/backend/tests/services/test_domain_verification.py
+++ b/backend/tests/services/test_domain_verification.py
@@ -1,0 +1,167 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Domain verification tests with mocked DNS/HTTPS: claim/reset semantics,
+per-record outcomes, verified transitions and SSL probe states, plus the
+domain API endpoints.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main  # noqa: F401 — ensures routers are registered
+from app.core.application import app
+from app.core.auth import get_current_user
+from app.database import get_db
+from app.models.help_center import HelpCenterSettings, DomainStatus, SSLStatus
+from app.services import domain_verification as dv
+
+BASE = "/api/v1/help-center"
+
+
+@pytest.fixture
+def row(db, test_organization):
+    settings_row = HelpCenterSettings(organization_id=test_organization.id, slug="test-org")
+    db.add(settings_row)
+    db.commit()
+    db.refresh(settings_row)
+    return settings_row
+
+
+@pytest.fixture
+def client(db, test_user):
+    from app.models.permission import Permission
+    perm = Permission(name="manage_knowledge")
+    db.add(perm)
+    test_user.role.permissions.append(perm)
+    db.commit()
+
+    async def override_user():
+        return test_user
+
+    def override_db():
+        yield db
+
+    app.dependency_overrides[get_current_user] = override_user
+    app.dependency_overrides[get_db] = override_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_set_domain_generates_token_and_resets_state(db, row):
+    row = dv.set_custom_domain(db, row, "help.customer.com")
+    assert row.custom_domain == "help.customer.com"
+    assert len(row.domain_verification_token) == 32
+    assert row.domain_status == DomainStatus.PENDING
+    first_token = row.domain_verification_token
+    # Re-claiming rotates the token and resets verification.
+    row.txt_record_verified = True
+    db.commit()
+    row = dv.set_custom_domain(db, row, "support.customer.com")
+    assert row.domain_verification_token != first_token
+    assert row.txt_record_verified is False
+
+
+def test_set_domain_rejects_base_domain_hosts(db, row):
+    with pytest.raises(ValueError):
+        dv.set_custom_domain(db, row, "acme.chattermate.help")
+
+
+def test_verify_partial_records_stay_pending(db, row):
+    dv.set_custom_domain(db, row, "help.customer.com")
+    with patch.object(dv, "check_txt_record", return_value=True), \
+         patch.object(dv, "check_cname_record", return_value=False):
+        row = dv.verify_custom_domain(db, row)
+    assert row.txt_record_verified is True
+    assert row.cname_record_verified is False
+    assert row.domain_status == DomainStatus.PENDING
+    assert row.ssl_status == SSLStatus.NONE.value
+    assert row.domain_verified_at is None
+
+
+def test_verify_both_records_marks_verified_and_probes_ssl(db, row):
+    dv.set_custom_domain(db, row, "help.customer.com")
+    with patch.object(dv, "check_txt_record", return_value=True), \
+         patch.object(dv, "check_cname_record", return_value=True), \
+         patch.object(dv, "probe_ssl", return_value=False):
+        row = dv.verify_custom_domain(db, row)
+    assert row.domain_status == DomainStatus.VERIFIED
+    assert row.domain_verified_at is not None
+    assert row.ssl_status == SSLStatus.PENDING.value
+
+    with patch.object(dv, "check_txt_record", return_value=True), \
+         patch.object(dv, "check_cname_record", return_value=True), \
+         patch.object(dv, "probe_ssl", return_value=True):
+        row = dv.verify_custom_domain(db, row)
+    assert row.ssl_status == SSLStatus.ACTIVE.value
+
+
+def test_verify_regression_unverifies(db, row):
+    dv.set_custom_domain(db, row, "help.customer.com")
+    with patch.object(dv, "check_txt_record", return_value=True), \
+         patch.object(dv, "check_cname_record", return_value=True), \
+         patch.object(dv, "probe_ssl", return_value=True):
+        row = dv.verify_custom_domain(db, row)
+    assert row.domain_status == DomainStatus.VERIFIED
+    # Records later removed at the DNS provider.
+    with patch.object(dv, "check_txt_record", return_value=False), \
+         patch.object(dv, "check_cname_record", return_value=True):
+        row = dv.verify_custom_domain(db, row)
+    assert row.domain_status == DomainStatus.PENDING
+    assert row.ssl_status == SSLStatus.NONE.value
+
+
+def test_clear_domain(db, row):
+    dv.set_custom_domain(db, row, "help.customer.com")
+    row = dv.clear_custom_domain(db, row)
+    assert row.custom_domain is None
+    assert row.domain_status == DomainStatus.UNVERIFIED
+
+
+# ---------- endpoints ----------
+
+def test_domain_endpoints_flow(client, db, test_organization):
+    set_response = client.post(f"{BASE}/domain", json={"domain": "Help.Customer.COM"})
+    assert set_response.status_code == 200
+    body = set_response.json()
+    assert body["custom_domain"] == "help.customer.com"
+    assert body["domain_status"] == "pending"
+    assert [r["type"] for r in body["records"]] == ["CNAME", "TXT"]
+    assert body["records"][1]["host"] == "_chattermate.help.customer.com"
+
+    with patch.object(dv, "check_txt_record", return_value=True), \
+         patch.object(dv, "check_cname_record", return_value=True), \
+         patch.object(dv, "probe_ssl", return_value=True):
+        verify_response = client.post(f"{BASE}/domain/verify")
+    assert verify_response.status_code == 200
+    assert verify_response.json()["domain_status"] == "verified"
+    assert verify_response.json()["ssl_status"] == "active"
+
+    status_response = client.get(f"{BASE}/domain/status")
+    assert status_response.json()["domain_status"] == "verified"
+
+    removed = client.delete(f"{BASE}/domain")
+    assert removed.json()["custom_domain"] is None
+
+
+def test_verify_without_domain_400(client):
+    assert client.post(f"{BASE}/domain/verify").status_code == 400
+
+
+def test_set_domain_rejects_invalid_hostnames(client):
+    assert client.post(f"{BASE}/domain", json={"domain": "not a domain"}).status_code == 422
+    assert client.post(f"{BASE}/domain", json={"domain": "x.chattermate.help"}).status_code == 400

--- a/backend/tests/services/test_faq_article_import.py
+++ b/backend/tests/services/test_faq_article_import.py
@@ -44,21 +44,32 @@ def _response(text="", url="https://help.example.com/", content=b"", content_typ
     return response
 
 
+# Chatwoot-style homepage: category cards, each a section heading + article
+# links, plus a curated "Featured Articles" cross-cut and a category page link.
 INDEX_HTML = """
 <html><body><main>
   <p>{filler}</p>
-  <a href="/articles/how-to-install">Install</a>
-  <a href="/articles/how-to-install#steps">Install anchor dupe</a>
-  <a href="https://help.example.com/articles/billing/">Billing</a>
-  <a href="https://other-site.com/articles/foreign">Foreign</a>
+  <section>
+    <h2>Featured Articles</h2>
+    <a href="/hc/atoa/articles/1-how-to-install">Install (featured)</a>
+  </section>
+  <section>
+    <h2>📞 Help and support</h2>
+    <a href="/hc/atoa/articles/1-how-to-install">Install</a>
+    <a href="/hc/atoa/articles/2-refunds">Refunds</a>
+    <a href="/hc/atoa/categories/9-help-and-support">View all</a>
+  </section>
+  <a href="https://other-site.com/hc/x/articles/9-foreign">Foreign</a>
   <a href="/downloads/guide.pdf">PDF</a>
-  <a href="/pricing">Pricing (outside /articles)</a>
+  <a href="/pricing">Pricing (not an article)</a>
 </main></body></html>
 """.format(filler="x" * 600)
 
 ARTICLE_HTML = """
 <html><head><title>How to install | Example Help</title></head><body>
-<nav class="breadcrumb"><a href="/">Home</a><a href="/articles">Guides</a><a href="#">Install</a></nav>
+<main>
+<nav><a href="/">Atoa Help Centre</a></nav>
+<div class="crumbs"><a href="/hc/atoa/en">Home</a></div>
 <article>
   <h1>How to install</h1>
   <p>{filler}</p>
@@ -67,21 +78,38 @@ ARTICLE_HTML = """
   <img src="/img/shot.png" alt="screenshot">
   <img src="data:image/png;base64,AAAA" alt="inline">
 </article>
+<span>Last updated on Sep 20, 2024</span>
+<footer><p>Made with <a href="https://www.chatwoot.com">Chatwoot</a></p></footer>
+</main>
 </body></html>
 """.format(filler="Installation takes about two minutes. " * 10)
 
 
-def test_discover_links_bounds_and_filters():
+def test_discover_links_sections_categories_and_filters():
     client = MagicMock()
-    with patch.object(faq_article_import, "_fetch_index_soup") as fetch:
-        from bs4 import BeautifulSoup
-        fetch.return_value = (BeautifulSoup(INDEX_HTML, "html.parser"), "https://help.example.com/articles")
-        links = discover_article_links(client, "https://help.example.com/articles", limit=10)
-    # Same-site only, fragment deduped, pdf skipped; /articles children first.
-    assert links[0] == "https://help.example.com/articles/how-to-install"
-    assert links[1] == "https://help.example.com/articles/billing"
-    assert links[-1] == "https://help.example.com/pricing"
-    assert not any("other-site.com" in link or link.endswith(".pdf") for link in links)
+    from bs4 import BeautifulSoup
+    # A category page reachable via the "View all" link returns the full list.
+    category_page = BeautifulSoup(
+        "<body><main><h1>Help and support</h1>"
+        '<a href="/hc/atoa/articles/2-refunds">Refunds</a>'
+        '<a href="/hc/atoa/articles/3-disputes">Disputes</a>'
+        "</main></body>",
+        "html.parser",
+    )
+    with patch.object(faq_article_import, "_fetch_index_soup") as index_fetch, \
+         patch.object(faq_article_import, "_fetch_soup") as page_fetch:
+        index_fetch.return_value = (BeautifulSoup(INDEX_HTML, "html.parser"), "https://help.example.com/hc/atoa/en")
+        page_fetch.return_value = (category_page, "https://help.example.com/hc/atoa/categories/9-help-and-support")
+        links = discover_article_links(client, "https://help.example.com/hc/atoa/en", limit=20)
+
+    by_url = dict(links)
+    # Only /articles/ pages; off-site, pdf and /pricing excluded.
+    assert not any("other-site.com" in u or u.endswith(".pdf") or "/pricing" in u for u, _ in links)
+    # Featured cross-cut isn't a category; the section heading tags the article.
+    assert by_url["https://help.example.com/hc/atoa/articles/1-how-to-install"] == "Help and support"
+    assert by_url["https://help.example.com/hc/atoa/articles/2-refunds"] == "Help and support"
+    # Article only on the followed category page still imported + categorised.
+    assert by_url["https://help.example.com/hc/atoa/articles/3-disputes"] == "Help and support"
 
 
 def test_discover_links_respects_limit():
@@ -97,7 +125,19 @@ def test_discover_links_respects_limit():
     assert len(links) == 5
 
 
-def test_fetch_article_converts_markdown_and_collects_images():
+def test_discover_links_flat_fallback_without_article_marker():
+    """A non-standard help page with no /articles/ links imports every link."""
+    client = MagicMock()
+    html = f"<body><main><p>{'x' * 600}</p><a href='/faq/pay'>Pay</a><a href='/faq/refund'>Refund</a></main></body>"
+    with patch.object(faq_article_import, "_fetch_index_soup") as fetch:
+        from bs4 import BeautifulSoup
+        fetch.return_value = (BeautifulSoup(html, "html.parser"), "https://help.example.com/faq")
+        links = discover_article_links(client, "https://help.example.com/faq", limit=10)
+    assert {u for u, _ in links} == {"https://help.example.com/faq/pay", "https://help.example.com/faq/refund"}
+    assert all(c is None for _, c in links)  # category resolved per-article later
+
+
+def test_fetch_article_converts_markdown_strips_chrome_and_collects_images():
     client = MagicMock()
     image = _response(content=b"\x89PNG", content_type="image/png")
     with patch.object(faq_article_import, "_fetch_soup") as fetch, \
@@ -105,22 +145,29 @@ def test_fetch_article_converts_markdown_and_collects_images():
         from bs4 import BeautifulSoup
         fetch.return_value = (
             BeautifulSoup(ARTICLE_HTML, "html.parser"),
-            "https://help.example.com/articles/how-to-install",
+            "https://help.example.com/hc/atoa/articles/1-how-to-install",
         )
-        article = fetch_article(client, "https://help.example.com/articles/how-to-install")
+        article = fetch_article(client, "https://help.example.com/hc/atoa/articles/1", "Help and support")
 
     assert article is not None
     assert article.title == "How to install"
-    assert article.category_hint == "Guides"  # breadcrumb second-to-last
+    assert article.category_hint == "Help and support"  # from the category override
     # h1 removed (would duplicate the question), list preserved as Markdown.
     assert "# How to install" not in article.markdown
     assert "1. Download the app." in article.markdown
     # Link absolutized.
     assert "[pricing](https://help.example.com/pricing)" in article.markdown
     # Real image collected as placeholder; data: image reduced to alt text.
-    assert "cm-pending-image://0" in article.markdown
+    assert "cm-pending-image://0.img" in article.markdown
     assert len(article.pending_images) == 1
     assert "base64" not in article.markdown
+    # Help-center chrome stripped: no Chatwoot footer, breadcrumb or metadata.
+    lowered = article.markdown.lower()
+    assert "chatwoot" not in lowered
+    assert "made with" not in lowered
+    assert "last updated" not in lowered
+    assert "[home]" not in lowered
+    assert "atoa help centre" not in lowered
 
 
 def test_converter_skips_oversized_and_wrong_type_images():
@@ -162,8 +209,10 @@ async def test_article_import_job_inserts_drafts(db, test_organization):
             title="How billing works", markdown="**Billing** steps.", category_hint="Billing",
         ),
     }
-    with patch.object(faq_article_import, "discover_article_links", return_value=list(articles)), \
-         patch.object(faq_article_import, "fetch_article", side_effect=lambda c, url: articles[url]):
+    # discover now yields (url, category) pairs; the category flows to fetch_article.
+    discovered = [(url, "Billing") for url in articles]
+    with patch.object(faq_article_import, "discover_article_links", return_value=discovered), \
+         patch.object(faq_article_import, "fetch_article", side_effect=lambda c, url, category: articles[url]):
         created = await run_article_import_job(db, job)
 
     assert created == 1

--- a/backend/tests/services/test_faq_article_import.py
+++ b/backend/tests/services/test_faq_article_import.py
@@ -1,0 +1,174 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Article-mode import tests: link discovery bounds, HTML→Markdown conversion
+(link absolutization, image placeholder/re-host, data: skip), and the
+end-to-end job with mocked fetches.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.faq import FAQ, FAQStatus
+from app.models.faq_generation_job import FAQGenerationJob, FAQJobType
+from app.repositories.faq import FAQRepository
+from app.services import faq_article_import
+from app.services.faq_article_import import (
+    _ArticleConverter,
+    discover_article_links,
+    fetch_article,
+    run_article_import_job,
+)
+
+
+def _response(text="", url="https://help.example.com/", content=b"", content_type="text/html"):
+    response = MagicMock()
+    response.text = text
+    response.url = url
+    response.content = content
+    response.headers = {"content-type": content_type}
+    response.raise_for_status = MagicMock()
+    return response
+
+
+INDEX_HTML = """
+<html><body><main>
+  <p>{filler}</p>
+  <a href="/articles/how-to-install">Install</a>
+  <a href="/articles/how-to-install#steps">Install anchor dupe</a>
+  <a href="https://help.example.com/articles/billing/">Billing</a>
+  <a href="https://other-site.com/articles/foreign">Foreign</a>
+  <a href="/downloads/guide.pdf">PDF</a>
+  <a href="/pricing">Pricing (outside /articles)</a>
+</main></body></html>
+""".format(filler="x" * 600)
+
+ARTICLE_HTML = """
+<html><head><title>How to install | Example Help</title></head><body>
+<nav class="breadcrumb"><a href="/">Home</a><a href="/articles">Guides</a><a href="#">Install</a></nav>
+<article>
+  <h1>How to install</h1>
+  <p>{filler}</p>
+  <ol><li>Download the app.</li><li>Run the installer.</li></ol>
+  <p>See <a href="/pricing">pricing</a> for plans.</p>
+  <img src="/img/shot.png" alt="screenshot">
+  <img src="data:image/png;base64,AAAA" alt="inline">
+</article>
+</body></html>
+""".format(filler="Installation takes about two minutes. " * 10)
+
+
+def test_discover_links_bounds_and_filters():
+    client = MagicMock()
+    with patch.object(faq_article_import, "_fetch_index_soup") as fetch:
+        from bs4 import BeautifulSoup
+        fetch.return_value = (BeautifulSoup(INDEX_HTML, "html.parser"), "https://help.example.com/articles")
+        links = discover_article_links(client, "https://help.example.com/articles", limit=10)
+    # Same-site only, fragment deduped, pdf skipped; /articles children first.
+    assert links[0] == "https://help.example.com/articles/how-to-install"
+    assert links[1] == "https://help.example.com/articles/billing"
+    assert links[-1] == "https://help.example.com/pricing"
+    assert not any("other-site.com" in link or link.endswith(".pdf") for link in links)
+
+
+def test_discover_links_respects_limit():
+    client = MagicMock()
+    many = "".join(f'<a href="/articles/a{i}">A{i}</a>' for i in range(50))
+    with patch.object(faq_article_import, "_fetch_index_soup") as fetch:
+        from bs4 import BeautifulSoup
+        fetch.return_value = (
+            BeautifulSoup(f"<body><main><p>{'x' * 600}</p>{many}</main></body>", "html.parser"),
+            "https://help.example.com/articles",
+        )
+        links = discover_article_links(client, "https://help.example.com/articles", limit=5)
+    assert len(links) == 5
+
+
+def test_fetch_article_converts_markdown_and_collects_images():
+    client = MagicMock()
+    image = _response(content=b"\x89PNG", content_type="image/png")
+    with patch.object(faq_article_import, "_fetch_soup") as fetch, \
+         patch.object(faq_article_import, "safe_get", return_value=image):
+        from bs4 import BeautifulSoup
+        fetch.return_value = (
+            BeautifulSoup(ARTICLE_HTML, "html.parser"),
+            "https://help.example.com/articles/how-to-install",
+        )
+        article = fetch_article(client, "https://help.example.com/articles/how-to-install")
+
+    assert article is not None
+    assert article.title == "How to install"
+    assert article.category_hint == "Guides"  # breadcrumb second-to-last
+    # h1 removed (would duplicate the question), list preserved as Markdown.
+    assert "# How to install" not in article.markdown
+    assert "1. Download the app." in article.markdown
+    # Link absolutized.
+    assert "[pricing](https://help.example.com/pricing)" in article.markdown
+    # Real image collected as placeholder; data: image reduced to alt text.
+    assert "cm-pending-image://0" in article.markdown
+    assert len(article.pending_images) == 1
+    assert "base64" not in article.markdown
+
+
+def test_converter_skips_oversized_and_wrong_type_images():
+    client = MagicMock()
+    too_big = _response(content=b"x" * (faq_article_import.MAX_FAQ_IMAGE_BYTES + 1), content_type="image/png")
+    wrong_type = _response(content=b"x", content_type="image/svg+xml")
+    for response in (too_big, wrong_type):
+        with patch.object(faq_article_import, "safe_get", return_value=response):
+            converter = _ArticleConverter(base_url="https://a.example.com/", client=client)
+            markdown = converter.convert('<img src="/i.png" alt="pic">')
+        assert converter.images == {}
+        assert "pic" in markdown and "![" not in markdown
+
+
+@pytest.mark.asyncio
+async def test_article_import_job_inserts_drafts(db, test_organization):
+    job = FAQGenerationJob(
+        organization_id=test_organization.id,
+        job_type=FAQJobType.IMPORT_ARTICLES.value,
+        source_url="https://help.example.com/articles",
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    # Duplicate-title article must dedup against existing FAQs.
+    FAQRepository(db).create(FAQ(
+        organization_id=test_organization.id, question="How to install",
+        answer="old", category="Guides",
+    ))
+
+    articles = {
+        "https://help.example.com/articles/one": faq_article_import.Article(
+            url="https://help.example.com/articles/one",
+            title="How to install", markdown="dupe", category_hint="Guides",
+        ),
+        "https://help.example.com/articles/two": faq_article_import.Article(
+            url="https://help.example.com/articles/two",
+            title="How billing works", markdown="**Billing** steps.", category_hint="Billing",
+        ),
+    }
+    with patch.object(faq_article_import, "discover_article_links", return_value=list(articles)), \
+         patch.object(faq_article_import, "fetch_article", side_effect=lambda c, url: articles[url]):
+        created = await run_article_import_job(db, job)
+
+    assert created == 1
+    row = db.query(FAQ).filter(FAQ.question == "How billing works").one()
+    assert row.status == FAQStatus.DRAFT.value
+    assert row.answer == "**Billing** steps."
+    assert row.source_label == "Imported from help.example.com"
+    assert row.knowledge_id is None

--- a/backend/tests/services/test_faq_generation.py
+++ b/backend/tests/services/test_faq_generation.py
@@ -78,6 +78,29 @@ def test_fail_orphaned_processing_reaps_only_processing(db, test_organization):
     assert done.status == FAQJobStatus.COMPLETED.value
 
 
+def test_stale_processing_job_excluded_from_active_and_reaped(db, test_organization):
+    """A processing job whose progress stopped advancing past the threshold is
+    treated as dead: hidden from active-job polling and reaped on enqueue."""
+    from datetime import datetime, timedelta, timezone
+
+    org = test_organization.id
+    repo = FAQGenerationJobRepository(db)
+    fresh = _make_job(db, org, job_type=FAQJobType.GENERATE_ALL.value, status=FAQJobStatus.PROCESSING.value)
+    stale = _make_job(db, org, job_type=FAQJobType.IMPORT_URL.value, status=FAQJobStatus.PROCESSING.value)
+    # Backdate the stale job's last progress well past FAQ_JOB_STALE_SECONDS.
+    stale.updated_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    db.commit()
+
+    active = repo.get_active_for_org(org)
+    assert active is not None and active.id == fresh.id  # stale one excluded
+
+    reaped = repo.fail_orphaned_processing("dead", older_than_seconds=600, organization_id=org)
+    assert reaped == 1
+    db.refresh(fresh); db.refresh(stale)
+    assert stale.status == FAQJobStatus.FAILED.value  # only the stale one
+    assert fresh.status == FAQJobStatus.PROCESSING.value
+
+
 def test_normalize_question():
     assert normalize_question("How do I sign up?") == normalize_question("how do i SIGN UP")
     assert normalize_question("  A,  b!! ") == "a b"

--- a/backend/tests/services/test_faq_generation.py
+++ b/backend/tests/services/test_faq_generation.py
@@ -118,7 +118,7 @@ async def test_run_generation_job_inserts_deduped_drafts(db, test_organization, 
         GeneratedFAQ(question="How do I sign up?", answer="dupe", category="Getting started"),
         GeneratedFAQ(question="Is my data safe?", answer="Yes.", category="SECURITY"),
     ]
-    mock_generator = SimpleNamespace(generate_from_text=AsyncMock(return_value=generated))
+    mock_generator = SimpleNamespace(generate_from_text=AsyncMock(return_value=generated), batch_chars=15000)
     with patch.object(faq_generation, "build_generator", return_value=mock_generator), \
          patch.object(faq_generation, "load_source_pages", return_value=["page one text"]):
         created = await run_generation_job(db, job)
@@ -146,7 +146,7 @@ async def test_run_generation_job_fails_without_sources(db, test_organization, t
 async def test_run_generation_job_fails_when_all_batches_fail(db, test_organization, test_ai_config):
     _make_knowledge(db, test_organization.id)
     job = _make_job(db, test_organization.id, job_type=FAQJobType.GENERATE_ALL.value)
-    mock_generator = SimpleNamespace(generate_from_text=AsyncMock(side_effect=RuntimeError("boom")))
+    mock_generator = SimpleNamespace(generate_from_text=AsyncMock(side_effect=RuntimeError("boom")), batch_chars=15000)
     with patch.object(faq_generation, "build_generator", return_value=mock_generator), \
          patch.object(faq_generation, "load_source_pages", return_value=["text"]):
         with pytest.raises(RuntimeError, match="every content batch"):
@@ -165,11 +165,11 @@ async def test_generate_source_job_scopes_to_one_source(db, test_organization, t
     )
     seen_sources = []
 
-    def fake_load(db_, knowledge):
+    def fake_load(db_, knowledge, max_chars=None):
         seen_sources.append(knowledge.source)
         return ["content"]
 
-    mock_generator = SimpleNamespace(generate_from_text=AsyncMock(return_value=[]))
+    mock_generator = SimpleNamespace(generate_from_text=AsyncMock(return_value=[]), batch_chars=15000)
     with patch.object(faq_generation, "build_generator", return_value=mock_generator), \
          patch.object(faq_generation, "load_source_pages", side_effect=fake_load):
         await run_generation_job(db, job)

--- a/backend/tests/services/test_faq_generation.py
+++ b/backend/tests/services/test_faq_generation.py
@@ -276,16 +276,39 @@ def _queue_item(org_id, source="docs.example.com", user_id=None):
     return SimpleNamespace(organization_id=org_id, source=source, user_id=user_id)
 
 
+def _adopt(db, org_id):
+    """Mark the org as having explicitly used generation (the opt-in signal)."""
+    _make_job(db, org_id, job_type=FAQJobType.GENERATE_ALL.value, status=FAQJobStatus.COMPLETED.value)
+
+
+def _allow_plan():
+    """Env-independent plan gate (local enterprise builds fail closed)."""
+    return patch("app.services.help_center_access.help_center_allowed", return_value=True)
+
+
 def test_auto_hook_skips_when_feature_never_used(db, test_organization):
     _make_knowledge(db, test_organization.id)
-    assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is None
+    with _allow_plan():
+        assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is None
+
+
+def test_auto_hook_settings_row_alone_is_not_opt_in(db, test_organization):
+    """Opening the admin page (which creates the settings row) must not turn
+    on auto-generation — only an explicit generate/import (or FAQ) does."""
+    _make_knowledge(db, test_organization.id)
+    db.add(HelpCenterSettings(organization_id=test_organization.id, slug="test-org"))
+    db.commit()
+    with _allow_plan():
+        assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is None
 
 
 def test_auto_hook_enqueues_for_adopted_org(db, test_organization):
     knowledge = _make_knowledge(db, test_organization.id)
     db.add(HelpCenterSettings(organization_id=test_organization.id, slug="test-org"))
     db.commit()
-    job = maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id))
+    _adopt(db, test_organization.id)
+    with _allow_plan():
+        job = maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id))
     assert job is not None
     assert job.job_type == FAQJobType.GENERATE_SOURCE.value
     assert job.knowledge_id == knowledge.id
@@ -298,19 +321,23 @@ def test_auto_hook_respects_auto_generate_toggle(db, test_organization):
         organization_id=test_organization.id, slug="test-org", auto_generate=False,
     ))
     db.commit()
-    assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is None
+    _adopt(db, test_organization.id)
+    with _allow_plan():
+        assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is None
 
 
 def test_auto_hook_dedups_active_job(db, test_organization):
     knowledge = _make_knowledge(db, test_organization.id)
     db.add(HelpCenterSettings(organization_id=test_organization.id, slug="test-org"))
     db.commit()
-    first = maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id))
-    assert first is not None
-    assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is None
-    # Once the first completes, a new one may be enqueued.
-    FAQGenerationJobRepository(db).mark_completed(first.id, faqs_created=0)
-    assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is not None
+    _adopt(db, test_organization.id)
+    with _allow_plan():
+        first = maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id))
+        assert first is not None
+        assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is None
+        # Once the first completes, a new one may be enqueued.
+        FAQGenerationJobRepository(db).mark_completed(first.id, faqs_created=0)
+        assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is not None
     assert knowledge.id is not None
 
 
@@ -318,6 +345,7 @@ def test_auto_hook_skips_when_plan_disallows(db, test_organization):
     _make_knowledge(db, test_organization.id)
     db.add(HelpCenterSettings(organization_id=test_organization.id, slug="test-org"))
     db.commit()
+    _adopt(db, test_organization.id)
     # Effective because the hook imports help_center_allowed at call time.
     with patch("app.services.help_center_access.help_center_allowed", return_value=False):
         assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is None

--- a/backend/tests/services/test_faq_generation.py
+++ b/backend/tests/services/test_faq_generation.py
@@ -91,6 +91,38 @@ def test_dedup_state_blocks_existing_and_repeats():
     assert [f.question for f in accepted] == ["What does it cost?"]
 
 
+def test_dedup_state_catches_fuzzy_rephrasings():
+    dedup = DedupState(["How do I reset my account password?"])
+    accepted = dedup.accept_new([
+        # Same content words, different filler/order → fuzzy dupe.
+        GeneratedFAQ(question="How can I reset the password on my account?", answer="a", category="c"),
+        # Genuinely different question sharing some words → kept.
+        GeneratedFAQ(question="How do I change my account email address?", answer="a", category="c"),
+    ])
+    assert [f.question for f in accepted] == ["How do I change my account email address?"]
+
+
+def test_dedup_state_short_questions_skip_fuzzy():
+    # < FUZZY_MIN_CONTENT_TOKENS content words: only exact matches dedup, so
+    # near-misses like these both survive.
+    dedup = DedupState(["How do I pay?"])
+    accepted = dedup.accept_new([
+        GeneratedFAQ(question="How do I pay invoices?", answer="a", category="c"),
+    ])
+    assert len(accepted) == 1
+
+
+def test_dedup_prompt_window_is_bounded():
+    questions = [f"How does feature number {i} work in the product today?" for i in range(100)]
+    dedup = DedupState(questions)
+    assert len(dedup.for_prompt) == faq_generation.MAX_PROMPT_QUESTIONS
+    # The full set still dedups beyond the window.
+    accepted = dedup.accept_new([
+        GeneratedFAQ(question=questions[0], answer="a", category="c"),
+    ])
+    assert accepted == []
+
+
 def test_category_merger_case_insensitive(db, test_organization):
     FAQRepository(db).create(FAQ(
         organization_id=test_organization.id, question="q", answer="a", category="Billing",

--- a/backend/tests/services/test_faq_generation.py
+++ b/backend/tests/services/test_faq_generation.py
@@ -62,6 +62,22 @@ def _make_job(db, org_id, **kwargs):
 
 # ---------- unit helpers ----------
 
+def test_fail_orphaned_processing_reaps_only_processing(db, test_organization):
+    """Worker-startup reap: processing jobs (orphaned by a kill) fail; pending
+    and terminal jobs are untouched."""
+    org = test_organization.id
+    stuck = _make_job(db, org, job_type=FAQJobType.IMPORT_ARTICLES.value, status=FAQJobStatus.PROCESSING.value)
+    pending = _make_job(db, org, job_type=FAQJobType.GENERATE_ALL.value, status=FAQJobStatus.PENDING.value)
+    done = _make_job(db, org, job_type=FAQJobType.IMPORT_URL.value, status=FAQJobStatus.COMPLETED.value)
+
+    reaped = FAQGenerationJobRepository(db).fail_orphaned_processing("killed")
+    assert reaped == 1
+    db.refresh(stuck); db.refresh(pending); db.refresh(done)
+    assert stuck.status == FAQJobStatus.FAILED.value and stuck.error == "killed"
+    assert pending.status == FAQJobStatus.PENDING.value
+    assert done.status == FAQJobStatus.COMPLETED.value
+
+
 def test_normalize_question():
     assert normalize_question("How do I sign up?") == normalize_question("how do i SIGN UP")
     assert normalize_question("  A,  b!! ") == "a b"

--- a/backend/tests/services/test_faq_generation.py
+++ b/backend/tests/services/test_faq_generation.py
@@ -208,6 +208,68 @@ async def test_generate_source_job_scopes_to_one_source(db, test_organization, t
     assert seen_sources == ["a.example.com"]
 
 
+@pytest.mark.asyncio
+async def test_generate_all_skips_sources_with_faqs(db, test_organization, test_ai_config):
+    """Regenerate only reads sources that haven't produced FAQs yet."""
+    done = _make_knowledge(db, test_organization.id, "done.example.com")
+    _make_knowledge(db, test_organization.id, "new.example.com")
+    FAQRepository(db).create(FAQ(
+        organization_id=test_organization.id, question="q", answer="a",
+        category="General", knowledge_id=done.id,
+    ))
+    job = _make_job(db, test_organization.id, job_type=FAQJobType.GENERATE_ALL.value)
+    seen = []
+
+    def fake_load(db_, knowledge, max_chars=None):
+        seen.append(knowledge.source)
+        return ["content"]
+
+    mock_generator = SimpleNamespace(generate_from_text=AsyncMock(return_value=[]), batch_chars=15000)
+    with patch.object(faq_generation, "build_generator", return_value=mock_generator), \
+         patch.object(faq_generation, "load_source_pages", side_effect=fake_load):
+        await run_generation_job(db, job)
+    assert seen == ["new.example.com"]
+
+
+@pytest.mark.asyncio
+async def test_generate_all_errors_when_everything_generated(db, test_organization, test_ai_config):
+    k = _make_knowledge(db, test_organization.id)
+    FAQRepository(db).create(FAQ(
+        organization_id=test_organization.id, question="q", answer="a",
+        category="General", knowledge_id=k.id,
+    ))
+    job = _make_job(db, test_organization.id, job_type=FAQJobType.GENERATE_ALL.value)
+    with patch.object(faq_generation, "build_generator", return_value=SimpleNamespace(batch_chars=15000)):
+        with pytest.raises(ValueError, match="already have FAQs"):
+            await run_generation_job(db, job)
+
+
+@pytest.mark.asyncio
+async def test_generate_all_explicit_ids_override_skip(db, test_organization, test_ai_config):
+    """knowledge_ids explicitly re-targets an already-generated source."""
+    done = _make_knowledge(db, test_organization.id, "done.example.com")
+    _make_knowledge(db, test_organization.id, "other.example.com")
+    FAQRepository(db).create(FAQ(
+        organization_id=test_organization.id, question="q", answer="a",
+        category="General", knowledge_id=done.id,
+    ))
+    job = _make_job(
+        db, test_organization.id,
+        job_type=FAQJobType.GENERATE_ALL.value, knowledge_ids=[done.id],
+    )
+    seen = []
+
+    def fake_load(db_, knowledge, max_chars=None):
+        seen.append(knowledge.source)
+        return ["content"]
+
+    mock_generator = SimpleNamespace(generate_from_text=AsyncMock(return_value=[]), batch_chars=15000)
+    with patch.object(faq_generation, "build_generator", return_value=mock_generator), \
+         patch.object(faq_generation, "load_source_pages", side_effect=fake_load):
+        await run_generation_job(db, job)
+    assert seen == ["done.example.com"]
+
+
 # ---------- auto-generation hook ----------
 
 def _queue_item(org_id, source="docs.example.com", user_id=None):

--- a/backend/tests/services/test_faq_generation.py
+++ b/backend/tests/services/test_faq_generation.py
@@ -1,0 +1,234 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+FAQ generation service tests: batching/dedup helpers, the end-to-end job with
+a mocked model, and the auto-generation hook's skip conditions.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.agents.faq_generator import GeneratedFAQ
+from app.models.faq import FAQ, FAQStatus
+from app.models.faq_generation_job import FAQGenerationJob, FAQJobStatus, FAQJobType
+from app.models.help_center import HelpCenterSettings
+from app.models.knowledge import Knowledge, SourceType
+from app.repositories.faq import FAQRepository
+from app.repositories.faq_generation_job import FAQGenerationJobRepository
+from app.services import faq_generation
+from app.services.faq_generation import (
+    CategoryMerger,
+    DedupState,
+    maybe_enqueue_auto_faq_job,
+    normalize_question,
+    pack_batches,
+    run_generation_job,
+)
+
+
+# ---------- helpers ----------
+
+def _make_knowledge(db, org_id, source="docs.example.com"):
+    knowledge = Knowledge(
+        source=source, source_type=SourceType.WEBSITE,
+        schema="ai", table_name="d_test", organization_id=org_id,
+    )
+    db.add(knowledge)
+    db.commit()
+    db.refresh(knowledge)
+    return knowledge
+
+
+def _make_job(db, org_id, **kwargs):
+    job = FAQGenerationJob(organization_id=org_id, **kwargs)
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+# ---------- unit helpers ----------
+
+def test_normalize_question():
+    assert normalize_question("How do I sign up?") == normalize_question("how do i SIGN UP")
+    assert normalize_question("  A,  b!! ") == "a b"
+
+
+def test_pack_batches_packs_whole_pages():
+    pages = ["a" * 6000, "b" * 6000, "c" * 6000]
+    batches = pack_batches(pages, max_chars=15000)
+    assert len(batches) == 2
+    assert "a" in batches[0] and "b" in batches[0]
+    assert batches[1].startswith("c")
+
+
+def test_pack_batches_truncates_oversize_item():
+    batches = pack_batches(["x" * 20000, "y" * 10], max_chars=15000)
+    assert len(batches) == 2
+    assert len(batches[0]) <= 15000  # oversized item truncated, never split
+
+
+def test_dedup_state_blocks_existing_and_repeats():
+    dedup = DedupState(["How do I sign up?"])
+    accepted = dedup.accept_new([
+        GeneratedFAQ(question="how do i sign up", answer="a", category="c"),   # rephrased dupe
+        GeneratedFAQ(question="What does it cost?", answer="a", category="c"),
+        GeneratedFAQ(question="What does it cost", answer="b", category="c"),  # same-run dupe
+    ])
+    assert [f.question for f in accepted] == ["What does it cost?"]
+
+
+def test_category_merger_case_insensitive(db, test_organization):
+    FAQRepository(db).create(FAQ(
+        organization_id=test_organization.id, question="q", answer="a", category="Billing",
+    ))
+    merger = CategoryMerger(db, test_organization.id)
+    assert merger.merge("BILLING") == "Billing"
+    assert merger.merge("Refunds") == "Refunds"
+    assert merger.merge("  ") == "General"
+    assert "Refunds" in merger.names
+
+
+# ---------- generation job ----------
+
+@pytest.mark.asyncio
+async def test_run_generation_job_inserts_deduped_drafts(db, test_organization, test_ai_config):
+    knowledge = _make_knowledge(db, test_organization.id)
+    # Pre-existing FAQ that generated output must not duplicate.
+    FAQRepository(db).create(FAQ(
+        organization_id=test_organization.id, question="How do I sign up?",
+        answer="Existing.", category="Getting started",
+    ))
+    job = _make_job(db, test_organization.id, job_type=FAQJobType.GENERATE_ALL.value)
+
+    generated = [
+        GeneratedFAQ(question="How do I sign up?", answer="dupe", category="Getting started"),
+        GeneratedFAQ(question="Is my data safe?", answer="Yes.", category="SECURITY"),
+    ]
+    mock_generator = SimpleNamespace(generate_from_text=AsyncMock(return_value=generated))
+    with patch.object(faq_generation, "build_generator", return_value=mock_generator), \
+         patch.object(faq_generation, "load_source_pages", return_value=["page one text"]):
+        created = await run_generation_job(db, job)
+
+    assert created == 1
+    rows = db.query(FAQ).filter(FAQ.question == "Is my data safe?").all()
+    assert len(rows) == 1
+    assert rows[0].status == FAQStatus.DRAFT.value
+    assert rows[0].knowledge_id == knowledge.id
+    assert rows[0].source_label == "docs.example.com"
+    assert rows[0].generation_job_id == job.id
+    # Category kept the model's spelling since no existing "security" category.
+    assert rows[0].category == "SECURITY"
+
+
+@pytest.mark.asyncio
+async def test_run_generation_job_fails_without_sources(db, test_organization, test_ai_config):
+    job = _make_job(db, test_organization.id, job_type=FAQJobType.GENERATE_ALL.value)
+    with patch.object(faq_generation, "build_generator", return_value=SimpleNamespace()):
+        with pytest.raises(ValueError, match="No knowledge sources"):
+            await run_generation_job(db, job)
+
+
+@pytest.mark.asyncio
+async def test_run_generation_job_fails_when_all_batches_fail(db, test_organization, test_ai_config):
+    _make_knowledge(db, test_organization.id)
+    job = _make_job(db, test_organization.id, job_type=FAQJobType.GENERATE_ALL.value)
+    mock_generator = SimpleNamespace(generate_from_text=AsyncMock(side_effect=RuntimeError("boom")))
+    with patch.object(faq_generation, "build_generator", return_value=mock_generator), \
+         patch.object(faq_generation, "load_source_pages", return_value=["text"]):
+        with pytest.raises(RuntimeError, match="every content batch"):
+            await run_generation_job(db, job)
+    # One retry per batch.
+    assert mock_generator.generate_from_text.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_source_job_scopes_to_one_source(db, test_organization, test_ai_config):
+    k1 = _make_knowledge(db, test_organization.id, "a.example.com")
+    _make_knowledge(db, test_organization.id, "b.example.com")
+    job = _make_job(
+        db, test_organization.id,
+        job_type=FAQJobType.GENERATE_SOURCE.value, knowledge_id=k1.id,
+    )
+    seen_sources = []
+
+    def fake_load(db_, knowledge):
+        seen_sources.append(knowledge.source)
+        return ["content"]
+
+    mock_generator = SimpleNamespace(generate_from_text=AsyncMock(return_value=[]))
+    with patch.object(faq_generation, "build_generator", return_value=mock_generator), \
+         patch.object(faq_generation, "load_source_pages", side_effect=fake_load):
+        await run_generation_job(db, job)
+    assert seen_sources == ["a.example.com"]
+
+
+# ---------- auto-generation hook ----------
+
+def _queue_item(org_id, source="docs.example.com", user_id=None):
+    return SimpleNamespace(organization_id=org_id, source=source, user_id=user_id)
+
+
+def test_auto_hook_skips_when_feature_never_used(db, test_organization):
+    _make_knowledge(db, test_organization.id)
+    assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is None
+
+
+def test_auto_hook_enqueues_for_adopted_org(db, test_organization):
+    knowledge = _make_knowledge(db, test_organization.id)
+    db.add(HelpCenterSettings(organization_id=test_organization.id, slug="test-org"))
+    db.commit()
+    job = maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id))
+    assert job is not None
+    assert job.job_type == FAQJobType.GENERATE_SOURCE.value
+    assert job.knowledge_id == knowledge.id
+    assert job.status == FAQJobStatus.PENDING.value
+
+
+def test_auto_hook_respects_auto_generate_toggle(db, test_organization):
+    _make_knowledge(db, test_organization.id)
+    db.add(HelpCenterSettings(
+        organization_id=test_organization.id, slug="test-org", auto_generate=False,
+    ))
+    db.commit()
+    assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is None
+
+
+def test_auto_hook_dedups_active_job(db, test_organization):
+    knowledge = _make_knowledge(db, test_organization.id)
+    db.add(HelpCenterSettings(organization_id=test_organization.id, slug="test-org"))
+    db.commit()
+    first = maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id))
+    assert first is not None
+    assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is None
+    # Once the first completes, a new one may be enqueued.
+    FAQGenerationJobRepository(db).mark_completed(first.id, faqs_created=0)
+    assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is not None
+    assert knowledge.id is not None
+
+
+def test_auto_hook_skips_when_plan_disallows(db, test_organization):
+    _make_knowledge(db, test_organization.id)
+    db.add(HelpCenterSettings(organization_id=test_organization.id, slug="test-org"))
+    db.commit()
+    # Effective because the hook imports help_center_allowed at call time.
+    with patch("app.services.help_center_access.help_center_allowed", return_value=False):
+        assert maybe_enqueue_auto_faq_job(db, _queue_item(test_organization.id)) is None
+
+
+def test_auto_hook_never_raises(db, test_organization):
+    broken = SimpleNamespace(organization_id=None, source=None, user_id=None)
+    assert maybe_enqueue_auto_faq_job(db, broken) is None

--- a/backend/tests/services/test_faq_import.py
+++ b/backend/tests/services/test_faq_import.py
@@ -135,8 +135,9 @@ async def test_pdf_import_job_extracts_and_cleans_up(db, test_organization, test
     db.commit()
     db.refresh(job)
 
-    extracted = [GeneratedFAQ(question="Do you offer refunds?", answer="Within 14 days.", category="Billing")]
-    mock_generator = SimpleNamespace(extract_from_faq_page=AsyncMock(return_value=extracted), batch_chars=15000)
+    # PDF import GENERATES FAQs from the document (not verbatim extraction).
+    generated = [GeneratedFAQ(question="Do you offer refunds?", answer="Within 14 days.", category="Billing")]
+    mock_generator = SimpleNamespace(generate_from_text=AsyncMock(return_value=generated), batch_chars=15000)
     deleted = []
 
     async def fake_load(stored):

--- a/backend/tests/services/test_faq_import.py
+++ b/backend/tests/services/test_faq_import.py
@@ -1,0 +1,104 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+FAQ import service tests: HTML-to-text cleanup, paragraph-safe batching, SSRF
+propagation, and the end-to-end import job with a mocked model.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from bs4 import BeautifulSoup
+
+from app.agents.faq_generator import GeneratedFAQ
+from app.knowledge.url_safety import BlockedHostError
+from app.models.faq import FAQ, FAQStatus
+from app.models.faq_generation_job import FAQGenerationJob, FAQJobType
+from app.services import faq_import
+from app.services.faq_generation import pack_batches
+from app.services.faq_import import _soup_to_text, _split_blocks, run_import_job
+
+
+def test_soup_to_text_strips_boilerplate_and_separates_blocks():
+    html = """
+    <html><head><script>var x=1;</script><style>.a{}</style></head>
+    <body><nav>Home | About</nav>
+    <main><h2>Billing</h2><p>How do I pay?</p><p>Use a card.</p></main>
+    <footer>© Example</footer></body></html>
+    """
+    text = _soup_to_text(BeautifulSoup(html, "html.parser"))
+    assert "How do I pay?" in text and "Billing" in text
+    assert "var x=1" not in text and "Home | About" not in text and "© Example" not in text
+    # Block elements are blank-line separated so batching keeps blocks whole.
+    assert "\n\n" in text
+    assert "\n\n\n" not in text
+
+
+def test_block_batching_keeps_blocks_whole():
+    blocks = [f"Question {i}?\nAnswer {i} " + "x" * 80 for i in range(10)]
+    text = "\n\n".join(blocks)
+    batches = pack_batches(_split_blocks(text), max_chars=300, sep="\n\n")
+    assert len(batches) > 1
+    # No Q&A block is cut across batches.
+    for i in range(10):
+        assert sum(f"Question {i}?" in b and f"Answer {i}" in b for b in batches) == 1
+
+
+@pytest.mark.asyncio
+async def test_import_job_inserts_drafts_with_source_label(db, test_organization, test_ai_config):
+    job = FAQGenerationJob(
+        organization_id=test_organization.id,
+        job_type=FAQJobType.IMPORT_URL.value,
+        source_url="https://support.example.com/faq",
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    extracted = [GeneratedFAQ(question="Do you offer refunds?", answer="Within 14 days.", category="Billing")]
+    mock_generator = SimpleNamespace(extract_from_faq_page=AsyncMock(return_value=extracted))
+    with patch.object(faq_import, "build_generator", return_value=mock_generator), \
+         patch.object(faq_import, "fetch_page_text", return_value="Do you offer refunds?\nWithin 14 days."):
+        created = await run_import_job(db, job)
+
+    assert created == 1
+    row = db.query(FAQ).filter(FAQ.organization_id == test_organization.id).one()
+    assert row.status == FAQStatus.DRAFT.value
+    assert row.knowledge_id is None
+    assert row.source_label == "Imported from support.example.com"
+
+
+@pytest.mark.asyncio
+async def test_import_job_propagates_ssrf_block(db, test_organization, test_ai_config):
+    job = FAQGenerationJob(
+        organization_id=test_organization.id,
+        job_type=FAQJobType.IMPORT_URL.value,
+        source_url="https://internal.example/faq",
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    with patch.object(faq_import, "build_generator", return_value=SimpleNamespace()), \
+         patch.object(faq_import, "fetch_page_text", side_effect=BlockedHostError("blocked")):
+        with pytest.raises(BlockedHostError):
+            await run_import_job(db, job)
+
+
+def test_fetch_page_text_ssrf_guard_blocks_before_fetch():
+    """The real fetch path consults url_safety on the initial URL."""
+    with patch("app.services.faq_import.safe_get", side_effect=BlockedHostError("blocked")), \
+         patch.object(faq_import, "_fetch_rendered_text", return_value=None):
+        with pytest.raises((BlockedHostError, ValueError)):
+            faq_import.fetch_page_text("https://169.254.169.254/faq")

--- a/backend/tests/services/test_faq_import.py
+++ b/backend/tests/services/test_faq_import.py
@@ -102,3 +102,80 @@ def test_fetch_page_text_ssrf_guard_blocks_before_fetch():
          patch.object(faq_import, "_fetch_rendered_text", return_value=None):
         with pytest.raises((BlockedHostError, ValueError)):
             faq_import.fetch_page_text("https://169.254.169.254/faq")
+
+
+# ---------- PDF import ----------
+
+def _tiny_pdf() -> bytes:
+    """A minimal one-page PDF with extractable text ('Do you offer refunds? Yes.')."""
+    from pypdf import PdfWriter
+    from io import BytesIO
+
+    writer = PdfWriter()
+    writer.add_blank_page(width=200, height=200)
+    buffer = BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+def test_pdf_to_text_reads_pages():
+    # A blank page yields no text; the function must cope without raising.
+    assert faq_import._pdf_to_text(_tiny_pdf()) == ""
+
+
+@pytest.mark.asyncio
+async def test_pdf_import_job_extracts_and_cleans_up(db, test_organization, test_ai_config):
+    job = FAQGenerationJob(
+        organization_id=test_organization.id,
+        job_type=FAQJobType.IMPORT_PDF.value,
+        source_url="/api/v1/uploads/help_center_imports/x.pdf",
+        source_file_name="refund-policy.pdf",
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    extracted = [GeneratedFAQ(question="Do you offer refunds?", answer="Within 14 days.", category="Billing")]
+    mock_generator = SimpleNamespace(extract_from_faq_page=AsyncMock(return_value=extracted), batch_chars=15000)
+    deleted = []
+
+    async def fake_load(stored):
+        return b"%PDF-fake"
+
+    async def fake_delete(stored):
+        deleted.append(stored)
+
+    with patch.object(faq_import, "build_generator", return_value=mock_generator), \
+         patch.object(faq_import, "_pdf_to_text", return_value="Do you offer refunds?\n\nWithin 14 days."), \
+         patch("app.services.file_storage.load_upload", side_effect=fake_load), \
+         patch("app.services.file_storage.delete_upload", side_effect=fake_delete):
+        created = await faq_import.run_pdf_import_job(db, job)
+
+    assert created == 1
+    row = db.query(FAQ).filter(FAQ.question == "Do you offer refunds?").one()
+    assert row.source_label == "Imported from refund-policy.pdf"
+    assert deleted == [job.source_url]  # import buffer removed
+
+
+@pytest.mark.asyncio
+async def test_pdf_import_job_fails_clearly_on_empty_text(db, test_organization, test_ai_config):
+    job = FAQGenerationJob(
+        organization_id=test_organization.id,
+        job_type=FAQJobType.IMPORT_PDF.value,
+        source_url="/api/v1/uploads/help_center_imports/y.pdf",
+        source_file_name="scan.pdf",
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    async def fake_load(stored):
+        return _tiny_pdf()
+
+    async def fake_delete(stored):
+        pass
+
+    with patch("app.services.file_storage.load_upload", side_effect=fake_load), \
+         patch("app.services.file_storage.delete_upload", side_effect=fake_delete):
+        with pytest.raises(ValueError, match="scanned images"):
+            await faq_import.run_pdf_import_job(db, job)

--- a/backend/tests/services/test_faq_import.py
+++ b/backend/tests/services/test_faq_import.py
@@ -68,7 +68,7 @@ async def test_import_job_inserts_drafts_with_source_label(db, test_organization
     db.refresh(job)
 
     extracted = [GeneratedFAQ(question="Do you offer refunds?", answer="Within 14 days.", category="Billing")]
-    mock_generator = SimpleNamespace(extract_from_faq_page=AsyncMock(return_value=extracted))
+    mock_generator = SimpleNamespace(extract_from_faq_page=AsyncMock(return_value=extracted), batch_chars=15000)
     with patch.object(faq_import, "build_generator", return_value=mock_generator), \
          patch.object(faq_import, "fetch_page_text", return_value="Do you offer refunds?\nWithin 14 days."):
         created = await run_import_job(db, job)

--- a/backend/tests/services/test_help_center_content.py
+++ b/backend/tests/services/test_help_center_content.py
@@ -1,0 +1,83 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from app.services.help_center_content import (
+    excerpt,
+    read_time_label,
+    read_time_minutes,
+    render_article_html,
+    to_plain_text,
+)
+
+RICH = """## Getting started
+
+From the dashboard, open [Settings](https://app.example.com/settings) and pick a connector.
+
+1. Click **Add source**.
+2. Authenticate.
+
+![shot](https://cdn.example.com/a.png)
+
+> Tip: assign roles as you invite.
+"""
+
+
+def test_render_produces_expected_tags():
+    html = render_article_html(RICH)
+    assert "<h2>" in html
+    assert "<ol>" in html and "<li>" in html
+    assert '<img alt="shot" src="https://cdn.example.com/a.png">' in html
+    assert "<blockquote>" in html
+    assert '<a href="https://app.example.com/settings"' in html
+
+
+def test_render_sanitizes_scripts_and_bad_urls():
+    html = render_article_html(
+        '<script>alert(1)</script>\n\n[bad](javascript:alert(1))\n\n<img src=x onerror=alert(1)>'
+    )
+    assert "<script" not in html
+    assert "javascript:" not in html
+    assert "onerror" not in html
+
+
+def test_render_rewrites_link_rel():
+    html = render_article_html("[docs](https://docs.example.com)")
+    assert 'rel="noopener noreferrer nofollow"' in html
+
+
+def test_empty_answer_renders_empty():
+    assert render_article_html("") == ""
+    assert render_article_html("   ") == ""
+
+
+def test_to_plain_text_strips_markdown_and_html():
+    plain = to_plain_text(RICH)
+    assert "##" not in plain and "**" not in plain
+    assert "<" not in plain and ">" not in plain
+    assert "Getting started" in plain and "Add source" in plain
+
+
+def test_excerpt_truncates_on_word_boundary():
+    long = "word " * 60
+    out = excerpt(long, length=40)
+    assert len(out) <= 41 and out.endswith("…")
+    assert " word" not in out[-2:]  # cut cleanly, not mid-word
+
+
+def test_read_time_is_at_least_one_minute():
+    assert read_time_minutes("short") == 1
+    assert read_time_label("short") == "1 min read"
+    assert read_time_minutes("word " * 800) >= 3

--- a/backend/tests/tools/test_knowledge_search_byagent.py
+++ b/backend/tests/tools/test_knowledge_search_byagent.py
@@ -84,9 +84,7 @@ def knowledge_search_tool(mock_db, mock_knowledge, mock_vector_db, mock_agent_kn
     with patch('app.tools.knowledge_search_byagent.SessionLocal') as mock_session_local, \
          patch('app.tools.knowledge_search_byagent.PgVector') as mock_pg_vector, \
          patch('app.tools.knowledge_search_byagent.AgentKnowledge') as mock_agent_knowledge_class, \
-         patch('app.tools.knowledge_search_byagent.KnowledgeRepository') as mock_knowledge_repo_class, \
-         patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo_class, \
-         patch('app.tools.knowledge_search_byagent.decrypt_api_key') as mock_decrypt_api_key:
+         patch('app.tools.knowledge_search_byagent.KnowledgeRepository') as mock_knowledge_repo_class:
         
         # Configure mocks
         mock_session_local.return_value.__enter__.return_value = mock_db
@@ -98,20 +96,13 @@ def knowledge_search_tool(mock_db, mock_knowledge, mock_vector_db, mock_agent_kn
         mock_knowledge_repo_class.return_value = mock_knowledge_repo
         mock_knowledge_repo.get_by_agent.return_value = [mock_knowledge]
         
-        # Create a mock for AIConfigRepository
-        mock_ai_config_repo = MagicMock()
-        mock_ai_config_repo_class.return_value = mock_ai_config_repo
-        mock_ai_config_repo.get_active_config.return_value = mock_ai_config
         
-        # Mock decrypt_api_key
-        mock_decrypt_api_key.return_value = "test-key"
         
         # Create the tool instance
         tool = KnowledgeSearchByAgent(agent_id=agent_id, org_id=org_id)
         
         # Store the mock objects for later access in tests
         tool._mock_knowledge_repo = mock_knowledge_repo
-        tool._mock_ai_config_repo = mock_ai_config_repo
         
         # Set the agent_knowledge directly
         tool.agent_knowledge = mock_agent_knowledge
@@ -403,8 +394,6 @@ def test_real_search_knowledge_base_with_results():
     org_id = uuid4()
 
     with patch('app.tools.knowledge_search_byagent.SessionLocal') as mock_session_local, \
-         patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo_class, \
-         patch('app.tools.knowledge_search_byagent.decrypt_api_key') as mock_decrypt, \
          patch('app.tools.knowledge_search_byagent.KnowledgeRepository') as mock_knowledge_repo_class, \
          patch('app.tools.knowledge_search_byagent.PgVector') as mock_pg_vector, \
          patch('app.tools.knowledge_search_byagent.AgentKnowledge') as mock_agent_knowledge_class:
@@ -416,11 +405,7 @@ def test_real_search_knowledge_base_with_results():
 
         mock_ai_config = MagicMock()
         mock_ai_config.encrypted_api_key = "encrypted_key"
-        mock_ai_config_repo = MagicMock()
-        mock_ai_config_repo.get_active_config.return_value = mock_ai_config
-        mock_ai_config_repo_class.return_value = mock_ai_config_repo
 
-        mock_decrypt.return_value = "decrypted_key"
 
         # Create the tool
         tool = KnowledgeSearchByAgent(agent_id=agent_id, org_id=org_id)
@@ -462,17 +447,13 @@ def test_real_search_knowledge_base_no_ai_config():
     agent_id = str(uuid4())
     org_id = uuid4()
 
-    with patch('app.tools.knowledge_search_byagent.SessionLocal') as mock_session_local, \
-         patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo_class:
+    with patch('app.tools.knowledge_search_byagent.SessionLocal') as mock_session_local:
 
         mock_db = MagicMock()
         mock_session_local.return_value.__enter__.return_value = mock_db
         mock_session_local.return_value.__exit__.return_value = None
 
         # No AI config available
-        mock_ai_config_repo = MagicMock()
-        mock_ai_config_repo.get_active_config.return_value = None
-        mock_ai_config_repo_class.return_value = mock_ai_config_repo
 
         # Should not raise an error
         tool = KnowledgeSearchByAgent(agent_id=agent_id, org_id=org_id)
@@ -488,8 +469,6 @@ def test_real_search_knowledge_base_with_source_filter():
     source_filter = "specific_doc.pdf"
 
     with patch('app.tools.knowledge_search_byagent.SessionLocal') as mock_session_local, \
-         patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo_class, \
-         patch('app.tools.knowledge_search_byagent.decrypt_api_key') as mock_decrypt, \
          patch('app.tools.knowledge_search_byagent.KnowledgeRepository') as mock_knowledge_repo_class, \
          patch('app.tools.knowledge_search_byagent.PgVector') as mock_pg_vector, \
          patch('app.tools.knowledge_search_byagent.AgentKnowledge') as mock_agent_knowledge_class:
@@ -501,11 +480,7 @@ def test_real_search_knowledge_base_with_source_filter():
 
         mock_ai_config = MagicMock()
         mock_ai_config.encrypted_api_key = "encrypted_key"
-        mock_ai_config_repo = MagicMock()
-        mock_ai_config_repo.get_active_config.return_value = mock_ai_config
-        mock_ai_config_repo_class.return_value = mock_ai_config_repo
 
-        mock_decrypt.return_value = "decrypted_key"
 
         # Create tool with source filter
         tool = KnowledgeSearchByAgent(agent_id=agent_id, org_id=org_id, source=source_filter)
@@ -553,8 +528,6 @@ def test_real_search_knowledge_base_no_content_docs():
     org_id = uuid4()
 
     with patch('app.tools.knowledge_search_byagent.SessionLocal') as mock_session_local, \
-         patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo_class, \
-         patch('app.tools.knowledge_search_byagent.decrypt_api_key') as mock_decrypt, \
          patch('app.tools.knowledge_search_byagent.KnowledgeRepository') as mock_knowledge_repo_class, \
          patch('app.tools.knowledge_search_byagent.PgVector') as mock_pg_vector, \
          patch('app.tools.knowledge_search_byagent.AgentKnowledge') as mock_agent_knowledge_class:
@@ -566,9 +539,6 @@ def test_real_search_knowledge_base_no_content_docs():
 
         mock_ai_config = MagicMock()
         mock_ai_config.encrypted_api_key = None
-        mock_ai_config_repo = MagicMock()
-        mock_ai_config_repo.get_active_config.return_value = mock_ai_config
-        mock_ai_config_repo_class.return_value = mock_ai_config_repo
 
         tool = KnowledgeSearchByAgent(agent_id=agent_id, org_id=org_id)
 
@@ -614,8 +584,6 @@ def test_real_search_knowledge_base_unknown_source_type():
     org_id = uuid4()
 
     with patch('app.tools.knowledge_search_byagent.SessionLocal') as mock_session_local, \
-         patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo_class, \
-         patch('app.tools.knowledge_search_byagent.decrypt_api_key') as mock_decrypt, \
          patch('app.tools.knowledge_search_byagent.KnowledgeRepository') as mock_knowledge_repo_class, \
          patch('app.tools.knowledge_search_byagent.PgVector') as mock_pg_vector, \
          patch('app.tools.knowledge_search_byagent.AgentKnowledge') as mock_agent_knowledge_class:
@@ -627,11 +595,7 @@ def test_real_search_knowledge_base_unknown_source_type():
 
         mock_ai_config = MagicMock()
         mock_ai_config.encrypted_api_key = "key"
-        mock_ai_config_repo = MagicMock()
-        mock_ai_config_repo.get_active_config.return_value = mock_ai_config
-        mock_ai_config_repo_class.return_value = mock_ai_config_repo
 
-        mock_decrypt.return_value = "key"
 
         tool = KnowledgeSearchByAgent(agent_id=agent_id, org_id=org_id)
 
@@ -672,8 +636,6 @@ def test_real_search_knowledge_base_document_without_score():
     org_id = uuid4()
 
     with patch('app.tools.knowledge_search_byagent.SessionLocal') as mock_session_local, \
-         patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo_class, \
-         patch('app.tools.knowledge_search_byagent.decrypt_api_key') as mock_decrypt, \
          patch('app.tools.knowledge_search_byagent.KnowledgeRepository') as mock_knowledge_repo_class, \
          patch('app.tools.knowledge_search_byagent.PgVector') as mock_pg_vector, \
          patch('app.tools.knowledge_search_byagent.AgentKnowledge') as mock_agent_knowledge_class:
@@ -685,11 +647,7 @@ def test_real_search_knowledge_base_document_without_score():
 
         mock_ai_config = MagicMock()
         mock_ai_config.encrypted_api_key = "key"
-        mock_ai_config_repo = MagicMock()
-        mock_ai_config_repo.get_active_config.return_value = mock_ai_config
-        mock_ai_config_repo_class.return_value = mock_ai_config_repo
 
-        mock_decrypt.return_value = "key"
 
         tool = KnowledgeSearchByAgent(agent_id=agent_id, org_id=org_id)
 
@@ -731,7 +689,6 @@ def test_real_search_knowledge_base_exception_handling():
     org_id = uuid4()
 
     with patch('app.tools.knowledge_search_byagent.SessionLocal') as mock_session_local, \
-         patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo_class, \
          patch('app.tools.knowledge_search_byagent.KnowledgeRepository') as mock_knowledge_repo_class:
 
         # Setup mocks for initialization
@@ -741,9 +698,6 @@ def test_real_search_knowledge_base_exception_handling():
 
         mock_ai_config = MagicMock()
         mock_ai_config.encrypted_api_key = None
-        mock_ai_config_repo = MagicMock()
-        mock_ai_config_repo.get_active_config.return_value = mock_ai_config
-        mock_ai_config_repo_class.return_value = mock_ai_config_repo
 
         tool = KnowledgeSearchByAgent(agent_id=agent_id, org_id=org_id)
 
@@ -765,8 +719,6 @@ def test_real_search_knowledge_base_lazy_init():
     org_id = uuid4()
 
     with patch('app.tools.knowledge_search_byagent.SessionLocal') as mock_session_local, \
-         patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo_class, \
-         patch('app.tools.knowledge_search_byagent.decrypt_api_key') as mock_decrypt, \
          patch('app.tools.knowledge_search_byagent.KnowledgeRepository') as mock_knowledge_repo_class, \
          patch('app.tools.knowledge_search_byagent.PgVector') as mock_pg_vector, \
          patch('app.tools.knowledge_search_byagent.AgentKnowledge') as mock_agent_knowledge_class, \
@@ -779,11 +731,7 @@ def test_real_search_knowledge_base_lazy_init():
 
         mock_ai_config = MagicMock()
         mock_ai_config.encrypted_api_key = "key"
-        mock_ai_config_repo = MagicMock()
-        mock_ai_config_repo.get_active_config.return_value = mock_ai_config
-        mock_ai_config_repo_class.return_value = mock_ai_config_repo
 
-        mock_decrypt.return_value = "key"
 
         # Create tool - agent_knowledge should be None initially
         tool = KnowledgeSearchByAgent(agent_id=agent_id, org_id=org_id)
@@ -839,7 +787,6 @@ def test_real_search_knowledge_base_no_sources_real():
     org_id = uuid4()
 
     with patch('app.tools.knowledge_search_byagent.SessionLocal') as mock_session_local, \
-         patch('app.tools.knowledge_search_byagent.AIConfigRepository') as mock_ai_config_repo_class, \
          patch('app.tools.knowledge_search_byagent.KnowledgeRepository') as mock_knowledge_repo_class:
 
         # Setup mocks for initialization
@@ -849,9 +796,6 @@ def test_real_search_knowledge_base_no_sources_real():
 
         mock_ai_config = MagicMock()
         mock_ai_config.encrypted_api_key = None
-        mock_ai_config_repo = MagicMock()
-        mock_ai_config_repo.get_active_config.return_value = mock_ai_config
-        mock_ai_config_repo_class.return_value = mock_ai_config_repo
 
         tool = KnowledgeSearchByAgent(agent_id=agent_id, org_id=org_id)
 

--- a/backend/tests/utils/test_model_context.py
+++ b/backend/tests/utils/test_model_context.py
@@ -1,0 +1,62 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from app.core.config import settings
+from app.utils.model_context import (
+    context_tokens_for,
+    faq_batch_chars_for,
+    output_tokens_for,
+)
+
+
+def test_longest_prefix_wins():
+    assert context_tokens_for("OPENAI", "gpt-4o-mini") == 128_000
+    assert context_tokens_for("OPENAI", "gpt-4") == 8_000  # bare gpt-4, not gpt-4o
+    assert context_tokens_for("MISTRAL", "mistral-large-latest") == 128_000
+    assert context_tokens_for("MISTRAL", "mistral-small") == 32_000
+
+
+def test_unknown_model_falls_back_to_provider_default():
+    assert context_tokens_for("ANTHROPIC", "some-future-model") == 200_000
+    assert context_tokens_for("GROQ", "unknown") == 8_000
+    assert context_tokens_for("", "") == 8_000  # unknown provider → global floor
+
+
+def test_env_override_wins(monkeypatch):
+    monkeypatch.setattr(settings, "FAQ_CONTEXT_TOKENS_OVERRIDE", 42_000)
+    assert context_tokens_for("OPENAI", "gpt-4o") == 42_000
+
+
+def test_small_context_model_keeps_floor_batch():
+    batch_chars, max_faqs = faq_batch_chars_for("GROQ", "llama3-8b-8192")
+    assert batch_chars == settings.FAQ_MAX_BATCH_CHARS
+    assert max_faqs >= 15
+
+
+def test_large_context_model_hits_ceiling():
+    batch_chars, max_faqs = faq_batch_chars_for("ANTHROPIC", "claude-sonnet-5")
+    assert batch_chars == settings.FAQ_MAX_BATCH_CHARS_CEILING
+    assert batch_chars > settings.FAQ_MAX_BATCH_CHARS
+    assert 15 <= max_faqs <= 40
+
+
+def test_mid_context_model_lands_between_floor_and_ceiling():
+    batch_chars, _ = faq_batch_chars_for("OPENAI", "gpt-3.5-turbo")
+    assert settings.FAQ_MAX_BATCH_CHARS <= batch_chars <= settings.FAQ_MAX_BATCH_CHARS_CEILING
+
+
+def test_output_reserve_scales_with_faq_count():
+    assert output_tokens_for(40) > output_tokens_for(15) > 0

--- a/frontend/src/__tests__/components/faq/FaqCard.spec.ts
+++ b/frontend/src/__tests__/components/faq/FaqCard.spec.ts
@@ -1,0 +1,126 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FaqCard from '../../../components/faq/FaqCard.vue'
+import type { FaqItem } from '../../../types/faq'
+
+const faq: FaqItem = {
+  id: 'f1',
+  question: 'How does billing work?',
+  answer: 'Plans are billed per seat, monthly or yearly.',
+  category: 'Billing',
+  status: 'published',
+  knowledge_id: 1,
+  source_label: 'Billing & refunds policy',
+}
+
+const createWrapper = (props = {}) =>
+  mount(FaqCard, {
+    props: {
+      faq,
+      editing: false,
+      draftQuestion: '',
+      draftAnswer: '',
+      ...props,
+    },
+  })
+
+describe('FaqCard display mode', () => {
+  it('renders question, answer and source label', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.find('.faq-card__question').text()).toBe('How does billing work?')
+    expect(wrapper.find('.faq-card__answer').text()).toBe('Plans are billed per seat, monthly or yearly.')
+    expect(wrapper.find('.faq-card__source').text()).toContain('Billing & refunds policy')
+  })
+
+  it('falls back to Generated when there is no source label', () => {
+    const wrapper = createWrapper({ faq: { ...faq, source_label: null } })
+    expect(wrapper.find('.faq-card__source').text()).toContain('Generated')
+  })
+
+  it('shows the publish pill state', () => {
+    const published = createWrapper()
+    expect(published.find('.pill').classes()).toContain('pill--published')
+    expect(published.find('.pill').text()).toContain('Published')
+
+    const draft = createWrapper({ faq: { ...faq, status: 'draft' } })
+    expect(draft.find('.pill').classes()).toContain('pill--draft')
+    expect(draft.find('.pill').text()).toContain('Draft')
+  })
+
+  it('emits toggle-status when the pill is clicked', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.pill').trigger('click')
+    expect(wrapper.emitted('toggle-status')).toHaveLength(1)
+  })
+
+  it('emits edit and delete from the icon buttons', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.icon-btn--edit').trigger('click')
+    await wrapper.find('.icon-btn--delete').trigger('click')
+    expect(wrapper.emitted('edit')).toHaveLength(1)
+    expect(wrapper.emitted('delete')).toHaveLength(1)
+  })
+
+  it('hides edit and delete and disables the pill when locked', () => {
+    const wrapper = createWrapper({ locked: true })
+    expect(wrapper.find('.icon-btn--edit').exists()).toBe(false)
+    expect(wrapper.find('.icon-btn--delete').exists()).toBe(false)
+    expect(wrapper.find('.pill').attributes('disabled')).toBeDefined()
+  })
+})
+
+describe('FaqCard edit mode', () => {
+  it('renders inputs bound to the drafts', () => {
+    const wrapper = createWrapper({
+      editing: true,
+      draftQuestion: 'Draft question?',
+      draftAnswer: 'Draft answer.',
+    })
+    expect((wrapper.find('.edit-question').element as HTMLInputElement).value).toBe('Draft question?')
+    expect((wrapper.find('.edit-answer').element as HTMLTextAreaElement).value).toBe('Draft answer.')
+    expect(wrapper.find('.edit-label').text()).toBe('EDITING')
+  })
+
+  it('labels a new FAQ', () => {
+    const wrapper = createWrapper({ editing: true, isNew: true })
+    expect(wrapper.find('.edit-label').text()).toBe('NEW FAQ')
+  })
+
+  it('emits draft updates on input', async () => {
+    const wrapper = createWrapper({ editing: true })
+    await wrapper.find('.edit-question').setValue('New question')
+    await wrapper.find('.edit-answer').setValue('New answer')
+    expect(wrapper.emitted('update:draftQuestion')?.[0]).toEqual(['New question'])
+    expect(wrapper.emitted('update:draftAnswer')?.[0]).toEqual(['New answer'])
+  })
+
+  it('emits save and cancel', async () => {
+    const wrapper = createWrapper({ editing: true })
+    await wrapper.find('.btn-save').trigger('click')
+    await wrapper.find('.btn-cancel').trigger('click')
+    expect(wrapper.emitted('save')).toHaveLength(1)
+    expect(wrapper.emitted('cancel')).toHaveLength(1)
+  })
+
+  it('disables Save while saving', () => {
+    const wrapper = createWrapper({ editing: true, saving: true })
+    expect(wrapper.find('.btn-save').attributes('disabled')).toBeDefined()
+    expect(wrapper.find('.btn-save').text()).toBe('Saving…')
+  })
+})

--- a/frontend/src/__tests__/components/faq/FaqCard.spec.ts
+++ b/frontend/src/__tests__/components/faq/FaqCard.spec.ts
@@ -14,9 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
+
+// FaqCard → MarkdownEditor → faqService → api → router → views → firebase,
+// which cannot initialize in the test environment.
+vi.mock('@/services/firebase', () => ({
+  messaging: {},
+  requestNotificationPermission: vi.fn(),
+}))
+vi.mock('@/services/faq', () => ({
+  faqService: { uploadImage: vi.fn() },
+}))
+
 import FaqCard from '../../../components/faq/FaqCard.vue'
+import MarkdownEditor from '../../../components/faq/MarkdownEditor.vue'
 import type { FaqItem } from '../../../types/faq'
 
 const faq: FaqItem = {
@@ -93,7 +105,8 @@ describe('FaqCard edit mode', () => {
       draftAnswer: 'Draft answer.',
     })
     expect((wrapper.find('.edit-question').element as HTMLInputElement).value).toBe('Draft question?')
-    expect((wrapper.find('.edit-answer').element as HTMLTextAreaElement).value).toBe('Draft answer.')
+    // The answer is edited through the MarkdownEditor component.
+    expect(wrapper.findComponent(MarkdownEditor).props('modelValue')).toBe('Draft answer.')
     expect(wrapper.find('.edit-label').text()).toBe('EDITING')
   })
 
@@ -105,7 +118,7 @@ describe('FaqCard edit mode', () => {
   it('emits draft updates on input', async () => {
     const wrapper = createWrapper({ editing: true })
     await wrapper.find('.edit-question').setValue('New question')
-    await wrapper.find('.edit-answer').setValue('New answer')
+    wrapper.findComponent(MarkdownEditor).vm.$emit('update:modelValue', 'New answer')
     expect(wrapper.emitted('update:draftQuestion')?.[0]).toEqual(['New question'])
     expect(wrapper.emitted('update:draftAnswer')?.[0]).toEqual(['New answer'])
   })

--- a/frontend/src/__tests__/components/faq/FaqGenerateBar.spec.ts
+++ b/frontend/src/__tests__/components/faq/FaqGenerateBar.spec.ts
@@ -1,0 +1,77 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FaqGenerateBar from '../../../components/faq/FaqGenerateBar.vue'
+
+const createWrapper = (props = {}) =>
+  mount(FaqGenerateBar, {
+    props: {
+      phase: 'idle' as const,
+      sourceCount: 5,
+      pageCount: 9,
+      faqCount: 12,
+      publishedCount: 7,
+      ...props,
+    },
+  })
+
+describe('FaqGenerateBar', () => {
+  it('shows knowledge base counts and Generate when idle', () => {
+    const wrapper = createWrapper()
+    expect(wrapper.find('.generate-bar__title').text()).toBe('Generate FAQs')
+    expect(wrapper.find('.generate-bar__sub').text()).toContain('Reading from 5 sources · 9 pages')
+    expect(wrapper.find('.btn--generate').text()).toContain('Generate')
+    expect(wrapper.find('.btn--generate').attributes('disabled')).toBeUndefined()
+  })
+
+  it('shows FAQ counts and Regenerate when ready', () => {
+    const wrapper = createWrapper({ phase: 'ready' })
+    expect(wrapper.find('.generate-bar__title').text()).toBe('FAQs ready to publish')
+    expect(wrapper.find('.generate-bar__sub').text()).toContain('12 FAQs · 7 published')
+    expect(wrapper.find('.btn--generate').text()).toContain('Regenerate')
+  })
+
+  it('disables the generate button while generating', () => {
+    const wrapper = createWrapper({ phase: 'generating' })
+    expect(wrapper.find('.generate-bar__title').text()).toBe('Generating FAQs…')
+    expect(wrapper.find('.btn--generate').text()).toContain('Generating…')
+    expect(wrapper.find('.btn--generate').attributes('disabled')).toBeDefined()
+  })
+
+  it('respects the disabled prop', () => {
+    const wrapper = createWrapper({ disabled: true })
+    expect(wrapper.find('.btn--generate').attributes('disabled')).toBeDefined()
+  })
+
+  it('emits generate, import and add', async () => {
+    const wrapper = createWrapper()
+    await wrapper.find('.btn--generate').trigger('click')
+    const ghostButtons = wrapper.findAll('.btn--ghost')
+    await ghostButtons[0].trigger('click')
+    await ghostButtons[1].trigger('click')
+    expect(wrapper.emitted('generate')).toHaveLength(1)
+    expect(wrapper.emitted('import')).toHaveLength(1)
+    expect(wrapper.emitted('add')).toHaveLength(1)
+  })
+
+  it('does not emit generate when disabled', async () => {
+    const wrapper = createWrapper({ phase: 'generating' })
+    await wrapper.find('.btn--generate').trigger('click')
+    expect(wrapper.emitted('generate')).toBeUndefined()
+  })
+})

--- a/frontend/src/__tests__/components/faq/FaqGenerationProgress.spec.ts
+++ b/frontend/src/__tests__/components/faq/FaqGenerationProgress.spec.ts
@@ -1,0 +1,74 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import FaqGenerationProgress from '../../../components/faq/FaqGenerationProgress.vue'
+import type { FaqGenerationJob, FaqJobStage } from '../../../types/faq'
+
+const job = (stage: FaqJobStage): FaqGenerationJob => ({
+  id: 1,
+  job_type: 'generate_all',
+  status: 'processing',
+  stage,
+  progress_percentage: 40,
+  faqs_created: 0,
+  source_url: null,
+  error: null,
+})
+
+const stepStates = (stage: FaqJobStage) => {
+  const wrapper = mount(FaqGenerationProgress, { props: { job: job(stage) } })
+  return wrapper.findAll('.step').map((step) => {
+    if (step.classes().includes('done')) return 'done'
+    if (step.classes().includes('active')) return 'active'
+    return 'todo'
+  })
+}
+
+describe('FaqGenerationProgress', () => {
+  it('renders four steps with the expected labels', () => {
+    const wrapper = mount(FaqGenerationProgress, { props: { job: job('analyzing_sources') } })
+    const labels = wrapper.findAll('.step__label').map((el) => el.text())
+    expect(labels).toEqual([
+      'Analyzing your sources',
+      'Extracting questions from your content',
+      'Drafting grounded answers',
+      'Grouping by topic',
+    ])
+  })
+
+  it('marks earlier stages done, the current stage active, later stages todo', () => {
+    expect(stepStates('drafting')).toEqual(['done', 'done', 'active', 'todo'])
+  })
+
+  it('starts with the first stage active', () => {
+    expect(stepStates('analyzing_sources')).toEqual(['active', 'todo', 'todo', 'todo'])
+    expect(stepStates('not_started')).toEqual(['active', 'todo', 'todo', 'todo'])
+  })
+
+  it('marks everything done when completed', () => {
+    expect(stepStates('completed')).toEqual(['done', 'done', 'done', 'done'])
+  })
+
+  it('shows pulsing dots only on the active step', () => {
+    const wrapper = mount(FaqGenerationProgress, { props: { job: job('drafting') } })
+    const steps = wrapper.findAll('.step')
+    expect(steps[2].find('.step__pulse').exists()).toBe(true)
+    expect(steps[0].find('.step__pulse').exists()).toBe(false)
+    expect(steps[3].find('.step__pulse').exists()).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/utils/color.spec.ts
+++ b/frontend/src/__tests__/utils/color.spec.ts
@@ -1,0 +1,53 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from 'vitest'
+import { contrastInk, hexToRgb } from '../../utils/color'
+
+describe('contrastInk', () => {
+  it('returns dark ink over light colors', () => {
+    expect(contrastInk('#FFFFFF')).toBe('#12131A')
+    expect(contrastInk('#C9F24E')).toBe('#12131A')
+  })
+
+  it('returns white ink over dark colors', () => {
+    expect(contrastInk('#0B0C10')).toBe('#FFFFFF')
+    expect(contrastInk('#4338CA')).toBe('#FFFFFF')
+  })
+
+  it('falls back to white for invalid input', () => {
+    expect(contrastInk('')).toBe('#FFFFFF')
+    expect(contrastInk('not-a-color')).toBe('#FFFFFF')
+    expect(contrastInk('#12')).toBe('#FFFFFF')
+  })
+})
+
+describe('hexToRgb', () => {
+  it('expands 3-digit hex values', () => {
+    expect(hexToRgb('#fff')).toEqual({ r: 255, g: 255, b: 255 })
+    expect(hexToRgb('#a1c')).toEqual({ r: 170, g: 17, b: 204 })
+  })
+
+  it('parses 6-digit hex values with or without the hash', () => {
+    expect(hexToRgb('#4338CA')).toEqual({ r: 67, g: 56, b: 202 })
+    expect(hexToRgb('4338CA')).toEqual({ r: 67, g: 56, b: 202 })
+  })
+
+  it('returns null for invalid input', () => {
+    expect(hexToRgb('#12345')).toBeNull()
+    expect(hexToRgb('zzzzzz')).toBeNull()
+  })
+})

--- a/frontend/src/components/faq/FaqCard.vue
+++ b/frontend/src/components/faq/FaqCard.vue
@@ -48,15 +48,18 @@ function onQuestionInput(event: Event) {
 
 const sourceLabel = () => props.faq.source_label || 'Generated'
 
-// Answers are stored as Markdown; strip the syntax for the compact card preview
-// (the public article page renders the full formatting).
+// Answers are stored as Markdown; strip the syntax and cap the length for the
+// compact, line-clamped card preview (the public article page and the editor
+// show the full formatted content).
+const PREVIEW_MAX_CHARS = 240
 function answerPreview(md: string): string {
-  return (md || '')
+  const text = (md || '')
     .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
     .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
     .replace(/[#>*_`~]/g, '')
     .replace(/\s+/g, ' ')
     .trim()
+  return text.length > PREVIEW_MAX_CHARS ? `${text.slice(0, PREVIEW_MAX_CHARS).trimEnd()}…` : text
 }
 </script>
 
@@ -185,6 +188,13 @@ function answerPreview(md: string): string {
   font-size: 13.5px;
   color: var(--muted);
   line-height: 1.55;
+  /* Keep every card compact and uniform — imported articles can be very long;
+     full content is on the public page and in the editor. */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .faq-card__source {

--- a/frontend/src/components/faq/FaqCard.vue
+++ b/frontend/src/components/faq/FaqCard.vue
@@ -16,6 +16,7 @@ limitations under the License.
 
 <script setup lang="ts">
 import type { FaqItem } from '@/types/faq'
+import MarkdownEditor from './MarkdownEditor.vue'
 
 const props = defineProps<{
   faq: FaqItem
@@ -41,11 +42,18 @@ function onQuestionInput(event: Event) {
   emit('update:draftQuestion', (event.target as HTMLInputElement).value)
 }
 
-function onAnswerInput(event: Event) {
-  emit('update:draftAnswer', (event.target as HTMLTextAreaElement).value)
-}
-
 const sourceLabel = () => props.faq.source_label || 'Generated'
+
+// Answers are stored as Markdown; strip the syntax for the compact card preview
+// (the public article page renders the full formatting).
+function answerPreview(md: string): string {
+  return (md || '')
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[#>*_`~]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
 </script>
 
 <template>
@@ -60,13 +68,12 @@ const sourceLabel = () => props.faq.source_label || 'Generated'
         :value="draftQuestion"
         @input="onQuestionInput"
       />
-      <textarea
+      <MarkdownEditor
         class="edit-answer"
-        rows="3"
-        placeholder="Answer"
-        :value="draftAnswer"
-        @input="onAnswerInput"
-      ></textarea>
+        :model-value="draftAnswer"
+        @update:model-value="$emit('update:draftAnswer', $event)"
+      />
+      <p class="edit-hint">Markdown supported — headings, <strong>bold</strong>, lists, links and images.</p>
       <div class="edit-actions">
         <button class="btn-save" type="button" :disabled="saving" @click="$emit('save')">
           {{ saving ? 'Saving…' : 'Save' }}
@@ -79,7 +86,7 @@ const sourceLabel = () => props.faq.source_label || 'Generated'
     <div v-else class="faq-card__row">
       <div class="faq-card__body">
         <div class="faq-card__question">{{ faq.question }}</div>
-        <div class="faq-card__answer">{{ faq.answer }}</div>
+        <div class="faq-card__answer">{{ answerPreview(faq.answer) }}</div>
         <div class="faq-card__source">
           <span class="faq-card__source-dot"></span>
           {{ sourceLabel() }}
@@ -244,8 +251,7 @@ const sourceLabel = () => props.faq.source_label || 'Generated'
   margin-bottom: 10px;
 }
 
-.edit-question,
-.edit-answer {
+.edit-question {
   width: 100%;
   background: var(--bg);
   border: 1px solid var(--o12);
@@ -254,20 +260,20 @@ const sourceLabel = () => props.faq.source_label || 'Generated'
   color: var(--text);
   outline: none;
   box-sizing: border-box;
-}
-
-.edit-question {
   font-size: 14.5px;
   font-weight: 600;
   margin-bottom: 9px;
 }
 
-.edit-answer {
-  font-family: var(--font-sans);
-  font-size: 13.5px;
-  color: var(--text3);
-  resize: vertical;
-  line-height: 1.55;
+/* .edit-answer wraps the MarkdownEditor, which supplies its own chrome. */
+.edit-hint {
+  margin: 8px 0 0;
+  font-size: 11.5px;
+  color: var(--muted2);
+}
+
+.edit-hint strong {
+  font-weight: 600;
 }
 
 .edit-actions {

--- a/frontend/src/components/faq/FaqCard.vue
+++ b/frontend/src/components/faq/FaqCard.vue
@@ -26,6 +26,9 @@ const props = defineProps<{
   draftQuestion: string
   draftAnswer: string
   locked?: boolean
+  /** Selection mode is on somewhere in the list (keeps checkboxes visible). */
+  selectable?: boolean
+  selected?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -34,6 +37,7 @@ const emit = defineEmits<{
   delete: []
   save: []
   cancel: []
+  'toggle-select': []
   'update:draftQuestion': [value: string]
   'update:draftAnswer': [value: string]
 }>()
@@ -57,7 +61,7 @@ function answerPreview(md: string): string {
 </script>
 
 <template>
-  <div class="faq-card" :class="{ 'faq-card--editing': editing }">
+  <div class="faq-card" :class="{ 'faq-card--editing': editing, 'faq-card--selecting': selectable, 'faq-card--selected': selected }">
     <!-- Edit mode -->
     <div v-if="editing">
       <div class="edit-label">{{ isNew ? 'NEW FAQ' : 'EDITING' }}</div>
@@ -84,6 +88,14 @@ function answerPreview(md: string): string {
 
     <!-- Display mode -->
     <div v-else class="faq-card__row">
+      <input
+        v-if="!locked"
+        class="faq-card__check"
+        type="checkbox"
+        :checked="selected"
+        :aria-label="`Select ${faq.question}`"
+        @change="$emit('toggle-select')"
+      />
       <div class="faq-card__body">
         <div class="faq-card__question">{{ faq.question }}</div>
         <div class="faq-card__answer">{{ answerPreview(faq.answer) }}</div>
@@ -124,6 +136,29 @@ function answerPreview(md: string): string {
 
 .faq-card--editing {
   border-color: var(--purple-border);
+}
+
+.faq-card--selected {
+  border-color: var(--teal-border);
+  background: var(--teal-bg);
+}
+
+.faq-card__check {
+  width: 16px;
+  height: 16px;
+  margin: 3px 0 0;
+  flex-shrink: 0;
+  accent-color: var(--c-teal);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.faq-card:hover .faq-card__check,
+.faq-card--selecting .faq-card__check,
+.faq-card__check:checked,
+.faq-card__check:focus-visible {
+  opacity: 1;
 }
 
 .faq-card__row {

--- a/frontend/src/components/faq/FaqCard.vue
+++ b/frontend/src/components/faq/FaqCard.vue
@@ -1,0 +1,308 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import type { FaqItem } from '@/types/faq'
+
+const props = defineProps<{
+  faq: FaqItem
+  editing: boolean
+  isNew?: boolean
+  saving?: boolean
+  draftQuestion: string
+  draftAnswer: string
+  locked?: boolean
+}>()
+
+const emit = defineEmits<{
+  'toggle-status': []
+  edit: []
+  delete: []
+  save: []
+  cancel: []
+  'update:draftQuestion': [value: string]
+  'update:draftAnswer': [value: string]
+}>()
+
+function onQuestionInput(event: Event) {
+  emit('update:draftQuestion', (event.target as HTMLInputElement).value)
+}
+
+function onAnswerInput(event: Event) {
+  emit('update:draftAnswer', (event.target as HTMLTextAreaElement).value)
+}
+
+const sourceLabel = () => props.faq.source_label || 'Generated'
+</script>
+
+<template>
+  <div class="faq-card" :class="{ 'faq-card--editing': editing }">
+    <!-- Edit mode -->
+    <div v-if="editing">
+      <div class="edit-label">{{ isNew ? 'NEW FAQ' : 'EDITING' }}</div>
+      <input
+        class="edit-question"
+        type="text"
+        placeholder="Question"
+        :value="draftQuestion"
+        @input="onQuestionInput"
+      />
+      <textarea
+        class="edit-answer"
+        rows="3"
+        placeholder="Answer"
+        :value="draftAnswer"
+        @input="onAnswerInput"
+      ></textarea>
+      <div class="edit-actions">
+        <button class="btn-save" type="button" :disabled="saving" @click="$emit('save')">
+          {{ saving ? 'Saving…' : 'Save' }}
+        </button>
+        <button class="btn-cancel" type="button" :disabled="saving" @click="$emit('cancel')">Cancel</button>
+      </div>
+    </div>
+
+    <!-- Display mode -->
+    <div v-else class="faq-card__row">
+      <div class="faq-card__body">
+        <div class="faq-card__question">{{ faq.question }}</div>
+        <div class="faq-card__answer">{{ faq.answer }}</div>
+        <div class="faq-card__source">
+          <span class="faq-card__source-dot"></span>
+          {{ sourceLabel() }}
+        </div>
+      </div>
+      <div class="faq-card__controls">
+        <button
+          class="pill"
+          :class="faq.status === 'published' ? 'pill--published' : 'pill--draft'"
+          type="button"
+          :disabled="locked"
+          @click="$emit('toggle-status')"
+        >
+          <span class="pill__dot"></span>
+          {{ faq.status === 'published' ? 'Published' : 'Draft' }}
+        </button>
+        <button v-if="!locked" class="icon-btn icon-btn--edit" type="button" title="Edit" @click="$emit('edit')">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9" /><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z" /></svg>
+        </button>
+        <button v-if="!locked" class="icon-btn icon-btn--delete" type="button" title="Delete" @click="$emit('delete')">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16" /><path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" /><path d="M6 7l1 13a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1l1-13" /></svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.faq-card {
+  background: var(--surface);
+  border: 1px solid var(--o08);
+  border-radius: 14px;
+  padding: 16px 18px;
+}
+
+.faq-card--editing {
+  border-color: var(--purple-border);
+}
+
+.faq-card__row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.faq-card__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.faq-card__question {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text2);
+  line-height: 1.4;
+  margin-bottom: 6px;
+}
+
+.faq-card__answer {
+  font-size: 13.5px;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.faq-card__source {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 11px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--faint);
+}
+
+.faq-card__source-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--faint);
+}
+
+.faq-card__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 13px;
+  border-radius: 9px;
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.pill:disabled {
+  cursor: default;
+}
+
+.pill__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.pill--published {
+  background: var(--teal-bg);
+  border: 1px solid var(--teal-border);
+  color: var(--c-teal);
+}
+
+.pill--published .pill__dot {
+  background: var(--c-teal);
+}
+
+.pill--draft {
+  background: var(--pill-idle-bg);
+  border: 1px solid var(--o12);
+  color: var(--pill-idle-fg);
+}
+
+.pill--draft .pill__dot {
+  background: var(--faint);
+}
+
+.icon-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 9px;
+  background: var(--o05);
+  border: 1px solid var(--o12);
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.icon-btn--edit:hover {
+  background: var(--o08);
+  color: var(--text2);
+}
+
+.icon-btn--delete:hover {
+  background: var(--coral-bg);
+  color: var(--c-coral);
+  border-color: var(--coral-border);
+}
+
+.edit-label {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  color: var(--c-purple);
+  margin-bottom: 10px;
+}
+
+.edit-question,
+.edit-answer {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--o12);
+  border-radius: 10px;
+  padding: 11px 13px;
+  color: var(--text);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.edit-question {
+  font-size: 14.5px;
+  font-weight: 600;
+  margin-bottom: 9px;
+}
+
+.edit-answer {
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  color: var(--text3);
+  resize: vertical;
+  line-height: 1.55;
+}
+
+.edit-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.btn-save {
+  padding: 9px 18px;
+  background: var(--accent-solid);
+  border: none;
+  border-radius: 9px;
+  color: var(--on-accent-solid);
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-save:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.btn-cancel {
+  padding: 9px 16px;
+  background: transparent;
+  border: 1px solid var(--o12);
+  border-radius: 9px;
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  font-weight: 500;
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/components/faq/FaqCategoryGroup.vue
+++ b/frontend/src/components/faq/FaqCategoryGroup.vue
@@ -18,12 +18,17 @@ limitations under the License.
 const props = defineProps<{
   category: string
   count: number
+  /** Published FAQs in this group (for the header stat). */
+  publishedCount?: number
   /** Cards in this group currently selected; undefined hides the select-all. */
   selectedCount?: number
+  /** Whether the group body is expanded. */
+  open?: boolean
 }>()
 
 defineEmits<{
   'toggle-all': [on: boolean]
+  toggle: []
 }>()
 
 const allSelected = () => props.selectedCount === props.count && props.count > 0
@@ -39,13 +44,29 @@ const allSelected = () => props.selectedCount === props.count && props.count > 0
         :checked="allSelected()"
         :indeterminate.prop="!!selectedCount && !allSelected()"
         :aria-label="`Select all in ${category}`"
+        @click.stop
         @change="$emit('toggle-all', !allSelected())"
       />
-      <span class="category-group__name">{{ category.toUpperCase() }}</span>
-      <span class="category-group__count">{{ count }} {{ count === 1 ? 'answer' : 'answers' }}</span>
+      <button
+        class="category-group__toggle"
+        type="button"
+        :aria-expanded="open"
+        @click="$emit('toggle')"
+      >
+        <svg
+          class="category-group__chevron"
+          :class="{ 'category-group__chevron--open': open }"
+          viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor"
+          stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"
+        ><path d="M9 6l6 6-6 6" /></svg>
+        <span class="category-group__name">{{ category.toUpperCase() }}</span>
+        <span class="category-group__count">
+          {{ count }} {{ count === 1 ? 'answer' : 'answers' }}<template v-if="publishedCount !== undefined"> · {{ publishedCount }} published</template>
+        </span>
+      </button>
       <div class="category-group__rule"></div>
     </div>
-    <div class="category-group__cards">
+    <div v-show="open" class="category-group__cards">
       <slot />
     </div>
   </div>
@@ -78,6 +99,27 @@ const allSelected = () => props.selectedCount === props.count && props.count > 0
 .category-group__check:checked,
 .category-group__check:indeterminate {
   opacity: 1;
+}
+
+.category-group__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  padding: 2px 0;
+  cursor: pointer;
+  color: inherit;
+}
+
+.category-group__chevron {
+  color: var(--muted2);
+  flex-shrink: 0;
+  transition: transform var(--transition-fast);
+}
+
+.category-group__chevron--open {
+  transform: rotate(90deg);
 }
 
 .category-group__name {

--- a/frontend/src/components/faq/FaqCategoryGroup.vue
+++ b/frontend/src/components/faq/FaqCategoryGroup.vue
@@ -1,0 +1,74 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+defineProps<{
+  category: string
+  count: number
+}>()
+</script>
+
+<template>
+  <div class="category-group">
+    <div class="category-group__header">
+      <span class="category-group__name">{{ category.toUpperCase() }}</span>
+      <span class="category-group__count">{{ count }} {{ count === 1 ? 'answer' : 'answers' }}</span>
+      <div class="category-group__rule"></div>
+    </div>
+    <div class="category-group__cards">
+      <slot />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.category-group {
+  margin-bottom: 18px;
+}
+
+.category-group__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  padding: 0 2px;
+}
+
+.category-group__name {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--accent-ink);
+}
+
+.category-group__count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted2);
+}
+
+.category-group__rule {
+  flex: 1;
+  height: 1px;
+  background: var(--o07);
+}
+
+.category-group__cards {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+</style>

--- a/frontend/src/components/faq/FaqCategoryGroup.vue
+++ b/frontend/src/components/faq/FaqCategoryGroup.vue
@@ -15,15 +15,32 @@ limitations under the License.
 -->
 
 <script setup lang="ts">
-defineProps<{
+const props = defineProps<{
   category: string
   count: number
+  /** Cards in this group currently selected; undefined hides the select-all. */
+  selectedCount?: number
 }>()
+
+defineEmits<{
+  'toggle-all': [on: boolean]
+}>()
+
+const allSelected = () => props.selectedCount === props.count && props.count > 0
 </script>
 
 <template>
   <div class="category-group">
     <div class="category-group__header">
+      <input
+        v-if="selectedCount !== undefined"
+        class="category-group__check"
+        type="checkbox"
+        :checked="allSelected()"
+        :indeterminate.prop="!!selectedCount && !allSelected()"
+        :aria-label="`Select all in ${category}`"
+        @change="$emit('toggle-all', !allSelected())"
+      />
       <span class="category-group__name">{{ category.toUpperCase() }}</span>
       <span class="category-group__count">{{ count }} {{ count === 1 ? 'answer' : 'answers' }}</span>
       <div class="category-group__rule"></div>
@@ -45,6 +62,22 @@ defineProps<{
   gap: 10px;
   margin-bottom: 10px;
   padding: 0 2px;
+}
+
+.category-group__check {
+  width: 14px;
+  height: 14px;
+  margin: 0;
+  accent-color: var(--c-teal);
+  cursor: pointer;
+  opacity: 0.55;
+  transition: opacity var(--transition-fast);
+}
+
+.category-group__header:hover .category-group__check,
+.category-group__check:checked,
+.category-group__check:indeterminate {
+  opacity: 1;
 }
 
 .category-group__name {

--- a/frontend/src/components/faq/FaqEmptyState.vue
+++ b/frontend/src/components/faq/FaqEmptyState.vue
@@ -1,0 +1,160 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import FaqOrb from './FaqOrb.vue'
+
+defineProps<{
+  sourceCount: number
+  pageCount: number
+}>()
+
+defineEmits<{
+  generate: []
+  import: []
+  add: []
+}>()
+</script>
+
+<template>
+  <div class="empty-state">
+    <FaqOrb class="empty-state__orb" :size="64" />
+    <h3 class="empty-state__title">No FAQs yet</h3>
+    <p class="empty-state__copy">
+      Let ChatterMate read your knowledge base and draft clear, ready-to-publish FAQs — grouped by
+      topic and kept in sync as your docs change.
+    </p>
+    <div class="empty-state__pill">
+      <span class="empty-state__dot"></span>
+      Reading from {{ sourceCount }} sources · {{ pageCount }} pages
+    </div>
+    <div class="empty-state__actions">
+      <button class="btn btn--primary" type="button" @click="$emit('generate')">
+        <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 3v4M3 5h4M6 17v4M4 19h4M13 3l2.5 6.5L22 12l-6.5 2.5L13 21l-2.5-6.5L4 12l6.5-2.5z" /></svg>
+        Generate from knowledge base
+      </button>
+      <button class="btn btn--ghost" type="button" @click="$emit('import')">Import existing FAQ</button>
+      <button class="btn btn--text" type="button" @click="$emit('add')">Add manually</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.empty-state {
+  background: var(--surface);
+  border: 1px dashed var(--o14);
+  border-radius: 16px;
+  padding: 56px 32px;
+  text-align: center;
+}
+
+.empty-state__orb {
+  margin: 0 auto 22px;
+}
+
+.empty-state__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0 0 10px;
+}
+
+.empty-state__copy {
+  font-size: 14.5px;
+  color: var(--muted);
+  line-height: 1.6;
+  margin: 0 auto 26px;
+  max-width: 440px;
+}
+
+.empty-state__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 14px;
+  border-radius: var(--radius-pill);
+  background: var(--o04);
+  border: 1px solid var(--o10);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text3);
+  margin-bottom: 26px;
+}
+
+.empty-state__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--c-teal);
+  box-shadow: 0 0 6px var(--c-teal);
+}
+
+.empty-state__actions {
+  display: flex;
+  gap: 11px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  border-radius: 12px;
+  font-family: var(--font-sans);
+  font-size: 15px;
+  cursor: pointer;
+  transition: filter var(--transition-fast), background-color var(--transition-fast);
+}
+
+.btn--primary {
+  padding: 14px 24px;
+  background: var(--grad-generate);
+  border: none;
+  color: var(--on-dark);
+  font-weight: 600;
+}
+
+.btn--primary:hover {
+  filter: brightness(1.1);
+}
+
+.btn--ghost {
+  padding: 14px 20px;
+  background: var(--o05);
+  border: 1px solid var(--o14);
+  color: var(--text2);
+  font-weight: 600;
+}
+
+.btn--ghost:hover {
+  background: var(--o08);
+}
+
+.btn--text {
+  padding: 14px 20px;
+  background: transparent;
+  border: 1px solid var(--o12);
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.btn--text:hover {
+  background: var(--o04);
+}
+</style>

--- a/frontend/src/components/faq/FaqGenerateBar.vue
+++ b/frontend/src/components/faq/FaqGenerateBar.vue
@@ -24,6 +24,8 @@ const props = defineProps<{
   pageCount: number
   faqCount: number
   publishedCount: number
+  /** Sources without FAQs yet (from the estimate); null = unknown. */
+  newSourceCount?: number | null
   disabled?: boolean
 }>()
 
@@ -47,11 +49,23 @@ const subtitle = computed(() =>
 
 const generateLabel = computed(() => {
   if (props.phase === 'generating') return 'Generating…'
-  if (props.phase === 'ready') return 'Regenerate'
+  if (props.phase === 'ready') {
+    // Regenerate only reads new (ungenerated) sources — say so.
+    if (typeof props.newSourceCount === 'number' && props.newSourceCount > 0) {
+      return `Generate ${props.newSourceCount} new source${props.newSourceCount === 1 ? '' : 's'}`
+    }
+    return 'Regenerate'
+  }
   return 'Generate'
 })
 
-const generateDisabled = computed(() => props.phase === 'generating' || props.disabled)
+const noNewSources = computed(() => props.phase === 'ready' && props.newSourceCount === 0)
+
+const generateDisabled = computed(() => props.phase === 'generating' || props.disabled || noNewSources.value)
+
+const generateTitle = computed(() =>
+  noNewSources.value ? 'All knowledge sources already have FAQs' : undefined,
+)
 </script>
 
 <template>
@@ -75,7 +89,7 @@ const generateDisabled = computed(() => props.phase === 'generating' || props.di
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M12 5v14M5 12h14" /></svg>
         Add FAQ
       </button>
-      <button class="btn btn--generate" type="button" :disabled="generateDisabled" @click="$emit('generate')">
+      <button class="btn btn--generate" type="button" :disabled="generateDisabled" :title="generateTitle" @click="$emit('generate')">
         <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 3v4M3 5h4M6 17v4M4 19h4M13 3l2.5 6.5L22 12l-6.5 2.5L13 21l-2.5-6.5L4 12l6.5-2.5z" /></svg>
         {{ generateLabel }}
       </button>

--- a/frontend/src/components/faq/FaqGenerateBar.vue
+++ b/frontend/src/components/faq/FaqGenerateBar.vue
@@ -1,0 +1,162 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import FaqOrb from './FaqOrb.vue'
+
+const props = defineProps<{
+  phase: 'idle' | 'generating' | 'ready'
+  sourceCount: number
+  pageCount: number
+  faqCount: number
+  publishedCount: number
+  disabled?: boolean
+}>()
+
+defineEmits<{
+  generate: []
+  import: []
+  add: []
+}>()
+
+const title = computed(() => {
+  if (props.phase === 'generating') return 'Generating FAQs…'
+  if (props.phase === 'ready') return 'FAQs ready to publish'
+  return 'Generate FAQs'
+})
+
+const subtitle = computed(() =>
+  props.phase === 'ready'
+    ? `${props.faqCount} FAQs · ${props.publishedCount} published`
+    : `Reading from ${props.sourceCount} sources · ${props.pageCount} pages`,
+)
+
+const generateLabel = computed(() => {
+  if (props.phase === 'generating') return 'Generating…'
+  if (props.phase === 'ready') return 'Regenerate'
+  return 'Generate'
+})
+
+const generateDisabled = computed(() => props.phase === 'generating' || props.disabled)
+</script>
+
+<template>
+  <div class="generate-bar">
+    <div class="generate-bar__lead">
+      <FaqOrb :size="40" />
+      <div>
+        <div class="generate-bar__title">{{ title }}</div>
+        <div class="generate-bar__sub">
+          <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5.5A2 2 0 0 1 6 4h5v16H6a2 2 0 0 0-2 1.5z" /><path d="M20 5.5A2 2 0 0 0 18 4h-5v16h5a2 2 0 0 1 2 1.5z" /></svg>
+          {{ subtitle }}
+        </div>
+      </div>
+    </div>
+    <div class="generate-bar__actions">
+      <button class="btn btn--ghost" type="button" @click="$emit('import')">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12" /><path d="M8 11l4 4 4-4" /><path d="M5 21h14" /></svg>
+        Import
+      </button>
+      <button class="btn btn--ghost" type="button" @click="$emit('add')">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M12 5v14M5 12h14" /></svg>
+        Add FAQ
+      </button>
+      <button class="btn btn--generate" type="button" :disabled="generateDisabled" @click="$emit('generate')">
+        <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 3v4M3 5h4M6 17v4M4 19h4M13 3l2.5 6.5L22 12l-6.5 2.5L13 21l-2.5-6.5L4 12l6.5-2.5z" /></svg>
+        {{ generateLabel }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.generate-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 22px;
+  background: var(--surface);
+  border: 1px solid var(--o08);
+  border-radius: 16px;
+  flex-wrap: wrap;
+}
+
+.generate-bar__lead {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.generate-bar__title {
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--text2);
+}
+
+.generate-bar__sub {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.generate-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-radius: 11px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color var(--transition-fast);
+}
+
+.btn--ghost {
+  background: var(--o05);
+  border: 1px solid var(--o14);
+  color: var(--text2);
+}
+
+.btn--ghost:hover {
+  background: var(--o08);
+}
+
+.btn--generate {
+  padding: 12px 20px;
+  background: var(--purple-bg);
+  border: 1px solid var(--purple-border);
+  color: var(--c-purple);
+}
+
+.btn--generate:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+</style>

--- a/frontend/src/components/faq/FaqGenerationProgress.vue
+++ b/frontend/src/components/faq/FaqGenerationProgress.vue
@@ -1,0 +1,205 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { FaqGenerationJob, FaqJobStage } from '@/types/faq'
+import FaqOrb from './FaqOrb.vue'
+
+const props = defineProps<{ job: FaqGenerationJob }>()
+
+const STAGE_ORDER: FaqJobStage[] = ['analyzing_sources', 'extracting', 'drafting', 'grouping']
+const STAGE_LABELS = [
+  'Analyzing your sources',
+  'Extracting questions from your content',
+  'Drafting grounded answers',
+  'Grouping by topic',
+]
+
+const steps = computed(() => {
+  const stage = props.job.stage
+  // Before the first stage report, the first step is active; when the job
+  // finishes, everything is done.
+  const activeIndex = stage === 'completed' ? STAGE_ORDER.length : Math.max(0, STAGE_ORDER.indexOf(stage))
+  return STAGE_LABELS.map((label, index) => ({
+    label,
+    state: index < activeIndex ? 'done' : index === activeIndex ? 'active' : 'todo',
+  }))
+})
+</script>
+
+<template>
+  <div class="progress-card">
+    <div class="progress-card__head">
+      <FaqOrb :size="48" />
+      <div>
+        <div class="progress-card__title">Reading your knowledge base…</div>
+        <div class="progress-card__note">
+          This usually takes under a minute. You can leave this page — we'll keep working.
+        </div>
+      </div>
+    </div>
+    <div class="progress-track">
+      <div class="progress-track__sweep"></div>
+    </div>
+    <div class="steps">
+      <div v-for="step in steps" :key="step.label" class="step" :class="step.state">
+        <span class="step__icon">
+          <svg v-if="step.state === 'done'" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="var(--on-accent-solid)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l4 4 10-10" /></svg>
+          <span v-else-if="step.state === 'active'" class="step__spinner"></span>
+          <span v-else class="step__dot"></span>
+        </span>
+        <span class="step__label">{{ step.label }}</span>
+        <span v-if="step.state === 'active'" class="step__pulse">
+          <span></span><span></span><span></span>
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.progress-card {
+  background: var(--surface);
+  border: 1px solid var(--o08);
+  border-radius: 16px;
+  padding: 40px 32px;
+}
+
+.progress-card__head {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 26px;
+}
+
+.progress-card__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 19px;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+.progress-card__note {
+  font-size: 13.5px;
+  color: var(--muted);
+  margin-top: 3px;
+}
+
+.progress-track {
+  height: 6px;
+  border-radius: var(--radius-pill);
+  background: var(--o08);
+  overflow: hidden;
+  margin-bottom: 26px;
+  position: relative;
+}
+
+.progress-track__sweep {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 38%;
+  border-radius: var(--radius-pill);
+  background: var(--grad-generate);
+  animation: faq-progress 1.5s ease-in-out infinite;
+}
+
+@keyframes faq-progress {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(320%); }
+}
+
+.steps {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.step {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+}
+
+.step__icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.step.done .step__icon {
+  background: var(--accent-solid);
+}
+
+.step__spinner {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid var(--c-purple);
+  border-top-color: transparent;
+  animation: faq-spin 0.8s linear infinite;
+}
+
+@keyframes faq-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.step__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--faint);
+}
+
+.step__label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text2);
+}
+
+.step.todo .step__label {
+  color: var(--muted2);
+}
+
+.step__pulse {
+  display: inline-flex;
+  gap: 3px;
+  margin-left: 2px;
+}
+
+.step__pulse span {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--c-purple);
+  animation: faq-pulse 1s ease-in-out infinite;
+}
+
+.step__pulse span:nth-child(2) { animation-delay: 0.2s; }
+.step__pulse span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes faq-pulse {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 1; }
+}
+</style>

--- a/frontend/src/components/faq/FaqImportModal.vue
+++ b/frontend/src/components/faq/FaqImportModal.vue
@@ -16,6 +16,7 @@ limitations under the License.
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { toast } from 'vue-sonner'
 import Modal from '@/components/common/Modal.vue'
 import FaqOrb from './FaqOrb.vue'
 import type { FaqImportMode } from '@/types/faq'
@@ -85,8 +86,20 @@ const fileSize = computed(() => {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 })
 
+const dragOver = ref(false)
+
+function setPdf(file: File | null | undefined) {
+  if (file && file.type === 'application/pdf') pdfFile.value = file
+  else if (file) toast.error('Please choose a PDF file')
+}
+
 function onPdfChange(event: Event) {
-  pdfFile.value = (event.target as HTMLInputElement).files?.[0] ?? null
+  setPdf((event.target as HTMLInputElement).files?.[0] ?? null)
+}
+
+function onDrop(event: DragEvent) {
+  dragOver.value = false
+  setPdf(event.dataTransfer?.files?.[0])
 }
 
 function submit() {
@@ -134,7 +147,13 @@ function submit() {
       </template>
       <template v-else>
         <label class="import-label" for="faq-import-pdf">PDF FILE (MAX 25MB)</label>
-        <label class="pdf-drop" :class="{ 'pdf-drop--filled': pdfFile }">
+        <label
+          class="pdf-drop"
+          :class="{ 'pdf-drop--filled': pdfFile, 'pdf-drop--drag': dragOver }"
+          @dragover.prevent="dragOver = true"
+          @dragleave.prevent="dragOver = false"
+          @drop.prevent="onDrop"
+        >
           <input id="faq-import-pdf" class="pdf-drop__input" type="file" accept="application/pdf" @change="onPdfChange" />
           <span class="pdf-drop__icon">
             <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z" /><path d="M9 13h6M9 17h4" /></svg>
@@ -284,6 +303,12 @@ function submit() {
 .pdf-drop--filled {
   border-style: solid;
   border-color: var(--purple-border);
+  background: var(--purple-bg);
+}
+
+.pdf-drop--drag {
+  border-style: solid;
+  border-color: var(--c-purple);
   background: var(--purple-bg);
 }
 

--- a/frontend/src/components/faq/FaqImportModal.vue
+++ b/frontend/src/components/faq/FaqImportModal.vue
@@ -78,6 +78,13 @@ const hint = computed(() => {
   return 'ChatterMate crawls the page, extracts each question and answer, and adds them here as drafts for you to review before publishing.'
 })
 
+const fileSize = computed(() => {
+  const bytes = pdfFile.value?.size ?? 0
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+})
+
 function onPdfChange(event: Event) {
   pdfFile.value = (event.target as HTMLInputElement).files?.[0] ?? null
 }
@@ -127,9 +134,22 @@ function submit() {
       </template>
       <template v-else>
         <label class="import-label" for="faq-import-pdf">PDF FILE (MAX 25MB)</label>
-        <div class="import-input import-input--file">
-          <input id="faq-import-pdf" type="file" accept="application/pdf" @change="onPdfChange" />
-        </div>
+        <label class="pdf-drop" :class="{ 'pdf-drop--filled': pdfFile }">
+          <input id="faq-import-pdf" class="pdf-drop__input" type="file" accept="application/pdf" @change="onPdfChange" />
+          <span class="pdf-drop__icon">
+            <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3v4a1 1 0 0 0 1 1h4" /><path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2z" /><path d="M9 13h6M9 17h4" /></svg>
+          </span>
+          <span class="pdf-drop__text">
+            <template v-if="pdfFile">
+              <span class="pdf-drop__name">{{ pdfFile.name }}</span>
+              <span class="pdf-drop__meta">{{ fileSize }} · Choose a different file</span>
+            </template>
+            <template v-else>
+              <span class="pdf-drop__name">Choose a PDF or drop it here</span>
+              <span class="pdf-drop__meta">PDF only, up to 25 MB</span>
+            </template>
+          </span>
+        </label>
       </template>
       <div class="import-hint">
         <FaqOrb :size="34" />
@@ -243,9 +263,74 @@ function submit() {
   font-family: var(--font-mono);
 }
 
-.import-input--file input {
-  font-family: var(--font-sans);
+.pdf-drop {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  padding: 16px 18px;
+  margin-bottom: 16px;
+  background: var(--bg);
+  border: 1.5px dashed var(--o14);
+  border-radius: 12px;
   cursor: pointer;
+  transition: border-color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.pdf-drop:hover {
+  border-color: var(--c-purple);
+  background: var(--purple-bg);
+}
+
+.pdf-drop--filled {
+  border-style: solid;
+  border-color: var(--purple-border);
+  background: var(--purple-bg);
+}
+
+.pdf-drop__input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.pdf-drop__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  border-radius: 10px;
+  background: var(--o05);
+  color: var(--muted);
+}
+
+.pdf-drop--filled .pdf-drop__icon {
+  background: var(--surface);
+  color: var(--c-purple);
+}
+
+.pdf-drop__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.pdf-drop__name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pdf-drop__meta {
+  font-size: 12px;
+  color: var(--muted);
 }
 
 .import-hint {

--- a/frontend/src/components/faq/FaqImportModal.vue
+++ b/frontend/src/components/faq/FaqImportModal.vue
@@ -28,10 +28,12 @@ const props = defineProps<{
 const emit = defineEmits<{
   close: []
   submit: [url: string, mode: FaqImportMode]
+  'submit-pdf': [file: File]
 }>()
 
 const url = ref('')
 const mode = ref<FaqImportMode>('qa')
+const pdfFile = ref<File | null>(null)
 
 const MODES: { value: FaqImportMode; title: string; description: string }[] = [
   {
@@ -44,6 +46,11 @@ const MODES: { value: FaqImportMode; title: string; description: string }[] = [
     title: 'Article pages',
     description: 'Imports every article linked from the page as-is — text, images and links. No AI.',
   },
+  {
+    value: 'pdf',
+    title: 'PDF document',
+    description: 'AI extracts questions & answers from an uploaded PDF. Uses AI credits.',
+  },
 ]
 
 watch(
@@ -52,20 +59,35 @@ watch(
     if (!open) {
       url.value = ''
       mode.value = 'qa'
+      pdfFile.value = null
     }
   },
 )
 
-const canSubmit = computed(() => url.value.trim().length > 0 && !props.submitting)
+const canSubmit = computed(() => {
+  if (props.submitting) return false
+  if (mode.value === 'pdf') return pdfFile.value !== null
+  return url.value.trim().length > 0
+})
 
-const hint = computed(() =>
-  mode.value === 'articles'
-    ? 'ChatterMate follows the article links on that page and imports each article verbatim as a draft — formatting and images included.'
-    : 'ChatterMate crawls the page, extracts each question and answer, and adds them here as drafts for you to review before publishing.',
-)
+const hint = computed(() => {
+  if (mode.value === 'articles')
+    return 'ChatterMate follows the article links on that page and imports each article verbatim as a draft — formatting and images included.'
+  if (mode.value === 'pdf')
+    return 'ChatterMate reads the PDF, extracts each question and answer, and adds them here as drafts for you to review before publishing.'
+  return 'ChatterMate crawls the page, extracts each question and answer, and adds them here as drafts for you to review before publishing.'
+})
+
+function onPdfChange(event: Event) {
+  pdfFile.value = (event.target as HTMLInputElement).files?.[0] ?? null
+}
 
 function submit() {
   if (!canSubmit.value) return
+  if (mode.value === 'pdf') {
+    if (pdfFile.value) emit('submit-pdf', pdfFile.value)
+    return
+  }
   const cleaned = url.value.trim().replace(/^https?:\/\//i, '')
   emit('submit', `https://${cleaned}`, mode.value)
 }
@@ -90,17 +112,25 @@ function submit() {
         </label>
       </div>
 
-      <label class="import-label" for="faq-import-url">{{ mode === 'articles' ? 'HELP CENTER INDEX URL' : 'FAQ PAGE URL' }}</label>
-      <div class="import-input">
-        <span class="import-input__prefix">https://</span>
-        <input
-          id="faq-import-url"
-          v-model="url"
-          type="text"
-          placeholder="support.yourcompany.com/faq"
-          @keydown.enter="submit"
-        />
-      </div>
+      <template v-if="mode !== 'pdf'">
+        <label class="import-label" for="faq-import-url">{{ mode === 'articles' ? 'HELP CENTER INDEX URL' : 'FAQ PAGE URL' }}</label>
+        <div class="import-input">
+          <span class="import-input__prefix">https://</span>
+          <input
+            id="faq-import-url"
+            v-model="url"
+            type="text"
+            placeholder="support.yourcompany.com/faq"
+            @keydown.enter="submit"
+          />
+        </div>
+      </template>
+      <template v-else>
+        <label class="import-label" for="faq-import-pdf">PDF FILE (MAX 25MB)</label>
+        <div class="import-input import-input--file">
+          <input id="faq-import-pdf" type="file" accept="application/pdf" @change="onPdfChange" />
+        </div>
+      </template>
       <div class="import-hint">
         <FaqOrb :size="34" />
         <div>{{ hint }}</div>
@@ -109,7 +139,7 @@ function submit() {
         <button class="btn-cancel" type="button" @click="$emit('close')">Cancel</button>
         <button class="btn-import" type="button" :disabled="!canSubmit" @click="submit">
           <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12" /><path d="M8 11l4 4 4-4" /><path d="M5 21h14" /></svg>
-          {{ submitting ? 'Importing…' : mode === 'articles' ? 'Import articles' : 'Import FAQs' }}
+          {{ submitting ? 'Importing…' : mode === 'articles' ? 'Import articles' : mode === 'pdf' ? 'Import PDF' : 'Import FAQs' }}
         </button>
       </div>
     </template>
@@ -126,9 +156,15 @@ function submit() {
 
 .mode-cards {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, 1fr);
   gap: 10px;
   margin-bottom: 18px;
+}
+
+@media (max-width: 560px) {
+  .mode-cards {
+    grid-template-columns: 1fr;
+  }
 }
 
 .mode-card {
@@ -205,6 +241,11 @@ function submit() {
   font-size: 13.5px;
   padding: 13px 4px;
   font-family: var(--font-mono);
+}
+
+.import-input--file input {
+  font-family: var(--font-sans);
+  cursor: pointer;
 }
 
 .import-hint {

--- a/frontend/src/components/faq/FaqImportModal.vue
+++ b/frontend/src/components/faq/FaqImportModal.vue
@@ -1,0 +1,181 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import Modal from '@/components/common/Modal.vue'
+import FaqOrb from './FaqOrb.vue'
+
+const props = defineProps<{
+  open: boolean
+  submitting?: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+  submit: [url: string]
+}>()
+
+const url = ref('')
+
+watch(
+  () => props.open,
+  (open) => {
+    if (!open) url.value = ''
+  },
+)
+
+const canSubmit = computed(() => url.value.trim().length > 0 && !props.submitting)
+
+function submit() {
+  if (!canSubmit.value) return
+  const cleaned = url.value.trim().replace(/^https?:\/\//i, '')
+  emit('submit', `https://${cleaned}`)
+}
+</script>
+
+<template>
+  <Modal v-if="open" @close="$emit('close')">
+    <template #title>Migrate an existing FAQ page</template>
+    <template #content>
+      <p class="import-sub">Paste a help-center or FAQ URL — we detect every question &amp; answer pair.</p>
+      <label class="import-label" for="faq-import-url">FAQ PAGE URL</label>
+      <div class="import-input">
+        <span class="import-input__prefix">https://</span>
+        <input
+          id="faq-import-url"
+          v-model="url"
+          type="text"
+          placeholder="support.yourcompany.com/faq"
+          @keydown.enter="submit"
+        />
+      </div>
+      <div class="import-hint">
+        <FaqOrb :size="34" />
+        <div>
+          ChatterMate crawls the page, extracts each question and answer, and adds them here as
+          drafts for you to review before publishing.
+        </div>
+      </div>
+      <div class="import-actions">
+        <button class="btn-cancel" type="button" @click="$emit('close')">Cancel</button>
+        <button class="btn-import" type="button" :disabled="!canSubmit" @click="submit">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12" /><path d="M8 11l4 4 4-4" /><path d="M5 21h14" /></svg>
+          {{ submitting ? 'Importing…' : 'Import FAQs' }}
+        </button>
+      </div>
+    </template>
+  </Modal>
+</template>
+
+<style scoped>
+.import-sub {
+  font-size: 13px;
+  color: var(--muted);
+  margin: -12px 0 18px;
+  line-height: 1.5;
+}
+
+.import-label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--muted2);
+  margin-bottom: 8px;
+}
+
+.import-input {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--bg);
+  border: 1px solid var(--o12);
+  border-radius: 11px;
+  padding: 0 14px;
+  margin-bottom: 16px;
+  font-family: var(--font-mono);
+}
+
+.import-input__prefix {
+  color: var(--faint);
+  font-size: 13.5px;
+}
+
+.import-input input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-size: 13.5px;
+  padding: 13px 4px;
+  font-family: var(--font-mono);
+}
+
+.import-hint {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  background: var(--o03);
+  border: 1px solid var(--o07);
+  border-radius: 12px;
+  margin-bottom: 20px;
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.import-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.btn-cancel {
+  padding: 11px 18px;
+  background: transparent;
+  border: 1px solid var(--o12);
+  border-radius: 10px;
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.btn-import {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 20px;
+  background: var(--c-purple);
+  border: none;
+  border-radius: 10px;
+  color: var(--on-accent);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-import:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+</style>

--- a/frontend/src/components/faq/FaqImportModal.vue
+++ b/frontend/src/components/faq/FaqImportModal.vue
@@ -18,6 +18,7 @@ limitations under the License.
 import { computed, ref, watch } from 'vue'
 import Modal from '@/components/common/Modal.vue'
 import FaqOrb from './FaqOrb.vue'
+import type { FaqImportMode } from '@/types/faq'
 
 const props = defineProps<{
   open: boolean
@@ -26,33 +27,70 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   close: []
-  submit: [url: string]
+  submit: [url: string, mode: FaqImportMode]
 }>()
 
 const url = ref('')
+const mode = ref<FaqImportMode>('qa')
+
+const MODES: { value: FaqImportMode; title: string; description: string }[] = [
+  {
+    value: 'qa',
+    title: 'Q&A page',
+    description: 'AI reads one page and extracts each question & answer. Uses AI credits.',
+  },
+  {
+    value: 'articles',
+    title: 'Article pages',
+    description: 'Imports every article linked from the page as-is — text, images and links. No AI.',
+  },
+]
 
 watch(
   () => props.open,
   (open) => {
-    if (!open) url.value = ''
+    if (!open) {
+      url.value = ''
+      mode.value = 'qa'
+    }
   },
 )
 
 const canSubmit = computed(() => url.value.trim().length > 0 && !props.submitting)
 
+const hint = computed(() =>
+  mode.value === 'articles'
+    ? 'ChatterMate follows the article links on that page and imports each article verbatim as a draft — formatting and images included.'
+    : 'ChatterMate crawls the page, extracts each question and answer, and adds them here as drafts for you to review before publishing.',
+)
+
 function submit() {
   if (!canSubmit.value) return
   const cleaned = url.value.trim().replace(/^https?:\/\//i, '')
-  emit('submit', `https://${cleaned}`)
+  emit('submit', `https://${cleaned}`, mode.value)
 }
 </script>
 
 <template>
   <Modal v-if="open" @close="$emit('close')">
-    <template #title>Migrate an existing FAQ page</template>
+    <template #title>Migrate an existing help center</template>
     <template #content>
-      <p class="import-sub">Paste a help-center or FAQ URL — we detect every question &amp; answer pair.</p>
-      <label class="import-label" for="faq-import-url">FAQ PAGE URL</label>
+      <p class="import-sub">Paste a help-center or FAQ URL and choose how to bring the content in.</p>
+
+      <div class="mode-cards" role="radiogroup" aria-label="Import mode">
+        <label
+          v-for="option in MODES"
+          :key="option.value"
+          class="mode-card"
+          :class="{ 'mode-card--active': mode === option.value }"
+        >
+          <input v-model="mode" class="mode-card__radio" type="radio" name="faq-import-mode" :value="option.value" />
+          <span class="mode-card__title">{{ option.title }}</span>
+          <span class="mode-card__desc">{{ option.description }}</span>
+        </label>
+      </div>
+
+      <label class="import-label" for="faq-import-url">{{ mode === 'articles' ? 'HELP CENTER INDEX URL' : 'FAQ PAGE URL' }}</label>
       <div class="import-input">
         <span class="import-input__prefix">https://</span>
         <input
@@ -65,16 +103,13 @@ function submit() {
       </div>
       <div class="import-hint">
         <FaqOrb :size="34" />
-        <div>
-          ChatterMate crawls the page, extracts each question and answer, and adds them here as
-          drafts for you to review before publishing.
-        </div>
+        <div>{{ hint }}</div>
       </div>
       <div class="import-actions">
         <button class="btn-cancel" type="button" @click="$emit('close')">Cancel</button>
         <button class="btn-import" type="button" :disabled="!canSubmit" @click="submit">
           <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12" /><path d="M8 11l4 4 4-4" /><path d="M5 21h14" /></svg>
-          {{ submitting ? 'Importing…' : 'Import FAQs' }}
+          {{ submitting ? 'Importing…' : mode === 'articles' ? 'Import articles' : 'Import FAQs' }}
         </button>
       </div>
     </template>
@@ -87,6 +122,52 @@ function submit() {
   color: var(--muted);
   margin: -12px 0 18px;
   line-height: 1.5;
+}
+
+.mode-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.mode-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 13px 14px;
+  background: var(--o03);
+  border: 1px solid var(--o12);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.mode-card--active {
+  background: var(--purple-bg);
+  border-color: var(--purple-border);
+}
+
+.mode-card__radio {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.mode-card__title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text2);
+}
+
+.mode-card--active .mode-card__title {
+  color: var(--c-purple);
+}
+
+.mode-card__desc {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.45;
 }
 
 .import-label {

--- a/frontend/src/components/faq/FaqOrb.vue
+++ b/frontend/src/components/faq/FaqOrb.vue
@@ -1,0 +1,86 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(defineProps<{ size?: number }>(), { size: 40 })
+
+const style = computed(() => ({
+  width: `${props.size}px`,
+  height: `${props.size}px`,
+  '--orb-blur': `${props.size * 0.05}px`,
+  '--orb-inset': `${props.size * 0.21}px`,
+  '--orb-shadow': `${props.size * 0.22}px`,
+}))
+</script>
+
+<template>
+  <div class="orb" :style="style" aria-hidden="true">
+    <div class="orb__gradient"></div>
+    <div class="orb__core"></div>
+    <div class="orb__ring"></div>
+  </div>
+</template>
+
+<style scoped>
+.orb {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.orb__gradient {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: conic-gradient(
+    from 0deg,
+    var(--c-purple),
+    var(--c-teal),
+    var(--accent-ink),
+    var(--c-coral),
+    var(--c-purple)
+  );
+  filter: blur(var(--orb-blur));
+  animation: orb-spin 6s linear infinite;
+}
+
+.orb__core {
+  position: absolute;
+  inset: var(--orb-inset);
+  border-radius: 50%;
+  background: radial-gradient(circle at 40% 35%, rgba(255, 255, 255, 0.92), var(--o12) 55%, transparent 72%);
+  animation: orb-pulse 2.6s ease-in-out infinite;
+}
+
+.orb__ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  box-shadow: inset 0 0 var(--orb-shadow) rgba(0, 0, 0, 0.4);
+}
+
+@keyframes orb-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+@keyframes orb-pulse {
+  0% { opacity: 0.4; }
+  50% { opacity: 1; }
+  100% { opacity: 0.4; }
+}
+</style>

--- a/frontend/src/components/faq/FaqProLockOverlay.vue
+++ b/frontend/src/components/faq/FaqProLockOverlay.vue
@@ -1,0 +1,178 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useEnterpriseFeatures } from '@/composables/useEnterpriseFeatures'
+import { useSubscriptionStorage } from '@/utils/storage'
+
+const props = defineProps<{
+  /** Server-side plan verdict (settings.plan_allowed). false always locks. */
+  planAllowed?: boolean | null
+}>()
+
+const PRO_PRICE_NOTE = 'Included in Pro · $39/agent/mo'
+
+const router = useRouter()
+const { hasEnterpriseModule } = useEnterpriseFeatures()
+const subscriptionStorage = useSubscriptionStorage()
+
+const isLocked = computed(() => {
+  if (props.planAllowed === false) return true
+  return (
+    hasEnterpriseModule &&
+    (!subscriptionStorage.hasFeature('help_center') || !subscriptionStorage.isSubscriptionActive())
+  )
+})
+
+function goToSubscription() {
+  router.push('/settings/subscription')
+}
+</script>
+
+<template>
+  <div class="lock-wrap">
+    <div class="lock-wrap__content" :class="{ 'lock-wrap__content--locked': isLocked }">
+      <slot />
+    </div>
+    <div v-if="isLocked" class="lock-overlay">
+      <div class="lock-card">
+        <div class="lock-card__icon">
+          <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="var(--c-purple)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="11" width="14" height="10" rx="2.2" /><path d="M8 11V8a4 4 0 0 1 8 0v3" /></svg>
+        </div>
+        <h3 class="lock-card__title">Auto-generate FAQs with Pro</h3>
+        <p class="lock-card__copy">
+          ChatterMate reads every knowledge source and drafts clear, ready-to-publish FAQs — grouped
+          by topic and kept in sync as your docs change.
+        </p>
+        <div class="lock-card__actions">
+          <button class="btn-upgrade" type="button" @click="goToSubscription">
+            <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" stroke="none"><path d="M13 2 4 14h6l-1 8 9-12h-6z" /></svg>
+            Upgrade to Pro
+          </button>
+          <button class="btn-compare" type="button" @click="goToSubscription">Compare plans</button>
+        </div>
+        <div class="lock-card__note">{{ PRO_PRICE_NOTE }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.lock-wrap {
+  position: relative;
+}
+
+.lock-wrap__content--locked {
+  filter: grayscale(0.9) saturate(0.5);
+  opacity: 0.55;
+  pointer-events: none;
+  user-select: none;
+}
+
+.lock-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--scrim);
+  backdrop-filter: blur(6px);
+  border-radius: 18px;
+}
+
+.lock-card {
+  max-width: 440px;
+  text-align: center;
+  background: var(--surface);
+  border: 1px solid var(--purple-border);
+  border-radius: 20px;
+  padding: 34px 32px;
+  box-shadow: var(--shadow-lg);
+}
+
+.lock-card__icon {
+  width: 52px;
+  height: 52px;
+  margin: 0 auto 18px;
+  border-radius: 14px;
+  background: var(--purple-bg);
+  border: 1px solid var(--purple-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lock-card__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 21px;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0 0 10px;
+}
+
+.lock-card__copy {
+  font-size: 14.5px;
+  color: var(--muted);
+  line-height: 1.6;
+  margin: 0 0 22px;
+}
+
+.lock-card__actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn-upgrade {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 13px 22px;
+  background: var(--c-purple);
+  border: 1px solid var(--c-purple);
+  border-radius: 11px;
+  color: var(--on-accent);
+  font-family: var(--font-sans);
+  font-size: 14.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-compare {
+  padding: 13px 20px;
+  background: var(--o05);
+  border: 1px solid var(--o14);
+  border-radius: 11px;
+  color: var(--text2);
+  font-family: var(--font-sans);
+  font-size: 14.5px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.lock-card__note {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted2);
+  margin-top: 18px;
+}
+</style>

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -148,7 +148,7 @@ function askDelete(faq: FaqItem) {
 }
 
 async function askGenerate() {
-  await fetchEstimate()
+  await fetchEstimate(true) // full estimate incl. page counts for the dialog
   const e = estimate.value
   if (!e) {
     // Estimate unavailable (e.g. plan check failed) — let the backend decide.

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -16,6 +16,7 @@ limitations under the License.
 
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { toast } from 'vue-sonner'
 import type { FaqItem } from '@/types/faq'
 import { useFaqWorkspace } from '@/composables/useFaqWorkspace'
 import { useHelpCenterSettings } from '@/composables/useHelpCenterSettings'
@@ -38,6 +39,8 @@ const {
   faqs,
   job,
   settings,
+  estimate,
+  fetchEstimate,
   sourceCount,
   pageCount,
   phase,
@@ -102,12 +105,14 @@ async function onImportSubmit(url: string) {
   }
 }
 
-// A single reusable confirm dialog for deletes.
+// A single reusable confirm dialog for deletes and generation.
 interface ConfirmState {
   title: string
   message: string
   actionLabel: string
   busyLabel: string
+  intent?: 'danger' | 'primary'
+  disabledReason?: string
   action: () => Promise<void>
 }
 const confirmState = ref<ConfirmState | null>(null)
@@ -119,7 +124,45 @@ function askDelete(faq: FaqItem) {
     message: `Delete “${faq.question}”? This cannot be undone.`,
     actionLabel: 'Delete',
     busyLabel: 'Deleting…',
+    intent: 'danger',
     action: () => deleteFaq(faq),
+  }
+}
+
+async function askGenerate() {
+  await fetchEstimate()
+  const e = estimate.value
+  if (!e) {
+    // Estimate unavailable (e.g. plan check failed) — let the backend decide.
+    await startGeneration()
+    return
+  }
+  if (e.total_sources === 0) {
+    toast.error('No knowledge sources to generate from. Add knowledge first.')
+    return
+  }
+  if (e.new_sources === 0) {
+    toast.info('All knowledge sources already have FAQs — nothing new to generate.')
+    return
+  }
+  const sources = `${e.new_sources} new source${e.new_sources === 1 ? '' : 's'}`
+  const pages = e.pages ? ` (~${e.pages} page${e.pages === 1 ? '' : 's'})` : ''
+  let message = `Generate FAQs from ${sources}${pages}?`
+  let disabledReason: string | undefined
+  if (e.metered) {
+    message += ` This will use about ${e.estimated_calls} message credit${e.estimated_calls === 1 ? '' : 's'}.`
+    if (e.remaining_credits !== null && e.estimated_calls > e.remaining_credits) {
+      disabledReason = `Only ${e.remaining_credits} credits left this period — upgrade your plan or switch to your own AI model.`
+    }
+  }
+  confirmState.value = {
+    title: 'Generate FAQs',
+    message,
+    actionLabel: 'Generate',
+    busyLabel: 'Starting…',
+    intent: 'primary',
+    disabledReason,
+    action: () => startGeneration(),
   }
 }
 
@@ -177,7 +220,8 @@ onUnmounted(stopPolling)
           :page-count="pageCount"
           :faq-count="faqs.length"
           :published-count="publishedCount"
-          @generate="startGeneration"
+          :new-source-count="estimate?.new_sources ?? null"
+          @generate="askGenerate"
           @import="importOpen = true"
           @add="startAdd"
         />
@@ -186,7 +230,7 @@ onUnmounted(stopPolling)
           v-if="phase === 'empty' && !isNewFaq"
           :source-count="sourceCount"
           :page-count="pageCount"
-          @generate="startGeneration"
+          @generate="askGenerate"
           @import="importOpen = true"
           @add="startAdd"
         />
@@ -263,9 +307,16 @@ onUnmounted(stopPolling)
       <div class="confirm__card">
         <h3 class="confirm__title">{{ confirmState.title }}</h3>
         <p class="confirm__msg">{{ confirmState.message }}</p>
+        <p v-if="confirmState.disabledReason" class="confirm__blocked">{{ confirmState.disabledReason }}</p>
         <div class="confirm__actions">
           <button class="confirm__cancel" type="button" :disabled="confirmBusy" @click="confirmState = null">Cancel</button>
-          <button class="confirm__delete" type="button" :disabled="confirmBusy" @click="runConfirm">
+          <button
+            class="confirm__go"
+            :class="confirmState.intent === 'primary' ? 'confirm__go--primary' : 'confirm__go--danger'"
+            type="button"
+            :disabled="confirmBusy || !!confirmState.disabledReason"
+            @click="runConfirm"
+          >
             {{ confirmBusy ? confirmState.busyLabel : confirmState.actionLabel }}
           </button>
         </div>
@@ -402,15 +453,39 @@ onUnmounted(stopPolling)
   cursor: pointer;
 }
 
-.confirm__delete {
+.confirm__go {
   padding: 10px 18px;
-  background: var(--coral-bg);
-  border: 1px solid var(--coral-border);
   border-radius: 10px;
-  color: var(--c-coral);
   font-family: var(--font-sans);
   font-size: 13.5px;
   font-weight: 600;
   cursor: pointer;
+}
+
+.confirm__go:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.confirm__go--danger {
+  background: var(--coral-bg);
+  border: 1px solid var(--coral-border);
+  color: var(--c-coral);
+}
+
+.confirm__go--primary {
+  background: var(--purple-bg);
+  border: 1px solid var(--purple-border);
+  color: var(--c-purple);
+}
+
+.confirm__blocked {
+  font-size: 13px;
+  color: var(--c-coral);
+  background: var(--coral-bg);
+  border: 1px solid var(--coral-border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  margin: -8px 0 20px;
 }
 </style>

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -17,7 +17,7 @@ limitations under the License.
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { toast } from 'vue-sonner'
-import type { FaqImportMode, FaqItem } from '@/types/faq'
+import type { FaqImportMode, FaqItem, FaqStatus } from '@/types/faq'
 import { useFaqWorkspace } from '@/composables/useFaqWorkspace'
 import { useHelpCenterSettings } from '@/composables/useHelpCenterSettings'
 import FaqGenerateBar from './FaqGenerateBar.vue'
@@ -47,6 +47,15 @@ const {
   barPhase,
   publishedCount,
   groupedFaqs,
+  searchQuery,
+  categoryFilter,
+  statusFilter,
+  categories,
+  hasActiveFilters,
+  filteredCount,
+  resetFilters,
+  toggleCategory,
+  isCategoryOpen,
   editingId,
   isNewFaq,
   draftQuestion,
@@ -206,6 +215,16 @@ function selectedInCategory(items: FaqItem[]): number {
   return items.reduce((n, item) => n + (selectedIds.value.has(item.id) ? 1 : 0), 0)
 }
 
+function publishedInCategory(items: FaqItem[]): number {
+  return items.reduce((n, item) => n + (item.status === 'published' ? 1 : 0), 0)
+}
+
+const STATUS_FILTERS: { v: 'all' | FaqStatus; l: string }[] = [
+  { v: 'all', l: 'All' },
+  { v: 'published', l: 'Published' },
+  { v: 'draft', l: 'Draft' },
+]
+
 async function runConfirm() {
   const state = confirmState.value
   if (!state) return
@@ -277,47 +296,85 @@ onUnmounted(stopPolling)
 
         <FaqGenerationProgress v-else-if="phase === 'generating' && job" :job="job" />
 
-        <div v-else class="faq-list">
-          <FaqCard
-            v-if="isNewFaq"
-            :faq="newFaqStub"
-            :editing="true"
-            :is-new="true"
-            :saving="isSaving"
-            v-model:draft-question="draftQuestion"
-            v-model:draft-answer="draftAnswer"
-            @save="saveEdit"
-            @cancel="cancelEdit"
-          />
-          <FaqCategoryGroup
-            v-for="[category, items] in groupedFaqs"
-            :key="category"
-            :category="category"
-            :count="items.length"
-            :selected-count="selectedInCategory(items)"
-            @toggle-all="setSelected(items, $event)"
-          >
+        <template v-else>
+          <div v-if="isNewFaq" class="faq-list faq-list--new">
             <FaqCard
-              v-for="faq in items"
-              :key="faq.id"
-              :faq="faq"
-              :editing="editingId === faq.id"
+              :faq="newFaqStub"
+              :editing="true"
+              :is-new="true"
               :saving="isSaving"
-              :selectable="selectionActive"
-              :selected="selectedIds.has(faq.id)"
-              :draft-question="draftQuestion"
-              :draft-answer="draftAnswer"
-              @update:draft-question="draftQuestion = $event"
-              @update:draft-answer="draftAnswer = $event"
-              @toggle-select="toggleSelect(faq.id)"
-              @toggle-status="togglePublish(faq)"
-              @edit="startEdit(faq)"
-              @delete="askDelete(faq)"
+              v-model:draft-question="draftQuestion"
+              v-model:draft-answer="draftAnswer"
               @save="saveEdit"
               @cancel="cancelEdit"
             />
-          </FaqCategoryGroup>
-        </div>
+          </div>
+
+          <!-- Search + filter toolbar (only once there are FAQs to filter) -->
+          <template v-if="faqs.length">
+            <div class="faq-toolbar">
+              <div class="faq-search">
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7" /><path d="M21 21l-4.3-4.3" /></svg>
+                <input v-model="searchQuery" type="search" placeholder="Search questions & answers…" aria-label="Search FAQs" />
+              </div>
+              <select v-model="categoryFilter" class="faq-select" aria-label="Filter by category">
+                <option :value="null">All topics</option>
+                <option v-for="c in categories" :key="c" :value="c">{{ c }}</option>
+              </select>
+              <div class="faq-status-filter" role="group" aria-label="Filter by status">
+                <button
+                  v-for="opt in STATUS_FILTERS"
+                  :key="opt.v"
+                  class="faq-status-filter__btn"
+                  :class="{ 'faq-status-filter__btn--active': statusFilter === opt.v }"
+                  type="button"
+                  @click="statusFilter = opt.v"
+                >{{ opt.l }}</button>
+              </div>
+            </div>
+
+            <div v-if="hasActiveFilters" class="faq-resultcount">{{ filteredCount }} of {{ faqs.length }} shown</div>
+          </template>
+
+          <div v-if="faqs.length && groupedFaqs.size === 0" class="faq-noresults">
+            <p>No FAQs match your filters.</p>
+            <button v-if="hasActiveFilters" class="faq-noresults__clear" type="button" @click="resetFilters">Clear filters</button>
+          </div>
+
+          <div v-else-if="groupedFaqs.size" class="faq-list">
+            <FaqCategoryGroup
+              v-for="[category, items] in groupedFaqs"
+              :key="category"
+              :category="category"
+              :count="items.length"
+              :published-count="publishedInCategory(items)"
+              :selected-count="selectedInCategory(items)"
+              :open="isCategoryOpen(category)"
+              @toggle="toggleCategory(category)"
+              @toggle-all="setSelected(items, $event)"
+            >
+              <FaqCard
+                v-for="faq in items"
+                :key="faq.id"
+                :faq="faq"
+                :editing="editingId === faq.id"
+                :saving="isSaving"
+                :selectable="selectionActive"
+                :selected="selectedIds.has(faq.id)"
+                :draft-question="draftQuestion"
+                :draft-answer="draftAnswer"
+                @update:draft-question="draftQuestion = $event"
+                @update:draft-answer="draftAnswer = $event"
+                @toggle-select="toggleSelect(faq.id)"
+                @toggle-status="togglePublish(faq)"
+                @edit="startEdit(faq)"
+                @delete="askDelete(faq)"
+                @save="saveEdit"
+                @cancel="cancelEdit"
+              />
+            </FaqCategoryGroup>
+          </div>
+        </template>
       </div>
 
       <div v-show="tab === 'settings'" class="tab-panel">
@@ -447,6 +504,107 @@ onUnmounted(stopPolling)
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+
+.faq-list--new {
+  margin-bottom: 16px;
+}
+
+.faq-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 18px;
+  flex-wrap: wrap;
+}
+
+.faq-search {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex: 1;
+  min-width: 200px;
+  padding: 0 12px;
+  background: var(--surface);
+  border: 1px solid var(--o12);
+  border-radius: 11px;
+  color: var(--muted);
+}
+
+.faq-search input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  padding: 10px 0;
+}
+
+.faq-select {
+  padding: 10px 12px;
+  background: var(--surface);
+  border: 1px solid var(--o12);
+  border-radius: 11px;
+  color: var(--text2);
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.faq-status-filter {
+  display: inline-flex;
+  padding: 3px;
+  background: var(--o05);
+  border: 1px solid var(--o12);
+  border-radius: 11px;
+}
+
+.faq-status-filter__btn {
+  padding: 7px 13px;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.faq-status-filter__btn--active {
+  background: var(--surface);
+  color: var(--text2);
+  box-shadow: 0 1px 3px var(--scrim);
+}
+
+.faq-resultcount {
+  margin: -8px 0 14px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted2);
+}
+
+.faq-noresults {
+  padding: 40px 0;
+  text-align: center;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.faq-noresults__clear {
+  margin-top: 12px;
+  padding: 8px 16px;
+  background: var(--o05);
+  border: 1px solid var(--o12);
+  border-radius: 10px;
+  color: var(--text2);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
 }
 
 .settings-section:not(:first-child) {

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -84,6 +84,10 @@ watch(
 
 defineExpose({ settings })
 
+// Tabs keep the (potentially long) FAQ list and the settings on separate
+// panes so neither forces the other into a long scroll.
+const tab = ref<'faqs' | 'settings'>('faqs')
+
 // Import modal state.
 const importOpen = ref(false)
 const importSubmitting = ref(false)
@@ -155,64 +159,101 @@ onUnmounted(stopPolling)
     <div v-if="phase === 'loading'" class="loading">Loading your FAQs…</div>
 
     <template v-else>
-      <FaqGenerateBar
-        class="workspace-bar"
-        :phase="barPhase"
-        :source-count="sourceCount"
-        :page-count="pageCount"
-        :faq-count="faqs.length"
-        :published-count="publishedCount"
-        @generate="startGeneration"
-        @import="importOpen = true"
-        @add="startAdd"
-      />
+      <nav class="tabs" role="tablist">
+        <button class="tab" :class="{ 'tab--active': tab === 'faqs' }" type="button" role="tab" :aria-selected="tab === 'faqs'" @click="tab = 'faqs'">
+          FAQs
+          <span v-if="faqs.length" class="tab__count">{{ faqs.length }}</span>
+        </button>
+        <button class="tab" :class="{ 'tab--active': tab === 'settings' }" type="button" role="tab" :aria-selected="tab === 'settings'" @click="tab = 'settings'">
+          Help center
+        </button>
+      </nav>
 
-      <FaqEmptyState
-        v-if="phase === 'empty' && !isNewFaq"
-        :source-count="sourceCount"
-        :page-count="pageCount"
-        @generate="startGeneration"
-        @import="importOpen = true"
-        @add="startAdd"
-      />
-
-      <FaqGenerationProgress v-else-if="phase === 'generating' && job" :job="job" />
-
-      <div v-else class="faq-list">
-        <FaqCard
-          v-if="isNewFaq"
-          :faq="newFaqStub"
-          :editing="true"
-          :is-new="true"
-          :saving="isSaving"
-          v-model:draft-question="draftQuestion"
-          v-model:draft-answer="draftAnswer"
-          @save="saveEdit"
-          @cancel="cancelEdit"
+      <div v-show="tab === 'faqs'" class="tab-panel">
+        <FaqGenerateBar
+          class="workspace-bar"
+          :phase="barPhase"
+          :source-count="sourceCount"
+          :page-count="pageCount"
+          :faq-count="faqs.length"
+          :published-count="publishedCount"
+          @generate="startGeneration"
+          @import="importOpen = true"
+          @add="startAdd"
         />
-        <FaqCategoryGroup
-          v-for="[category, items] in groupedFaqs"
-          :key="category"
-          :category="category"
-          :count="items.length"
-        >
+
+        <FaqEmptyState
+          v-if="phase === 'empty' && !isNewFaq"
+          :source-count="sourceCount"
+          :page-count="pageCount"
+          @generate="startGeneration"
+          @import="importOpen = true"
+          @add="startAdd"
+        />
+
+        <FaqGenerationProgress v-else-if="phase === 'generating' && job" :job="job" />
+
+        <div v-else class="faq-list">
           <FaqCard
-            v-for="faq in items"
-            :key="faq.id"
-            :faq="faq"
-            :editing="editingId === faq.id"
+            v-if="isNewFaq"
+            :faq="newFaqStub"
+            :editing="true"
+            :is-new="true"
             :saving="isSaving"
-            :draft-question="draftQuestion"
-            :draft-answer="draftAnswer"
-            @update:draft-question="draftQuestion = $event"
-            @update:draft-answer="draftAnswer = $event"
-            @toggle-status="togglePublish(faq)"
-            @edit="startEdit(faq)"
-            @delete="askDelete(faq)"
+            v-model:draft-question="draftQuestion"
+            v-model:draft-answer="draftAnswer"
             @save="saveEdit"
             @cancel="cancelEdit"
           />
-        </FaqCategoryGroup>
+          <FaqCategoryGroup
+            v-for="[category, items] in groupedFaqs"
+            :key="category"
+            :category="category"
+            :count="items.length"
+          >
+            <FaqCard
+              v-for="faq in items"
+              :key="faq.id"
+              :faq="faq"
+              :editing="editingId === faq.id"
+              :saving="isSaving"
+              :draft-question="draftQuestion"
+              :draft-answer="draftAnswer"
+              @update:draft-question="draftQuestion = $event"
+              @update:draft-answer="draftAnswer = $event"
+              @toggle-status="togglePublish(faq)"
+              @edit="startEdit(faq)"
+              @delete="askDelete(faq)"
+              @save="saveEdit"
+              @cancel="cancelEdit"
+            />
+          </FaqCategoryGroup>
+        </div>
+      </div>
+
+      <div v-show="tab === 'settings'" class="tab-panel">
+        <template v-if="settings">
+          <HelpCenterAppearance
+            class="settings-section"
+            :settings="settings"
+            :save-state="saveState"
+            @update="queueSave"
+            @save-now="saveNow"
+            @upload-logo="uploadLogo"
+            @remove-logo="removeLogo"
+          />
+          <HelpCenterPublic
+            class="settings-section"
+            :settings="settings"
+            :domain-busy="domainBusy"
+            @toggle-enabled="saveNow({ enabled: $event })"
+            @update-ai="saveNow($event)"
+            @set-domain="setDomain"
+            @verify-domain="verifyDomain"
+            @remove-domain="removeDomain"
+          />
+        </template>
+        <div v-else class="loading">Loading settings…</div>
       </div>
     </template>
 
@@ -231,27 +272,6 @@ onUnmounted(stopPolling)
       </div>
     </div>
 
-    <template v-if="settings">
-      <HelpCenterAppearance
-        class="settings-section"
-        :settings="settings"
-        :save-state="saveState"
-        @update="queueSave"
-        @save-now="saveNow"
-        @upload-logo="uploadLogo"
-        @remove-logo="removeLogo"
-      />
-      <HelpCenterPublic
-        class="settings-section"
-        :settings="settings"
-        :domain-busy="domainBusy"
-        @toggle-enabled="saveNow({ enabled: $event })"
-        @update-ai="saveNow($event)"
-        @set-domain="setDomain"
-        @verify-domain="verifyDomain"
-        @remove-domain="removeDomain"
-      />
-    </template>
   </div>
 </template>
 
@@ -268,6 +288,53 @@ onUnmounted(stopPolling)
   color: var(--muted);
 }
 
+.tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--o08);
+  margin-bottom: 20px;
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.tab:hover {
+  color: var(--text);
+}
+
+.tab--active {
+  color: var(--text);
+  border-bottom-color: var(--c-teal);
+}
+
+.tab__count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+  background: var(--o08);
+  color: var(--muted2);
+}
+
+.tab--active .tab__count {
+  background: var(--teal-bg);
+  color: var(--c-teal);
+}
+
 .workspace-bar {
   margin-bottom: 16px;
 }
@@ -278,7 +345,7 @@ onUnmounted(stopPolling)
   gap: 10px;
 }
 
-.settings-section {
+.settings-section:not(:first-child) {
   margin-top: 36px;
 }
 

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -165,7 +165,7 @@ onUnmounted(stopPolling)
           <span v-if="faqs.length" class="tab__count">{{ faqs.length }}</span>
         </button>
         <button class="tab" :class="{ 'tab--active': tab === 'settings' }" type="button" role="tab" :aria-selected="tab === 'settings'" @click="tab = 'settings'">
-          Help center
+          Customization
         </button>
       </nav>
 

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -1,0 +1,349 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import type { FaqItem } from '@/types/faq'
+import { useFaqWorkspace } from '@/composables/useFaqWorkspace'
+import { useHelpCenterSettings } from '@/composables/useHelpCenterSettings'
+import FaqGenerateBar from './FaqGenerateBar.vue'
+import FaqEmptyState from './FaqEmptyState.vue'
+import FaqGenerationProgress from './FaqGenerationProgress.vue'
+import FaqCategoryGroup from './FaqCategoryGroup.vue'
+import FaqCard from './FaqCard.vue'
+import FaqImportModal from './FaqImportModal.vue'
+import HelpCenterAppearance from './HelpCenterAppearance.vue'
+import HelpCenterPublic from './HelpCenterPublic.vue'
+
+const props = defineProps<{ organizationId?: string }>()
+
+const emit = defineEmits<{
+  'plan-allowed': [allowed: boolean]
+}>()
+
+const {
+  faqs,
+  job,
+  settings,
+  sourceCount,
+  pageCount,
+  phase,
+  barPhase,
+  publishedCount,
+  groupedFaqs,
+  editingId,
+  isNewFaq,
+  draftQuestion,
+  draftAnswer,
+  isSaving,
+  refresh,
+  startPolling,
+  stopPolling,
+  startGeneration,
+  submitImport,
+  togglePublish,
+  startEdit,
+  startAdd,
+  cancelEdit,
+  saveEdit,
+  deleteFaq,
+} = useFaqWorkspace(() => props.organizationId)
+
+const {
+  saveState,
+  queueSave,
+  saveNow,
+  uploadLogo,
+  removeLogo,
+  domainBusy,
+  setDomain,
+  verifyDomain,
+  removeDomain,
+} = useHelpCenterSettings(settings)
+
+// Surface the server-side plan verdict to the view's lock overlay.
+watch(
+  () => settings.value?.plan_allowed,
+  (allowed) => {
+    if (typeof allowed === 'boolean') emit('plan-allowed', allowed)
+  },
+)
+
+defineExpose({ settings })
+
+// Import modal state.
+const importOpen = ref(false)
+const importSubmitting = ref(false)
+
+async function onImportSubmit(url: string) {
+  importSubmitting.value = true
+  try {
+    const ok = await submitImport(url)
+    if (ok) importOpen.value = false
+  } finally {
+    importSubmitting.value = false
+  }
+}
+
+// A single reusable confirm dialog for deletes.
+interface ConfirmState {
+  title: string
+  message: string
+  actionLabel: string
+  busyLabel: string
+  action: () => Promise<void>
+}
+const confirmState = ref<ConfirmState | null>(null)
+const confirmBusy = ref(false)
+
+function askDelete(faq: FaqItem) {
+  confirmState.value = {
+    title: 'Delete FAQ',
+    message: `Delete “${faq.question}”? This cannot be undone.`,
+    actionLabel: 'Delete',
+    busyLabel: 'Deleting…',
+    action: () => deleteFaq(faq),
+  }
+}
+
+async function runConfirm() {
+  const state = confirmState.value
+  if (!state) return
+  confirmBusy.value = true
+  try {
+    await state.action()
+  } finally {
+    confirmBusy.value = false
+    confirmState.value = null
+  }
+}
+
+// Placeholder card for a manually added FAQ.
+const newFaqStub = computed<FaqItem>(() => ({
+  id: 'new',
+  question: '',
+  answer: '',
+  category: 'New',
+  status: 'draft',
+  knowledge_id: null,
+  source_label: 'Added manually',
+}))
+
+onMounted(() => {
+  refresh()
+  startPolling()
+})
+
+onUnmounted(stopPolling)
+</script>
+
+<template>
+  <div class="faq-workspace">
+    <div v-if="phase === 'loading'" class="loading">Loading your FAQs…</div>
+
+    <template v-else>
+      <FaqGenerateBar
+        class="workspace-bar"
+        :phase="barPhase"
+        :source-count="sourceCount"
+        :page-count="pageCount"
+        :faq-count="faqs.length"
+        :published-count="publishedCount"
+        @generate="startGeneration"
+        @import="importOpen = true"
+        @add="startAdd"
+      />
+
+      <FaqEmptyState
+        v-if="phase === 'empty' && !isNewFaq"
+        :source-count="sourceCount"
+        :page-count="pageCount"
+        @generate="startGeneration"
+        @import="importOpen = true"
+        @add="startAdd"
+      />
+
+      <FaqGenerationProgress v-else-if="phase === 'generating' && job" :job="job" />
+
+      <div v-else class="faq-list">
+        <FaqCard
+          v-if="isNewFaq"
+          :faq="newFaqStub"
+          :editing="true"
+          :is-new="true"
+          :saving="isSaving"
+          v-model:draft-question="draftQuestion"
+          v-model:draft-answer="draftAnswer"
+          @save="saveEdit"
+          @cancel="cancelEdit"
+        />
+        <FaqCategoryGroup
+          v-for="[category, items] in groupedFaqs"
+          :key="category"
+          :category="category"
+          :count="items.length"
+        >
+          <FaqCard
+            v-for="faq in items"
+            :key="faq.id"
+            :faq="faq"
+            :editing="editingId === faq.id"
+            :saving="isSaving"
+            :draft-question="draftQuestion"
+            :draft-answer="draftAnswer"
+            @update:draft-question="draftQuestion = $event"
+            @update:draft-answer="draftAnswer = $event"
+            @toggle-status="togglePublish(faq)"
+            @edit="startEdit(faq)"
+            @delete="askDelete(faq)"
+            @save="saveEdit"
+            @cancel="cancelEdit"
+          />
+        </FaqCategoryGroup>
+      </div>
+    </template>
+
+    <FaqImportModal :open="importOpen" :submitting="importSubmitting" @close="importOpen = false" @submit="onImportSubmit" />
+
+    <div v-if="confirmState" class="confirm" role="dialog" aria-modal="true">
+      <div class="confirm__card">
+        <h3 class="confirm__title">{{ confirmState.title }}</h3>
+        <p class="confirm__msg">{{ confirmState.message }}</p>
+        <div class="confirm__actions">
+          <button class="confirm__cancel" type="button" :disabled="confirmBusy" @click="confirmState = null">Cancel</button>
+          <button class="confirm__delete" type="button" :disabled="confirmBusy" @click="runConfirm">
+            {{ confirmBusy ? confirmState.busyLabel : confirmState.actionLabel }}
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <template v-if="settings">
+      <HelpCenterAppearance
+        class="settings-section"
+        :settings="settings"
+        :save-state="saveState"
+        @update="queueSave"
+        @save-now="saveNow"
+        @upload-logo="uploadLogo"
+        @remove-logo="removeLogo"
+      />
+      <HelpCenterPublic
+        class="settings-section"
+        :settings="settings"
+        :domain-busy="domainBusy"
+        @toggle-enabled="saveNow({ enabled: $event })"
+        @update-ai="saveNow($event)"
+        @set-domain="setDomain"
+        @verify-domain="verifyDomain"
+        @remove-domain="removeDomain"
+      />
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.faq-workspace {
+  display: flex;
+  flex-direction: column;
+}
+
+.loading {
+  padding: 48px 0;
+  text-align: center;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.workspace-bar {
+  margin-bottom: 16px;
+}
+
+.faq-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.settings-section {
+  margin-top: 36px;
+}
+
+.confirm {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: var(--scrim);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.confirm__card {
+  background: var(--surface);
+  border: 1px solid var(--o12);
+  border-radius: 16px;
+  padding: 24px;
+  max-width: 400px;
+  width: 100%;
+}
+
+.confirm__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--text);
+  margin: 0 0 8px;
+}
+
+.confirm__msg {
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1.55;
+  margin: 0 0 20px;
+}
+
+.confirm__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.confirm__cancel {
+  padding: 10px 16px;
+  background: transparent;
+  border: 1px solid var(--o12);
+  border-radius: 10px;
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.confirm__delete {
+  padding: 10px 18px;
+  background: var(--coral-bg);
+  border: 1px solid var(--coral-border);
+  border-radius: 10px;
+  color: var(--c-coral);
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -64,6 +64,7 @@ const {
   stopPolling,
   startGeneration,
   submitImport,
+  submitPdfImport,
   togglePublish,
   startEdit,
   startAdd,
@@ -106,6 +107,16 @@ async function onImportSubmit(url: string, mode: FaqImportMode) {
   importSubmitting.value = true
   try {
     const ok = await submitImport(url, mode)
+    if (ok) importOpen.value = false
+  } finally {
+    importSubmitting.value = false
+  }
+}
+
+async function onPdfImportSubmit(file: File) {
+  importSubmitting.value = true
+  try {
+    const ok = await submitPdfImport(file)
     if (ok) importOpen.value = false
   } finally {
     importSubmitting.value = false
@@ -335,7 +346,7 @@ onUnmounted(stopPolling)
       </div>
     </template>
 
-    <FaqImportModal :open="importOpen" :submitting="importSubmitting" @close="importOpen = false" @submit="onImportSubmit" />
+    <FaqImportModal :open="importOpen" :submitting="importSubmitting" @close="importOpen = false" @submit="onImportSubmit" @submit-pdf="onPdfImportSubmit" />
 
     <div v-if="selectionActive" class="bulkbar" role="toolbar" aria-label="Bulk actions">
       <span class="bulkbar__count">{{ selectedIds.size }} selected</span>

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -52,6 +52,13 @@ const {
   draftQuestion,
   draftAnswer,
   isSaving,
+  selectedIds,
+  selectionActive,
+  toggleSelect,
+  setSelected,
+  clearSelection,
+  bulkSetStatus,
+  bulkDelete,
   refresh,
   startPolling,
   stopPolling,
@@ -166,6 +173,28 @@ async function askGenerate() {
   }
 }
 
+function askBulkDelete() {
+  const n = selectedIds.value.size
+  confirmState.value = {
+    title: `Delete ${n} FAQ${n === 1 ? '' : 's'}`,
+    message: 'Published articles will disappear from your help center. This cannot be undone.',
+    actionLabel: 'Delete',
+    busyLabel: 'Deleting…',
+    intent: 'danger',
+    action: async () => {
+      try {
+        await bulkDelete()
+      } catch (error: any) {
+        toast.error(error.message)
+      }
+    },
+  }
+}
+
+function selectedInCategory(items: FaqItem[]): number {
+  return items.reduce((n, item) => n + (selectedIds.value.has(item.id) ? 1 : 0), 0)
+}
+
 async function runConfirm() {
   const state = confirmState.value
   if (!state) return
@@ -254,6 +283,8 @@ onUnmounted(stopPolling)
             :key="category"
             :category="category"
             :count="items.length"
+            :selected-count="selectedInCategory(items)"
+            @toggle-all="setSelected(items, $event)"
           >
             <FaqCard
               v-for="faq in items"
@@ -261,10 +292,13 @@ onUnmounted(stopPolling)
               :faq="faq"
               :editing="editingId === faq.id"
               :saving="isSaving"
+              :selectable="selectionActive"
+              :selected="selectedIds.has(faq.id)"
               :draft-question="draftQuestion"
               :draft-answer="draftAnswer"
               @update:draft-question="draftQuestion = $event"
               @update:draft-answer="draftAnswer = $event"
+              @toggle-select="toggleSelect(faq.id)"
               @toggle-status="togglePublish(faq)"
               @edit="startEdit(faq)"
               @delete="askDelete(faq)"
@@ -302,6 +336,14 @@ onUnmounted(stopPolling)
     </template>
 
     <FaqImportModal :open="importOpen" :submitting="importSubmitting" @close="importOpen = false" @submit="onImportSubmit" />
+
+    <div v-if="selectionActive" class="bulkbar" role="toolbar" aria-label="Bulk actions">
+      <span class="bulkbar__count">{{ selectedIds.size }} selected</span>
+      <button class="bulkbar__btn" type="button" @click="bulkSetStatus('published')">Publish</button>
+      <button class="bulkbar__btn" type="button" @click="bulkSetStatus('draft')">Unpublish</button>
+      <button class="bulkbar__btn bulkbar__btn--danger" type="button" @click="askBulkDelete">Delete</button>
+      <button class="bulkbar__clear" type="button" aria-label="Clear selection" @click="clearSelection">✕</button>
+    </div>
 
     <div v-if="confirmState" class="confirm" role="dialog" aria-modal="true">
       <div class="confirm__card">
@@ -398,6 +440,67 @@ onUnmounted(stopPolling)
 
 .settings-section:not(:first-child) {
   margin-top: 36px;
+}
+
+.bulkbar {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 90;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: var(--surface);
+  border: 1px solid var(--o14);
+  border-radius: var(--radius-pill);
+  box-shadow: 0 8px 30px var(--scrim);
+}
+
+.bulkbar__count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--muted);
+  padding: 0 6px;
+}
+
+.bulkbar__btn {
+  padding: 8px 14px;
+  background: var(--o05);
+  border: 1px solid var(--o12);
+  border-radius: var(--radius-pill);
+  color: var(--text2);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.bulkbar__btn:hover {
+  background: var(--o08);
+}
+
+.bulkbar__btn--danger {
+  background: var(--coral-bg);
+  border-color: var(--coral-border);
+  color: var(--c-coral);
+}
+
+.bulkbar__clear {
+  width: 30px;
+  height: 30px;
+  background: transparent;
+  border: none;
+  border-radius: 50%;
+  color: var(--muted);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.bulkbar__clear:hover {
+  background: var(--o08);
+  color: var(--text);
 }
 
 .confirm {

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -17,7 +17,7 @@ limitations under the License.
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { toast } from 'vue-sonner'
-import type { FaqItem } from '@/types/faq'
+import type { FaqImportMode, FaqItem } from '@/types/faq'
 import { useFaqWorkspace } from '@/composables/useFaqWorkspace'
 import { useHelpCenterSettings } from '@/composables/useHelpCenterSettings'
 import FaqGenerateBar from './FaqGenerateBar.vue'
@@ -102,10 +102,10 @@ const tab = ref<'faqs' | 'settings'>('faqs')
 const importOpen = ref(false)
 const importSubmitting = ref(false)
 
-async function onImportSubmit(url: string) {
+async function onImportSubmit(url: string, mode: FaqImportMode) {
   importSubmitting.value = true
   try {
-    const ok = await submitImport(url)
+    const ok = await submitImport(url, mode)
     if (ok) importOpen.value = false
   } finally {
     importSubmitting.value = false

--- a/frontend/src/components/faq/HelpCenterAppearance.vue
+++ b/frontend/src/components/faq/HelpCenterAppearance.vue
@@ -44,6 +44,16 @@ const isPreset = computed(() =>
 const hexDraft = ref(props.settings.brand_color)
 watch(() => props.settings.brand_color, (v) => { hexDraft.value = v })
 
+// The native <input type=color> only accepts #rrggbb — expand 3-digit and drop
+// alpha from 8-digit so opening the picker starts on the real color, never
+// silently resetting to black.
+const pickerValue = computed(() => {
+  const body = (props.settings.brand_color || '').replace(/^#/, '')
+  if (body.length === 3) return `#${[...body].map((c) => c + c).join('')}`
+  if (body.length >= 6) return `#${body.slice(0, 6)}`
+  return '#000000'
+})
+
 function saveColor(value: string) {
   if (value.toLowerCase() !== (props.settings.brand_color || '').toLowerCase()) {
     emit('save-now', { brand_color: value })
@@ -134,7 +144,7 @@ function removeLink(index: number) {
               :style="!isPreset ? { background: settings.brand_color, boxShadow: `0 0 0 2px ${settings.brand_color}` } : {}"
               title="Custom color"
             >
-              <input type="color" class="swatch__picker" :value="settings.brand_color" @change="onPicker" />
+              <input type="color" class="swatch__picker" :value="pickerValue" @change="onPicker" />
               <svg v-if="isPreset" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14" /></svg>
             </label>
           </div>

--- a/frontend/src/components/faq/HelpCenterAppearance.vue
+++ b/frontend/src/components/faq/HelpCenterAppearance.vue
@@ -1,0 +1,365 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { HelpCenterSettings, HelpCenterSettingsUpdate } from '@/types/faq'
+import type { SaveState } from '@/composables/useHelpCenterSettings'
+import HelpCenterLogoField from './HelpCenterLogoField.vue'
+import HelpCenterPreview from './HelpCenterPreview.vue'
+
+const props = defineProps<{
+  settings: HelpCenterSettings
+  saveState: SaveState
+}>()
+
+const emit = defineEmits<{
+  update: [payload: HelpCenterSettingsUpdate]
+  'save-now': [payload: HelpCenterSettingsUpdate]
+  'upload-logo': [file: File]
+  'remove-logo': []
+}>()
+
+const BRAND_SWATCHES = ['#4338CA', '#0E8C8C', '#CF5B38', '#6D5BD0', '#1F8A5B', '#2A6FDB']
+
+const saveStateLabel = computed(() => {
+  if (props.saveState === 'saving') return 'Saving…'
+  if (props.saveState === 'saved') return 'Saved'
+  if (props.saveState === 'error') return "Couldn't save — edit again to retry"
+  return ''
+})
+
+/** Text fields: mutate in place for instant feedback, emit for debounced save. */
+function onText(field: 'cta_text' | 'cta_url', event: Event) {
+  const value = (event.target as HTMLInputElement).value
+  props.settings[field] = value
+  emit('update', { [field]: value })
+}
+
+// Header link rows are mutated in place — the settings engine deep-watches
+// header_links and debounce-saves.
+function addLink() {
+  props.settings.header_links.push({ label: 'New link', url: '' })
+}
+
+function removeLink(index: number) {
+  props.settings.header_links.splice(index, 1)
+}
+</script>
+
+<template>
+  <section class="appearance">
+    <div class="section-head">
+      <h2 class="section-head__title">Help center appearance</h2>
+      <span class="section-head__sub">logo, color &amp; header links</span>
+      <span v-if="saveStateLabel" class="section-head__save" :class="`is-${saveState}`">{{ saveStateLabel }}</span>
+    </div>
+
+    <div class="appearance__card">
+      <!-- controls -->
+      <div class="controls">
+        <div>
+          <label class="mono-label">LOGO</label>
+          <HelpCenterLogoField
+            :logo-url="settings.logo_url"
+            @upload="$emit('upload-logo', $event)"
+            @remove="$emit('remove-logo')"
+          />
+        </div>
+
+        <div>
+          <label class="mono-label">BRAND COLOR</label>
+          <div class="swatches">
+            <button
+              v-for="color in BRAND_SWATCHES"
+              :key="color"
+              class="swatch"
+              :class="{ 'swatch--selected': settings.brand_color === color }"
+              :style="{ background: color, boxShadow: settings.brand_color === color ? `0 0 0 2px ${color}` : 'none' }"
+              type="button"
+              :title="color"
+              @click="$emit('save-now', { brand_color: color })"
+            ></button>
+          </div>
+          <p class="hint">Recolors buttons, links, search and highlights across your help center.</p>
+        </div>
+
+        <div>
+          <label class="mono-label">HEADER LINKS</label>
+          <p class="hint hint--tight">Links shown in your help center header — point them back to your website.</p>
+          <div class="link-rows">
+            <div v-for="(link, index) in settings.header_links" :key="index" class="link-row">
+              <input v-model="link.label" class="text-input text-input--label" type="text" placeholder="Label" />
+              <div class="url-input">
+                <span class="url-input__prefix">https://</span>
+                <input v-model="link.url" type="text" placeholder="yoursite.com" />
+              </div>
+              <button class="remove-btn" type="button" title="Remove" @click="removeLink(index)">
+                <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
+              </button>
+            </div>
+          </div>
+          <button class="add-link" type="button" @click="addLink">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M12 5v14M5 12h14" /></svg>
+            Add link
+          </button>
+
+          <div class="divider"></div>
+
+          <label class="mono-label">PRIMARY BUTTON</label>
+          <div class="link-row">
+            <input class="text-input text-input--label" type="text" placeholder="Label" :value="settings.cta_text || ''" @input="onText('cta_text', $event)" />
+            <div class="url-input">
+              <span class="url-input__prefix">https://</span>
+              <input type="text" placeholder="app.yoursite.com" :value="settings.cta_url || ''" @input="onText('cta_url', $event)" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- live preview -->
+      <div class="preview-col">
+        <label class="mono-label">LIVE PREVIEW</label>
+        <HelpCenterPreview :settings="settings" />
+        <p class="preview-note">
+          Changes apply instantly to your published help center at
+          <span class="preview-note__url">{{ settings.live_url }}</span>.
+        </p>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.section-head__title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 19px;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0;
+}
+
+.section-head__sub,
+.section-head__save {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--muted2);
+}
+
+.section-head__save {
+  margin-left: auto;
+}
+
+.section-head__save.is-saved {
+  color: var(--c-teal);
+}
+
+.section-head__save.is-error {
+  color: var(--c-coral);
+}
+
+.appearance__card {
+  background: var(--surface);
+  border: 1px solid var(--o08);
+  border-radius: 18px;
+  padding: 22px;
+  display: grid;
+  grid-template-columns: 1fr 1.05fr;
+  gap: 26px;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .appearance__card {
+    grid-template-columns: 1fr;
+  }
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-width: 0;
+}
+
+.mono-label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--muted2);
+  margin-bottom: 10px;
+}
+
+.swatches {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.swatch {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  cursor: pointer;
+  padding: 0;
+  border: 2px solid transparent;
+}
+
+.swatch--selected {
+  border-color: var(--text);
+}
+
+.hint {
+  font-size: 12.5px;
+  color: var(--muted);
+  margin: 11px 0 0;
+  line-height: 1.5;
+}
+
+.hint--tight {
+  margin: 0 0 12px;
+}
+
+.link-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  margin-bottom: 12px;
+}
+
+.link-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.text-input {
+  background: var(--bg);
+  border: 1px solid var(--o10);
+  border-radius: 9px;
+  padding: 9px 11px;
+  font-size: 13px;
+  font-family: var(--font-sans);
+  color: var(--text);
+  outline: none;
+}
+
+.text-input--label {
+  width: 112px;
+  flex-shrink: 0;
+}
+
+.url-input {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  background: var(--bg);
+  border: 1px solid var(--o10);
+  border-radius: 9px;
+  padding: 0 11px;
+  font-family: var(--font-mono);
+}
+
+.url-input__prefix {
+  color: var(--faint);
+  font-size: 12.5px;
+}
+
+.url-input input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-size: 12.5px;
+  padding: 9px 3px;
+  font-family: var(--font-mono);
+}
+
+.remove-btn {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  background: var(--o05);
+  border: 1px solid var(--o10);
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.remove-btn:hover {
+  background: var(--coral-bg);
+  color: var(--c-coral);
+  border-color: var(--coral-border);
+}
+
+.add-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 14px;
+  background: var(--o05);
+  border: 1px dashed var(--o16);
+  border-radius: 9px;
+  color: var(--text2);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.add-link:hover {
+  background: var(--o08);
+  border-color: var(--o25);
+}
+
+.divider {
+  height: 1px;
+  background: var(--o07);
+  margin: 18px 0;
+}
+
+.preview-col {
+  min-width: 0;
+}
+
+.preview-note {
+  font-size: 12px;
+  color: var(--muted2);
+  margin: 11px 0 0;
+  line-height: 1.5;
+}
+
+.preview-note__url {
+  font-family: var(--font-mono);
+  color: var(--text3);
+}
+</style>

--- a/frontend/src/components/faq/HelpCenterAppearance.vue
+++ b/frontend/src/components/faq/HelpCenterAppearance.vue
@@ -119,12 +119,18 @@ function removeLink(index: number) {
 
           <div class="divider"></div>
 
-          <label class="mono-label">PRIMARY BUTTON</label>
-          <div class="link-row">
-            <input class="text-input text-input--label" type="text" placeholder="Label" :value="settings.cta_text || ''" @input="onText('cta_text', $event)" />
+          <div class="row-head">
+            <label class="mono-label mono-label--inline">PRIMARY BUTTON</label>
+            <label class="switch switch--sm">
+              <input type="checkbox" :checked="settings.cta_enabled" @change="$emit('save-now', { cta_enabled: ($event.target as HTMLInputElement).checked })" />
+              <span class="switch__track"><span class="switch__knob"></span></span>
+            </label>
+          </div>
+          <div class="link-row" :class="{ 'link-row--off': !settings.cta_enabled }">
+            <input class="text-input text-input--label" type="text" placeholder="Label" :disabled="!settings.cta_enabled" :value="settings.cta_text || ''" @input="onText('cta_text', $event)" />
             <div class="url-input">
               <span class="url-input__prefix">https://</span>
-              <input type="text" placeholder="app.yoursite.com" :value="settings.cta_url || ''" @input="onText('cta_url', $event)" />
+              <input type="text" placeholder="app.yoursite.com" :disabled="!settings.cta_enabled" :value="settings.cta_url || ''" @input="onText('cta_url', $event)" />
             </div>
           </div>
         </div>
@@ -345,6 +351,84 @@ function removeLink(index: number) {
   height: 1px;
   background: var(--o07);
   margin: 18px 0;
+}
+
+.row-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.mono-label--inline {
+  margin-bottom: 0;
+}
+
+.link-row--off {
+  opacity: 0.5;
+}
+
+.link-row--off .text-input,
+.link-row--off .url-input {
+  cursor: not-allowed;
+}
+
+/* Toggle switch (scoped copy of the shared switch styling). */
+.switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.switch input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.switch__track {
+  position: relative;
+  width: 38px;
+  height: 22px;
+  border-radius: var(--radius-pill);
+  background: var(--o12);
+  transition: background 0.18s ease;
+}
+
+.switch__knob {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.18s ease;
+}
+
+.switch input:checked + .switch__track {
+  background: var(--c-teal);
+}
+
+.switch input:checked + .switch__track .switch__knob {
+  transform: translateX(16px);
+}
+
+.switch--sm .switch__track {
+  width: 34px;
+  height: 20px;
+}
+
+.switch--sm .switch__knob {
+  width: 14px;
+  height: 14px;
+}
+
+.switch--sm input:checked + .switch__track .switch__knob {
+  transform: translateX(14px);
 }
 
 .preview-col {

--- a/frontend/src/components/faq/HelpCenterAppearance.vue
+++ b/frontend/src/components/faq/HelpCenterAppearance.vue
@@ -15,7 +15,8 @@ limitations under the License.
 -->
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { toast } from 'vue-sonner'
 import type { HelpCenterSettings, HelpCenterSettingsUpdate } from '@/types/faq'
 import type { SaveState } from '@/composables/useHelpCenterSettings'
 import HelpCenterLogoField from './HelpCenterLogoField.vue'
@@ -34,6 +35,38 @@ const emit = defineEmits<{
 }>()
 
 const BRAND_SWATCHES = ['#4338CA', '#0E8C8C', '#CF5B38', '#6D5BD0', '#1F8A5B', '#2A6FDB']
+
+// Custom brand color: native picker + hex field, both saving immediately.
+const isPreset = computed(() =>
+  BRAND_SWATCHES.some((c) => c.toLowerCase() === (props.settings.brand_color || '').toLowerCase()),
+)
+
+const hexDraft = ref(props.settings.brand_color)
+watch(() => props.settings.brand_color, (v) => { hexDraft.value = v })
+
+function saveColor(value: string) {
+  if (value.toLowerCase() !== (props.settings.brand_color || '').toLowerCase()) {
+    emit('save-now', { brand_color: value })
+  }
+}
+
+function onPicker(event: Event) {
+  saveColor((event.target as HTMLInputElement).value.toUpperCase())
+}
+
+function commitHex() {
+  const raw = hexDraft.value.trim()
+  const body = raw.replace(/^#/, '')
+  // Accept 3, 6 or 8 hex digits (matches the backend validator).
+  if (!/^[0-9a-fA-F]{3}$|^[0-9a-fA-F]{6}$|^[0-9a-fA-F]{8}$/.test(body)) {
+    toast.error('Enter a hex color like #4338CA')
+    hexDraft.value = props.settings.brand_color
+    return
+  }
+  const hex = `#${body.toUpperCase()}`
+  hexDraft.value = hex
+  saveColor(hex)
+}
 
 const saveStateLabel = computed(() => {
   if (props.saveState === 'saving') return 'Saving…'
@@ -87,13 +120,39 @@ function removeLink(index: number) {
               v-for="color in BRAND_SWATCHES"
               :key="color"
               class="swatch"
-              :class="{ 'swatch--selected': settings.brand_color === color }"
-              :style="{ background: color, boxShadow: settings.brand_color === color ? `0 0 0 2px ${color}` : 'none' }"
+              :class="{ 'swatch--selected': settings.brand_color.toLowerCase() === color.toLowerCase() }"
+              :style="{ background: color, boxShadow: settings.brand_color.toLowerCase() === color.toLowerCase() ? `0 0 0 2px ${color}` : 'none' }"
               type="button"
               :title="color"
               @click="$emit('save-now', { brand_color: color })"
             ></button>
+
+            <!-- Custom color: swatch opens the OS picker; shows current color when off-preset. -->
+            <label
+              class="swatch swatch--custom"
+              :class="{ 'swatch--selected': !isPreset }"
+              :style="!isPreset ? { background: settings.brand_color, boxShadow: `0 0 0 2px ${settings.brand_color}` } : {}"
+              title="Custom color"
+            >
+              <input type="color" class="swatch__picker" :value="settings.brand_color" @change="onPicker" />
+              <svg v-if="isPreset" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14" /></svg>
+            </label>
           </div>
+
+          <div class="hex-field">
+            <span class="hex-field__hash">#</span>
+            <input
+              :value="hexDraft.replace(/^#/, '')"
+              maxlength="8"
+              spellcheck="false"
+              placeholder="4338CA"
+              aria-label="Brand color hex code"
+              @input="hexDraft = ($event.target as HTMLInputElement).value"
+              @keydown.enter="commitHex"
+              @blur="commitHex"
+            />
+          </div>
+
           <p class="hint">Recolors buttons, links, search and highlights across your help center.</p>
         </div>
 
@@ -236,6 +295,63 @@ function removeLink(index: number) {
 
 .swatch--selected {
   border-color: var(--text);
+}
+
+.swatch--custom {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  background: var(--o05);
+  border: 2px dashed var(--o25);
+  color: var(--muted);
+}
+
+.swatch--custom.swatch--selected {
+  border-style: solid;
+  color: #fff;
+}
+
+/* The native color input fills the swatch but stays invisible — the label is
+   the visible control and clicking anywhere opens the OS picker. */
+.swatch__picker {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.hex-field {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 12px;
+  background: var(--bg);
+  border: 1px solid var(--o10);
+  border-radius: 9px;
+  padding: 0 11px;
+  font-family: var(--font-mono);
+}
+
+.hex-field__hash {
+  color: var(--faint);
+  font-size: 13px;
+}
+
+.hex-field input {
+  width: 84px;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  text-transform: uppercase;
+  padding: 9px 2px 9px 4px;
 }
 
 .hint {

--- a/frontend/src/components/faq/HelpCenterDomainPanel.vue
+++ b/frontend/src/components/faq/HelpCenterDomainPanel.vue
@@ -1,0 +1,332 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type { HelpCenterDomain } from '@/types/faq'
+
+const props = defineProps<{
+  domain: HelpCenterDomain | null
+  busy: boolean
+}>()
+
+const emit = defineEmits<{
+  'set-domain': [domain: string]
+  'verify-domain': []
+  'remove-domain': []
+}>()
+
+const domainInput = ref(props.domain?.custom_domain || '')
+
+watch(
+  () => props.domain?.custom_domain,
+  (value) => {
+    domainInput.value = value || ''
+  },
+)
+
+const currentDomain = computed(() => props.domain?.custom_domain || '')
+const normalizedInput = computed(() => domainInput.value.trim().replace(/^https?:\/\//i, ''))
+const isVerified = computed(() => !!currentDomain.value && props.domain?.domain_status === 'verified')
+const isConnected = computed(() => isVerified.value && normalizedInput.value === currentDomain.value)
+
+const statusPill = computed(() => {
+  if (isVerified.value) return { label: 'Connected', cls: 'status-pill--teal' }
+  if (currentDomain.value) return { label: 'Pending verification', cls: 'status-pill--warn' }
+  return { label: 'Not configured', cls: 'status-pill--idle' }
+})
+
+const sslPill = computed(() => {
+  const status = props.domain?.ssl_status
+  if (status === 'active') return { label: 'Active', cls: 'record-pill--teal' }
+  if (status === 'failed') return { label: 'Failed', cls: 'record-pill--coral' }
+  return { label: 'Provisioning', cls: 'record-pill--idle' }
+})
+
+function onDomainAction() {
+  if (!normalizedInput.value || props.busy || isConnected.value) return
+  if (normalizedInput.value !== currentDomain.value) emit('set-domain', normalizedInput.value)
+  else emit('verify-domain')
+}
+</script>
+
+<template>
+  <div>
+    <div class="domain-head">
+      <h3 class="domain-head__title">Custom domain</h3>
+      <span class="status-pill" :class="statusPill.cls">
+        <span class="status-pill__dot"></span>
+        {{ statusPill.label }}
+      </span>
+    </div>
+    <p class="domain-copy">
+      Serve your help center from your own subdomain instead of the ChatterMate URL. Add the
+      records below at your DNS provider, then verify.
+    </p>
+
+    <div class="domain-form">
+      <div class="domain-input">
+        <span class="domain-input__prefix">https://</span>
+        <input v-model="domainInput" type="text" placeholder="help.yourcompany.com" />
+      </div>
+      <button class="btn-verify" type="button" :disabled="busy || isConnected || !normalizedInput" @click="onDomainAction">
+        {{ isConnected ? 'Connected ✓' : busy ? 'Working…' : 'Verify domain' }}
+      </button>
+      <button v-if="currentDomain" class="icon-btn" type="button" title="Remove domain" :disabled="busy" @click="$emit('remove-domain')">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16" /><path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" /><path d="M6 7l1 13a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1l1-13" /></svg>
+      </button>
+    </div>
+
+    <div v-if="domain?.records?.length" class="dns-table">
+      <div class="dns-table__head">
+        <div>TYPE</div><div>NAME / HOST</div><div>VALUE</div><div class="dns-table__right">STATUS</div>
+      </div>
+      <div v-for="record in domain.records" :key="`${record.type}-${record.host}`" class="dns-table__row">
+        <div class="dns-table__type">{{ record.type }}</div>
+        <div class="dns-table__cell">{{ record.host }}</div>
+        <div class="dns-table__cell">{{ record.value }}</div>
+        <div class="dns-table__right">
+          <span class="record-pill" :class="record.verified ? 'record-pill--teal' : 'record-pill--warn'">
+            {{ record.verified ? 'Active' : 'Pending' }}
+          </span>
+        </div>
+      </div>
+      <div class="ssl-row">
+        <div class="ssl-row__lead">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="10" width="16" height="10" rx="2" /><path d="M8 10V7a4 4 0 0 1 8 0v3" /></svg>
+          <span>SSL certificate</span>
+        </div>
+        <span class="record-pill" :class="sslPill.cls">{{ sslPill.label }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.domain-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.domain-head__title {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 16px;
+  color: var(--text);
+  margin: 0;
+}
+
+.domain-copy {
+  font-size: 13.5px;
+  color: var(--muted);
+  max-width: 520px;
+  line-height: 1.55;
+  margin: 6px 0 16px;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.status-pill__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.status-pill--teal {
+  background: var(--teal-bg);
+  border: 1px solid var(--teal-border);
+  color: var(--c-teal);
+}
+
+.status-pill--warn {
+  background: var(--warning-bg);
+  border: 1px solid color-mix(in srgb, var(--c-warn) 30%, transparent);
+  color: var(--c-warn);
+}
+
+.status-pill--idle {
+  background: var(--pill-idle-bg);
+  border: 1px solid var(--o12);
+  color: var(--pill-idle-fg);
+}
+
+.domain-form {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 18px;
+  flex-wrap: wrap;
+}
+
+.domain-input {
+  flex: 1;
+  min-width: 240px;
+  display: flex;
+  align-items: center;
+  background: var(--bg);
+  border: 1px solid var(--o10);
+  border-radius: 11px;
+  padding: 0 14px;
+  font-family: var(--font-mono);
+}
+
+.domain-input__prefix {
+  color: var(--faint);
+  font-size: 13.5px;
+}
+
+.domain-input input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-size: 13.5px;
+  padding: 13px 4px;
+  font-family: var(--font-mono);
+}
+
+.btn-verify {
+  padding: 0 20px;
+  background: var(--accent-solid);
+  border: none;
+  border-radius: 11px;
+  color: var(--on-accent-solid);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-verify:disabled {
+  opacity: 0.65;
+  cursor: default;
+}
+
+.icon-btn {
+  width: 46px;
+  border-radius: 11px;
+  background: var(--o05);
+  border: 1px solid var(--o12);
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-btn:hover {
+  background: var(--coral-bg);
+  color: var(--c-coral);
+  border-color: var(--coral-border);
+}
+
+.dns-table {
+  background: var(--bg);
+  border: 1px solid var(--o08);
+  border-radius: 13px;
+  overflow: hidden;
+}
+
+.dns-table__head,
+.dns-table__row {
+  display: grid;
+  grid-template-columns: 0.7fr 1.3fr 1.6fr 0.7fr;
+  align-items: center;
+  padding: 11px 16px;
+  border-bottom: 1px solid var(--o06);
+  font-family: var(--font-mono);
+}
+
+.dns-table__head {
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  color: var(--muted2);
+  border-bottom-color: var(--o07);
+}
+
+.dns-table__row {
+  padding: 13px 16px;
+  font-size: 12.5px;
+}
+
+.dns-table__type {
+  color: var(--c-purple);
+  font-weight: 600;
+}
+
+.dns-table__cell {
+  color: var(--text3);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dns-table__right {
+  text-align: right;
+}
+
+.record-pill {
+  display: inline-block;
+  padding: 3px 9px;
+  border-radius: 7px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.record-pill--teal {
+  background: var(--teal-bg);
+  border: 1px solid var(--teal-border);
+  color: var(--c-teal);
+}
+
+.record-pill--coral {
+  background: var(--coral-bg);
+  border: 1px solid var(--coral-border);
+  color: var(--c-coral);
+}
+
+.record-pill--idle {
+  background: var(--o05);
+  border: 1px solid var(--o12);
+  color: var(--muted);
+}
+
+.ssl-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+}
+
+.ssl-row__lead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--muted);
+}
+</style>

--- a/frontend/src/components/faq/HelpCenterDomainPanel.vue
+++ b/frontend/src/components/faq/HelpCenterDomainPanel.vue
@@ -16,6 +16,7 @@ limitations under the License.
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { toast } from 'vue-sonner'
 import type { HelpCenterDomain } from '@/types/faq'
 
 const props = defineProps<{
@@ -40,12 +41,17 @@ watch(
 
 const currentDomain = computed(() => props.domain?.custom_domain || '')
 const normalizedInput = computed(() => domainInput.value.trim().replace(/^https?:\/\//i, ''))
-const isVerified = computed(() => !!currentDomain.value && props.domain?.domain_status === 'verified')
-const isConnected = computed(() => isVerified.value && normalizedInput.value === currentDomain.value)
+const isVerified = computed(() => currentDomain.value !== '' && props.domain?.domain_status === 'verified')
+
+// empty → enter a domain · pending → add DNS records + verify · connected → live
+const phase = computed<'empty' | 'pending' | 'connected'>(() => {
+  if (!currentDomain.value) return 'empty'
+  return isVerified.value ? 'connected' : 'pending'
+})
 
 const statusPill = computed(() => {
-  if (isVerified.value) return { label: 'Connected', cls: 'status-pill--teal' }
-  if (currentDomain.value) return { label: 'Pending verification', cls: 'status-pill--warn' }
+  if (phase.value === 'connected') return { label: 'Connected', cls: 'status-pill--teal' }
+  if (phase.value === 'pending') return { label: 'Pending verification', cls: 'status-pill--warn' }
   return { label: 'Not configured', cls: 'status-pill--idle' }
 })
 
@@ -56,10 +62,20 @@ const sslPill = computed(() => {
   return { label: 'Provisioning', cls: 'record-pill--idle' }
 })
 
-function onDomainAction() {
-  if (!normalizedInput.value || props.busy || isConnected.value) return
-  if (normalizedInput.value !== currentDomain.value) emit('set-domain', normalizedInput.value)
-  else emit('verify-domain')
+const liveUrl = computed(() => `https://${currentDomain.value}`)
+
+function addDomain() {
+  if (!normalizedInput.value || props.busy) return
+  emit('set-domain', normalizedInput.value)
+}
+
+async function copy(text: string) {
+  try {
+    await navigator.clipboard.writeText(text)
+    toast.success('Copied')
+  } catch {
+    toast.error('Could not copy — select and copy manually')
+  }
 }
 </script>
 
@@ -72,46 +88,93 @@ function onDomainAction() {
         {{ statusPill.label }}
       </span>
     </div>
-    <p class="domain-copy">
-      Serve your help center from your own subdomain instead of the ChatterMate URL. Add the
-      records below at your DNS provider, then verify.
-    </p>
 
-    <div class="domain-form">
-      <div class="domain-input">
-        <span class="domain-input__prefix">https://</span>
-        <input v-model="domainInput" type="text" placeholder="help.yourcompany.com" />
+    <!-- Step 1: enter a domain -->
+    <template v-if="phase === 'empty'">
+      <p class="domain-copy">
+        Serve your help center from your own subdomain instead of the ChatterMate URL.
+        Enter it below and we'll show you the two DNS records to add.
+      </p>
+      <div class="domain-form">
+        <div class="domain-input">
+          <span class="domain-input__prefix">https://</span>
+          <input
+            v-model="domainInput"
+            type="text"
+            placeholder="help.yourcompany.com"
+            @keydown.enter="addDomain"
+          />
+        </div>
+        <button class="btn-primary" type="button" :disabled="busy || !normalizedInput" @click="addDomain">
+          {{ busy ? 'Working…' : 'Add domain' }}
+        </button>
       </div>
-      <button class="btn-verify" type="button" :disabled="busy || isConnected || !normalizedInput" @click="onDomainAction">
-        {{ isConnected ? 'Connected ✓' : busy ? 'Working…' : 'Verify domain' }}
-      </button>
-      <button v-if="currentDomain" class="icon-btn" type="button" title="Remove domain" :disabled="busy" @click="$emit('remove-domain')">
-        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16" /><path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" /><path d="M6 7l1 13a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1l1-13" /></svg>
-      </button>
-    </div>
+    </template>
 
-    <div v-if="domain?.records?.length" class="dns-table">
-      <div class="dns-table__head">
-        <div>TYPE</div><div>NAME / HOST</div><div>VALUE</div><div class="dns-table__right">STATUS</div>
+    <!-- Step 2: add the DNS records, then verify -->
+    <template v-else>
+      <div class="domain-current">
+        <div class="domain-current__lead">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9" /><path d="M3 12h18" /><path d="M12 3a15 15 0 0 1 0 18a15 15 0 0 1 0-18z" /></svg>
+          <a v-if="phase === 'connected'" :href="liveUrl" target="_blank" rel="noopener" class="domain-current__name domain-current__name--link">{{ currentDomain }}</a>
+          <span v-else class="domain-current__name">{{ currentDomain }}</span>
+        </div>
+        <button class="link-btn" type="button" :disabled="busy" @click="$emit('remove-domain')">Remove</button>
       </div>
-      <div v-for="record in domain.records" :key="`${record.type}-${record.host}`" class="dns-table__row">
-        <div class="dns-table__type">{{ record.type }}</div>
-        <div class="dns-table__cell">{{ record.host }}</div>
-        <div class="dns-table__cell">{{ record.value }}</div>
-        <div class="dns-table__right">
-          <span class="record-pill" :class="record.verified ? 'record-pill--teal' : 'record-pill--warn'">
-            {{ record.verified ? 'Active' : 'Pending' }}
+
+      <template v-if="phase === 'pending'">
+        <ol class="steps">
+          <li>Add these two records at your DNS provider.</li>
+          <li>Come back and click <strong>Verify domain</strong> — DNS changes can take a few minutes.</li>
+        </ol>
+
+        <div class="records">
+          <div v-for="record in domain?.records || []" :key="`${record.type}-${record.host}`" class="record" :class="{ 'record--ok': record.verified }">
+            <div class="record__top">
+              <span class="record__type">{{ record.type }}</span>
+              <span class="record-pill" :class="record.verified ? 'record-pill--teal' : 'record-pill--warn'">
+                {{ record.verified ? 'Detected' : 'Waiting' }}
+              </span>
+            </div>
+            <div class="record__field">
+              <span class="record__label">Name / Host</span>
+              <div class="record__value">
+                <code>{{ record.host }}</code>
+                <button class="copy-btn" type="button" title="Copy" @click="copy(record.host)">
+                  <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2" /><path d="M5 15V5a2 2 0 0 1 2-2h10" /></svg>
+                </button>
+              </div>
+            </div>
+            <div class="record__field">
+              <span class="record__label">Value</span>
+              <div class="record__value">
+                <code>{{ record.value }}</code>
+                <button class="copy-btn" type="button" title="Copy" @click="copy(record.value)">
+                  <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2" /><path d="M5 15V5a2 2 0 0 1 2-2h10" /></svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="verify-row">
+          <button class="btn-primary" type="button" :disabled="busy" @click="$emit('verify-domain')">
+            {{ busy ? 'Checking…' : 'Verify domain' }}
+          </button>
+          <span class="ssl-note">
+            <span class="record-pill" :class="sslPill.cls">SSL {{ sslPill.label }}</span>
+            issued automatically once verified
           </span>
         </div>
-      </div>
-      <div class="ssl-row">
-        <div class="ssl-row__lead">
-          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="10" width="16" height="10" rx="2" /><path d="M8 10V7a4 4 0 0 1 8 0v3" /></svg>
-          <span>SSL certificate</span>
-        </div>
-        <span class="record-pill" :class="sslPill.cls">{{ sslPill.label }}</span>
-      </div>
-    </div>
+      </template>
+
+      <template v-else>
+        <p class="domain-copy domain-copy--ok">
+          Your help center is live at <a :href="liveUrl" target="_blank" rel="noopener">{{ currentDomain }}</a>.
+          <span class="record-pill" :class="sslPill.cls">SSL {{ sslPill.label }}</span>
+        </p>
+      </template>
+    </template>
   </div>
 </template>
 
@@ -133,9 +196,21 @@ function onDomainAction() {
 .domain-copy {
   font-size: 13.5px;
   color: var(--muted);
-  max-width: 520px;
+  max-width: 560px;
   line-height: 1.55;
   margin: 6px 0 16px;
+}
+
+.domain-copy--ok {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.domain-copy a {
+  color: var(--c-teal);
+  font-weight: 600;
 }
 
 .status-pill {
@@ -176,7 +251,6 @@ function onDomainAction() {
 .domain-form {
   display: flex;
   gap: 10px;
-  margin-bottom: 18px;
   flex-wrap: wrap;
 }
 
@@ -209,8 +283,9 @@ function onDomainAction() {
   font-family: var(--font-mono);
 }
 
-.btn-verify {
+.btn-primary {
   padding: 0 20px;
+  min-height: 44px;
   background: var(--accent-solid);
   border: none;
   border-radius: 11px;
@@ -221,72 +296,178 @@ function onDomainAction() {
   cursor: pointer;
 }
 
-.btn-verify:disabled {
+.btn-primary:disabled {
   opacity: 0.65;
   cursor: default;
 }
 
-.icon-btn {
-  width: 46px;
-  border-radius: 11px;
-  background: var(--o05);
-  border: 1px solid var(--o12);
-  color: var(--muted);
-  cursor: pointer;
+/* current domain header */
+.domain-current {
   display: flex;
   align-items: center;
-  justify-content: center;
-}
-
-.icon-btn:hover {
-  background: var(--coral-bg);
-  color: var(--c-coral);
-  border-color: var(--coral-border);
-}
-
-.dns-table {
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  margin: 6px 0 16px;
   background: var(--bg);
   border: 1px solid var(--o08);
-  border-radius: 13px;
-  overflow: hidden;
+  border-radius: 11px;
 }
 
-.dns-table__head,
-.dns-table__row {
-  display: grid;
-  grid-template-columns: 0.7fr 1.3fr 1.6fr 0.7fr;
+.domain-current__lead {
+  display: flex;
   align-items: center;
-  padding: 11px 16px;
-  border-bottom: 1px solid var(--o06);
+  gap: 10px;
+  min-width: 0;
+  color: var(--muted);
+}
+
+.domain-current__name {
   font-family: var(--font-mono);
-}
-
-.dns-table__head {
-  font-size: 10.5px;
-  letter-spacing: 0.06em;
-  color: var(--muted2);
-  border-bottom-color: var(--o07);
-}
-
-.dns-table__row {
-  padding: 13px 16px;
-  font-size: 12.5px;
-}
-
-.dns-table__type {
-  color: var(--c-purple);
+  font-size: 14px;
   font-weight: 600;
-}
-
-.dns-table__cell {
-  color: var(--text3);
+  color: var(--text2);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.dns-table__right {
-  text-align: right;
+.domain-current__name--link {
+  color: var(--c-teal);
+  text-decoration: none;
+}
+
+.link-btn {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.link-btn:hover {
+  color: var(--c-coral);
+}
+
+.link-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* steps + records */
+.steps {
+  margin: 0 0 14px;
+  padding-left: 20px;
+  font-size: 13.5px;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.steps strong {
+  color: var(--text2);
+}
+
+.records {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+.record {
+  background: var(--bg);
+  border: 1px solid var(--o08);
+  border-radius: 12px;
+  padding: 13px 14px;
+}
+
+.record--ok {
+  border-color: var(--teal-border);
+}
+
+.record__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.record__type {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--c-purple);
+}
+
+.record__field {
+  margin-top: 8px;
+}
+
+.record__label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  color: var(--muted2);
+  margin-bottom: 4px;
+}
+
+.record__value {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--surface);
+  border: 1px solid var(--o08);
+  border-radius: 8px;
+  padding: 7px 9px;
+}
+
+.record__value code {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--text3);
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.copy-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  background: var(--o05);
+  border: 1px solid var(--o12);
+  border-radius: 7px;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.copy-btn:hover {
+  background: var(--o08);
+  color: var(--text2);
+}
+
+.verify-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.ssl-note {
+  font-size: 12.5px;
+  color: var(--muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .record-pill {
@@ -303,6 +484,12 @@ function onDomainAction() {
   color: var(--c-teal);
 }
 
+.record-pill--warn {
+  background: var(--warning-bg);
+  border: 1px solid color-mix(in srgb, var(--c-warn) 30%, transparent);
+  color: var(--c-warn);
+}
+
 .record-pill--coral {
   background: var(--coral-bg);
   border: 1px solid var(--coral-border);
@@ -312,21 +499,6 @@ function onDomainAction() {
 .record-pill--idle {
   background: var(--o05);
   border: 1px solid var(--o12);
-  color: var(--muted);
-}
-
-.ssl-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
-}
-
-.ssl-row__lead {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12.5px;
   color: var(--muted);
 }
 </style>

--- a/frontend/src/components/faq/HelpCenterLogoField.vue
+++ b/frontend/src/components/faq/HelpCenterLogoField.vue
@@ -1,0 +1,187 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const props = defineProps<{ logoUrl: string | null }>()
+
+const emit = defineEmits<{
+  upload: [file: File]
+  remove: []
+}>()
+
+const fileInput = ref<HTMLInputElement | null>(null)
+
+const logoName = computed(() => {
+  if (!props.logoUrl) return ''
+  return props.logoUrl.split('/').pop()?.split('?')[0] || 'logo'
+})
+
+function onFileChange(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  if (file) emit('upload', file)
+  input.value = ''
+}
+</script>
+
+<template>
+  <div>
+    <input ref="fileInput" class="file-input" type="file" accept=".png,.svg" @change="onFileChange" />
+    <div v-if="logoUrl" class="logo-row">
+      <div class="logo-chip">
+        <img class="logo-chip__img" :src="logoUrl" alt="Logo" />
+        <div class="logo-chip__name">{{ logoName }}</div>
+      </div>
+      <button class="btn-sm" type="button" @click="fileInput?.click()">Replace</button>
+      <button class="icon-btn" type="button" title="Remove logo" @click="$emit('remove')">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16" /><path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" /><path d="M6 7l1 13a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1l1-13" /></svg>
+      </button>
+    </div>
+    <button v-else class="upload-btn" type="button" @click="fileInput?.click()">
+      <span class="upload-btn__icon">
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 16V4" /><path d="M8 8l4-4 4 4" /><path d="M4 20h16" /></svg>
+      </span>
+      <span>
+        <span class="upload-btn__title">Upload your logo</span>
+        <span class="upload-btn__sub">PNG or SVG, up to 2 MB · shown top-left</span>
+      </span>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.file-input {
+  display: none;
+}
+
+.logo-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.logo-chip {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 10px 14px;
+  background: var(--bg);
+  border: 1px solid var(--o10);
+  border-radius: 11px;
+  margin-right: 6px;
+  min-width: 0;
+}
+
+.logo-chip__img {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.logo-chip__name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.btn-sm {
+  padding: 9px 13px;
+  background: var(--o05);
+  border: 1px solid var(--o12);
+  border-radius: 9px;
+  color: var(--text2);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-sm:hover {
+  background: var(--o08);
+}
+
+.icon-btn {
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  border-radius: 9px;
+  background: var(--o05);
+  border: 1px solid var(--o12);
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-btn:hover {
+  background: var(--coral-bg);
+  color: var(--c-coral);
+  border-color: var(--coral-border);
+}
+
+.upload-btn {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 16px;
+  background: var(--bg);
+  border: 1.5px dashed var(--o16);
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-sans);
+}
+
+.upload-btn:hover {
+  border-color: var(--o30);
+}
+
+.upload-btn__icon {
+  width: 38px;
+  height: 38px;
+  flex-shrink: 0;
+  border-radius: 10px;
+  background: var(--o05);
+  border: 1px solid var(--o10);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+}
+
+.upload-btn__title {
+  display: block;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text2);
+}
+
+.upload-btn__sub {
+  display: block;
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+</style>

--- a/frontend/src/components/faq/HelpCenterPreview.vue
+++ b/frontend/src/components/faq/HelpCenterPreview.vue
@@ -1,0 +1,243 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { HelpCenterSettings } from '@/types/faq'
+import { contrastInk } from '@/utils/color'
+
+const props = defineProps<{ settings: HelpCenterSettings }>()
+
+const brand = computed(() => props.settings.brand_color || '#4338CA')
+const ink = computed(() => contrastInk(brand.value))
+
+const address = computed(() => {
+  const domain = props.settings.domain
+  if (domain?.domain_status === 'verified' && domain.custom_domain) return domain.custom_domain
+  return `${props.settings.slug || 'your-company'}.chattermate.help`
+})
+
+const rootStyle = computed(() => ({ '--hc-brand': brand.value, '--hc-ink': ink.value }))
+
+// Hero tint from the brand color at low alpha (1F = ~12%).
+const heroStyle = computed(() => ({
+  background: `linear-gradient(180deg, ${brand.value}1F, #FFFFFF 92%)`,
+}))
+</script>
+
+<template>
+  <div class="preview" :style="rootStyle">
+    <!-- browser chrome -->
+    <div class="preview__chrome">
+      <span class="preview__dot"></span><span class="preview__dot"></span><span class="preview__dot"></span>
+      <div class="preview__address">{{ address }}</div>
+    </div>
+    <!-- site header -->
+    <div class="preview__header">
+      <div class="preview__brand">
+        <img v-if="settings.logo_url" class="preview__logo-img" :src="settings.logo_url" alt="Logo" />
+        <div v-else class="preview__logo-mark"><div class="preview__logo-diamond"></div></div>
+        <span class="preview__brand-name">{{ settings.title || 'Your company' }}</span>
+      </div>
+      <div class="preview__nav">
+        <span v-for="link in settings.header_links" :key="link.label" class="preview__nav-link">{{ link.label }}</span>
+        <span class="preview__cta">{{ settings.cta_text || 'Sign in' }}</span>
+      </div>
+    </div>
+    <!-- hero -->
+    <div class="preview__hero" :style="heroStyle">
+      <div class="preview__hero-title">How can we help?</div>
+      <div class="preview__search">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="#9AA0AD" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7" /><line x1="21" y1="21" x2="16.65" y2="16.65" /></svg>
+        <span class="preview__search-hint">Search for answers…</span>
+        <span class="preview__search-btn">Search</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* This component simulates the visitor-facing help center, an external
+   light-mode website — the fixed light palette below is deliberate and must
+   NOT follow the admin app's theme tokens. */
+.preview {
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid var(--o10);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.28);
+}
+
+.preview__chrome {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 13px;
+  background: #ebedf1;
+  border-bottom: 1px solid #dde0e7;
+}
+
+.preview__dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #c6cad3;
+}
+
+.preview__address {
+  margin-left: 9px;
+  flex: 1;
+  height: 20px;
+  border-radius: 6px;
+  background: #ffffff;
+  display: flex;
+  align-items: center;
+  padding: 0 11px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: #9aa0ad;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preview__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 14px;
+  background: #ffffff;
+  border-bottom: 1px solid #ecedf2;
+}
+
+.preview__brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.preview__logo-img {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.preview__logo-mark {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--hc-brand);
+}
+
+.preview__logo-diamond {
+  width: 11px;
+  height: 11px;
+  border-radius: 3px;
+  background: var(--hc-ink);
+  transform: rotate(45deg);
+}
+
+.preview__brand-name {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 14px;
+  color: #1a1b25;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preview__nav {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.preview__nav-link {
+  font-size: 12.5px;
+  color: #5a6172;
+  white-space: nowrap;
+}
+
+.preview__cta {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 15px;
+  border-radius: 9px;
+  font-size: 12.5px;
+  font-weight: 600;
+  white-space: nowrap;
+  background: var(--hc-brand);
+  color: var(--hc-ink);
+}
+
+.preview__hero {
+  padding: 22px 20px 20px;
+}
+
+.preview__hero-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 19px;
+  color: #1a1b25;
+  text-align: center;
+  margin-bottom: 13px;
+}
+
+.preview__search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #ffffff;
+  border: 1px solid #e4e6ec;
+  border-radius: 11px;
+  padding: 5px 5px 5px 13px;
+  max-width: 340px;
+  margin: 0 auto;
+  box-shadow: 0 8px 20px rgba(40, 36, 90, 0.08);
+}
+
+.preview__search svg {
+  flex-shrink: 0;
+}
+
+.preview__search-hint {
+  flex: 1;
+  font-size: 12.5px;
+  color: #9aa0ad;
+}
+
+.preview__search-btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 9px 16px;
+  border-radius: 9px;
+  font-size: 12.5px;
+  font-weight: 600;
+  white-space: nowrap;
+  background: var(--hc-brand);
+  color: var(--hc-ink);
+}
+</style>

--- a/frontend/src/components/faq/HelpCenterPreview.vue
+++ b/frontend/src/components/faq/HelpCenterPreview.vue
@@ -54,7 +54,7 @@ const heroStyle = computed(() => ({
       </div>
       <div class="preview__nav">
         <span v-for="link in settings.header_links" :key="link.label" class="preview__nav-link">{{ link.label }}</span>
-        <span class="preview__cta">{{ settings.cta_text || 'Sign in' }}</span>
+        <span v-if="settings.cta_enabled && settings.cta_text" class="preview__cta">{{ settings.cta_text }}</span>
       </div>
     </div>
     <!-- hero -->

--- a/frontend/src/components/faq/HelpCenterPublic.vue
+++ b/frontend/src/components/faq/HelpCenterPublic.vue
@@ -1,0 +1,283 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import type { HelpCenterSettings } from '@/types/faq'
+import HelpCenterDomainPanel from './HelpCenterDomainPanel.vue'
+
+defineProps<{
+  settings: HelpCenterSettings
+  domainBusy: boolean
+}>()
+
+const emit = defineEmits<{
+  'toggle-enabled': [enabled: boolean]
+  'update-ai': [payload: { agent_id?: string | null; ai_search_enabled?: boolean }]
+  'set-domain': [domain: string]
+  'verify-domain': []
+  'remove-domain': []
+}>()
+
+function onAgentChange(event: Event) {
+  const value = (event.target as HTMLSelectElement).value
+  emit('update-ai', { agent_id: value || null })
+}
+</script>
+
+<template>
+  <section class="public">
+    <h2 class="public__heading">Public help center</h2>
+
+    <div class="public__card">
+      <!-- publish row -->
+      <div class="publish-row">
+        <div class="publish-row__lead">
+          <label class="switch">
+            <input type="checkbox" :checked="settings.enabled" @change="emit('toggle-enabled', ($event.target as HTMLInputElement).checked)" />
+            <span class="switch__track"><span class="switch__knob"></span></span>
+          </label>
+          <span class="status-pill" :class="settings.enabled ? 'status-pill--teal' : 'status-pill--idle'">
+            <span class="status-pill__dot" :class="{ 'status-pill__dot--glow': settings.enabled }"></span>
+            {{ settings.enabled ? 'Published' : 'Draft' }}
+          </span>
+          <span class="publish-row__text">{{ settings.published_count }} published FAQs live at</span>
+          <a v-if="settings.live_url" class="publish-row__url" :href="settings.live_url" target="_blank" rel="noopener">{{ settings.live_url }}</a>
+        </div>
+        <a v-if="settings.live_url" class="btn-ghost" :href="settings.live_url" target="_blank" rel="noopener">Open help center →</a>
+      </div>
+
+      <!-- AI search -->
+      <div class="block">
+        <label class="mono-label">AI SEARCH</label>
+        <div class="ai-row">
+          <select class="agent-select" :value="settings.agent_id || ''" @change="onAgentChange">
+            <option value="">Choose an agent…</option>
+            <option v-for="agent in settings.agents" :key="agent.id" :value="agent.id">{{ agent.name }}</option>
+          </select>
+          <label class="switch switch--labelled">
+            <input type="checkbox" :checked="settings.ai_search_enabled" @change="emit('update-ai', { ai_search_enabled: ($event.target as HTMLInputElement).checked })" />
+            <span class="switch__track"><span class="switch__knob"></span></span>
+            <span class="switch__label">AI answers in search</span>
+          </label>
+        </div>
+        <p class="hint">
+          Visitors get instant AI answers grounded in this agent's knowledge — and can chat with it
+          via the embedded widget.
+        </p>
+      </div>
+
+      <!-- custom domain -->
+      <div class="block">
+        <HelpCenterDomainPanel
+          :domain="settings.domain"
+          :busy="domainBusy"
+          @set-domain="emit('set-domain', $event)"
+          @verify-domain="emit('verify-domain')"
+          @remove-domain="emit('remove-domain')"
+        />
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.public__heading {
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 19px;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0 0 16px;
+}
+
+.public__card {
+  background: var(--surface);
+  border: 1px solid var(--o08);
+  border-radius: 18px;
+  overflow: hidden;
+}
+
+.publish-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 22px;
+  border-bottom: 1px solid var(--o07);
+  flex-wrap: wrap;
+}
+
+.publish-row__lead {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.publish-row__text {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.publish-row__url {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--accent-ink);
+  text-decoration: none;
+}
+
+.btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: var(--o05);
+  border: 1px solid var(--o14);
+  border-radius: 10px;
+  color: var(--text2);
+  text-decoration: none;
+  font-size: 13.5px;
+  font-weight: 600;
+}
+
+.btn-ghost:hover {
+  background: var(--o08);
+}
+
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  cursor: pointer;
+}
+
+.switch input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.switch__track {
+  width: 38px;
+  height: 22px;
+  border-radius: var(--radius-pill);
+  background: var(--toggle-track-off);
+  padding: 2px;
+  display: inline-flex;
+  transition: background-color var(--transition-fast);
+  box-sizing: border-box;
+}
+
+.switch input:checked + .switch__track {
+  background: var(--toggle-on-teal);
+}
+
+.switch__knob {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--toggle-knob);
+  transition: transform var(--transition-fast);
+}
+
+.switch input:checked + .switch__track .switch__knob {
+  transform: translateX(16px);
+}
+
+.switch__label {
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--text2);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+.status-pill__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.status-pill__dot--glow {
+  box-shadow: 0 0 6px var(--c-teal);
+}
+
+.status-pill--teal {
+  background: var(--teal-bg);
+  border: 1px solid var(--teal-border);
+  color: var(--c-teal);
+}
+
+.status-pill--idle {
+  background: var(--pill-idle-bg);
+  border: 1px solid var(--o12);
+  color: var(--pill-idle-fg);
+}
+
+.block {
+  padding: 22px;
+  border-bottom: 1px solid var(--o07);
+}
+
+.block:last-child {
+  border-bottom: none;
+}
+
+.mono-label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--muted2);
+  margin-bottom: 12px;
+}
+
+.ai-row {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+
+.agent-select {
+  min-width: 220px;
+  background: var(--bg);
+  border: 1px solid var(--o12);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  color: var(--text);
+  outline: none;
+}
+
+.hint {
+  font-size: 12.5px;
+  color: var(--muted);
+  margin: 12px 0 0;
+  line-height: 1.55;
+}
+</style>

--- a/frontend/src/components/faq/HelpCenterPublic.vue
+++ b/frontend/src/components/faq/HelpCenterPublic.vue
@@ -25,7 +25,7 @@ defineProps<{
 
 const emit = defineEmits<{
   'toggle-enabled': [enabled: boolean]
-  'update-ai': [payload: { agent_id?: string | null; ai_search_enabled?: boolean }]
+  'update-ai': [payload: { agent_id?: string | null; ai_search_enabled?: boolean; chat_widget_enabled?: boolean }]
   'set-domain': [domain: string]
   'verify-domain': []
   'remove-domain': []
@@ -59,24 +59,34 @@ function onAgentChange(event: Event) {
         <a v-if="settings.live_url" class="btn-ghost" :href="settings.live_url" target="_blank" rel="noopener">Open help center →</a>
       </div>
 
-      <!-- AI search -->
+      <!-- AI agent + surfaces -->
       <div class="block">
-        <label class="mono-label">AI SEARCH</label>
+        <label class="mono-label">AI AGENT</label>
         <div class="ai-row">
           <select class="agent-select" :value="settings.agent_id || ''" @change="onAgentChange">
             <option value="">Choose an agent…</option>
             <option v-for="agent in settings.agents" :key="agent.id" :value="agent.id">{{ agent.name }}</option>
           </select>
+        </div>
+        <div class="toggle-list">
           <label class="switch switch--labelled">
             <input type="checkbox" :checked="settings.ai_search_enabled" @change="emit('update-ai', { ai_search_enabled: ($event.target as HTMLInputElement).checked })" />
             <span class="switch__track"><span class="switch__knob"></span></span>
-            <span class="switch__label">AI answers in search</span>
+            <span class="switch__label">
+              AI quick summary in search
+              <span class="switch__sub">Instant AI answer above search results, grounded in this agent's knowledge.</span>
+            </span>
+          </label>
+          <label class="switch switch--labelled">
+            <input type="checkbox" :checked="settings.chat_widget_enabled" @change="emit('update-ai', { chat_widget_enabled: ($event.target as HTMLInputElement).checked })" />
+            <span class="switch__track"><span class="switch__knob"></span></span>
+            <span class="switch__label">
+              Chat widget
+              <span class="switch__sub">Embed this agent's chat widget so visitors can start a conversation.</span>
+            </span>
           </label>
         </div>
-        <p class="hint">
-          Visitors get instant AI answers grounded in this agent's knowledge — and can chat with it
-          via the embedded widget.
-        </p>
+        <p class="hint">Both surfaces use the agent above — pick one, both, or neither.</p>
       </div>
 
       <!-- custom domain -->
@@ -199,9 +209,30 @@ function onAgentChange(event: Event) {
 }
 
 .switch__label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   font-size: 13.5px;
   font-weight: 500;
   color: var(--text2);
+}
+
+.switch__sub {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--text3, var(--text2));
+  opacity: 0.85;
+}
+
+.toggle-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.switch--labelled {
+  align-items: flex-start;
 }
 
 .status-pill {

--- a/frontend/src/components/faq/MarkdownEditor.vue
+++ b/frontend/src/components/faq/MarkdownEditor.vue
@@ -1,0 +1,266 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed, nextTick, ref } from 'vue'
+import { marked } from 'marked'
+import { toast } from 'vue-sonner'
+import { faqService } from '@/services/faq'
+
+const props = withDefaults(
+  defineProps<{ modelValue: string; placeholder?: string }>(),
+  { placeholder: 'Answer — Markdown supported (headings, **bold**, lists, links, images)' },
+)
+const emit = defineEmits<{ 'update:modelValue': [value: string] }>()
+
+const textarea = ref<HTMLTextAreaElement | null>(null)
+const fileInput = ref<HTMLInputElement | null>(null)
+const mode = ref<'write' | 'preview'>('write')
+const uploading = ref(false)
+
+// Preview renders in a sandboxed iframe (no allow-scripts): it safely shows
+// images/links from the author's Markdown without executing anything, and
+// sidesteps the app-wide DOMPurify hook that strips <img> elsewhere.
+const previewDoc = computed(() => {
+  const body = props.modelValue.trim()
+    ? (marked.parse(props.modelValue, { breaks: true, async: false }) as string)
+    : '<p style="color:#9aa0ad">Nothing to preview yet.</p>'
+  return `<!doctype html><html><head><meta charset="utf-8"><style>
+    body{font-family:system-ui,-apple-system,sans-serif;font-size:14px;line-height:1.7;color:#2a303e;margin:14px;}
+    h1,h2,h3,h4{font-weight:700;line-height:1.3;margin:20px 0 10px;color:#1a1b25;}
+    h1{font-size:20px}h2{font-size:17px}h3{font-size:15px}
+    a{color:#4338ca;font-weight:600}
+    img{max-width:100%;height:auto;border-radius:10px;border:1px solid #ececf2;margin:6px 0}
+    ul,ol{padding-left:22px}li{margin:4px 0}
+    blockquote{margin:6px 0;padding:10px 14px;background:#f4f2fd;border-left:3px solid #6d5bd0;border-radius:8px}
+    code{font-family:ui-monospace,monospace;background:#f1f2f6;border-radius:4px;padding:1px 5px}
+    pre{background:#f1f2f6;border-radius:10px;padding:12px;overflow-x:auto}
+    pre code{background:none;padding:0}
+    table{border-collapse:collapse;width:100%}th,td{border:1px solid #ececf2;padding:6px 9px}
+  </style></head><body>${body}</body></html>`
+})
+
+/** Replace the current selection (or insert at caret), then restore focus/caret. */
+function replaceSelection(transform: (selected: string) => { text: string; caretOffset?: number }) {
+  const el = textarea.value
+  if (!el) return
+  const start = el.selectionStart
+  const end = el.selectionEnd
+  const value = props.modelValue
+  const selected = value.slice(start, end)
+  const { text, caretOffset } = transform(selected)
+  const next = value.slice(0, start) + text + value.slice(end)
+  emit('update:modelValue', next)
+  const caret = caretOffset === undefined ? start + text.length : start + caretOffset
+  nextTick(() => {
+    el.focus()
+    el.setSelectionRange(caret, caret)
+  })
+}
+
+function wrap(before: string, after: string, placeholder: string) {
+  replaceSelection((sel) => {
+    const inner = sel || placeholder
+    return { text: `${before}${inner}${after}`, caretOffset: before.length + inner.length }
+  })
+}
+
+function prefixLine(prefix: string, placeholder: string) {
+  replaceSelection((sel) => {
+    const inner = sel || placeholder
+    return { text: `${prefix}${inner}`, caretOffset: prefix.length + inner.length }
+  })
+}
+
+function insertLink() {
+  replaceSelection((sel) => {
+    const label = sel || 'link text'
+    return { text: `[${label}](https://)`, caretOffset: label.length + 3 }
+  })
+}
+
+async function onFile(event: Event) {
+  const input = event.target as HTMLInputElement
+  const file = input.files?.[0]
+  input.value = ''
+  if (!file) return
+  uploading.value = true
+  try {
+    const url = await faqService.uploadImage(file)
+    const alt = file.name.replace(/\.[^.]+$/, '')
+    replaceSelection(() => ({ text: `\n![${alt}](${url})\n` }))
+  } catch (error: any) {
+    toast.error(error?.message || 'Failed to upload image')
+  } finally {
+    uploading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="md-editor">
+    <div class="md-toolbar">
+      <div class="md-tools">
+        <button type="button" class="md-btn" title="Heading" @click="prefixLine('## ', 'Heading')">H</button>
+        <button type="button" class="md-btn md-btn--bold" title="Bold" @click="wrap('**', '**', 'bold')">B</button>
+        <button type="button" class="md-btn" title="Bullet list" @click="prefixLine('- ', 'List item')">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="20" y2="6"/><line x1="8" y1="12" x2="20" y2="12"/><line x1="8" y1="18" x2="20" y2="18"/><circle cx="3.5" cy="6" r="1"/><circle cx="3.5" cy="12" r="1"/><circle cx="3.5" cy="18" r="1"/></svg>
+        </button>
+        <button type="button" class="md-btn" title="Link" @click="insertLink">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7 0l2-2a5 5 0 0 0-7-7l-1 1"/><path d="M14 11a5 5 0 0 0-7 0l-2 2a5 5 0 0 0 7 7l1-1"/></svg>
+        </button>
+        <button type="button" class="md-btn" title="Insert image" :disabled="uploading" @click="fileInput?.click()">
+          <svg v-if="!uploading" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></svg>
+          <span v-else class="md-spin"></span>
+        </button>
+        <input ref="fileInput" type="file" accept="image/png,image/jpeg,image/gif,image/webp" hidden @change="onFile" />
+      </div>
+      <div class="md-modes">
+        <button type="button" class="md-mode" :class="{ 'md-mode--on': mode === 'write' }" @click="mode = 'write'">Write</button>
+        <button type="button" class="md-mode" :class="{ 'md-mode--on': mode === 'preview' }" @click="mode = 'preview'">Preview</button>
+      </div>
+    </div>
+
+    <textarea
+      v-show="mode === 'write'"
+      ref="textarea"
+      class="md-textarea"
+      rows="8"
+      :placeholder="placeholder"
+      :value="modelValue"
+      @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
+    ></textarea>
+
+    <iframe v-show="mode === 'preview'" class="md-preview" :srcdoc="previewDoc" sandbox="" title="Answer preview"></iframe>
+  </div>
+</template>
+
+<style scoped>
+.md-editor {
+  border: 1px solid var(--o12);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+.md-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--o08);
+  background: var(--o03);
+}
+
+.md-tools {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.md-btn {
+  min-width: 30px;
+  height: 30px;
+  padding: 0 7px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  cursor: pointer;
+}
+
+.md-btn:hover {
+  background: var(--o08);
+  color: var(--text2);
+}
+
+.md-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.md-btn--bold {
+  font-weight: 700;
+}
+
+.md-modes {
+  display: flex;
+  gap: 2px;
+  background: var(--o05);
+  border-radius: 8px;
+  padding: 2px;
+}
+
+.md-mode {
+  padding: 5px 11px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.md-mode--on {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.md-textarea {
+  width: 100%;
+  display: block;
+  background: var(--bg);
+  border: none;
+  padding: 12px 13px;
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  line-height: 1.6;
+  outline: none;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.md-preview {
+  width: 100%;
+  height: 240px;
+  border: none;
+  background: #fff;
+  display: block;
+}
+
+.md-spin {
+  width: 13px;
+  height: 13px;
+  border: 2px solid var(--o16);
+  border-top-color: var(--c-purple);
+  border-radius: 50%;
+  animation: md-spin 0.7s linear infinite;
+}
+
+@keyframes md-spin {
+  to { transform: rotate(360deg); }
+}
+</style>

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -102,7 +102,7 @@ const navItems = computed(() => [
     {
         to: '/faq',
         icon: 'faq',
-        label: 'FAQ',
+        label: 'Help center',
         show: permissionChecks.canManageKnowledge()
     },
     {

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -31,6 +31,7 @@ const NAV_ICONS: Record<string, string> = {
     people: '<circle cx="9" cy="8" r="2.6"/><path d="M4 18a5 4.5 0 0 1 10 0"/><path d="M15.5 6.2a2.6 2.6 0 0 1 0 4.6"/><path d="M16 13.6A5 4.5 0 0 1 20 18"/>',
     analytics: '<line x1="5" y1="17" x2="5" y2="13"/><line x1="10" y1="17" x2="10" y2="9"/><line x1="15" y1="17" x2="15" y2="6"/><line x1="20" y1="17" x2="20" y2="11"/>',
     knowledge: '<path d="M4 5.5A2 2 0 0 1 6 4h5v16H6a2 2 0 0 0-2 1.5z"/><path d="M20 5.5A2 2 0 0 0 18 4h-5v16h5a2 2 0 0 1 2 1.5z"/>',
+    faq: '<circle cx="12" cy="12" r="9"/><path d="M9.3 9.3a2.7 2.7 0 0 1 5.2 1c0 1.8-2.5 2-2.5 3.3"/><circle cx="12" cy="17" r=".6" fill="currentColor"/>',
     org: '<rect x="4" y="4" width="14" height="16" rx="2"/><line x1="20" y1="20" x2="20" y2="11"/><line x1="18" y1="11" x2="22" y2="11"/><circle cx="8" cy="9" r=".6" fill="currentColor"/><circle cx="12" cy="9" r=".6" fill="currentColor"/><circle cx="8" cy="13" r=".6" fill="currentColor"/><circle cx="12" cy="13" r=".6" fill="currentColor"/>',
     subscription: '<rect x="3" y="6" width="18" height="12" rx="2.5"/><line x1="3" y1="10" x2="21" y2="10"/><line x1="7" y1="14" x2="11" y2="14"/>',
     integrations: '<line x1="12" y1="12" x2="6" y2="6"/><line x1="12" y1="12" x2="18" y2="6"/><line x1="12" y1="12" x2="12" y2="19"/><circle cx="12" cy="12" r="2.2" fill="currentColor"/><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="19" r="2"/>',
@@ -96,6 +97,12 @@ const navItems = computed(() => [
         to: '/knowledge',
         icon: 'knowledge',
         label: 'Knowledge',
+        show: permissionChecks.canManageKnowledge()
+    },
+    {
+        to: '/faq',
+        icon: 'faq',
+        label: 'FAQ',
         show: permissionChecks.canManageKnowledge()
     },
     {

--- a/frontend/src/composables/useFaqWorkspace.ts
+++ b/frontend/src/composables/useFaqWorkspace.ts
@@ -250,6 +250,17 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     }
   }
 
+  async function submitPdfImport(file: File): Promise<boolean> {
+    try {
+      job.value = await faqService.importPdf(file)
+      toast.success('Import started — drafts will appear when it finishes')
+      return true
+    } catch (error: any) {
+      toast.error(error.message)
+      return false
+    }
+  }
+
   async function togglePublish(faq: FaqItem): Promise<void> {
     const nextStatus = faq.status === 'published' ? 'draft' : 'published'
     const previous = faq.status
@@ -350,6 +361,7 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     pollTick,
     startGeneration,
     submitImport,
+    submitPdfImport,
     togglePublish,
     startEdit,
     startAdd,

--- a/frontend/src/composables/useFaqWorkspace.ts
+++ b/frontend/src/composables/useFaqWorkspace.ts
@@ -134,11 +134,16 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
   )
 
   const filteredFaqs = computed(() => {
-    const q = searchQuery.value.trim().toLowerCase()
+    // Tokenized: every term must appear somewhere (question/answer/category),
+    // so "close my" matches "How to close my account".
+    const terms = searchQuery.value.trim().toLowerCase().split(/\s+/).filter(Boolean)
     return faqs.value.filter((f) => {
       if (categoryFilter.value && f.category !== categoryFilter.value) return false
       if (statusFilter.value !== 'all' && f.status !== statusFilter.value) return false
-      if (q && !`${f.question} ${f.answer}`.toLowerCase().includes(q)) return false
+      if (terms.length) {
+        const haystack = `${f.question} ${f.answer} ${f.category}`.toLowerCase()
+        if (!terms.every((t) => haystack.includes(t))) return false
+      }
       return true
     })
   })

--- a/frontend/src/composables/useFaqWorkspace.ts
+++ b/frontend/src/composables/useFaqWorkspace.ts
@@ -1,0 +1,293 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { computed, ref } from 'vue'
+import { toast } from 'vue-sonner'
+
+import { faqService } from '@/services/faq'
+import { knowledgeService } from '@/services/knowledge'
+import type { FaqGenerationJob, FaqItem, HelpCenterSettings } from '@/types/faq'
+
+export type WorkspacePhase = 'loading' | 'empty' | 'generating' | 'populated'
+
+// Fast tick while a job is running; relaxed tick while a domain/SSL state is
+// pending. Idle = no requests at all.
+const ACTIVE_POLL_MS = 3000
+const IDLE_POLL_MS = 10000
+
+export function useFaqWorkspace(organizationId: () => string | undefined) {
+  const faqs = ref<FaqItem[]>([])
+  const job = ref<FaqGenerationJob | null>(null)
+  const settings = ref<HelpCenterSettings | null>(null)
+  const sourceCount = ref(0)
+  const pageCount = ref(0)
+  const isLoading = ref(false)
+  const loadedOnce = ref(false)
+
+  // Inline edit state (one card at a time).
+  const editingId = ref<string | null>(null)
+  const isNewFaq = ref(false)
+  const draftQuestion = ref('')
+  const draftAnswer = ref('')
+  const isSaving = ref(false)
+
+  let pollTimer: ReturnType<typeof setInterval> | null = null
+  let lastPollAt = 0
+
+  const isJobActive = computed(
+    () => job.value?.status === 'pending' || job.value?.status === 'processing',
+  )
+
+  const phase = computed<WorkspacePhase>(() => {
+    if (isLoading.value && !loadedOnce.value) return 'loading'
+    // Regenerating with existing FAQs keeps the list visible — only the
+    // generate bar flips; the full progress card is for first-run only.
+    if (isJobActive.value && faqs.value.length === 0) return 'generating'
+    return faqs.value.length > 0 ? 'populated' : 'empty'
+  })
+
+  const barPhase = computed<'idle' | 'generating' | 'ready'>(() => {
+    if (isJobActive.value) return 'generating'
+    return faqs.value.length > 0 ? 'ready' : 'idle'
+  })
+
+  const publishedCount = computed(() => faqs.value.filter((f) => f.status === 'published').length)
+
+  const groupedFaqs = computed(() => {
+    const groups = new Map<string, FaqItem[]>()
+    for (const faq of faqs.value) {
+      const list = groups.get(faq.category) || []
+      list.push(faq)
+      groups.set(faq.category, list)
+    }
+    return groups
+  })
+
+  const domainPending = computed(() => {
+    const domain = settings.value?.domain
+    if (!domain?.custom_domain) return false
+    return domain.domain_status !== 'verified' || domain.ssl_status === 'pending'
+  })
+
+  // Bounded safety cap; a curated FAQ list should never approach this.
+  const MAX_FAQ_PAGES = 10
+
+  async function fetchFaqs(): Promise<void> {
+    const all: FaqItem[] = []
+    let page = 1
+    for (;;) {
+      const response = await faqService.getFaqs({ page })
+      all.push(...response.faqs)
+      if (page >= response.pagination.total_pages || page >= MAX_FAQ_PAGES) break
+      page += 1
+    }
+    faqs.value = all
+  }
+
+  async function fetchJob(): Promise<void> {
+    job.value = await faqService.getJob(true)
+  }
+
+  async function fetchSettings(): Promise<void> {
+    settings.value = await faqService.getSettings()
+  }
+
+  async function fetchCounts(): Promise<void> {
+    const orgId = organizationId()
+    if (!orgId) return
+    const response = await knowledgeService.getKnowledgeByOrganization(orgId, 1, 100)
+    const items = response.knowledge || []
+    sourceCount.value = response.pagination?.total ?? response.pagination?.total_count ?? items.length
+    pageCount.value = items.reduce(
+      (sum: number, item: { pages?: unknown[] }) => sum + (item.pages?.length || 1),
+      0,
+    )
+  }
+
+  async function refresh(): Promise<void> {
+    isLoading.value = true
+    try {
+      await Promise.all([fetchFaqs(), fetchJob(), fetchSettings(), fetchCounts()])
+      loadedOnce.value = true
+    } catch (error: any) {
+      toast.error(error.message)
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function pollTick(): Promise<void> {
+    const interval = isJobActive.value ? ACTIVE_POLL_MS : IDLE_POLL_MS
+    if (!isJobActive.value && !domainPending.value) return
+    const now = Date.now()
+    if (now - lastPollAt < interval - 100) return
+    lastPollAt = now
+    try {
+      if (isJobActive.value) {
+        const wasActive = job.value?.id
+        await fetchJob()
+        const stillActive = job.value?.status === 'pending' || job.value?.status === 'processing'
+        if (wasActive && !stillActive) {
+          await Promise.all([fetchFaqs(), fetchSettings()])
+          const finished = await faqService.getJob(false)
+          if (finished?.status === 'failed') {
+            toast.error(finished.error || 'FAQ generation failed')
+          } else if (finished) {
+            toast.success(
+              finished.faqs_created
+                ? `${finished.faqs_created} draft FAQ${finished.faqs_created === 1 ? '' : 's'} ready to review`
+                : 'No new FAQs found — existing FAQs already cover this content',
+            )
+          }
+        }
+      } else if (domainPending.value) {
+        await fetchSettings()
+      }
+    } catch {
+      // Transient polling errors are silent; the next tick retries.
+    }
+  }
+
+  function startPolling(): void {
+    stopPolling()
+    pollTimer = setInterval(pollTick, ACTIVE_POLL_MS)
+  }
+
+  function stopPolling(): void {
+    if (pollTimer) {
+      clearInterval(pollTimer)
+      pollTimer = null
+    }
+  }
+
+  async function startGeneration(): Promise<void> {
+    try {
+      job.value = await faqService.startGeneration()
+    } catch (error: any) {
+      toast.error(error.message)
+    }
+  }
+
+  async function submitImport(url: string): Promise<boolean> {
+    try {
+      job.value = await faqService.importFaq(url)
+      toast.success('Import started — drafts will appear when it finishes')
+      return true
+    } catch (error: any) {
+      toast.error(error.message)
+      return false
+    }
+  }
+
+  async function togglePublish(faq: FaqItem): Promise<void> {
+    const nextStatus = faq.status === 'published' ? 'draft' : 'published'
+    const previous = faq.status
+    faq.status = nextStatus // optimistic
+    try {
+      await faqService.setStatus([faq.id], nextStatus)
+    } catch (error: any) {
+      faq.status = previous
+      toast.error(error.message)
+    }
+  }
+
+  function startEdit(faq: FaqItem): void {
+    editingId.value = faq.id
+    isNewFaq.value = false
+    draftQuestion.value = faq.question
+    draftAnswer.value = faq.answer
+  }
+
+  function startAdd(): void {
+    editingId.value = 'new'
+    isNewFaq.value = true
+    draftQuestion.value = ''
+    draftAnswer.value = ''
+  }
+
+  function cancelEdit(): void {
+    editingId.value = null
+    isNewFaq.value = false
+    draftQuestion.value = ''
+    draftAnswer.value = ''
+  }
+
+  async function saveEdit(): Promise<void> {
+    const question = draftQuestion.value.trim()
+    const answer = draftAnswer.value.trim()
+    if (!question || !answer) {
+      toast.error('Both a question and an answer are required')
+      return
+    }
+    isSaving.value = true
+    try {
+      if (isNewFaq.value) {
+        const created = await faqService.createFaq({ question, answer })
+        faqs.value = [...faqs.value, created]
+      } else if (editingId.value) {
+        const updated = await faqService.updateFaq(editingId.value, { question, answer })
+        faqs.value = faqs.value.map((f) => (f.id === updated.id ? updated : f))
+      }
+      cancelEdit()
+    } catch (error: any) {
+      toast.error(error.message)
+    } finally {
+      isSaving.value = false
+    }
+  }
+
+  async function deleteFaq(faq: FaqItem): Promise<void> {
+    try {
+      await faqService.deleteFaq(faq.id)
+      faqs.value = faqs.value.filter((f) => f.id !== faq.id)
+      if (editingId.value === faq.id) cancelEdit()
+    } catch (error: any) {
+      toast.error(error.message)
+    }
+  }
+
+  return {
+    faqs,
+    job,
+    settings,
+    sourceCount,
+    pageCount,
+    isLoading,
+    phase,
+    barPhase,
+    publishedCount,
+    groupedFaqs,
+    isJobActive,
+    editingId,
+    isNewFaq,
+    draftQuestion,
+    draftAnswer,
+    isSaving,
+    refresh,
+    fetchSettings,
+    startPolling,
+    stopPolling,
+    pollTick,
+    startGeneration,
+    submitImport,
+    togglePublish,
+    startEdit,
+    startAdd,
+    cancelEdit,
+    saveEdit,
+    deleteFaq,
+  }
+}

--- a/frontend/src/composables/useFaqWorkspace.ts
+++ b/frontend/src/composables/useFaqWorkspace.ts
@@ -19,7 +19,7 @@ import { toast } from 'vue-sonner'
 
 import { faqService } from '@/services/faq'
 import { knowledgeService } from '@/services/knowledge'
-import type { FaqGenerationJob, FaqItem, HelpCenterSettings } from '@/types/faq'
+import type { FaqGenerationJob, FaqItem, GenerateEstimate, HelpCenterSettings } from '@/types/faq'
 
 export type WorkspacePhase = 'loading' | 'empty' | 'generating' | 'populated'
 
@@ -32,6 +32,7 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
   const faqs = ref<FaqItem[]>([])
   const job = ref<FaqGenerationJob | null>(null)
   const settings = ref<HelpCenterSettings | null>(null)
+  const estimate = ref<GenerateEstimate | null>(null)
   const sourceCount = ref(0)
   const pageCount = ref(0)
   const isLoading = ref(false)
@@ -105,6 +106,16 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     settings.value = await faqService.getSettings()
   }
 
+  async function fetchEstimate(): Promise<void> {
+    // Non-fatal: locked plans 403 here; the generate button then just says
+    // "Generate" without the new-source count.
+    try {
+      estimate.value = await faqService.getGenerateEstimate()
+    } catch {
+      estimate.value = null
+    }
+  }
+
   async function fetchCounts(): Promise<void> {
     const orgId = organizationId()
     if (!orgId) return
@@ -120,7 +131,7 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
   async function refresh(): Promise<void> {
     isLoading.value = true
     try {
-      await Promise.all([fetchFaqs(), fetchJob(), fetchSettings(), fetchCounts()])
+      await Promise.all([fetchFaqs(), fetchJob(), fetchSettings(), fetchCounts(), fetchEstimate()])
       loadedOnce.value = true
     } catch (error: any) {
       toast.error(error.message)
@@ -141,7 +152,7 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
         await fetchJob()
         const stillActive = job.value?.status === 'pending' || job.value?.status === 'processing'
         if (wasActive && !stillActive) {
-          await Promise.all([fetchFaqs(), fetchSettings()])
+          await Promise.all([fetchFaqs(), fetchSettings(), fetchEstimate()])
           const finished = await faqService.getJob(false)
           if (finished?.status === 'failed') {
             toast.error(finished.error || 'FAQ generation failed')
@@ -173,9 +184,9 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     }
   }
 
-  async function startGeneration(): Promise<void> {
+  async function startGeneration(knowledgeIds?: number[]): Promise<void> {
     try {
-      job.value = await faqService.startGeneration()
+      job.value = await faqService.startGeneration(knowledgeIds)
     } catch (error: any) {
       toast.error(error.message)
     }
@@ -263,6 +274,8 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     faqs,
     job,
     settings,
+    estimate,
+    fetchEstimate,
     sourceCount,
     pageCount,
     isLoading,

--- a/frontend/src/composables/useFaqWorkspace.ts
+++ b/frontend/src/composables/useFaqWorkspace.ts
@@ -82,6 +82,9 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     faqs.value = faqs.value.filter((f) => !selectedIds.value.has(f.id))
     clearSelection()
     toast.success(`${deleted} FAQ${deleted === 1 ? '' : 's'} deleted`)
+    // Deleting a source's FAQs makes it eligible for generation again — the
+    // Generate button's new-source count must not stay stale/disabled.
+    void fetchEstimate()
   }
 
   // Inline edit state (one card at a time).
@@ -152,11 +155,14 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     settings.value = await faqService.getSettings()
   }
 
-  async function fetchEstimate(): Promise<void> {
+  async function fetchEstimate(includePages = false): Promise<void> {
+    // Background fetches (page load, deletes, job completion) skip the
+    // per-source page scan — the button label only needs new_sources. The
+    // confirm dialog passes includePages=true for the full call estimate.
     // Non-fatal: locked plans 403 here; the generate button then just says
     // "Generate" without the new-source count.
     try {
-      estimate.value = await faqService.getGenerateEstimate()
+      estimate.value = await faqService.getGenerateEstimate(includePages)
     } catch {
       estimate.value = null
     }
@@ -323,6 +329,8 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
       await faqService.deleteFaq(faq.id)
       faqs.value = faqs.value.filter((f) => f.id !== faq.id)
       if (editingId.value === faq.id) cancelEdit()
+      // Keep the Generate button's new-source count fresh (see bulkDelete).
+      void fetchEstimate()
     } catch (error: any) {
       toast.error(error.message)
     }

--- a/frontend/src/composables/useFaqWorkspace.ts
+++ b/frontend/src/composables/useFaqWorkspace.ts
@@ -116,15 +116,62 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
 
   const publishedCount = computed(() => faqs.value.filter((f) => f.status === 'published').length)
 
+  // ---- search + filter + collapse (all client-side over the loaded set) ----
+  const searchQuery = ref('')
+  const categoryFilter = ref<string | null>(null)
+  const statusFilter = ref<'all' | FaqStatus>('all')
+  const collapsedCategories = ref<Set<string>>(new Set())
+
+  const categories = computed(() =>
+    [...new Set(faqs.value.map((f) => f.category))].sort((a, b) => a.localeCompare(b)),
+  )
+
+  const hasActiveFilters = computed(
+    () =>
+      searchQuery.value.trim() !== '' ||
+      categoryFilter.value !== null ||
+      statusFilter.value !== 'all',
+  )
+
+  const filteredFaqs = computed(() => {
+    const q = searchQuery.value.trim().toLowerCase()
+    return faqs.value.filter((f) => {
+      if (categoryFilter.value && f.category !== categoryFilter.value) return false
+      if (statusFilter.value !== 'all' && f.status !== statusFilter.value) return false
+      if (q && !`${f.question} ${f.answer}`.toLowerCase().includes(q)) return false
+      return true
+    })
+  })
+
+  const filteredCount = computed(() => filteredFaqs.value.length)
+
   const groupedFaqs = computed(() => {
     const groups = new Map<string, FaqItem[]>()
-    for (const faq of faqs.value) {
+    for (const faq of filteredFaqs.value) {
       const list = groups.get(faq.category) || []
       list.push(faq)
       groups.set(faq.category, list)
     }
     return groups
   })
+
+  function resetFilters(): void {
+    searchQuery.value = ''
+    categoryFilter.value = null
+    statusFilter.value = 'all'
+  }
+
+  function toggleCategory(category: string): void {
+    const next = new Set(collapsedCategories.value)
+    if (next.has(category)) next.delete(category)
+    else next.add(category)
+    collapsedCategories.value = next
+  }
+
+  // While filtering/searching, always show matches regardless of collapse state.
+  function isCategoryOpen(category: string): boolean {
+    return hasActiveFilters.value || !collapsedCategories.value.has(category)
+  }
 
   const domainPending = computed(() => {
     const domain = settings.value?.domain
@@ -349,6 +396,15 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     barPhase,
     publishedCount,
     groupedFaqs,
+    searchQuery,
+    categoryFilter,
+    statusFilter,
+    categories,
+    hasActiveFilters,
+    filteredCount,
+    resetFilters,
+    toggleCategory,
+    isCategoryOpen,
     isJobActive,
     selectedIds,
     selectionActive,

--- a/frontend/src/composables/useFaqWorkspace.ts
+++ b/frontend/src/composables/useFaqWorkspace.ts
@@ -19,7 +19,7 @@ import { toast } from 'vue-sonner'
 
 import { faqService } from '@/services/faq'
 import { knowledgeService } from '@/services/knowledge'
-import type { FaqGenerationJob, FaqItem, GenerateEstimate, HelpCenterSettings } from '@/types/faq'
+import type { FaqGenerationJob, FaqItem, FaqStatus, GenerateEstimate, HelpCenterSettings } from '@/types/faq'
 
 export type WorkspacePhase = 'loading' | 'empty' | 'generating' | 'populated'
 
@@ -37,6 +37,52 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
   const pageCount = ref(0)
   const isLoading = ref(false)
   const loadedOnce = ref(false)
+
+  // Multi-select state for bulk publish/unpublish/delete.
+  const selectedIds = ref<Set<string>>(new Set())
+  const selectionActive = computed(() => selectedIds.value.size > 0)
+
+  function toggleSelect(id: string): void {
+    const next = new Set(selectedIds.value)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    selectedIds.value = next
+  }
+
+  function setSelected(items: FaqItem[], on: boolean): void {
+    const next = new Set(selectedIds.value)
+    for (const item of items) {
+      if (on) next.add(item.id)
+      else next.delete(item.id)
+    }
+    selectedIds.value = next
+  }
+
+  function clearSelection(): void {
+    selectedIds.value = new Set()
+  }
+
+  async function bulkSetStatus(status: FaqStatus): Promise<void> {
+    const ids = [...selectedIds.value]
+    if (!ids.length) return
+    try {
+      const updated = await faqService.setStatus(ids, status)
+      faqs.value = faqs.value.map((f) => (selectedIds.value.has(f.id) ? { ...f, status } : f))
+      clearSelection()
+      toast.success(`${updated} FAQ${updated === 1 ? '' : 's'} ${status === 'published' ? 'published' : 'moved to draft'}`)
+    } catch (error: any) {
+      toast.error(error.message)
+    }
+  }
+
+  async function bulkDelete(): Promise<void> {
+    const ids = [...selectedIds.value]
+    if (!ids.length) return
+    const deleted = await faqService.bulkDelete(ids)
+    faqs.value = faqs.value.filter((f) => !selectedIds.value.has(f.id))
+    clearSelection()
+    toast.success(`${deleted} FAQ${deleted === 1 ? '' : 's'} deleted`)
+  }
 
   // Inline edit state (one card at a time).
   const editingId = ref<string | null>(null)
@@ -130,6 +176,7 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
 
   async function refresh(): Promise<void> {
     isLoading.value = true
+    clearSelection()
     try {
       await Promise.all([fetchFaqs(), fetchJob(), fetchSettings(), fetchCounts(), fetchEstimate()])
       loadedOnce.value = true
@@ -284,6 +331,13 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     publishedCount,
     groupedFaqs,
     isJobActive,
+    selectedIds,
+    selectionActive,
+    toggleSelect,
+    setSelected,
+    clearSelection,
+    bulkSetStatus,
+    bulkDelete,
     editingId,
     isNewFaq,
     draftQuestion,

--- a/frontend/src/composables/useFaqWorkspace.ts
+++ b/frontend/src/composables/useFaqWorkspace.ts
@@ -19,7 +19,7 @@ import { toast } from 'vue-sonner'
 
 import { faqService } from '@/services/faq'
 import { knowledgeService } from '@/services/knowledge'
-import type { FaqGenerationJob, FaqItem, FaqStatus, GenerateEstimate, HelpCenterSettings } from '@/types/faq'
+import type { FaqGenerationJob, FaqImportMode, FaqItem, FaqStatus, GenerateEstimate, HelpCenterSettings } from '@/types/faq'
 
 export type WorkspacePhase = 'loading' | 'empty' | 'generating' | 'populated'
 
@@ -239,9 +239,9 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     }
   }
 
-  async function submitImport(url: string): Promise<boolean> {
+  async function submitImport(url: string, mode: FaqImportMode = 'qa'): Promise<boolean> {
     try {
-      job.value = await faqService.importFaq(url)
+      job.value = await faqService.importFaq(url, mode)
       toast.success('Import started — drafts will appear when it finishes')
       return true
     } catch (error: any) {

--- a/frontend/src/composables/useFaqWorkspace.ts
+++ b/frontend/src/composables/useFaqWorkspace.ts
@@ -72,19 +72,27 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
       toast.success(`${updated} FAQ${updated === 1 ? '' : 's'} ${status === 'published' ? 'published' : 'moved to draft'}`)
     } catch (error: any) {
       toast.error(error.message)
+      // A batch may have partially applied server-side (>200 selection splits
+      // into requests) — refetch so the list matches the backend.
+      await refresh()
     }
   }
 
   async function bulkDelete(): Promise<void> {
     const ids = [...selectedIds.value]
     if (!ids.length) return
-    const deleted = await faqService.bulkDelete(ids)
-    faqs.value = faqs.value.filter((f) => !selectedIds.value.has(f.id))
-    clearSelection()
-    toast.success(`${deleted} FAQ${deleted === 1 ? '' : 's'} deleted`)
-    // Deleting a source's FAQs makes it eligible for generation again — the
-    // Generate button's new-source count must not stay stale/disabled.
-    void fetchEstimate()
+    try {
+      const deleted = await faqService.bulkDelete(ids)
+      faqs.value = faqs.value.filter((f) => !selectedIds.value.has(f.id))
+      clearSelection()
+      toast.success(`${deleted} FAQ${deleted === 1 ? '' : 's'} deleted`)
+      // Deleting a source's FAQs makes it eligible for generation again — the
+      // Generate button's new-source count must not stay stale/disabled.
+      void fetchEstimate()
+    } catch (error: any) {
+      toast.error(error.message)
+      await refresh() // partial batch may have deleted server-side; resync
+    }
   }
 
   // Inline edit state (one card at a time).

--- a/frontend/src/composables/useHelpCenterSettings.ts
+++ b/frontend/src/composables/useHelpCenterSettings.ts
@@ -1,0 +1,176 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { computed, ref, watch, type Ref } from 'vue'
+import { toast } from 'vue-sonner'
+
+import { faqService } from '@/services/faq'
+import type { HelpCenterSettings, HelpCenterSettingsUpdate } from '@/types/faq'
+
+export type SaveState = 'idle' | 'saving' | 'saved' | 'error'
+
+const AUTOSAVE_DEBOUNCE_MS = 800
+const MAX_LOGO_BYTES = 2 * 1024 * 1024
+
+/** Appearance/settings editing with debounced autosave — the design has no
+ * Save button ("changes apply instantly to your published help center"). */
+export function useHelpCenterSettings(settings: Ref<HelpCenterSettings | null>) {
+  const saveState = ref<SaveState>('idle')
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  let saveInFlight = false
+  let trailingSave: HelpCenterSettingsUpdate | null = null
+  let suppressWatch = false
+
+  const brandColor = computed(() => settings.value?.brand_color || '#4338CA')
+
+  function applyResponse(updated: HelpCenterSettings): void {
+    suppressWatch = true
+    settings.value = updated
+    // Release after the watcher has seen (and ignored) this assignment.
+    setTimeout(() => {
+      suppressWatch = false
+    }, 0)
+  }
+
+  async function save(payload: HelpCenterSettingsUpdate): Promise<void> {
+    if (saveInFlight) {
+      trailingSave = { ...(trailingSave || {}), ...payload }
+      return
+    }
+    saveInFlight = true
+    saveState.value = 'saving'
+    try {
+      applyResponse(await faqService.updateSettings(payload))
+      saveState.value = 'saved'
+    } catch (error: any) {
+      saveState.value = 'error'
+      toast.error(error.message)
+    } finally {
+      saveInFlight = false
+      if (trailingSave) {
+        const queued = trailingSave
+        trailingSave = null
+        void save(queued)
+      }
+    }
+  }
+
+  /** Debounced path for text inputs (links, CTA, labels). */
+  function queueSave(payload: HelpCenterSettingsUpdate): void {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => void save(payload), AUTOSAVE_DEBOUNCE_MS)
+  }
+
+  /** Immediate path for discrete actions (swatch click, toggles, selects). */
+  async function saveNow(payload: HelpCenterSettingsUpdate): Promise<void> {
+    if (debounceTimer) clearTimeout(debounceTimer)
+    await save(payload)
+  }
+
+  // Deep-watch branding fields the inputs mutate in place (header_links rows).
+  watch(
+    () => settings.value?.header_links,
+    (links, previous) => {
+      if (suppressWatch || links === undefined || previous === undefined) return
+      queueSave({ header_links: links })
+    },
+    { deep: true },
+  )
+
+  async function uploadLogo(file: File): Promise<void> {
+    if (file.size > MAX_LOGO_BYTES) {
+      toast.error('Logo must be 2 MB or smaller')
+      return
+    }
+    saveState.value = 'saving'
+    try {
+      applyResponse(await faqService.uploadLogo(file))
+      saveState.value = 'saved'
+    } catch (error: any) {
+      saveState.value = 'error'
+      toast.error(error.message)
+    }
+  }
+
+  async function removeLogo(): Promise<void> {
+    saveState.value = 'saving'
+    try {
+      applyResponse(await faqService.removeLogo())
+      saveState.value = 'saved'
+    } catch (error: any) {
+      saveState.value = 'error'
+      toast.error(error.message)
+    }
+  }
+
+  // Domain lifecycle (explicit Verify button — never autosaved).
+  const domainBusy = ref(false)
+
+  async function setDomain(domain: string): Promise<void> {
+    domainBusy.value = true
+    try {
+      const result = await faqService.setDomain(domain)
+      if (settings.value) settings.value = { ...settings.value, domain: result }
+    } catch (error: any) {
+      toast.error(error.message)
+    } finally {
+      domainBusy.value = false
+    }
+  }
+
+  async function verifyDomain(): Promise<void> {
+    domainBusy.value = true
+    try {
+      const result = await faqService.verifyDomain()
+      if (settings.value) settings.value = { ...settings.value, domain: result }
+      if (result.domain_status === 'verified') {
+        toast.success('Domain verified')
+      } else {
+        toast.info('Records not visible yet — DNS changes can take a few minutes to propagate')
+      }
+    } catch (error: any) {
+      toast.error(error.message)
+    } finally {
+      domainBusy.value = false
+    }
+  }
+
+  async function removeDomain(): Promise<void> {
+    domainBusy.value = true
+    try {
+      const result = await faqService.removeDomain()
+      if (settings.value) settings.value = { ...settings.value, domain: result }
+    } catch (error: any) {
+      toast.error(error.message)
+    } finally {
+      domainBusy.value = false
+    }
+  }
+
+  return {
+    saveState,
+    brandColor,
+    queueSave,
+    saveNow,
+    uploadLogo,
+    removeLogo,
+    domainBusy,
+    setDomain,
+    verifyDomain,
+    removeDomain,
+  }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -79,6 +79,17 @@ const baseRoutes = [
     },
   },
   {
+    path: '/faq',
+    name: 'faq',
+    component: () => import('@/views/FaqView.vue'),
+    meta: {
+      requiresAuth: true,
+      layout: 'dashboard',
+      title: 'FAQ & Help Center',
+      permissions: ['manage_knowledge'],
+    },
+  },
+  {
     path: '/widget/:id',
     name: 'widget',
     component: () => import('@/webclient/WidgetBuilder.vue'),

--- a/frontend/src/services/faq.ts
+++ b/frontend/src/services/faq.ts
@@ -20,6 +20,7 @@ import type {
   FaqItem,
   FaqListResponse,
   FaqStatus,
+  GenerateEstimate,
   HelpCenterDomain,
   HelpCenterSettings,
   HelpCenterSettingsUpdate,
@@ -87,9 +88,21 @@ export const faqService = {
     }
   },
 
-  async startGeneration(): Promise<FaqGenerationJob> {
+  async getGenerateEstimate(): Promise<GenerateEstimate> {
     try {
-      const response = await api.post('/help-center/generate')
+      const response = await api.get('/help-center/generate/estimate')
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to load generation estimate')
+    }
+  },
+
+  async startGeneration(knowledgeIds?: number[]): Promise<FaqGenerationJob> {
+    try {
+      const response = await api.post(
+        '/help-center/generate',
+        knowledgeIds?.length ? { knowledge_ids: knowledgeIds } : {},
+      )
       return response.data
     } catch (error: any) {
       throw errorMessage(error, 'Failed to start generation')

--- a/frontend/src/services/faq.ts
+++ b/frontend/src/services/faq.ts
@@ -98,9 +98,11 @@ export const faqService = {
     }
   },
 
-  async getGenerateEstimate(): Promise<GenerateEstimate> {
+  async getGenerateEstimate(includePages = true): Promise<GenerateEstimate> {
     try {
-      const response = await api.get('/help-center/generate/estimate')
+      const response = await api.get('/help-center/generate/estimate', {
+        params: { include_pages: includePages },
+      })
       return response.data
     } catch (error: any) {
       throw errorMessage(error, 'Failed to load generation estimate')

--- a/frontend/src/services/faq.ts
+++ b/frontend/src/services/faq.ts
@@ -128,6 +128,19 @@ export const faqService = {
     }
   },
 
+  async importPdf(file: File): Promise<FaqGenerationJob> {
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+      const response = await api.post('/help-center/import/pdf', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      })
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to start PDF import')
+    }
+  },
+
   async getJob(active = true): Promise<FaqGenerationJob | null> {
     try {
       const response = await api.get('/help-center/jobs', { params: { active } })

--- a/frontend/src/services/faq.ts
+++ b/frontend/src/services/faq.ts
@@ -18,6 +18,7 @@ import api from './api'
 import type {
   FaqGenerationJob,
   FaqItem,
+  FaqImportMode,
   FaqListResponse,
   FaqStatus,
   GenerateEstimate,
@@ -118,9 +119,9 @@ export const faqService = {
     }
   },
 
-  async importFaq(url: string): Promise<FaqGenerationJob> {
+  async importFaq(url: string, mode: FaqImportMode = 'qa'): Promise<FaqGenerationJob> {
     try {
-      const response = await api.post('/help-center/import', { url })
+      const response = await api.post('/help-center/import', { url, mode })
       return response.data
     } catch (error: any) {
       throw errorMessage(error, 'Failed to start import')

--- a/frontend/src/services/faq.ts
+++ b/frontend/src/services/faq.ts
@@ -1,0 +1,179 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import api from './api'
+import type {
+  FaqGenerationJob,
+  FaqItem,
+  FaqListResponse,
+  FaqStatus,
+  HelpCenterDomain,
+  HelpCenterSettings,
+  HelpCenterSettingsUpdate,
+} from '@/types/faq'
+
+function errorMessage(error: any, fallback: string): Error {
+  return new Error(error.response?.data?.detail || fallback)
+}
+
+export const faqService = {
+  async getFaqs(params: { status?: FaqStatus; category?: string; q?: string; page?: number; page_size?: number } = {}): Promise<FaqListResponse> {
+    try {
+      const response = await api.get('/help-center/faqs', { params: { page_size: 200, ...params } })
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to load FAQs')
+    }
+  },
+
+  async createFaq(payload: { question: string; answer: string; category?: string; status?: FaqStatus }): Promise<FaqItem> {
+    try {
+      const response = await api.post('/help-center/faqs', payload)
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to create FAQ')
+    }
+  },
+
+  async updateFaq(id: string, payload: Partial<Pick<FaqItem, 'question' | 'answer' | 'category' | 'status'>>): Promise<FaqItem> {
+    try {
+      const response = await api.put(`/help-center/faqs/${id}`, payload)
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to update FAQ')
+    }
+  },
+
+  async deleteFaq(id: string): Promise<void> {
+    try {
+      await api.delete(`/help-center/faqs/${id}`)
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to delete FAQ')
+    }
+  },
+
+  async setStatus(ids: string[], status: FaqStatus): Promise<number> {
+    try {
+      const response = await api.post('/help-center/faqs/bulk-status', { faq_ids: ids, status })
+      return response.data.updated
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to update FAQ status')
+    }
+  },
+
+  async startGeneration(): Promise<FaqGenerationJob> {
+    try {
+      const response = await api.post('/help-center/generate')
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to start generation')
+    }
+  },
+
+  async importFaq(url: string): Promise<FaqGenerationJob> {
+    try {
+      const response = await api.post('/help-center/import', { url })
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to start import')
+    }
+  },
+
+  async getJob(active = true): Promise<FaqGenerationJob | null> {
+    try {
+      const response = await api.get('/help-center/jobs', { params: { active } })
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to load job status')
+    }
+  },
+
+  async getSettings(): Promise<HelpCenterSettings> {
+    try {
+      const response = await api.get('/help-center/settings')
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to load help center settings')
+    }
+  },
+
+  async updateSettings(payload: HelpCenterSettingsUpdate): Promise<HelpCenterSettings> {
+    try {
+      const response = await api.put('/help-center/settings', payload)
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to save help center settings')
+    }
+  },
+
+  async uploadLogo(file: File): Promise<HelpCenterSettings> {
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+      const response = await api.post('/help-center/logo', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      })
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to upload logo')
+    }
+  },
+
+  async removeLogo(): Promise<HelpCenterSettings> {
+    try {
+      const response = await api.delete('/help-center/logo')
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to remove logo')
+    }
+  },
+
+  async setDomain(domain: string): Promise<HelpCenterDomain> {
+    try {
+      const response = await api.post('/help-center/domain', { domain })
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to set custom domain')
+    }
+  },
+
+  async removeDomain(): Promise<HelpCenterDomain> {
+    try {
+      const response = await api.delete('/help-center/domain')
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to remove custom domain')
+    }
+  },
+
+  async verifyDomain(): Promise<HelpCenterDomain> {
+    try {
+      const response = await api.post('/help-center/domain/verify')
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to verify domain')
+    }
+  },
+
+  async getDomainStatus(): Promise<HelpCenterDomain> {
+    try {
+      const response = await api.get('/help-center/domain/status')
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to load domain status')
+    }
+  },
+}

--- a/frontend/src/services/faq.ts
+++ b/frontend/src/services/faq.ts
@@ -31,6 +31,16 @@ function errorMessage(error: any, fallback: string): Error {
   return new Error(error.response?.data?.detail || fallback)
 }
 
+// Backend bulk endpoints cap faq_ids at 200 (MAX_BULK_IDS in schemas/faq.py);
+// split larger selections so a select-all over a big FAQ set still works.
+const MAX_BULK_IDS = 200
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const batches: T[][] = []
+  for (let i = 0; i < items.length; i += size) batches.push(items.slice(i, i + size))
+  return batches
+}
+
 export const faqService = {
   async getFaqs(params: { status?: FaqStatus; category?: string; q?: string; page?: number; page_size?: number } = {}): Promise<FaqListResponse> {
     try {
@@ -82,8 +92,12 @@ export const faqService = {
 
   async setStatus(ids: string[], status: FaqStatus): Promise<number> {
     try {
-      const response = await api.post('/help-center/faqs/bulk-status', { faq_ids: ids, status })
-      return response.data.updated
+      let updated = 0
+      for (const batch of chunk(ids, MAX_BULK_IDS)) {
+        const response = await api.post('/help-center/faqs/bulk-status', { faq_ids: batch, status })
+        updated += response.data.updated
+      }
+      return updated
     } catch (error: any) {
       throw errorMessage(error, 'Failed to update FAQ status')
     }
@@ -91,8 +105,12 @@ export const faqService = {
 
   async bulkDelete(ids: string[]): Promise<number> {
     try {
-      const response = await api.post('/help-center/faqs/bulk-delete', { faq_ids: ids })
-      return response.data.deleted
+      let deleted = 0
+      for (const batch of chunk(ids, MAX_BULK_IDS)) {
+        const response = await api.post('/help-center/faqs/bulk-delete', { faq_ids: batch })
+        deleted += response.data.deleted
+      }
+      return deleted
     } catch (error: any) {
       throw errorMessage(error, 'Failed to delete FAQs')
     }

--- a/frontend/src/services/faq.ts
+++ b/frontend/src/services/faq.ts
@@ -88,6 +88,15 @@ export const faqService = {
     }
   },
 
+  async bulkDelete(ids: string[]): Promise<number> {
+    try {
+      const response = await api.post('/help-center/faqs/bulk-delete', { faq_ids: ids })
+      return response.data.deleted
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to delete FAQs')
+    }
+  },
+
   async getGenerateEstimate(): Promise<GenerateEstimate> {
     try {
       const response = await api.get('/help-center/generate/estimate')

--- a/frontend/src/services/faq.ts
+++ b/frontend/src/services/faq.ts
@@ -39,6 +39,19 @@ export const faqService = {
     }
   },
 
+  async uploadImage(file: File): Promise<string> {
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+      const response = await api.post('/help-center/faqs/image', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      })
+      return response.data.url as string
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to upload image')
+    }
+  },
+
   async createFaq(payload: { question: string; answer: string; category?: string; status?: FaqStatus }): Promise<FaqItem> {
     try {
       const response = await api.post('/help-center/faqs', payload)

--- a/frontend/src/types/faq.ts
+++ b/frontend/src/types/faq.ts
@@ -41,7 +41,7 @@ export interface FaqListResponse {
   pagination: FaqPagination
 }
 
-export type FaqImportMode = 'qa' | 'articles'
+export type FaqImportMode = 'qa' | 'articles' | 'pdf'
 
 export type FaqJobStatus = 'pending' | 'processing' | 'completed' | 'failed'
 export type FaqJobStage =

--- a/frontend/src/types/faq.ts
+++ b/frontend/src/types/faq.ts
@@ -41,6 +41,8 @@ export interface FaqListResponse {
   pagination: FaqPagination
 }
 
+export type FaqImportMode = 'qa' | 'articles'
+
 export type FaqJobStatus = 'pending' | 'processing' | 'completed' | 'failed'
 export type FaqJobStage =
   | 'not_started'
@@ -61,7 +63,7 @@ export interface GenerateEstimate {
 
 export interface FaqGenerationJob {
   id: number
-  job_type: 'generate_all' | 'generate_source' | 'import_url'
+  job_type: 'generate_all' | 'generate_source' | 'import_url' | 'import_articles' | 'import_pdf'
   status: FaqJobStatus
   stage: FaqJobStage
   progress_percentage: number

--- a/frontend/src/types/faq.ts
+++ b/frontend/src/types/faq.ts
@@ -103,6 +103,7 @@ export interface HelpCenterSettings {
   auto_generate: boolean
   agent_id: string | null
   ai_search_enabled: boolean
+  chat_widget_enabled: boolean
   live_url: string | null
   published_count: number
   plan_allowed: boolean
@@ -123,5 +124,6 @@ export type HelpCenterSettingsUpdate = Partial<
     | 'auto_generate'
     | 'agent_id'
     | 'ai_search_enabled'
+    | 'chat_widget_enabled'
   >
 >

--- a/frontend/src/types/faq.ts
+++ b/frontend/src/types/faq.ts
@@ -1,0 +1,127 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export type FaqStatus = 'draft' | 'published'
+
+export interface FaqItem {
+  id: string
+  question: string
+  answer: string
+  category: string
+  status: FaqStatus
+  knowledge_id: number | null
+  source_label: string | null
+  created_at?: string | null
+  updated_at?: string | null
+}
+
+export interface FaqPagination {
+  total: number
+  page: number
+  page_size: number
+  total_pages: number
+}
+
+export interface FaqListResponse {
+  faqs: FaqItem[]
+  pagination: FaqPagination
+}
+
+export type FaqJobStatus = 'pending' | 'processing' | 'completed' | 'failed'
+export type FaqJobStage =
+  | 'not_started'
+  | 'analyzing_sources'
+  | 'extracting'
+  | 'drafting'
+  | 'grouping'
+  | 'completed'
+
+export interface FaqGenerationJob {
+  id: number
+  job_type: 'generate_all' | 'generate_source' | 'import_url'
+  status: FaqJobStatus
+  stage: FaqJobStage
+  progress_percentage: number
+  faqs_created: number
+  source_url: string | null
+  error: string | null
+  created_at?: string | null
+}
+
+export interface HelpCenterHeaderLink {
+  label: string
+  url: string
+}
+
+export interface HelpCenterAgentOption {
+  id: string
+  name: string
+  has_widget: boolean
+}
+
+export type DomainStatus = 'unverified' | 'pending' | 'verified'
+export type SslStatus = 'none' | 'pending' | 'active' | 'failed'
+
+export interface HelpCenterDnsRecord {
+  type: 'CNAME' | 'TXT'
+  host: string
+  value: string
+  verified: boolean
+}
+
+export interface HelpCenterDomain {
+  custom_domain: string | null
+  domain_status: DomainStatus
+  ssl_status: SslStatus
+  records: HelpCenterDnsRecord[]
+  domain_verified_at: string | null
+}
+
+export interface HelpCenterSettings {
+  enabled: boolean
+  slug: string | null
+  title: string | null
+  description: string | null
+  logo_url: string | null
+  brand_color: string
+  header_links: HelpCenterHeaderLink[]
+  cta_text: string | null
+  cta_url: string | null
+  auto_generate: boolean
+  agent_id: string | null
+  ai_search_enabled: boolean
+  live_url: string | null
+  published_count: number
+  plan_allowed: boolean
+  agents: HelpCenterAgentOption[]
+  domain: HelpCenterDomain | null
+}
+
+export type HelpCenterSettingsUpdate = Partial<
+  Pick<
+    HelpCenterSettings,
+    | 'enabled'
+    | 'title'
+    | 'description'
+    | 'brand_color'
+    | 'header_links'
+    | 'cta_text'
+    | 'cta_url'
+    | 'auto_generate'
+    | 'agent_id'
+    | 'ai_search_enabled'
+  >
+>

--- a/frontend/src/types/faq.ts
+++ b/frontend/src/types/faq.ts
@@ -21,6 +21,7 @@ export interface FaqItem {
   question: string
   answer: string
   category: string
+  slug?: string | null
   status: FaqStatus
   knowledge_id: number | null
   source_label: string | null

--- a/frontend/src/types/faq.ts
+++ b/frontend/src/types/faq.ts
@@ -50,6 +50,15 @@ export type FaqJobStage =
   | 'grouping'
   | 'completed'
 
+export interface GenerateEstimate {
+  total_sources: number
+  new_sources: number
+  pages: number
+  estimated_calls: number
+  metered: boolean
+  remaining_credits: number | null
+}
+
 export interface FaqGenerationJob {
   id: number
   job_type: 'generate_all' | 'generate_source' | 'import_url'

--- a/frontend/src/types/faq.ts
+++ b/frontend/src/types/faq.ts
@@ -100,6 +100,7 @@ export interface HelpCenterSettings {
   header_links: HelpCenterHeaderLink[]
   cta_text: string | null
   cta_url: string | null
+  cta_enabled: boolean
   auto_generate: boolean
   agent_id: string | null
   ai_search_enabled: boolean
@@ -121,6 +122,7 @@ export type HelpCenterSettingsUpdate = Partial<
     | 'header_links'
     | 'cta_text'
     | 'cta_url'
+    | 'cta_enabled'
     | 'auto_generate'
     | 'agent_id'
     | 'ai_search_enabled'

--- a/frontend/src/utils/color.ts
+++ b/frontend/src/utils/color.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export interface Rgb {
+  r: number
+  g: number
+  b: number
+}
+
+export function hexToRgb(hex: string): Rgb | null {
+  let value = hex.trim().replace(/^#/, '')
+  if (value.length === 3) {
+    value = value
+      .split('')
+      .map((ch) => ch + ch)
+      .join('')
+  }
+  if (!/^[0-9a-fA-F]{6}$/.test(value)) return null
+  return {
+    r: parseInt(value.slice(0, 2), 16),
+    g: parseInt(value.slice(2, 4), 16),
+    b: parseInt(value.slice(4, 6), 16),
+  }
+}
+
+/** WCAG relative luminance (0 = black, 1 = white). */
+export function relativeLuminance({ r, g, b }: Rgb): number {
+  const linear = (channel: number) => {
+    const c = channel / 255
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+  }
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b)
+}
+
+/** Dark or light ink over an arbitrary brand color (mirrors the backend's
+ * contrast_ink so admin preview and public page always agree). */
+export function contrastInk(hex: string): '#12131A' | '#FFFFFF' {
+  const rgb = hexToRgb(hex)
+  if (!rgb) return '#FFFFFF'
+  return relativeLuminance(rgb) > 0.45 ? '#12131A' : '#FFFFFF'
+}

--- a/frontend/src/views/FaqView.vue
+++ b/frontend/src/views/FaqView.vue
@@ -1,0 +1,111 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import DashboardLayout from '@/layouts/DashboardLayout.vue'
+import FaqProLockOverlay from '@/components/faq/FaqProLockOverlay.vue'
+import FaqWorkspace from '@/components/faq/FaqWorkspace.vue'
+import { userService } from '@/services/user'
+
+const organizationId = computed(() => userService.getCurrentUser()?.organization_id ?? '')
+
+const planAllowed = ref<boolean | null>(null)
+const workspaceRef = ref<InstanceType<typeof FaqWorkspace> | null>(null)
+
+const liveUrl = computed(() => workspaceRef.value?.settings?.live_url || null)
+</script>
+
+<template>
+  <DashboardLayout>
+    <div class="faq-view">
+      <div class="page-header">
+        <div>
+          <h1 class="page-header__title">FAQ &amp; Help Center</h1>
+          <p class="page-header__subtitle">
+            Turn your knowledge base into a public help center. Generate FAQs automatically, review
+            them, then publish.
+          </p>
+        </div>
+        <a v-if="liveUrl" class="page-header__link" :href="liveUrl" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /><path d="M15 3h6v6" /><path d="M10 14 21 3" /></svg>
+          View public FAQ
+        </a>
+      </div>
+
+      <FaqProLockOverlay :plan-allowed="planAllowed">
+        <FaqWorkspace
+          v-if="organizationId"
+          ref="workspaceRef"
+          :organization-id="organizationId"
+          @plan-allowed="planAllowed = $event"
+        />
+      </FaqProLockOverlay>
+    </div>
+  </DashboardLayout>
+</template>
+
+<style scoped>
+.faq-view {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 32px 24px 60px;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 28px;
+  flex-wrap: wrap;
+}
+
+.page-header__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 30px;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  margin: 0 0 8px;
+}
+
+.page-header__subtitle {
+  font-size: 15px;
+  color: var(--muted);
+  margin: 0;
+  max-width: 560px;
+  line-height: 1.55;
+}
+
+.page-header__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 17px;
+  background: var(--o05);
+  border: 1px solid var(--o14);
+  border-radius: 11px;
+  color: var(--text2);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.page-header__link:hover {
+  background: var(--o08);
+}
+</style>

--- a/frontend/src/views/FaqView.vue
+++ b/frontend/src/views/FaqView.vue
@@ -33,7 +33,7 @@ const liveUrl = computed(() => workspaceRef.value?.settings?.live_url || null)
     <div class="faq-view">
       <div class="page-header">
         <div>
-          <h1 class="page-header__title">FAQ &amp; Help Center</h1>
+          <h1 class="page-header__title">Help center</h1>
           <p class="page-header__subtitle">
             Turn your knowledge base into a public help center. Generate FAQs automatically, review
             them, then publish.
@@ -41,7 +41,7 @@ const liveUrl = computed(() => workspaceRef.value?.settings?.live_url || null)
         </div>
         <a v-if="liveUrl" class="page-header__link" :href="liveUrl" target="_blank" rel="noopener">
           <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" /><path d="M15 3h6v6" /><path d="M10 14 21 3" /></svg>
-          View public FAQ
+          View public help center
         </a>
       </div>
 


### PR DESCRIPTION
Turns an org's existing knowledge base into a customer-facing help center: AI-drafted FAQs reviewed and published in a new **FAQ & Help Center** admin page, served as an SEO-friendly public site at `{slug}.chattermate.help` or the customer's own domain. OSS/self-hosted installs get everything unrestricted; on cloud the feature is Pro-gated (flag ships in [enterprise_backend#18](https://github.com/chattermate/enterprise_backend/pull/18)).

## What's included

**Generation & import**
- FAQ generator agent reads stored knowledge text straight from the per-org vector table (no re-crawl), packs whole pages into batches, drafts grounded Q&As with the org's configured model (Groq gets the shared json-tool structured-output path with truncation salvage), dedups against existing questions and merges categories case-insensitively
- Migration path: paste an existing FAQ page URL — SSRF-guarded fetch (browser fallback for JS-rendered pages), block-aware extraction so Q&A pairs never split across batches
- Auto-generation: once an org has adopted the feature, each newly processed knowledge source enqueues a per-source draft job and notifies for review
- Jobs run in an independent loop inside the knowledge_processor container (a long FAQ job never delays ingestion)

**Admin (`/faq` page + `/api/v1/help-center`)**
- Workspace with empty / generating (4-stage progress) / populated states, inline edit, publish toggles, bulk publish, categories
- Branding: logo (content-type-validated, SVG active-content screen), brand color with live preview, header links, CTA — debounced autosave
- AI search: agent mapping (auto-defaulted) + toggle; custom domain claim → CNAME/TXT records table → verify (dnspython) → SSL probe
- One-active-job-per-type enforced by a partial unique index (no check-then-insert race)

**Public site (backend SSR)**
- Host-dispatch ASGI layer routes help-center hosts to a standalone Jinja2 app: published FAQs grouped by category, server-side search, JSON-LD FAQPage, canonical/og tags, escaped org content, brand theming
- **Ask AI**: rate-limited (rightmost-XFF key, Redis fixed window with in-memory fallback), concurrency-capped one-shot answer grounded in the mapped agent's knowledge + published FAQs; short-lived DB sessions around the LLM await; every ask logged to `help_center_queries` for hosted-model metering
- Embedded chat widget of the mapped agent; sitemap/robots/healthz

**Also**
- Shared Groq structured-output helpers extracted from chat_agent (bracket-aware truncation repair benefits chat too)
- Generic `feature_gate` service (existing per-feature gate copies can migrate later)
- Fix: knowledge notifications passed `metadata=` (shadowed `Base.metadata`, silently unpersisted) instead of `notification_metadata=`
- `HELP_CENTER_INFRA.md` runbook: wildcard cert, host-nginx blocks, per-domain certbot, Cloudflare caveat (docs/ is gitignored, hence root-level)

## Verified
- 1559 backend + 120 frontend tests pass (7 pre-existing `test_session_to_agent` failures unrelated, fail on clean main)
- Live E2E on the dev stack: real Groq generation produced 267 drafts across 33 categories from 68 crawled pages; publish, appearance autosave → public recolor, domain claim + DNS table, public SSR page, grounded Ask AI answer and widget embed all exercised in the browser (dark + light themes)
- Migration `f7a1c2d3e4b5` upgrade/downgrade roundtripped on the dev DB

## Before cloud rollout
1. Merge + deploy enterprise_backend#18 (plan flag + backfill + ask metering)
2. Register `chattermate.help`, wildcard cert + host nginx per `HELP_CENTER_INFRA.md`
3. `cname.chattermate.chat` A record + `HELP_CENTER_TARGET_IPS` env

---

## Added since the initial PR

**Rich Markdown articles + SEO article pages**
- FAQ answers are authored/stored as Markdown and rendered to sanitized HTML (python-markdown → nh3 allowlist); admin gets a Markdown editor with image upload (stable absolute URLs) and a sandboxed-iframe preview
- Every published FAQ gets its own SEO page at `/a/{slug}` (per-org unique slug, backfilled) with QAPage JSON-LD, canonical/OG tags, related-articles grid, and sitemap listing

**Generation/import overhaul**
- Batch size derives from the org's model context window (curated lookup, `FAQ_CONTEXT_TOKENS_OVERRIDE`) — fewer, larger calls on big-context models
- Fuzzy dedup (token-set Jaccard + difflib) replaces shipping 200 existing questions per prompt
- Generation metered against the message limit on the hosted model only (`llm_calls`/`metered` columns, `FAQ_METER_OWN_KEY`); pre-run credit estimate + 402 guard; enterprise `message_limit` counts FAQ calls (submodule PR)
- Regenerate reads only sources without FAQs; auto-generation now requires explicit opt-in (a settings row alone no longer arms it)
- Plain-JSON structured-output fallback for providers where agno native structured outputs are unreliable (Ollama/HuggingFace/Mistral)
- FAQ jobs process one-at-a-time by default (`MAX_CONCURRENT_FAQ_JOBS`, env-configurable); orphaned/stale `processing` jobs are reaped on worker start and via read-side staleness so the UI never polls forever

**Import: article-mode + PDF**
- Article mode crawls a help-center portal (Chatwoot/Zendesk/Intercom) structure — follows category listing pages for complete per-category coverage, imports each `/articles/` page as-is (HTML→Markdown via markdownify, images re-hosted, links absolutized, platform chrome stripped), no LLM/credits
- PDF import: upload → pypdf text → **generates** FAQs from the document (product guides aren't verbatim Q&A)

**Admin UX**
- FAQ list is searchable/filterable (relevance-ranked, tokenized), category groups collapsible, cards compact (clamped previews); bulk delete + multi-select with select-all
- Themed PDF drop-zone; two-step custom-domain setup with copyable DNS record cards; custom brand color (picker + hex)

**Public search** — relevance-ranked token search (was whole-query substring; "close my" now matches "How to close my account")

All new backend/frontend paths covered by unit tests; two review passes with fixes applied. Widget build artifacts and the enterprise submodule pointer are intentionally excluded from every commit.
