### PR TITLE
feat(help-center): store 'Was this helpful?' votes + admin counts

### DIFF
--- a/backend/alembic/versions/add_hc_faq_feedback_001_add_faq_feedback.py
+++ b/backend/alembic/versions/add_hc_faq_feedback_001_add_faq_feedback.py
@@ -1,0 +1,42 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Per-article "Was this helpful?" counters on faqs: helpful_yes / helpful_no.
+Votes are aggregated as counts (de-duplicated per IP/day at the API); no
+per-vote rows are stored.
+
+Revision ID: add_hc_faq_feedback_001
+Revises: add_hc_job_meter_001
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "add_hc_faq_feedback_001"
+down_revision = "add_hc_job_meter_001"
+branch_labels = None
+depends_on = None
+
+TABLE = "faqs"
+
+
+def upgrade() -> None:
+    op.add_column(TABLE, sa.Column("helpful_yes", sa.Integer(), nullable=False, server_default="0"))
+    op.add_column(TABLE, sa.Column("helpful_no", sa.Integer(), nullable=False, server_default="0"))
+
+
+def downgrade() -> None:
+    op.drop_column(TABLE, "helpful_no")
+    op.drop_column(TABLE, "helpful_yes")

--- a/backend/app/api/help_center_public.py
+++ b/backend/app/api/help_center_public.py
@@ -29,6 +29,7 @@ from app.core.config import settings
 from app.database import get_db
 from app.models.faq import FAQ
 from app.models.help_center import HelpCenterSettings
