### PR TITLE
Help Center: knowledge-source picker + same-domain subpage guard

### DIFF
--- a/backend/app/api/help_center/generation.py
+++ b/backend/app/api/help_center/generation.py
@@ -32,6 +32,7 @@ from app.models.schemas.faq import (
     GenerateRequest,
     GenerationEstimateResponse,
     GenerationJobResponse,
+    GenerationSourceResponse,
     ImportRequest,
 )
 from app.models.user import User
@@ -143,6 +144,13 @@ async def generation_estimate(
         estimated_calls=estimate.estimated_calls,
         metered=metered,
         remaining_credits=remaining_message_credits(db, org_id) if metered else None,
+        sources=[
+            GenerationSourceResponse(
+                id=s.id, name=s.name, source_type=s.source_type,
+                has_faqs=s.has_faqs, pages=s.pages, estimated_calls=s.estimated_calls,
+            )
+            for s in estimate.sources
+        ],
     )
 
 

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -1635,15 +1635,16 @@ async def add_subpage(
 
             # A subpage of a URL-based source must be on the SAME registrable
             # domain as that source — otherwise a single plan-limited source
-            # could accumulate content from arbitrary other domains.
+            # could accumulate content from arbitrary other domains. domain_of_url
+            # normalizes a scheme-less value (so 'evil.com/x' can't parse as a
+            # path with no host and slip past) and is ccTLD-aware (so a *.co.uk
+            # source can't accept another *.co.uk domain).
             clean_url = (url or "").strip() or None
             if clean_url:
-                from urllib.parse import urlparse
-                from app.knowledge.sitemap_parser import _registrable_domain
+                from app.knowledge.domains import domain_of_url
 
-                parent_domain = _registrable_domain(urlparse(knowledge.source).hostname or "")
-                subpage_domain = _registrable_domain(urlparse(clean_url).hostname or "")
-                if parent_domain and subpage_domain and subpage_domain != parent_domain:
+                parent_domain = domain_of_url(knowledge.source)
+                if parent_domain and domain_of_url(clean_url) != parent_domain:
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
                         detail=f"Subpage URL must be on the same domain as the source ({parent_domain}).",

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -1633,8 +1633,24 @@ async def add_subpage(
                     detail="Subpage name already exists. Please use a unique name."
                 )
 
+            # A subpage of a URL-based source must be on the SAME registrable
+            # domain as that source — otherwise a single plan-limited source
+            # could accumulate content from arbitrary other domains.
+            clean_url = (url or "").strip() or None
+            if clean_url:
+                from urllib.parse import urlparse
+                from app.knowledge.sitemap_parser import _registrable_domain
+
+                parent_domain = _registrable_domain(urlparse(knowledge.source).hostname or "")
+                subpage_domain = _registrable_domain(urlparse(clean_url).hostname or "")
+                if parent_domain and subpage_domain and subpage_domain != parent_domain:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Subpage URL must be on the same domain as the source ({parent_domain}).",
+                    )
+
             # Embed and insert the new subpage into the vector database
-            page_editor.insert_subpage(knowledge, subpage_name, content, (url or "").strip() or None)
+            page_editor.insert_subpage(knowledge, subpage_name, content, clean_url)
 
             logger.info(f"Added new subpage '{subpage_name}' to knowledge {knowledge_id}")
             

--- a/backend/app/knowledge/domains.py
+++ b/backend/app/knowledge/domains.py
@@ -1,0 +1,56 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Single canonical registrable-domain helper, used everywhere a sub-page URL is
+compared against its source's domain (website crawler, sitemap parser, manual
+add-subpage). Same-domain enforcement stops one plan-limited knowledge source
+from accumulating content across unrelated domains. Handles common ccTLDs
+(co.uk, com.au, …) so 'a.example.co.uk' → 'example.co.uk' rather than 'co.uk'
+(the latter would wrongly treat every *.co.uk host as one domain).
+"""
+
+from urllib.parse import urlparse
+
+# Second-level labels that sit under a 2-letter ccTLD (best-effort; a full
+# public-suffix list would be a heavy dependency for marginal gain here).
+_CCTLD_SECOND_LEVELS = frozenset(
+    {"co", "com", "org", "net", "edu", "gov", "ac", "gov", "ltd", "plc", "me", "or", "ne"}
+)
+
+
+def registrable_domain(host: str) -> str:
+    """Registrable domain for a HOST (not a full URL): lowercased, port/userinfo
+    already stripped by the caller's urlparse(...).hostname, 'www.' removed."""
+    host = (host or "").lower().strip().rstrip(".")
+    if host.startswith("www."):
+        host = host[4:]
+    if not host:
+        return ""
+    parts = host.split(".")
+    if len(parts) > 2 and parts[-2] in _CCTLD_SECOND_LEVELS and len(parts[-1]) == 2:
+        return ".".join(parts[-3:])
+    return ".".join(parts[-2:]) if len(parts) > 1 else host
+
+
+def domain_of_url(url: str) -> str:
+    """Registrable domain of a URL string. A scheme-less value ('example.com/x')
+    is normalized so its host is still recognised (else it would parse as a
+    path with no hostname and silently bypass a same-domain check)."""
+    text = (url or "").strip()
+    if not text:
+        return ""
+    if "://" not in text:
+        text = f"https://{text}"
+    return registrable_domain(urlparse(text).hostname or "")

