### PR TITLE
fix(help-center): hide browse-topics while searching (mobile)

### DIFF
--- a/backend/app/templates/help_center/base.html
+++ b/backend/app/templates/help_center/base.html
@@ -251,6 +251,10 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
 
       /* Redundant on mobile — the "Still need a hand?" CTA below covers it. */
       .hc-help-card { display: none; }
+      /* While searching, get the whole browse-topics column out of the way so
+         the results (and the Ask-AI card) sit right under the search box,
+         instead of on a "second page" below every category. */
+      body.hc-searching .hc-aside { display: none; }
       .hc-cta { padding: 30px; }
       .hc-article-card { padding: 24px 20px; }
       .hc-related-grid { grid-template-columns: 1fr; }

--- a/backend/app/templates/help_center/index.html
+++ b/backend/app/templates/help_center/index.html
@@ -257,6 +257,9 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
     function search(raw) {
       var q = (raw || '').trim().toLowerCase();
       clearBtn.style.display = q ? 'block' : 'none';
+      // Drives the mobile rule that hides the browse-topics column while a
+      // search is active, so results surface directly under the search box.
+      document.body.classList.toggle('hc-searching', !!q);
       if (!q) { if (activeCat) browse(activeCat); return; }
       topics.forEach(function (x) { x.classList.remove('active'); });
       var terms = q.split(/\s+/);


### PR DESCRIPTION
On mobile the full browse-topics grid stayed above the search results, so searching pushed answers onto a 'second page'. Now a `body.hc-searching` class (toggled by the search JS) hides the topics column while a query is active — the results and the Ask-AI card sit directly under the search box, matching the Facebook Help Centre pattern. Clearing the search restores the topics. Desktop unchanged. Template-only; no rebuild.