### PR TITLE
fix(help-center): admin logo URL absolute + tighten mobile search gap

### DIFF
--- a/backend/app/api/help_center/branding.py
+++ b/backend/app/api/help_center/branding.py
@@ -40,6 +40,7 @@ from app.repositories.help_center import HelpCenterRepository
 from app.services.file_storage import resolve_public_url, store_upload
 from app.services.help_center_access import check_help_center_access, help_center_allowed
 from app.services.help_center_settings import get_or_create_settings, live_url
+from app.services.help_center_images import absolute_upload_url
 from app.services.image_security import sanitize_image
 
 router = APIRouter()
@@ -92,7 +93,12 @@ async def settings_response(
         .all()
     )
     response = HelpCenterSettingsResponse.model_validate(row)
-    response.logo_url = await resolve_public_url(row.logo_url) if row.logo_url else None
+    # Absolute (api-origin) URL: the admin runs on app.chattermate.chat, whose
+    # nginx serves any *.png path as a static asset — a host-relative
+    # /api/v1/uploads/*.png would 404 there. Anchor to the backend origin.
+    response.logo_url = (
+        absolute_upload_url(await resolve_public_url(row.logo_url)) if row.logo_url else None
+    )
     response.live_url = live_url(row)
     response.published_count = FAQRepository(db).count_published(organization_id)
     response.plan_allowed = help_center_allowed(db, organization_id)

--- a/backend/app/templates/help_center/base.html
+++ b/backend/app/templates/help_center/base.html
@@ -253,8 +253,11 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
       .hc-help-card { display: none; }
       /* While searching, get the whole browse-topics column out of the way so
          the results (and the Ask-AI card) sit right under the search box,
-         instead of on a "second page" below every category. */
+         instead of on a "second page" below every category. Also tighten the
+         hero/body padding so results sit close to the search box. */
       body.hc-searching .hc-aside { display: none; }
+      body.hc-searching .hc-hero { padding-bottom: 8px; }
+      body.hc-searching .hc-body { padding-top: 8px; }
       .hc-cta { padding: 30px; }
       .hc-article-card { padding: 24px 20px; }
       .hc-related-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
Two small fixes.

## Admin preview logo 404
The admin runs on `app.chattermate.chat`, whose nginx has a `\.(png|jpg|…)$` location that serves any image path as a static frontend asset. So the admin's host-relative `/api/v1/uploads/<logo>.png` never reaches the backend → 404 (the public site already dodged this via the absolute api-origin URL in #195). Fix: emit an absolute `absolute_upload_url` for the admin too. The backend serves the file fine (logs show 200); this just points the admin at the right origin.

## Tighten mobile search gap
Now that the topic grid hides on search, ~40px of hero+body padding sat between the search box and the first result. Reduce it in the `hc-searching` state (~16px).

Backend + template only; no rebuild.