### PR TITLE
feat(help-center): grouped desktop layout, larger short answers, custom-domain DNS fix

### DIFF
--- a/backend/app/services/domain_verification.py
+++ b/backend/app/services/domain_verification.py
@@ -23,6 +23,7 @@ host dispatcher will ever serve the domain. SSL turns active once an HTTPS
 probe against /healthz succeeds with a valid certificate.
 """
 
+import os
 import secrets
 from datetime import datetime, timezone
 
@@ -39,6 +40,16 @@ logger = get_logger(__name__)
 DNS_LIFETIME_SECONDS = 5.0
 SSL_PROBE_TIMEOUT_SECONDS = 10.0
 TXT_RECORD_PREFIX = "_chattermate"
+# Public resolvers for verification lookups. The container's own resolver is
+# Docker's embedded DNS (127.0.0.11) for service discovery — it negatively
+# caches names that didn't exist when first queried (so a TXT added *after* the
+# customer set up the domain keeps returning NXDOMAIN). Query public DNS
+# directly, and let self-hosters override if their network blocks these.
+_PUBLIC_DNS_RESOLVERS = [
+    ip.strip()
+    for ip in os.getenv("DOMAIN_VERIFY_DNS_RESOLVERS", "1.1.1.1,8.8.8.8,9.9.9.9").split(",")
+    if ip.strip()
+]
 
 
 def generate_verification_token() -> str:
@@ -57,6 +68,8 @@ def _resolver():
     import dns.resolver
 
     resolver = dns.resolver.Resolver()
+    if _PUBLIC_DNS_RESOLVERS:
+        resolver.nameservers = _PUBLIC_DNS_RESOLVERS
     resolver.lifetime = DNS_LIFETIME_SECONDS
     return resolver
 

--- a/backend/app/templates/help_center/base.html
+++ b/backend/app/templates/help_center/base.html
@@ -251,10 +251,25 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
       .hc-main { min-width: 0; }
       .hc-aside-label { margin-bottom: 10px; }
 
-      /* Topics as a compact 2-column grid: scannable, and — unlike a nowrap row —
-         it can't blow out the page width and force horizontal scrolling. */
-      .hc-topics { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-      .hc-topic { width: auto; min-width: 0; padding: 10px 11px; gap: 9px; }
+      /* Topics: a compact 3-row band that scrolls left/right. Fixed-width
+         auto-columns + overflow-x keep the scroll contained to this strip (the
+         page never scrolls sideways), so it stays short instead of a tall grid. */
+      .hc-topics {
+        display: grid;
+        grid-auto-flow: column;
+        grid-template-rows: repeat(3, auto);
+        grid-auto-columns: 46%;
+        gap: 8px;
+        overflow-x: auto;
+        overscroll-behavior-x: contain;
+        scroll-snap-type: x proximity;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        padding: 0 2px 4px;
+        margin: 0 -2px;
+      }
+      .hc-topics::-webkit-scrollbar { display: none; }
+      .hc-topic { width: auto; min-width: 0; padding: 10px 11px; gap: 9px; scroll-snap-align: start; }
       .hc-topic-icon { width: 26px; height: 26px; }
       .hc-topic-name { font-size: 13.5px; }
 

--- a/backend/app/templates/help_center/base.html
+++ b/backend/app/templates/help_center/base.html
@@ -147,6 +147,12 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
     .hc-read { font-size: 12px; color: #b4b9c4; white-space: nowrap; }
     .hc-chev { color: #8a90a0; display: flex; }
 
+    /* ---------- grouped browse: every category with its own articles ---------- */
+    .hc-groups { display: flex; flex-direction: column; gap: 30px; }
+    .hc-group { scroll-margin-top: 90px; }
+    .hc-group-head { margin-bottom: 14px; }
+    .hc-group-head h2 { font-size: 19px; }
+
     .hc-empty { text-align: center; padding: 56px 20px; background: #fff; border: 1px solid #ececf2; border-radius: 18px; }
     .hc-empty-icon { width: 52px; height: 52px; margin: 0 auto 18px; border-radius: 14px; background: #f5f6f9; border: 1px solid #ececf2; display: flex; align-items: center; justify-content: center; color: #9aa0ad; }
     .hc-empty h3 { font-family: var(--display); font-weight: 600; font-size: 19px; margin: 0 0 8px; }
@@ -163,6 +169,9 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
 
     /* rendered Markdown body */
     .hc-article-body { font-size: 15.5px; color: #3a4152; line-height: 1.72; }
+    /* A short, single-paragraph answer reads larger so it doesn't look lost in
+       the card's whitespace. */
+    .hc-article-body > p:only-child { font-size: 18px; line-height: 1.6; color: #2a3040; }
     .hc-article-body > :first-child { margin-top: 0; }
     .hc-article-body > :last-child { margin-bottom: 0; }
     .hc-article-body p { margin: 0 0 16px; }

--- a/backend/app/templates/help_center/index.html
+++ b/backend/app/templates/help_center/index.html
@@ -113,35 +113,55 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
       </div>
       {% endif %}
 
-      <div class="hc-head" id="hc-head"{% if not groups %} hidden{% endif %}>
-        <div class="hc-head-icon" id="hc-head-icon" style="--ic: {{ colors[first_cat] if first_cat else '#6d5bd0' }};">
-          <svg viewBox="0 0 24 24" width="19" height="19" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path></svg>
+      <!-- Search-results header (shown only while a query is active). -->
+      <div class="hc-head" id="hc-head" hidden>
+        <div class="hc-head-icon" id="hc-head-icon" style="--ic: #6d5bd0;">
+          <svg viewBox="0 0 24 24" width="19" height="19" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
         </div>
         <div style="min-width:0;">
-          <h2 id="hc-head-title">{{ first_cat }}</h2>
-          <div class="hc-head-sub" id="hc-head-sub">{% if groups %}{{ groups[0][1] | length }} {{ 'article' if groups[0][1] | length == 1 else 'articles' }}{% endif %}</div>
+          <h2 id="hc-head-title">Search results</h2>
+          <div class="hc-head-sub" id="hc-head-sub"></div>
         </div>
       </div>
 
-      <div class="hc-list" id="hc-list">
+      <!-- Flat, relevance-ranked results — cards move here while searching. -->
+      <div class="hc-list" id="hc-search-results" hidden></div>
+
+      <!-- Browse view: every category with its own articles (Option B). On
+           desktop all sections show and the sidebar jump-scrolls to them; on
+           mobile the topic grid filters to one section at a time. -->
+      <div class="hc-groups" id="hc-groups">
         {% for category, faqs in groups %}
-          {% for faq in faqs %}
-          <a class="hc-card" href="/a/{{ faq.slug }}" data-category="{{ category }}"
-             data-title="{{ faq.search_title }}" data-search="{{ faq.search_text }}"
-             style="--ic: {{ colors[category] }};">
-            <span class="hc-card-main">
-              <span class="hc-tag">{{ category }}</span>
-              <span class="hc-qtext">{{ faq.question }}</span>
-              <span class="hc-preview">{{ faq.preview }}</span>
-            </span>
-            <span class="hc-card-meta">
-              <span class="hc-read">{{ faq.read_time }}</span>
-              <span class="hc-chev">
-                <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"></path></svg>
+        <section class="hc-group" id="cat-{{ loop.index0 }}" data-category="{{ category }}" style="--ic: {{ colors[category] }};">
+          <div class="hc-head hc-group-head">
+            <div class="hc-head-icon">
+              <svg viewBox="0 0 24 24" width="19" height="19" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path></svg>
+            </div>
+            <div style="min-width:0;">
+              <h2>{{ category }}</h2>
+              <div class="hc-head-sub">{{ faqs | length }} {{ 'article' if faqs | length == 1 else 'articles' }}</div>
+            </div>
+          </div>
+          <div class="hc-list">
+            {% for faq in faqs %}
+            <a class="hc-card" href="/a/{{ faq.slug }}" data-category="{{ category }}"
+               data-title="{{ faq.search_title }}" data-search="{{ faq.search_text }}"
+               style="--ic: {{ colors[category] }};">
+              <span class="hc-card-main">
+                <span class="hc-tag">{{ category }}</span>
+                <span class="hc-qtext">{{ faq.question }}</span>
+                <span class="hc-preview">{{ faq.preview }}</span>
               </span>
-            </span>
-          </a>
-          {% endfor %}
+              <span class="hc-card-meta">
+                <span class="hc-read">{{ faq.read_time }}</span>
+                <span class="hc-chev">
+                  <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"></path></svg>
+                </span>
+              </span>
+            </a>
+            {% endfor %}
+          </div>
+        </section>
         {% endfor %}
       </div>
 
@@ -170,20 +190,22 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
     var input = document.getElementById('hc-search');
     var clearBtn = document.getElementById('hc-clear');
     var topics = [].slice.call(document.querySelectorAll('.hc-topic'));
+    var groupsWrap = document.getElementById('hc-groups');
+    var groups = [].slice.call(document.querySelectorAll('.hc-group'));
     var cards = [].slice.call(document.querySelectorAll('.hc-card'));
-    var list = document.getElementById('hc-list');
-    // Search reorders cards by relevance; browsing restores document order.
-    var originalOrder = cards.slice();
+    // Remember each card's home group + document order so search (which moves
+    // matched cards into a flat ranked list) can put them back on clear.
+    cards.forEach(function (c, i) { c._home = c.parentNode; c._idx = i; });
+    var results = document.getElementById('hc-search-results');
     var head = document.getElementById('hc-head');
-    var headIcon = document.getElementById('hc-head-icon');
     var headTitle = document.getElementById('hc-head-title');
     var headSub = document.getElementById('hc-head-sub');
     var empty = document.getElementById('hc-empty');
     var emptyTitle = document.getElementById('hc-empty-title');
     var aiWrap = document.getElementById('hc-ai-wrap');
+    var mq = window.matchMedia('(max-width: 860px)');
     var activeCat = topics.length ? topics[0].getAttribute('data-category') : null;
 
-    function articles(n) { return n + ' ' + (n === 1 ? 'article' : 'articles'); }
     function resetAi() {
       if (!aiWrap) return;
       aiWrap.hidden = true;
@@ -192,30 +214,53 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
       var b = document.getElementById('hc-ask-btn'); if (b) b.hidden = false;
     }
 
-    function restoreOrder() {
-      originalOrder.forEach(function (card) { list.appendChild(card); });
+    function sectionFor(cat) {
+      return groups.filter(function (g) { return g.getAttribute('data-category') === cat; })[0];
     }
 
-    // ----- browse a single category -----
-    function browse(cat) {
-      activeCat = cat;
-      restoreOrder();
-      var count = 0;
-      cards.forEach(function (card) {
-        var show = card.getAttribute('data-category') === cat;
-        card.hidden = !show;
-        if (show) count++;
+    // Return every card to its home group in original document order.
+    function restoreCards() {
+      cards.slice().sort(function (a, b) { return a._idx - b._idx; }).forEach(function (c) {
+        c.hidden = false;
+        if (c.parentNode !== c._home) c._home.appendChild(c);
       });
-      var t = topics.filter(function (x) { return x.getAttribute('data-category') === cat; })[0];
-      topics.forEach(function (x) { x.classList.toggle('active', x === t); });
-      if (t && head) {
-        head.hidden = false;
-        headIcon.style.setProperty('--ic', t.getAttribute('data-color'));
-        headTitle.textContent = cat;
-        headSub.textContent = articles(count);
-      }
-      if (empty) empty.hidden = true;
+    }
+
+    // Desktop shows every category section; mobile shows one at a time.
+    function applyGroupVisibility() {
+      groups.forEach(function (g) {
+        g.hidden = mq.matches && g.getAttribute('data-category') !== activeCat;
+      });
+    }
+
+    function markActive() {
+      topics.forEach(function (x) { x.classList.toggle('active', x.getAttribute('data-category') === activeCat); });
+    }
+
+    // ----- browse: grouped category sections -----
+    function showBrowse() {
+      document.body.classList.remove('hc-searching');
+      restoreCards();
+      if (results) results.hidden = true;
+      if (head) head.hidden = true;
+      if (empty) empty.hidden = !!groups.length;
+      if (groupsWrap) groupsWrap.hidden = false;
+      markActive();
+      applyGroupVisibility();
       resetAi();
+    }
+
+    // Pick a category: mobile filters to its section, desktop scrolls to it.
+    function selectCategory(cat) {
+      if (input) input.value = '';
+      activeCat = cat;
+      showBrowse();
+      if (mq.matches) {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      } else {
+        var sec = sectionFor(cat);
+        if (sec) sec.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
     }
 
     // ----- search across all categories -----
@@ -256,11 +301,10 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
 
     function search(raw) {
       var q = (raw || '').trim().toLowerCase();
-      clearBtn.style.display = q ? 'block' : 'none';
-      // Drives the mobile rule that hides the browse-topics column while a
-      // search is active, so results surface directly under the search box.
+      if (clearBtn) clearBtn.style.display = q ? 'block' : 'none';
       document.body.classList.toggle('hc-searching', !!q);
-      if (!q) { if (activeCat) browse(activeCat); return; }
+      if (!q) { showBrowse(); return; }
+      if (groupsWrap) groupsWrap.hidden = true;
       topics.forEach(function (x) { x.classList.remove('active'); });
       var terms = q.split(/\s+/);
       var matches = [];
@@ -272,17 +316,17 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
         if (score) matches.push({ card: card, score: score });
       });
       matches.sort(function (a, b) { return b.score - a.score; });
-      matches.forEach(function (m) { list.appendChild(m.card); });
+      matches.forEach(function (m) { results.appendChild(m.card); });
+      if (results) results.hidden = false;
       var count = matches.length;
       if (head) {
         head.hidden = false;
-        headIcon.style.setProperty('--ic', topics.length ? topics[0].getAttribute('data-color') : 'var(--brand)');
         headTitle.textContent = 'Search results';
         headSub.textContent = count + (count === 1 ? ' answer' : ' answers') + ' for “' + raw.trim() + '”';
       }
       if (empty) {
         empty.hidden = count > 0;
-        emptyTitle.textContent = 'No results for “' + raw.trim() + '”';
+        if (emptyTitle) emptyTitle.textContent = 'No results for “' + raw.trim() + '”';
       }
       if (aiWrap) {
         resetAi();
@@ -299,16 +343,23 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
     if (input) {
       input.addEventListener('input', function () { search(input.value); });
       if (input.value) search(input.value);
-      else if (wantTopic && topics.some(function (t) { return t.getAttribute('data-category') === wantTopic; })) browse(wantTopic);
-      else if (activeCat) browse(activeCat);
+      else if (wantTopic && topics.some(function (t) { return t.getAttribute('data-category') === wantTopic; })) selectCategory(wantTopic);
+      else showBrowse();
+    } else {
+      showBrowse();
     }
     if (clearBtn) clearBtn.addEventListener('click', function () { input.value = ''; input.focus(); search(''); });
 
     topics.forEach(function (t) {
-      t.addEventListener('click', function () { input.value = ''; search(''); browse(t.getAttribute('data-category')); });
+      t.addEventListener('click', function () { selectCategory(t.getAttribute('data-category')); });
     });
     [].slice.call(document.querySelectorAll('[data-jump]')).forEach(function (chip) {
-      chip.addEventListener('click', function () { input.value = ''; search(''); browse(chip.getAttribute('data-jump')); window.scrollTo({ top: 0, behavior: 'smooth' }); });
+      chip.addEventListener('click', function () { selectCategory(chip.getAttribute('data-jump')); });
+    });
+
+    // Re-apply per-breakpoint group visibility when crossing 860px (not searching).
+    mq.addEventListener('change', function () {
+      if (!document.body.classList.contains('hc-searching')) applyGroupVisibility();
     });
   })();
   </script>

--- a/backend/app/templates/help_center/index.html
+++ b/backend/app/templates/help_center/index.html
@@ -361,6 +361,27 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
     mq.addEventListener('change', function () {
       if (!document.body.classList.contains('hc-searching')) applyGroupVisibility();
     });
+
+    // Desktop scroll-spy: highlight the category whose section is at the top of
+    // the viewport as you scroll through the grouped list.
+    var spyScheduled = false;
+    function syncActiveToScroll() {
+      spyScheduled = false;
+      if (mq.matches || document.body.classList.contains('hc-searching')) return;
+      var current = null;
+      for (var i = 0; i < groups.length; i++) {
+        if (groups[i].getBoundingClientRect().top - 100 <= 0) current = groups[i];
+        else break;
+      }
+      if (!current) current = groups[0];
+      if (current) {
+        var cat = current.getAttribute('data-category');
+        if (cat !== activeCat) { activeCat = cat; markActive(); }
+      }
+    }
+    window.addEventListener('scroll', function () {
+      if (!spyScheduled) { spyScheduled = true; window.requestAnimationFrame(syncActiveToScroll); }
+    }, { passive: true });
   })();
   </script>
 


### PR DESCRIPTION
Three help-center changes.

## Desktop layout (Option B)
Article list now renders **every category as its own section** so the main column is as tall as the sidebar — no empty space beside the lower categories. Desktop shows all sections (sidebar jump-scrolls); mobile still filters to one section (short scroll preserved); search moves matches into a flat ranked list and hides the grouped view; clearing restores. Render- + browser-tested (desktop all-groups, mobile filter, search, clear-restore).

## Short answers
A short single-paragraph answer renders larger (18px) so it doesn't look lost in the card whitespace.

## Custom-domain verification (fix)
Verification resolved TXT/CNAME through the container's Docker DNS (127.0.0.11), which **negatively caches** names that didn't exist when first queried — so a TXT added *after* domain setup kept returning NXDOMAIN ('Waiting' forever) even though public resolvers saw it. Now queries public DNS (1.1.1.1/8.8.8.8/9.9.9.9, overridable via `DOMAIN_VERIFY_DNS_RESOLVERS`). Confirmed on prod: `127.0.0.11`→NXDOMAIN, `1.1.1.1`→the record.

Note: the approved 'Was this helpful?' storage is a separate follow-up (migration + admin UI).