### PR TITLE
fix(help-center): mobile layout, absolute logo URL, image crop + upload hardening

### DIFF
--- a/backend/app/api/help_center/branding.py
+++ b/backend/app/api/help_center/branding.py
@@ -16,7 +16,6 @@ limitations under the License.
 Help-center settings + branding endpoints (settings get/put, logo upload).
 """
 
-import io
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
@@ -41,17 +40,18 @@ from app.repositories.help_center import HelpCenterRepository
 from app.services.file_storage import resolve_public_url, store_upload
 from app.services.help_center_access import check_help_center_access, help_center_allowed
 from app.services.help_center_settings import get_or_create_settings, live_url
+from app.services.image_security import sanitize_image
 
 router = APIRouter()
 
 MAX_LOGO_BYTES = 2 * 1024 * 1024
-# Extensions are derived from the VALIDATED content type, never the client
-# filename — a filename-derived extension could store scriptable content
-# (.svg/.html) under the static uploads mount.
-_LOGO_TYPES = {"image/png": ".png", "image/svg+xml": ".svg"}
-# Conservative SVG screen: the logo renders on the public help center, so
-# active content in an uploaded SVG would be stored XSS there.
-_SVG_FORBIDDEN = (b"<script", b"javascript:", b"onload=", b"onerror=", b"onclick=", b"<foreignobject")
+# Raster only — SVG is active markup and would be stored XSS on the public help
+# center, so it is not accepted; the admin cropper rasterises to PNG client-side.
+_LOGO_TYPES = {"image/png", "image/jpeg", "image/webp"}
+# Reject anything larger than this on a side up front (decompression-bomb guard);
+# the stored logo is then downscaled to LOGO_FIT_DIM (header renders it ~30px).
+MAX_LOGO_DIM = 4000
+LOGO_FIT_DIM = 512
 
 
 def domain_status_response(row: HelpCenterSettings) -> DomainStatusResponse:
@@ -157,27 +157,21 @@ async def upload_logo(
     row = get_or_create_settings(db, current_user.organization)
 
     content = await file.read()
-    if len(content) > MAX_LOGO_BYTES:
-        raise HTTPException(status_code=400, detail="Logo must be 2 MB or smaller.")
-    if file.content_type not in _LOGO_TYPES:
-        raise HTTPException(status_code=400, detail="Logo must be a PNG or SVG file.")
-    if file.content_type == "image/svg+xml":
-        lowered = content.lower()
-        if any(marker in lowered for marker in _SVG_FORBIDDEN):
-            raise HTTPException(status_code=400, detail="SVG logos must not contain scripts or event handlers.")
-    else:
-        try:
-            from PIL import Image
-            Image.open(io.BytesIO(content)).verify()
-        except Exception:
-            raise HTTPException(status_code=400, detail="Invalid image file.")
-
-    file_name = f"{uuid4()}{_LOGO_TYPES[file.content_type]}"
-    row.logo_url = await store_upload(
+    # Validate, bomb-guard, downscale and re-encode to a clean PNG/JPEG — the
+    # stored bytes carry no metadata or non-image payload.
+    safe_bytes, content_type, ext = sanitize_image(
         content,
+        allowed_content_types=_LOGO_TYPES,
+        max_bytes=MAX_LOGO_BYTES,
+        max_dim=MAX_LOGO_DIM,
+        fit=LOGO_FIT_DIM,
+    )
+    file_name = f"{uuid4()}{ext}"
+    row.logo_url = await store_upload(
+        safe_bytes,
         f"help_center/{current_user.organization_id}",
         file_name,
-        content_type=file.content_type,
+        content_type=content_type,
     )
     row = HelpCenterRepository(db).update(row)
     return await settings_response(db, row, current_user.organization_id)

--- a/backend/app/api/help_center/faqs.py
+++ b/backend/app/api/help_center/faqs.py
@@ -35,7 +35,10 @@ from app.models.schemas.pagination import Pagination
 from app.models.user import User
 from app.repositories.faq import FAQRepository
 from app.services.help_center_access import check_help_center_access
+from app.services.image_security import sanitize_image
 from app.services.help_center_images import (
+    FAQ_IMAGE_FIT_DIM,
+    FAQ_IMAGE_MAX_DIM,
     FAQ_IMAGE_TYPES,
     MAX_FAQ_IMAGE_BYTES,
     store_article_image,
@@ -115,12 +118,17 @@ async def upload_faq_image(
     absolute URL the editor inserts as ![](url)."""
     check_help_center_access(db, current_user.organization_id)
     content = await file.read()