--- a/backend/app/knowledge/enhanced_website_reader.py
+++ b/backend/app/knowledge/enhanced_website_reader.py
@@ -174,29 +174,13 @@ class EnhancedWebsiteReader(WebsiteReader):
         :param url: The URL to extract the primary domain from.
         :return: The primary domain.
         """
-        # Normalize URL first to ensure it has a protocol
-        url = self._normalize_url(url)
+        # Delegate to the shared registrable-domain helper (ccTLD-aware,
+        # port/userinfo stripped via hostname) so every same-domain check in
+        # the codebase agrees.
+        from app.knowledge.domains import registrable_domain
 
-        # Parse the URL to get the host (hostname drops any :port and userinfo,
-        # so 'example.com:8443' can't slip past a domain-equality check).
-        parsed_url = urlparse(url)
-        netloc = (parsed_url.hostname or parsed_url.netloc or "").lower()
-
-        # Strip 'www.' prefix if present
-        if netloc.startswith('www.'):
-            netloc = netloc[4:]
-        
-        # Get the relevant domain part (last two components for common domains)
-        parts = netloc.split('.')
-        
-        # Special case for country code TLDs with subdomains (e.g., co.uk, com.au)
-        if len(parts) > 2 and parts[-2] in ['co', 'com', 'org', 'net', 'edu', 'gov', 'ac'] and len(parts[-1]) == 2:
-            domain = '.'.join(parts[-3:])  # Include subdomains like example.co.uk
-        else:
-            domain = '.'.join(parts[-2:] if len(parts) > 1 else parts)  # domain.com or just domain
-        
-
-        return domain
+        parsed_url = urlparse(self._normalize_url(url))
+        return registrable_domain(parsed_url.hostname or parsed_url.netloc or "")
     
     def _extract_main_content(self, soup: BeautifulSoup) -> str:
         """

