### PR TITLE
fix(help-center): footer org logo + SSL probe via public DNS

### DIFF
--- a/backend/app/services/domain_verification.py
+++ b/backend/app/services/domain_verification.py
@@ -131,6 +131,7 @@ def probe_ssl(domain: str) -> bool:
         return False
     try:
         ctx = ssl.create_default_context()
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_2
         with socket.create_connection((ip, 443), timeout=SSL_PROBE_TIMEOUT_SECONDS) as sock:
             with ctx.wrap_socket(sock, server_hostname=domain) as tls:
                 tls.sendall(

--- a/backend/app/services/domain_verification.py
+++ b/backend/app/services/domain_verification.py
@@ -27,7 +27,6 @@ import os
 import secrets
 from datetime import datetime, timezone
 
-import httpx
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
@@ -116,14 +115,30 @@ def check_cname_record(domain: str) -> bool:
 
 
 def probe_ssl(domain: str) -> bool:
-    """HTTPS reachability with certificate validation — flips ssl_status to
-    ACTIVE once the cert is actually being served for this domain."""
+    """HTTPS reachability + certificate validation, resolving via PUBLIC DNS.
+    The container's own resolver (Docker embedded DNS) negatively caches a
+    custom domain that didn't exist before its cert was provisioned — so httpx
+    (which uses the system resolver) would keep failing. Resolve the A record
+    ourselves and connect to that IP with SNI = the domain, which also verifies
+    the served cert is actually issued for this domain."""
+    import socket
+    import ssl
+
     try:
-        response = httpx.get(
-            f"https://{domain}/healthz", timeout=SSL_PROBE_TIMEOUT_SECONDS, follow_redirects=False
-        )
-        return response.status_code == 200
-    except httpx.HTTPError as e:
+        ip = str(_resolver().resolve(domain, "A")[0])
+    except Exception as e:
+        logger.info(f"SSL probe DNS for {domain} not ready: {e}")
+        return False
+    try:
+        ctx = ssl.create_default_context()
+        with socket.create_connection((ip, 443), timeout=SSL_PROBE_TIMEOUT_SECONDS) as sock:
+            with ctx.wrap_socket(sock, server_hostname=domain) as tls:
+                tls.sendall(
+                    f"GET /healthz HTTP/1.1\r\nHost: {domain}\r\nConnection: close\r\n\r\n".encode()
+                )
+                status_line = tls.recv(128).split(b"\r\n", 1)[0]
+        return b" 200 " in status_line
+    except (OSError, ssl.SSLError) as e:
         logger.info(f"SSL probe for {domain} not ready: {e}")
         return False
 

--- a/backend/app/templates/help_center/base.html
+++ b/backend/app/templates/help_center/base.html
@@ -338,7 +338,11 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
   <footer class="hc-footer">
     <div class="hc-footer-in">
       <div class="hc-footer-org">
-        <span class="hc-mark"><span></span></span>
+        {% if logo_url %}
+          <img class="hc-logo" src="{{ logo_url }}" alt="{{ row.organization.name }} logo">
+        {% else %}
+          <span class="hc-mark"><span></span></span>
+        {% endif %}
         <span class="hc-name">{{ row.organization.name }}</span>
       </div>
       <a class="hc-powered" href="https://chattermate.chat" target="_blank" rel="noopener">


### PR DESCRIPTION
Two fixes.

## Footer logo
The public help-center footer always rendered the generic brand mark, even when the org uploaded a logo (the header already used it). Now the footer uses `logo_url` too, falling back to the mark.

## Custom-domain SSL stuck on 'Provisioning'
`probe_ssl` fetched `https://<domain>/healthz` via httpx, which uses the container's Docker DNS (127.0.0.11) — that **negatively caches** a custom domain that didn't exist before its cert was provisioned, so the probe kept failing and `ssl_status` never left 'pending'. Now it resolves the A record via **public DNS** and connects to that IP with **SNI = the domain** (raw ssl socket), which also validates the served cert is actually issued for the domain. Removes the now-unused `httpx` import.

Confirmed on prod: `support.chattermate.chat` serves 200 with a valid cert; the old probe failed only due to the Docker-DNS negative cache.