-    if len(content) > MAX_FAQ_IMAGE_BYTES:
-        raise HTTPException(status_code=400, detail="Image must be 5MB or smaller.")
-    # Extension comes from the VALIDATED content type, never the client filename.
-    if file.content_type not in FAQ_IMAGE_TYPES:
-        raise HTTPException(status_code=400, detail="Use a PNG, JPEG, GIF or WebP image.")
-    return {"url": await store_article_image(content, file.content_type)}
+    # Validate, bomb-guard, downscale and re-encode from decoded pixels — strips
+    # metadata/payloads and normalises to PNG/JPEG (content type is derived here,
+    # never from the client filename).
+    safe_bytes, content_type, _ext = sanitize_image(
+        content,
+        allowed_content_types=set(FAQ_IMAGE_TYPES),
+        max_bytes=MAX_FAQ_IMAGE_BYTES,
+        max_dim=FAQ_IMAGE_MAX_DIM,
+        fit=FAQ_IMAGE_FIT_DIM,
+    )
+    return {"url": await store_article_image(safe_bytes, content_type)}
 
 
 @router.put("/faqs/{faq_id}", response_model=FAQResponse)

--- a/backend/app/api/help_center_public.py
+++ b/backend/app/api/help_center_public.py
@@ -30,6 +30,7 @@ from app.database import get_db
 from app.models.faq import FAQ
 from app.models.help_center import HelpCenterSettings
 from app.services.file_storage import resolve_public_url