--- a/backend/app/knowledge/enhanced_website_reader.py
+++ b/backend/app/knowledge/enhanced_website_reader.py
@@ -176,11 +176,12 @@ class EnhancedWebsiteReader(WebsiteReader):
         """
         # Normalize URL first to ensure it has a protocol
         url = self._normalize_url(url)
-        
-        # Parse the URL to get the netloc
+
+        # Parse the URL to get the host (hostname drops any :port and userinfo,
+        # so 'example.com:8443' can't slip past a domain-equality check).
         parsed_url = urlparse(url)
-        netloc = parsed_url.netloc
-        
+        netloc = (parsed_url.hostname or parsed_url.netloc or "").lower()
+
         # Strip 'www.' prefix if present
         if netloc.startswith('www.'):
             netloc = netloc[4:]
@@ -542,9 +543,12 @@ class EnhancedWebsiteReader(WebsiteReader):
         if current_url in self._visited:
             return None
 
-        if not urlparse(current_url).netloc.endswith(primary_domain):
+        # Same registrable domain only (equality, not a loose suffix match) —
+        # the per-URL guard that also protects sitemap-seeded crawls.
+        if self._get_primary_domain(current_url) != primary_domain:
+            logger.debug(f"Skipping cross-domain URL {current_url} (root domain {primary_domain})")
             return None
-            
+
         if current_depth > self.max_depth:
             return None
         
@@ -1021,9 +1025,11 @@ class EnhancedWebsiteReader(WebsiteReader):
             if full_url == base_canonical or full_url in seen:
                 continue
 
-            # Check if it's in the same domain
-            link_domain = parsed_url.netloc
-            is_same_domain = link_domain.endswith(primary_domain)
+            # Same REGISTRABLE domain only (equality, not suffix): a substring
+            # match like 'evilexample.com'.endswith('example.com') would let a
+            # crawl fan out across unrelated domains — a way to pull many
+            # domains' content under one plan-limited knowledge source.
+            is_same_domain = self._get_primary_domain(full_url) == primary_domain
 
             if (
                 is_same_domain

--- a/backend/app/knowledge/sitemap_parser.py
+++ b/backend/app/knowledge/sitemap_parser.py
@@ -196,11 +196,18 @@ def fetch_sitemap_urls(
 
             found_pages, child_sitemaps = _parse(content)
             for page in found_pages:
-                if page not in seen_pages:
-                    seen_pages.add(page)
-                    pages.append(page)
-                    if len(pages) >= max_urls:
-                        break
+                if page in seen_pages:
+                    continue
+                # Page <loc>s must be on the root's registrable domain too — a
+                # sitemap that lists other domains' URLs would otherwise pull
+                # them all in under one plan-limited knowledge source.
+                if _registrable_domain(urlparse(page).hostname or "") != root_domain:
+                    logger.warning(f"Skipping cross-domain sitemap page: {page}")
+                    continue
+                seen_pages.add(page)
+                pages.append(page)
+                if len(pages) >= max_urls:
+                    break
             for child in child_sitemaps:
                 if child in visited_sitemaps or child in to_visit:
                     continue

--- a/backend/app/knowledge/sitemap_parser.py
+++ b/backend/app/knowledge/sitemap_parser.py
@@ -53,12 +53,11 @@ def _local_name(tag: str) -> str:
 
 
 def _registrable_domain(host: str) -> str:
-    """Best-effort registrable domain (last two labels) for same-site checks."""
-    host = (host or "").lower().rstrip(".")
-    if host.startswith("www."):
-        host = host[4:]
-    parts = host.split(".")
-    return ".".join(parts[-2:]) if len(parts) >= 2 else host
+    """Registrable domain for same-site checks — the shared ccTLD-aware helper
+    so 'a.example.co.uk' → 'example.co.uk' (not 'co.uk')."""
+    from app.knowledge.domains import registrable_domain
+
+    return registrable_domain(host)
 
 
 def _bounded_gunzip(data: bytes) -> Optional[bytes]:

--- a/backend/app/models/schemas/faq.py
+++ b/backend/app/models/schemas/faq.py
@@ -106,15 +106,26 @@ class GenerateRequest(BaseModel):
     knowledge_ids: Optional[List[int]] = Field(default=None, max_length=MAX_BULK_IDS)
 
 
+class GenerationSourceResponse(BaseModel):
+    """One knowledge source in the generation picker."""
+    id: int
+    name: str
+    source_type: str
+    has_faqs: bool
+    pages: int
+    estimated_calls: int
+
+
 class GenerationEstimateResponse(BaseModel):
-    """Confirm-dialog numbers for a generation run. remaining_credits is None
-    when unlimited (OSS, no cap, or org on its own model key)."""
+    """Confirm-dialog / source-picker numbers for a generation run.
+    remaining_credits is None when unlimited (OSS, no cap, or own model key)."""
     total_sources: int
     new_sources: int
     pages: int
     estimated_calls: int
     metered: bool
     remaining_credits: Optional[int] = None
+    sources: List[GenerationSourceResponse] = []
 
 
 class ImportRequest(BaseModel):

--- a/backend/app/services/faq_usage.py
+++ b/backend/app/services/faq_usage.py
@@ -139,7 +139,13 @@ def estimate_generation_calls(
     for source in all_sources:
         source_pages = count_source_pages(db, source) if count_pages else None
         pages = source_pages or 0
-        calls = max(1, math.ceil(pages / PAGES_PER_CALL)) if pages else 1
+        if source_pages is None:
+            # Unreadable now, or page-count skipped (count_pages=False) — assume
+            # one call so the estimate isn't zero.
+            calls = 1
+        else:
+            # A readable but empty source produces nothing → costs no call.
+            calls = max(1, math.ceil(pages / PAGES_PER_CALL)) if pages else 0
         source_list.append(
             SourceEstimate(
                 id=source.id,

--- a/backend/app/services/faq_usage.py
+++ b/backend/app/services/faq_usage.py
@@ -52,11 +52,22 @@ OVER_BUDGET_MESSAGE = (
 
 
 @dataclass
+class SourceEstimate:
+    id: int
+    name: str
+    source_type: str
+    has_faqs: bool
+    pages: int
+    estimated_calls: int
+
+
+@dataclass
 class GenerationEstimate:
     total_sources: int
     new_sources: int
     pages: int
     estimated_calls: int
+    sources: List[SourceEstimate]
 
 
 def generation_is_metered(db: Session, organization_id: UUID) -> bool:
@@ -102,40 +113,53 @@ def estimate_generation_calls(
     read (new-only unless explicitly targeted) and roughly how many LLM calls
     that costs. Unreadable sources count as one call each.
 
+    Always returns the FULL per-source list (for the generation source picker),
+    each with its own page/call estimate and whether it already has FAQs. The
+    aggregate counts (new_sources/pages/estimated_calls) cover the run's TARGET
+    sources: the explicit `knowledge_ids` selection, or — when none is given —
+    every source that doesn't yet have FAQs.
+
     count_pages=False skips the per-source page COUNT over the vector tables
-    (two cheap queries instead of N aggregate scans) — for surfaces that only
-    need the source counts, like the Generate button label. estimated_calls
-    is then a 1-per-source lower bound."""
-    query = db.query(Knowledge).filter(Knowledge.organization_id == organization_id)
-    if knowledge_ids:
-        query = query.filter(Knowledge.id.in_(knowledge_ids))
-    sources = query.all()
-
+    (cheap — for surfaces that only need counts, like the Generate button
+    label); per-source estimated_calls is then a 1-per-source lower bound."""
+    all_sources = (
+        db.query(Knowledge).filter(Knowledge.organization_id == organization_id).all()
+    )
     generated = FAQRepository(db).knowledge_ids_with_faqs(organization_id)
-    targets = sources if knowledge_ids else [s for s in sources if s.id not in generated]
+    existing_ids = {s.id for s in all_sources}
+    target_ids = (
+        (set(knowledge_ids) & existing_ids)
+        if knowledge_ids
+        else {s.id for s in all_sources if s.id not in generated}
+    )
 
-    if not count_pages:
-        return GenerationEstimate(
-            total_sources=len(sources),
-            new_sources=len(targets),
-            pages=0,
-            estimated_calls=len(targets),
+    source_list: List[SourceEstimate] = []
+    agg_pages = 0
+    agg_calls = 0
+    for source in all_sources:
+        source_pages = count_source_pages(db, source) if count_pages else None
+        pages = source_pages or 0
+        calls = max(1, math.ceil(pages / PAGES_PER_CALL)) if pages else 1
+        source_list.append(
+            SourceEstimate(
+                id=source.id,
+                name=source.source,
+                source_type=source.source_type.value if hasattr(source.source_type, "value") else str(source.source_type),
+                has_faqs=source.id in generated,
+                pages=pages,
+                estimated_calls=calls,
+            )
         )
+        if source.id in target_ids:
+            agg_pages += pages
+            agg_calls += calls
 
-    pages = 0
-    estimated_calls = 0
-    for source in targets:
-        source_pages = count_source_pages(db, source)
-        if source_pages is None:
-            estimated_calls += 1
-            continue
-        pages += source_pages
-        estimated_calls += max(1, math.ceil(source_pages / PAGES_PER_CALL)) if source_pages else 0
     return GenerationEstimate(
-        total_sources=len(sources),
-        new_sources=len(targets),
-        pages=pages,
-        estimated_calls=estimated_calls,
+        total_sources=len(all_sources),
+        new_sources=len(target_ids),
+        pages=agg_pages,
+        estimated_calls=agg_calls,
+        sources=source_list,
     )
 
 

--- a/backend/tests/api/test_help_center_api.py
+++ b/backend/tests/api/test_help_center_api.py
@@ -229,6 +229,11 @@ def test_generate_estimate_reports_new_sources(client, db, test_organization, te
     assert body["total_sources"] == 2
     assert body["new_sources"] == 1
     assert body["estimated_calls"] >= 1
+    # Per-source list for the picker: both sources, with has_faqs per source.
+    by_name = {s["name"]: s for s in body["sources"]}
+    assert set(by_name) == {"done.example.com", "new.example.com"}
+    assert by_name["done.example.com"]["has_faqs"] is True
+    assert by_name["new.example.com"]["has_faqs"] is False
 
 
 def test_import_rejects_internal_hosts(client, test_ai_config):

--- a/backend/tests/knowledge/test_domains.py
+++ b/backend/tests/knowledge/test_domains.py
@@ -1,0 +1,47 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from app.knowledge.domains import domain_of_url, registrable_domain
+
+
+def test_registrable_domain_basics():
+    assert registrable_domain("www.site.com") == "site.com"
+    assert registrable_domain("blog.site.com") == "site.com"
+    assert registrable_domain("SITE.com") == "site.com"
+    assert registrable_domain("") == ""
+    assert registrable_domain("localhost") == "localhost"
+
+
+def test_registrable_domain_cctld_aware():
+    # ccTLDs keep three labels so distinct *.co.uk are NOT collapsed to 'co.uk'.
+    assert registrable_domain("a.b.example.co.uk") == "example.co.uk"
+    assert registrable_domain("mycompany.co.uk") == "mycompany.co.uk"
+    assert registrable_domain("competitor.co.uk") == "competitor.co.uk"
+    assert registrable_domain("shop.example.com.au") == "example.com.au"
+
+
+def test_domain_of_url_normalizes_and_strips_port():
+    assert domain_of_url("https://www.site.com:8443/x") == "site.com"
+    # Scheme-less values still resolve their host (can't slip past as a path).
+    assert domain_of_url("evil.com/page") == "evil.com"
+    assert domain_of_url("site.com") == "site.com"
+    assert domain_of_url("") == ""
+
+
+def test_domain_of_url_distinguishes_cctld_domains():
+    # The add-subpage guard relies on these being DIFFERENT.
+    assert domain_of_url("https://mycompany.co.uk") != domain_of_url("https://competitor.co.uk")
+    assert domain_of_url("https://mycompany.co.uk/a") == domain_of_url("blog.mycompany.co.uk/b")

--- a/backend/tests/knowledge/test_enhanced_website_reader.py
+++ b/backend/tests/knowledge/test_enhanced_website_reader.py
@@ -217,6 +217,31 @@ class TestEnhancedWebsiteReader(unittest.TestCase):
         # /docs and /docs/ collapse to a single canonical link.
         self.assertEqual(links, ['https://site.com/docs'])
 
+    def test_extract_links_rejects_other_registrable_domains(self):
+        """Only same-registrable-domain links are kept — a substring match like
+        'evilsite.com'.endswith('site.com') must NOT slip through (that would let
+        one plan-limited source fan out across unrelated domains)."""
+        html = """
+        <html><body>
+          <a href="https://site.com/a">same</a>
+          <a href="https://blog.site.com/b">subdomain (same registrable)</a>
+          <a href="https://evilsite.com/c">lookalike suffix</a>
+          <a href="https://notsite.com/d">another lookalike</a>
+          <a href="https://other.com/e">unrelated</a>
+        </body></html>
+        """
+        soup = BeautifulSoup(html, 'html.parser')
+        links = self.reader._extract_links(soup, 'https://site.com')
+        self.assertIn('https://site.com/a', links)
+        self.assertIn('https://blog.site.com/b', links)
+        self.assertNotIn('https://evilsite.com/c', links)
+        self.assertNotIn('https://notsite.com/d', links)
+        self.assertNotIn('https://other.com/e', links)
+
+    def test_get_primary_domain_strips_port_and_www(self):
+        self.assertEqual(self.reader._get_primary_domain('https://www.site.com:8443/x'), 'site.com')
+        self.assertEqual(self.reader._get_primary_domain('https://a.b.example.co.uk/x'), 'example.co.uk')
+
     @patch('httpx.Client')
     def test_crawl_with_successful_request(self, mock_client):
         """Test crawling with successful HTTP requests"""

--- a/backend/tests/knowledge/test_sitemap_parser.py
+++ b/backend/tests/knowledge/test_sitemap_parser.py
@@ -107,6 +107,20 @@ def test_cross_domain_child_sitemap_is_skipped():
     assert urls == ["https://site.com/1"]  # evil.com child skipped
 
 
+def test_cross_domain_page_loc_is_skipped():
+    """A page <loc> on another registrable domain is dropped, so one source
+    can't pull in other domains' URLs. Subdomains of the root are kept."""
+    mixed = f"""<urlset {NS}>
+      <url><loc>https://site.com/a</loc></url>
+      <url><loc>https://blog.site.com/b</loc></url>
+      <url><loc>https://evilsite.com/c</loc></url>
+      <url><loc>https://other.com/d</loc></url>
+    </urlset>""".encode()
+    with patch.object(sitemap_parser, "_fetch", _fake_fetch({"https://site.com/sitemap.xml": mixed})):
+        urls = sitemap_parser.fetch_sitemap_urls("https://site.com/sitemap.xml", max_urls=50)
+    assert urls == ["https://site.com/a", "https://blog.site.com/b"]
+
+
 def test_bounded_gunzip_rejects_oversize(monkeypatch):
     monkeypatch.setattr(sitemap_parser, "MAX_DECOMPRESSED_BYTES", 100)
     bomb = gzip.compress(b"A" * 5000)  # decompresses to 5000 > 100

--- a/frontend/src/components/faq/FaqSourcePicker.vue
+++ b/frontend/src/components/faq/FaqSourcePicker.vue
@@ -33,18 +33,18 @@ const emit = defineEmits<{
 const sources = computed<GenerationSource[]>(() => props.estimate?.sources ?? [])
 const selected = ref<Set<number>>(new Set())
 
-// Default selection = sources without FAQs (the "new" ones). Re-seed whenever
-// the picker opens with a fresh estimate.
+// Default selection = sources without FAQs (the "new" ones). Seed only when the
+// picker OPENS (not on later estimate changes) so a background refetch can't
+// wipe the user's manual selection mid-interaction.
 watch(
-  () => [props.open, props.estimate] as const,
-  ([open]) => {
-    if (open) {
-      const next = new Set<number>()
-      for (const s of sources.value) if (!s.has_faqs) next.add(s.id)
-      // If everything already has FAQs, start from all so the user can regenerate.
-      if (next.size === 0) for (const s of sources.value) next.add(s.id)
-      selected.value = next
-    }
+  () => props.open,
+  (open) => {
+    if (!open) return
+    const next = new Set<number>()
+    for (const s of sources.value) if (!s.has_faqs) next.add(s.id)
+    // If everything already has FAQs, start from all so the user can regenerate.
+    if (next.size === 0) for (const s of sources.value) next.add(s.id)
+    selected.value = next
   },
   { immediate: true },
 )

--- a/frontend/src/components/faq/FaqSourcePicker.vue
+++ b/frontend/src/components/faq/FaqSourcePicker.vue
@@ -1,0 +1,293 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import Modal from '@/components/common/Modal.vue'
+import type { GenerateEstimate, GenerationSource } from '@/types/faq'
+
+const props = defineProps<{
+  open: boolean
+  estimate: GenerateEstimate | null
+  submitting?: boolean
+}>()
+
+const emit = defineEmits<{
+  close: []
+  generate: [knowledgeIds: number[]]
+}>()
+
+const sources = computed<GenerationSource[]>(() => props.estimate?.sources ?? [])
+const selected = ref<Set<number>>(new Set())
+
+// Default selection = sources without FAQs (the "new" ones). Re-seed whenever
+// the picker opens with a fresh estimate.
+watch(
+  () => [props.open, props.estimate] as const,
+  ([open]) => {
+    if (open) {
+      const next = new Set<number>()
+      for (const s of sources.value) if (!s.has_faqs) next.add(s.id)
+      // If everything already has FAQs, start from all so the user can regenerate.
+      if (next.size === 0) for (const s of sources.value) next.add(s.id)
+      selected.value = next
+    }
+  },
+  { immediate: true },
+)
+
+function toggle(id: number) {
+  const next = new Set(selected.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  selected.value = next
+}
+
+const allSelected = computed(
+  () => sources.value.length > 0 && selected.value.size === sources.value.length,
+)
+
+function toggleAll() {
+  selected.value = allSelected.value ? new Set() : new Set(sources.value.map((s) => s.id))
+}
+
+const metered = computed(() => props.estimate?.metered ?? false)
+const remaining = computed(() => props.estimate?.remaining_credits ?? null)
+
+const selectedCredits = computed(() =>
+  sources.value.reduce((n, s) => (selected.value.has(s.id) ? n + s.estimated_calls : n), 0),
+)
+
+const overBudget = computed(
+  () => metered.value && remaining.value !== null && selectedCredits.value > remaining.value,
+)
+
+const canGenerate = computed(() => selected.value.size > 0 && !props.submitting && !overBudget.value)
+
+function labelFor(s: GenerationSource): string {
+  const pages = s.pages ? `${s.pages} page${s.pages === 1 ? '' : 's'}` : ''
+  return pages
+}
+
+function submit() {
+  if (!canGenerate.value) return
+  emit('generate', [...selected.value])
+}
+</script>
+
+<template>
+  <Modal v-if="open" @close="$emit('close')">
+    <template #title>Generate FAQs</template>
+    <template #content>
+      <p class="picker-sub">Choose which knowledge sources to generate FAQs from.</p>
+
+      <div class="picker-toolbar">
+        <button class="link-btn" type="button" @click="toggleAll">
+          {{ allSelected ? 'Clear all' : 'Select all' }}
+        </button>
+        <span class="picker-count">{{ selected.size }} of {{ sources.length }} selected</span>
+      </div>
+
+      <div class="picker-list">
+        <label
+          v-for="s in sources"
+          :key="s.id"
+          class="src"
+          :class="{ 'src--on': selected.has(s.id) }"
+        >
+          <input class="src__check" type="checkbox" :checked="selected.has(s.id)" @change="toggle(s.id)" />
+          <span class="src__body">
+            <span class="src__name" :title="s.name">{{ s.name }}</span>
+            <span class="src__meta">
+              <span class="src__type">{{ s.source_type }}</span>
+              <template v-if="labelFor(s)"> · {{ labelFor(s) }}</template>
+              <span v-if="s.has_faqs" class="src__badge">already generated</span>
+            </span>
+          </span>
+        </label>
+      </div>
+
+      <p v-if="metered" class="picker-credits" :class="{ 'picker-credits--over': overBudget }">
+        Uses about {{ selectedCredits }} credit{{ selectedCredits === 1 ? '' : 's' }}<template v-if="remaining !== null"> · {{ remaining }} remaining</template>
+        <template v-if="overBudget"> — not enough credits; upgrade or switch to your own AI model.</template>
+      </p>
+
+      <div class="picker-actions">
+        <button class="btn-cancel" type="button" @click="$emit('close')">Cancel</button>
+        <button class="btn-generate" type="button" :disabled="!canGenerate" @click="submit">
+          {{ submitting ? 'Starting…' : `Generate from ${selected.size} source${selected.size === 1 ? '' : 's'}` }}
+        </button>
+      </div>
+    </template>
+  </Modal>
+</template>
+
+<style scoped>
+.picker-sub {
+  font-size: 13.5px;
+  color: var(--muted);
+  margin: -12px 0 16px;
+  line-height: 1.5;
+}
+
+.picker-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.link-btn {
+  background: transparent;
+  border: none;
+  color: var(--c-purple);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.picker-count {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--muted2);
+}
+
+.picker-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 42vh;
+  overflow-y: auto;
+  margin-bottom: 16px;
+}
+
+.src {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  padding: 12px 13px;
+  background: var(--bg);
+  border: 1px solid var(--o10);
+  border-radius: 11px;
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.src--on {
+  border-color: var(--purple-border);
+  background: var(--purple-bg);
+}
+
+.src__check {
+  width: 16px;
+  height: 16px;
+  margin: 1px 0 0;
+  flex-shrink: 0;
+  accent-color: var(--c-purple);
+  cursor: pointer;
+}
+
+.src__body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.src__name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.src__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.src__type {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--muted2);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.src__badge {
+  padding: 1px 7px;
+  border-radius: 6px;
+  background: var(--o05);
+  border: 1px solid var(--o12);
+  font-size: 10.5px;
+  color: var(--muted);
+}
+
+.picker-credits {
+  font-size: 12.5px;
+  color: var(--muted);
+  margin: 0 0 16px;
+  line-height: 1.5;
+}
+
+.picker-credits--over {
+  color: var(--c-coral);
+}
+
+.picker-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.btn-cancel {
+  padding: 11px 18px;
+  background: transparent;
+  border: 1px solid var(--o12);
+  border-radius: 10px;
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.btn-generate {
+  padding: 11px 20px;
+  background: var(--purple-bg);
+  border: 1px solid var(--purple-border);
+  border-radius: 10px;
+  color: var(--c-purple);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-generate:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+</style>

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -120,8 +120,9 @@ const generating = ref(false)
 async function onPickSources(knowledgeIds: number[]) {
   generating.value = true
   try {
-    await startGeneration(knowledgeIds)
-    sourcePickerOpen.value = false
+    // Keep the picker open if the job didn't start (409/budget) — the error
+    // toast explains why and the user can adjust their selection.
+    if (await startGeneration(knowledgeIds)) sourcePickerOpen.value = false
   } finally {
     generating.value = false
   }
@@ -209,7 +210,9 @@ async function askGenerate() {
     busyLabel: 'Starting…',
     intent: 'primary',
     disabledReason,
-    action: () => startGeneration(),
+    action: async () => {
+      await startGeneration()
+    },
   }
 }
 

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -26,6 +26,7 @@ import FaqGenerationProgress from './FaqGenerationProgress.vue'
 import FaqCategoryGroup from './FaqCategoryGroup.vue'
 import FaqCard from './FaqCard.vue'
 import FaqImportModal from './FaqImportModal.vue'
+import FaqSourcePicker from './FaqSourcePicker.vue'
 import HelpCenterAppearance from './HelpCenterAppearance.vue'
 import HelpCenterPublic from './HelpCenterPublic.vue'
 
@@ -112,6 +113,20 @@ const tab = ref<'faqs' | 'settings'>('faqs')
 const importOpen = ref(false)
 const importSubmitting = ref(false)
 
+// Knowledge-source picker (shown when there are multiple sources).
+const sourcePickerOpen = ref(false)
+const generating = ref(false)
+
+async function onPickSources(knowledgeIds: number[]) {
+  generating.value = true
+  try {
+    await startGeneration(knowledgeIds)
+    sourcePickerOpen.value = false
+  } finally {
+    generating.value = false
+  }
+}
+
 async function onImportSubmit(url: string, mode: FaqImportMode) {
   importSubmitting.value = true
   try {
@@ -166,6 +181,11 @@ async function askGenerate() {
   }
   if (e.total_sources === 0) {
     toast.error('No knowledge sources to generate from. Add knowledge first.')
+    return
+  }
+  // Multiple sources → let the user pick which to generate from.
+  if (e.sources.length > 1) {
+    sourcePickerOpen.value = true
     return
   }
   if (e.new_sources === 0) {
@@ -404,6 +424,14 @@ onUnmounted(stopPolling)
     </template>
 
     <FaqImportModal :open="importOpen" :submitting="importSubmitting" @close="importOpen = false" @submit="onImportSubmit" @submit-pdf="onPdfImportSubmit" />
+
+    <FaqSourcePicker
+      :open="sourcePickerOpen"
+      :estimate="estimate"
+      :submitting="generating"
+      @close="sourcePickerOpen = false"
+      @generate="onPickSources"
+    />
 
     <div v-if="selectionActive" class="bulkbar" role="toolbar" aria-label="Bulk actions">
       <span class="bulkbar__count">{{ selectedIds.size }} selected</span>

--- a/frontend/src/composables/useFaqWorkspace.ts
+++ b/frontend/src/composables/useFaqWorkspace.ts
@@ -297,11 +297,13 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     }
   }
 
-  async function startGeneration(knowledgeIds?: number[]): Promise<void> {
+  async function startGeneration(knowledgeIds?: number[]): Promise<boolean> {
     try {
       job.value = await faqService.startGeneration(knowledgeIds)
+      return true
     } catch (error: any) {
       toast.error(error.message)
+      return false
     }
   }
 

--- a/frontend/src/services/knowledge.ts
+++ b/frontend/src/services/knowledge.ts
@@ -165,12 +165,20 @@ export const knowledgeService = {
   },
 
   async addSubpage(knowledgeId: number, subpageName: string, content: string, url?: string) {
-    const response = await api.post(`/knowledge/${knowledgeId}/subpage`, {
-      subpage_name: subpageName,
-      content,
-      ...(url ? { url } : {}),
-    })
-    return response.data
+    try {
+      const response = await api.post(`/knowledge/${knowledgeId}/subpage`, {
+        subpage_name: subpageName,
+        content,
+        ...(url ? { url } : {}),
+      })
+      return response.data
+    } catch (error: any) {
+      // Surface the backend's specific reason (wrong domain, subpage limit
+      // reached, duplicate name…) instead of a generic axios message.
+      throw new Error(
+        error.response?.data?.detail || error.response?.data?.message || 'Failed to add sub-page',
+      )
+    }
   },
 
   // Replace a whole sub-page's content and re-embed it. `pageId` is the page's

--- a/frontend/src/types/faq.ts
+++ b/frontend/src/types/faq.ts
@@ -52,6 +52,15 @@ export type FaqJobStage =
   | 'grouping'
   | 'completed'
 
+export interface GenerationSource {
+  id: number
+  name: string
+  source_type: string
+  has_faqs: boolean
+  pages: number
+  estimated_calls: number
+}
+
 export interface GenerateEstimate {
   total_sources: number
   new_sources: number
@@ -59,6 +68,7 @@ export interface GenerateEstimate {
   estimated_calls: number
   metered: boolean
   remaining_credits: number | null
+  sources: GenerationSource[]
 }
 
 export interface FaqGenerationJob {


### PR DESCRIPTION
Two related changes to the Help Center / Knowledge feature.

## 1. Security fix — restrict crawled/added subpages to the same registrable domain

A website/sitemap knowledge source could pull in content from **unrelated domains**, letting a free-plan user (1 source, few sub-pages) accumulate many domains' content under a single plan-limited source. Root cause: a loose suffix check (`netloc.endswith("site.com")`) matched `evilsite.com`, and the manual add-subpage endpoint did no domain check at all.

- **One canonical ccTLD-aware helper** (`app/knowledge/domains.py` — `registrable_domain` / `domain_of_url`), used by the crawler, sitemap parser and add-subpage so every same-domain check agrees. `a.example.co.uk` → `example.co.uk` (not `co.uk`), so distinct `*.co.uk` domains aren't conflated.
- **Website crawler** (`_extract_links`, `_process_url`): registrable-domain **equality** instead of `endswith`; port stripped via `hostname`. Subdomains of the root (`blog.site.com`) still allowed.
- **Sitemap**: page `<loc>` entries filtered by the root domain (previously only child sitemaps were).
- **`add_subpage`**: rejects a subpage URL on a different registrable domain than its source; `domain_of_url` normalizes a scheme-less value so `evil.com/x` can't parse as a hostless path and slip past.
- **Frontend**: `addSubpage` now surfaces the backend `detail` (wrong domain / subpage-limit / duplicate name) instead of a generic "Request failed".

## 2. Feature — pick which knowledge sources to generate FAQs from

When an org has **more than one** source, Generate opens a picker: a checkbox list of every source (name, type, page count, an "already generated" badge), pre-selecting the ones without FAQs, with select-all and a live credit estimate that blocks when over budget. Single-source orgs keep the simple confirm.

- Backend: `/generate/estimate` now returns a per-source breakdown (`id, name, source_type, has_faqs, pages, estimated_calls`) from data the estimate already computed; the chosen ids flow through the already-wired `startGeneration(knowledge_ids)` → `GenerateRequest` path.

## Review
Self-reviewed; fixes applied for a scheme-less/ccTLD subpage-guard bypass, a credit-estimate over-count on empty sources, and two picker-modal UX issues (keep open on 409/budget; don't reseed selection on background refetch). New unit tests for the domain helper, lookalike/ccTLD rejection, and the per-source estimate. Backend + frontend suites pass, type-check clean.