+from app.repositories.faq import FAQRepository
 from app.services.file_storage import resolve_public_url
 from app.services.help_center_images import absolute_upload_url
 from app.services.help_center_content import (
@@ -63,6 +64,10 @@ ASK_LIMIT_PER_DAY = 100
 
 class AskRequest(BaseModel):
     question: str = Field(min_length=3, max_length=MAX_QUESTION_CHARS)
+
+
+class FeedbackRequest(BaseModel):
+    helpful: bool
 
 
 def _client_ip(request: Request) -> str:
@@ -239,6 +244,23 @@ async def ask(payload: AskRequest, request: Request, db: Session = Depends(get_d
     if not answer:
         raise HTTPException(status_code=503, detail="Could not answer right now — please try again.")
     return {"answer": answer}
+
+
+@public_app.post("/a/{slug}/feedback")
+async def article_feedback(
+    slug: str, payload: FeedbackRequest, request: Request, db: Session = Depends(get_db)
+):
+    """Record a 'Was this helpful?' vote. One vote per article per IP per day
+    (deduped via the rate limiter; fail-open, idempotent — a repeat vote is a
+    silent no-op rather than an error)."""
+    row = _resolve_or_404(request, db)
+    faq = get_published_article(db, row, slug)
+    if not faq:
+        raise HTTPException(status_code=404, detail="Article not found")
+    ip = _client_ip(request)
+    if allow_request(f"faqfb:{faq.id}:{ip}", 1, 86400):
+        FAQRepository(db).record_feedback(faq.id, payload.helpful)
+    return {"ok": True}
 
 
 @public_app.get("/sitemap.xml")

--- a/backend/app/models/faq.py
+++ b/backend/app/models/faq.py
@@ -71,6 +71,9 @@ class FAQ(Base):
     )
     created_by = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
     sort_order = Column(Integer, nullable=False, default=0)
+    # "Was this helpful?" tallies (de-duplicated per IP/day at the API).
+    helpful_yes = Column(Integer, nullable=False, default=0, server_default="0")
+    helpful_no = Column(Integer, nullable=False, default=0, server_default="0")
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/app/models/schemas/faq.py
+++ b/backend/app/models/schemas/faq.py
@@ -82,6 +82,8 @@ class FAQResponse(BaseModel):
     status: FAQStatus
     knowledge_id: Optional[int] = None
     source_label: Optional[str] = None
+    helpful_yes: int = 0
+    helpful_no: int = 0
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
 

--- a/backend/app/repositories/faq.py
+++ b/backend/app/repositories/faq.py
@@ -173,6 +173,14 @@ class FAQRepository:
         self.db.delete(faq)
         self.db.commit()
 
+    def record_feedback(self, faq_id: UUID, helpful: bool) -> None:
+        """Atomically bump the 'Was this helpful?' tally for an article."""
+        column = FAQ.helpful_yes if helpful else FAQ.helpful_no
+        self.db.query(FAQ).filter(FAQ.id == faq_id).update(
+            {column: column + 1}, synchronize_session=False
+        )
+        self.db.commit()
+
     def bulk_set_status(
         self, organization_id: UUID, faq_ids: List[UUID], status: FAQStatus
     ) -> int:

--- a/backend/app/templates/help_center/article.html
+++ b/backend/app/templates/help_center/article.html
@@ -108,16 +108,24 @@ every other value stays autoescaped.
 {% block page_scripts %}
   <script>
   (function () {
-    // per-article feedback (client-only acknowledgement)
+    // per-article "Was this helpful?" — records the vote, then acknowledges.
     var fb = document.querySelector('[data-feedback]');
     if (!fb) return;
+    var voted = false;
     fb.addEventListener('click', function (e) {
       var btn = e.target.closest('[data-vote]');
-      if (!btn) return;
+      if (!btn || voted) return;
+      voted = true;
+      var helpful = btn.getAttribute('data-vote') === 'yes';
       fb.querySelectorAll('.hc-vote').forEach(function (v) { v.classList.remove('on-yes', 'on-no'); });
-      btn.classList.add(btn.getAttribute('data-vote') === 'yes' ? 'on-yes' : 'on-no');
+      btn.classList.add(helpful ? 'on-yes' : 'on-no');
       var thanks = fb.querySelector('.hc-thanks');
       if (thanks) thanks.hidden = false;
+      fetch(location.pathname + '/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ helpful: helpful })
+      }).catch(function () {});   // best-effort; the UI already acknowledged
     });
   })();
   </script>

--- a/backend/tests/api/test_help_center_public.py
+++ b/backend/tests/api/test_help_center_public.py
@@ -209,3 +209,22 @@ def test_resolve_help_center_via_verified_domain(db, test_organization, help_cen
     help_center.txt_record_verified = False
     db.commit()
     assert resolve_help_center(db, "help.customer.com") is None
+
+
+def test_article_feedback_records_and_dedupes(client, db, test_organization, help_center):
+    faq = _publish_faq(db, test_organization.id)
+    faq.slug = "how-do-i-sign-up"
+    db.commit()
+    r = client.post(f"/a/{faq.slug}/feedback", json={"helpful": True}, headers={"host": HOST})
+    assert r.status_code == 200 and r.json() == {"ok": True}
+    db.refresh(faq)
+    assert (faq.helpful_yes, faq.helpful_no) == (1, 0)
+    # Same client (IP) can't vote again — deduped, tallies unchanged.
+    client.post(f"/a/{faq.slug}/feedback", json={"helpful": False}, headers={"host": HOST})
+    db.refresh(faq)
+    assert (faq.helpful_yes, faq.helpful_no) == (1, 0)
+
+
+def test_article_feedback_unknown_slug_404(client, db, test_organization, help_center):
+    r = client.post("/a/does-not-exist/feedback", json={"helpful": True}, headers={"host": HOST})
+    assert r.status_code == 404

--- a/frontend/src/components/faq/FaqCard.vue
+++ b/frontend/src/components/faq/FaqCard.vue
@@ -105,6 +105,20 @@ function answerPreview(md: string): string {
         <div class="faq-card__source">
           <span class="faq-card__source-dot"></span>
           {{ sourceLabel() }}
+          <span
+            v-if="(faq.helpful_yes || 0) + (faq.helpful_no || 0) > 0"
+            class="faq-card__fb"
+            :title="`${faq.helpful_yes || 0} found this helpful, ${faq.helpful_no || 0} did not`"
+          >
+            <span class="faq-card__fb-item faq-card__fb-item--up">
+              <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M7 11v9H4a1 1 0 0 1-1-1v-7a1 1 0 0 1 1-1z" /><path d="M7 11l4-8a2 2 0 0 1 3 1.8V9h4.5a2 2 0 0 1 2 2.4l-1.4 7A2 2 0 0 1 17 20H7" /></svg>
+              {{ faq.helpful_yes || 0 }}
+            </span>
+            <span class="faq-card__fb-item faq-card__fb-item--down">
+              <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M17 13V4h3a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1z" /><path d="M17 13l-4 8a2 2 0 0 1-3-1.8V15H5.5a2 2 0 0 1-2-2.4l1.4-7A2 2 0 0 1 7 4h10" /></svg>
+              {{ faq.helpful_no || 0 }}
+            </span>
+          </span>
         </div>
       </div>
       <div class="faq-card__controls">
@@ -212,6 +226,29 @@ function answerPreview(md: string): string {
   height: 5px;
   border-radius: 50%;
   background: var(--faint);
+}
+
+.faq-card__fb {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding-left: 9px;
+  margin-left: 2px;
+  border-left: 1px solid var(--o10);
+}
+
+.faq-card__fb-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.faq-card__fb-item--up {
+  color: var(--c-teal, #1d9e75);
+}
+
+.faq-card__fb-item--down {
+  color: var(--c-coral, #d85a30);
 }
 
 .faq-card__controls {

--- a/frontend/src/types/faq.ts
+++ b/frontend/src/types/faq.ts
@@ -25,6 +25,8 @@ export interface FaqItem {
   status: FaqStatus
   knowledge_id: number | null
   source_label: string | null
+  helpful_yes?: number
+  helpful_no?: number
   created_at?: string | null
   updated_at?: string | null
 }


### PR DESCRIPTION
The article feedback buttons were client-only (nothing persisted). Now they're wired end to end.

## Backend
- Migration `add_hc_faq_feedback_001` adds `helpful_yes`/`helpful_no` counters to `faqs`.
- `FAQRepository.record_feedback(faq_id, helpful)` — atomic increment.
- Public `POST /a/{slug}/feedback` (`{helpful: bool}`) records a vote, **deduped one-per-article-per-IP per day** via the existing rate limiter (fail-open, idempotent — a repeat vote is a silent no-op).
- `FAQResponse` exposes the two counts.

## Public site
- The article's Yes/No buttons POST the vote (best-effort), then show the existing 'Thanks for the feedback!' acknowledgement. One vote per page view.

## Admin
- The FAQ card shows a 👍/👎 tally next to the source label when an article has votes.

## Verified
Migration applies on the dev DB; endpoint records the vote and dedupes a second same-IP vote (live test + 2 unit tests); `npm run type-check` clean. Migration auto-runs on deploy via start.sh.