+from app.services.help_center_images import absolute_upload_url
 from app.services.help_center_content import (
     excerpt,
     read_time_label,
@@ -89,7 +90,10 @@ async def _chrome_context(row: HelpCenterSettings) -> dict:
         "row": row,
         "brand_color": row.brand_color,
         "brand_ink": contrast_ink(row.brand_color),
-        "logo_url": await resolve_public_url(row.logo_url) if row.logo_url else None,
+        # Absolute (api-origin) URL: the public site is host-dispatched to a
+        # limited app that does NOT serve /api/v1/uploads, so a host-relative
+        # path would 404 on the help-center domain. Mirror article images.
+        "logo_url": absolute_upload_url(await resolve_public_url(row.logo_url)) if row.logo_url else None,
         "header_links": row.header_links or [],
         "widget_id": widget_id_for(row),
         # The widget LOADER (chattermate.min.js) is served by the frontend, while

--- a/backend/app/services/help_center_images.py
+++ b/backend/app/services/help_center_images.py
@@ -26,6 +26,10 @@ from app.core.config import settings
 from app.services.file_storage import store_upload
 
 MAX_FAQ_IMAGE_BYTES = 5 * 1024 * 1024
+# Reject larger-than-this on a side up front (bomb guard); downscale the stored
+# image to fit FAQ_IMAGE_FIT_DIM so article pages stay light.
+FAQ_IMAGE_MAX_DIM = 6000
+FAQ_IMAGE_FIT_DIM = 1600
 FAQ_IMAGE_TYPES = {
     "image/png": ".png",
     "image/jpeg": ".jpg",

--- a/backend/app/services/image_security.py
+++ b/backend/app/services/image_security.py
@@ -1,0 +1,117 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Hardening for user-uploaded images (help-center logo + article images). Every
+uploaded raster is:
+  - size-capped (bytes),
+  - checked for a real, decodable image (not a polyglot / renamed file),
+  - guarded against decompression bombs (pixel-count cap read from the header
+    BEFORE the full image is decoded),
+  - re-encoded from decoded pixels — which strips EXIF/metadata, trailing bytes
+    and any appended payload, and normalises the stored format.
+
+SVG is intentionally NOT accepted here: it is active markup and would be stored
+XSS on the public help center. Callers that previously took SVG rasterise on the
+client (the cropper) or drop it.
+"""
+
+import io
+
+from fastapi import HTTPException
+from PIL import Image
+
+# Refuse absurd pixel counts before decoding — a few-KB file can claim to be
+# tens of thousands of pixels per side and exhaust memory on decode.
+_MAX_PIXELS = 40_000_000  # 40 MP
+Image.MAX_IMAGE_PIXELS = _MAX_PIXELS
+
+# PIL format -> (content type, extension) for the formats we re-encode to.
+_PNG = ("image/png", ".png")
+_JPEG = ("image/jpeg", ".jpg")
+
+_FORMAT_CONTENT_TYPE = {
+    "PNG": "image/png",
+    "JPEG": "image/jpeg",
+    "WEBP": "image/webp",
+    "GIF": "image/gif",
+}
+
+
+def _open_validated(content: bytes, *, max_bytes: int, max_dim: int) -> Image.Image:
+    """Open bytes as an image, enforcing byte size, decodability and a pixel /
+    dimension cap (bomb guard) — all before the pixels are fully decoded."""
+    if not content:
+        raise HTTPException(status_code=400, detail="Empty image file.")
+    if len(content) > max_bytes:
+        raise HTTPException(status_code=400, detail=f"Image must be {max_bytes // (1024 * 1024)} MB or smaller.")
+    try:
+        img = Image.open(io.BytesIO(content))
+        width, height = img.size  # header only; no full decode yet
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid or corrupt image file.")
+    if width <= 0 or height <= 0:
+        raise HTTPException(status_code=400, detail="Invalid image dimensions.")
+    if width > max_dim or height > max_dim or width * height > _MAX_PIXELS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Image is too large — keep it within {max_dim}×{max_dim} pixels.",
+        )
+    try:
+        img.load()  # dimensions are now known-safe, so decoding is bounded
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid or corrupt image file.")
+    return img
+
+
+def sanitize_image(
+    content: bytes,
+    *,
+    allowed_content_types: set[str],
+    max_bytes: int,
+    max_dim: int,
+    fit: int | None = None,
+) -> tuple[bytes, str, str]:
+    """Validate and re-encode an uploaded raster image.
+
+    Returns (safe_bytes, content_type, extension). Raises HTTPException(400) on
+    anything that is not a clean, in-policy raster image. `fit`, when given,
+    downscales the longest side to at most `fit` px (aspect preserved).
+
+    JPEG re-encodes to JPEG (keeps photos small); everything else re-encodes to
+    PNG (keeps transparency). Either path strips metadata and any non-pixel
+    payload because the output is built from decoded pixels only.
+    """
+    img = _open_validated(content, max_bytes=max_bytes, max_dim=max_dim)
+
+    detected = _FORMAT_CONTENT_TYPE.get((img.format or "").upper())
+    if detected is None or detected not in allowed_content_types:
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported image type. Use PNG, JPEG or WebP.",
+        )
+
+    if fit and max(img.size) > fit:
+        img.thumbnail((fit, fit), Image.LANCZOS)
+
+    out = io.BytesIO()
+    if detected == "image/jpeg":
+        img.convert("RGB").save(out, format="JPEG", quality=85, optimize=True)
+        content_type, ext = _JPEG
+    else:
+        img.convert("RGBA").save(out, format="PNG", optimize=True)
+        content_type, ext = _PNG
+    return out.getvalue(), content_type, ext

--- a/backend/app/templates/help_center/base.html
+++ b/backend/app/templates/help_center/base.html
@@ -227,18 +227,28 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
     .js .hc-tag { display: none; }
 
     @media (max-width: 860px) {
-      /* Tighter hero so content starts higher up. */
-      .hc-hero { padding: 34px 20px 26px; }
-      .hc-hero h1 { font-size: 27px; margin-bottom: 8px; }
-      .hc-hero p.lead { font-size: 15px; margin-bottom: 20px; }
-      .hc-body { grid-template-columns: 1fr; gap: 18px; padding: 20px 18px 16px; }
-      .hc-aside { position: static; }
-      /* Topics become one swipeable row directly under the hero, instead of a
-         tall stacked list that pushes the articles far down the page. */
-      .hc-topics { flex-direction: row; flex-wrap: nowrap; gap: 8px; overflow-x: auto;
-        scrollbar-width: none; -webkit-overflow-scrolling: touch; padding: 2px 2px 6px; margin: 0 -2px; }
-      .hc-topics::-webkit-scrollbar { display: none; }
-      .hc-topic { width: auto; flex-shrink: 0; }
+      /* Compact hero so the topics and articles start higher up. */
+      .hc-hero { padding: 30px 20px 22px; }
+      .hc-hero h1 { font-size: 25px; margin-bottom: 6px; }
+      .hc-hero p.lead { font-size: 14.5px; margin-bottom: 16px; }
+      .hc-searchbar { padding: 5px 5px 5px 14px; }
+      .hc-searchbar input { padding: 11px 0; font-size: 15.5px; }
+      /* The 2-column topic grid below is the category picker on mobile, so the
+         duplicate "Popular" chips just add height. */
+      .hc-popular { display: none; }
+
+      .hc-body { grid-template-columns: 1fr; gap: 16px; padding: 18px 16px 16px; }
+      .hc-aside { position: static; min-width: 0; }
+      .hc-main { min-width: 0; }
+      .hc-aside-label { margin-bottom: 10px; }
+
+      /* Topics as a compact 2-column grid: scannable, and — unlike a nowrap row —
+         it can't blow out the page width and force horizontal scrolling. */
+      .hc-topics { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+      .hc-topic { width: auto; min-width: 0; padding: 10px 11px; gap: 9px; }
+      .hc-topic-icon { width: 26px; height: 26px; }
+      .hc-topic-name { font-size: 13.5px; }
+
       /* Redundant on mobile — the "Still need a hand?" CTA below covers it. */
       .hc-help-card { display: none; }
       .hc-cta { padding: 30px; }

--- a/backend/tests/services/test_image_security.py
+++ b/backend/tests/services/test_image_security.py
@@ -1,0 +1,94 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import io
+
+import pytest
+from fastapi import HTTPException
+from PIL import Image
+
+from app.services.image_security import sanitize_image
+
+RASTER = {"image/png", "image/jpeg", "image/webp"}
+
+
+def _img_bytes(fmt: str, size=(64, 48), color=(200, 30, 30)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color).save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def test_png_reencoded_to_png():
+    out, ctype, ext = sanitize_image(
+        _img_bytes("PNG"), allowed_content_types=RASTER, max_bytes=2_000_000, max_dim=4000
+    )
+    assert ctype == "image/png" and ext == ".png"
+    assert Image.open(io.BytesIO(out)).format == "PNG"
+
+
+def test_jpeg_stays_jpeg():
+    out, ctype, ext = sanitize_image(
+        _img_bytes("JPEG"), allowed_content_types=RASTER, max_bytes=2_000_000, max_dim=4000
+    )
+    assert ctype == "image/jpeg" and ext == ".jpg"
+    assert Image.open(io.BytesIO(out)).format == "JPEG"
+
+
+def test_fit_downscales_longest_side():
+    out, _c, _e = sanitize_image(
+        _img_bytes("PNG", size=(1200, 600)),
+        allowed_content_types=RASTER,
+        max_bytes=2_000_000,
+        max_dim=4000,
+        fit=512,
+    )
+    w, h = Image.open(io.BytesIO(out)).size
+    assert max(w, h) == 512 and (w, h) == (512, 256)
+
+
+def test_rejects_non_image():
+    with pytest.raises(HTTPException) as e:
+        sanitize_image(b"not an image", allowed_content_types=RASTER, max_bytes=2_000_000, max_dim=4000)
+    assert e.value.status_code == 400
+
+
+def test_rejects_oversized_bytes():
+    with pytest.raises(HTTPException) as e:
+        sanitize_image(_img_bytes("PNG"), allowed_content_types=RASTER, max_bytes=10, max_dim=4000)
+    assert e.value.status_code == 400
+
+
+def test_rejects_dimensions_over_cap():
+    with pytest.raises(HTTPException) as e:
+        sanitize_image(
+            _img_bytes("PNG", size=(300, 300)),
+            allowed_content_types=RASTER,
+            max_bytes=2_000_000,
+            max_dim=100,
+        )
+    assert e.value.status_code == 400
+
+
+def test_rejects_disallowed_format():
+    # GIF is a valid image but not in the allowlist here → rejected.
+    with pytest.raises(HTTPException) as e:
+        sanitize_image(_img_bytes("GIF"), allowed_content_types=RASTER, max_bytes=2_000_000, max_dim=4000)
+    assert e.value.status_code == 400
+
+
+def test_empty_rejected():
+    with pytest.raises(HTTPException):
+        sanitize_image(b"", allowed_content_types=RASTER, max_bytes=2_000_000, max_dim=4000)

--- a/frontend/src/components/faq/HelpCenterLogoField.vue
+++ b/frontend/src/components/faq/HelpCenterLogoField.vue
@@ -16,6 +16,8 @@ limitations under the License.
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { Cropper } from 'vue-advanced-cropper'
+import 'vue-advanced-cropper/dist/style.css'
 
 const props = defineProps<{ logoUrl: string | null }>()
 
@@ -24,43 +26,120 @@ const emit = defineEmits<{
   remove: []
 }>()
 
+// Raster only — SVG is rejected (it would be active markup on the public site).
+const ACCEPT = 'image/png,image/jpeg,image/webp'
+const MAX_BYTES = 2 * 1024 * 1024
+// Bound the exported canvas so the stored logo is small (header renders it ~30px).
+const OUTPUT_MAX = 512
+
 const fileInput = ref<HTMLInputElement | null>(null)
+const error = ref('')
+
+const showCropper = ref(false)
+const cropperImage = ref('')
+const cropper = ref<any>(null)
+const saving = ref(false)
 
 const logoName = computed(() => {
   if (!props.logoUrl) return ''
   return props.logoUrl.split('/').pop()?.split('?')[0] || 'logo'
 })
 
+function pick() {
+  error.value = ''
+  fileInput.value?.click()
+}
+
 function onFileChange(event: Event) {
   const input = event.target as HTMLInputElement
   const file = input.files?.[0]
-  if (file) emit('upload', file)
   input.value = ''
+  if (!file) return
+  if (!/^image\/(png|jpe?g|webp)$/.test(file.type)) {
+    error.value = 'Use a PNG, JPG or WebP image.'
+    return
+  }
+  if (file.size > MAX_BYTES) {
+    error.value = 'Image must be 2 MB or smaller.'
+    return
+  }
+  error.value = ''
+  cropperImage.value = URL.createObjectURL(file)
+  showCropper.value = true
+}
+
+async function confirmCrop() {
+  if (!cropper.value || saving.value) return
+  saving.value = true
+  try {
+    const { canvas } = cropper.value.getResult()
+    if (!canvas) throw new Error('no canvas')
+    const blob: Blob = await new Promise((resolve, reject) => {
+      canvas.toBlob((b: Blob | null) => (b ? resolve(b) : reject(new Error('blob'))), 'image/png')
+    })
+    emit('upload', new File([blob], 'logo.png', { type: 'image/png' }))
+    closeCropper()
+  } catch {
+    error.value = 'Could not process that image. Try another one.'
+  } finally {
+    saving.value = false
+  }
+}
+
+function closeCropper() {
+  showCropper.value = false
+  if (cropperImage.value) URL.revokeObjectURL(cropperImage.value)
+  cropperImage.value = ''
 }
 </script>
 
 <template>
   <div>
-    <input ref="fileInput" class="file-input" type="file" accept=".png,.svg" @change="onFileChange" />
+    <input ref="fileInput" class="file-input" type="file" :accept="ACCEPT" @change="onFileChange" />
     <div v-if="logoUrl" class="logo-row">
       <div class="logo-chip">
         <img class="logo-chip__img" :src="logoUrl" alt="Logo" />
         <div class="logo-chip__name">{{ logoName }}</div>
       </div>
-      <button class="btn-sm" type="button" @click="fileInput?.click()">Replace</button>
+      <button class="btn-sm" type="button" @click="pick">Replace</button>
       <button class="icon-btn" type="button" title="Remove logo" @click="$emit('remove')">
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16" /><path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" /><path d="M6 7l1 13a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1l1-13" /></svg>
       </button>
     </div>
-    <button v-else class="upload-btn" type="button" @click="fileInput?.click()">
+    <button v-else class="upload-btn" type="button" @click="pick">
       <span class="upload-btn__icon">
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 16V4" /><path d="M8 8l4-4 4 4" /><path d="M4 20h16" /></svg>
       </span>
       <span>
         <span class="upload-btn__title">Upload your logo</span>
-        <span class="upload-btn__sub">PNG or SVG, up to 2 MB · shown top-left</span>
+        <span class="upload-btn__sub">PNG, JPG or WebP, up to 2 MB · crop it to fit</span>
       </span>
     </button>
+
+    <p v-if="error" class="logo-error">{{ error }}</p>
+
+    <!-- Crop modal: the cropped canvas is exported as a fresh PNG, so nothing
+         from the original file (metadata, oversized pixels) reaches the server. -->
+    <div v-if="showCropper" class="crop-modal" @click.self="closeCropper">
+      <div class="crop-panel">
+        <div class="crop-head">Crop your logo</div>
+        <div class="crop-stage">
+          <Cropper
+            ref="cropper"
+            :src="cropperImage"
+            :canvas="{ maxWidth: OUTPUT_MAX, maxHeight: OUTPUT_MAX }"
+            image-restriction="fit-area"
+            background="var(--o05)"
+          />
+        </div>
+        <div class="crop-actions">
+          <button class="btn-cancel" type="button" @click="closeCropper">Cancel</button>
+          <button class="btn-save" type="button" :disabled="saving" @click="confirmCrop">
+            {{ saving ? 'Saving…' : 'Save logo' }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -183,5 +262,89 @@ function onFileChange(event: Event) {
   font-size: 12px;
   color: var(--muted);
   margin-top: 2px;
+}
+
+.logo-error {
+  margin: 8px 0 0;
+  font-size: 12.5px;
+  color: var(--c-coral);
+}
+
+/* ---- crop modal ---- */
+.crop-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(10, 12, 16, 0.55);
+}
+
+.crop-panel {
+  width: 100%;
+  max-width: 460px;
+  background: var(--surface, var(--bg));
+  border: 1px solid var(--o12);
+  border-radius: 16px;
+  box-shadow: 0 24px 60px rgba(10, 12, 16, 0.35);
+  overflow: hidden;
+}
+
+.crop-head {
+  padding: 16px 18px;
+  font-family: var(--font-sans);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text2);
+  border-bottom: 1px solid var(--o10);
+}
+
+.crop-stage {
+  height: 320px;
+  background: var(--o05);
+}
+
+.crop-stage :deep(.vue-advanced-cropper) {
+  height: 100%;
+}
+
+.crop-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--o10);
+}
+
+.btn-cancel {
+  padding: 10px 16px;
+  background: transparent;
+  border: 1px solid var(--o12);
+  border-radius: 10px;
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.btn-save {
+  padding: 10px 18px;
+  background: var(--purple-bg);
+  border: 1px solid var(--purple-border);
+  border-radius: 10px;
+  color: var(--c-purple);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-save:disabled {
+  opacity: 0.55;
+  cursor: default;
 }
 </style>


### PR DESCRIPTION
Follow-up to #194 (fixes the mobile break it introduced + the remaining logo issue, and adds the requested image crop / size / security).

## Mobile layout (fixes the sideways-scroll break)
#194 turned the 18-item topic nav into a `nowrap` row; with no `min-width:0` on the grid item that blew out the page width, so the whole layout scrolled horizontally and cards ran off-screen. Replaced with a robust **2-column topic grid**, compacted the hero, and hid the duplicate 'Popular' chips + aside help-card on mobile so articles are reachable without a long scroll.

## Logo renders on the public site
The public help center is host-dispatched to a limited app that does **not** serve `/api/v1/uploads`, so a host-relative logo path 404s there. Now emits an **absolute** api-origin URL via `absolute_upload_url` (same helper article images use).

## Image crop + size + security
- **New `app/services/image_security.py`**: validates the upload is a real image, guards against **decompression bombs** (pixel cap checked from the header before decoding), downscales, and **re-encodes from decoded pixels** — stripping EXIF/metadata and any appended/polyglot payload. Wired into both the logo and article-image endpoints.
- **Logo no longer accepts SVG** (active markup ⇒ stored XSS on the public site). The admin now **crops** client-side (`vue-advanced-cropper`, already a dep) and uploads a freshly-rendered PNG. Stored logo downscaled to 512px; article images to 1600px; both byte-capped as before.
- Unit tests for the sanitizer (valid re-encode, downscale, bomb/oversize/non-image/disallowed-type rejections).

## Notes
- The socket.io CORS 'Failed to connect' and the broken-logo data were **runtime** fixes already applied on prod (stale Redis `cors:origins` cleared + backend restart; logo path corrected); no code needed for those.
- All backend changes; frontend adds the crop modal. `npm run type-check` clean; sanitizer tests pass.