### PR TITLE
fix(help-center): emit FAQPage instead of QAPage on article pages

### DIFF
--- a/backend/app/api/help_center_public.py
+++ b/backend/app/api/help_center_public.py
@@ -108,22 +108,33 @@ async def _chrome_context(row: HelpCenterSettings) -> dict:
     }
 
 
-def _faq_json_ld(groups) -> dict:
-    """schema.org FAQPage structured data (Google FAQ rich results). Uses the
-    plain-text form of the (Markdown) answer."""
+def _question_entity(faq: FAQ) -> dict:
+    """One schema.org Question + acceptedAnswer, from the plain-text form of the
+    (Markdown) answer."""
+    return {
+        "@type": "Question",
+        "name": faq.question,
+        "acceptedAnswer": {"@type": "Answer", "text": to_plain_text(faq.answer)},
+    }
+
+
+def _faq_page_json_ld(faqs) -> dict:
+    """schema.org FAQPage structured data (Google FAQ rich results).
+
+    FAQPage - not QAPage - is the correct type for these owner-authored answers.
+    QAPage models community/forum pages where users submit competing answers and
+    requires answerCount/upvoteCount, which don't apply here.
+    """
     return {
         "@context": "https://schema.org",
         "@type": "FAQPage",
-        "mainEntity": [
-            {
-                "@type": "Question",
-                "name": faq.question,
-                "acceptedAnswer": {"@type": "Answer", "text": to_plain_text(faq.answer)},
-            }
-            for _category, faqs in groups
-            for faq in faqs
-        ],
+        "mainEntity": [_question_entity(faq) for faq in faqs],
     }
+
+
+def _faq_json_ld(groups) -> dict:
+    """FAQPage structured data for the index page's grouped-by-category FAQs."""
+    return _faq_page_json_ld(faq for _category, faqs in groups for faq in faqs)
 
 
 def _card_view(faq: FAQ) -> dict:
@@ -204,15 +215,7 @@ async def article(slug: str, request: Request, db: Session = Depends(get_db)):
         "related": related,
     }
     canonical = f"{live_url(row)}/a/{faq.slug}"
-    json_ld = {
-        "@context": "https://schema.org",
-        "@type": "QAPage",
-        "mainEntity": {
-            "@type": "Question",
-            "name": faq.question,
-            "acceptedAnswer": {"@type": "Answer", "text": to_plain_text(faq.answer)},
-        },
-    }
+    json_ld = _faq_page_json_ld([faq])
     context = {
         **await _chrome_context(row),
         "request": request,

--- a/backend/tests/api/test_help_center_public.py
+++ b/backend/tests/api/test_help_center_public.py
@@ -18,6 +18,8 @@ escaping and JSON-LD, plan/enabled gating (404s), Ask AI guards, host
 dispatch routing.
 """
 
+import json
+import re
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -125,6 +127,32 @@ def test_article_page_renders_sanitized_markdown(client, db, test_organization, 
     # the guard is on the injected payload, not the <script> tag in general.
     assert "<strong>Settings</strong>" in r.text
     assert "alert(1)" not in r.text
+
+
+def test_article_page_emits_faqpage_json_ld(client, db, test_organization, help_center):
+    """Owner-authored articles must be FAQPage, not QAPage. QAPage is for
+    community Q&A and requires answerCount, which Search Console flags as an
+    error on these pages."""
+    faq = _publish_faq(db, test_organization.id, answer="Click **Settings**.")
+    faq.slug = "how-do-i-sign-up"
+    db.commit()
+    r = client.get(f"/a/{faq.slug}", headers={"host": HOST})
+    assert r.status_code == 200
+
+    blocks = re.findall(
+        r'<script type="application/ld\+json">(.*?)</script>', r.text, re.DOTALL
+    )
+    assert blocks, "article page emitted no JSON-LD"
+    data = json.loads(blocks[0])
+    assert data["@type"] == "FAQPage"
+    # mainEntity must be a list — FAQPage models one-or-more Questions.
+    assert isinstance(data["mainEntity"], list)
+    question = data["mainEntity"][0]
+    assert question["@type"] == "Question"
+    assert question["name"] == "How do I sign up?"
+    # Answer text is plain text, with the Markdown stripped.
+    assert question["acceptedAnswer"]["text"] == "Click Settings ."
+    assert "QAPage" not in r.text
 
 
 def test_search_filters_results(client, db, test_organization, help_center):


### PR DESCRIPTION
## Summary
Search Console (Enhancements → Q&A) reported **4 invalid items, 1 critical**: `Missing field "answerCount" (in "mainEntity")` on help-center article pages, e.g. `support.chattermate.chat/a/what-does-the-free-forever-tier-include`.

The article handler emitted `@type: "QAPage"`. **Google explicitly names our exact case as an invalid use of QAPage**: *"An FAQ page written by the site itself with no way for users to submit alternative answers."* QAPage models community/forum pages where users submit competing answers, which is why it requires `answerCount`. Our help articles are owner-authored (one question, one answer from us), so `FAQPage` is the correct type — it needs only `name` + `acceptedAnswer.text`, both already present.

The index page already emitted FAQPage correctly via `_faq_json_ld()`; only the article page was wrong.

## Search impact (researched — worth reading before merge)
- **This clears the 4 GSC errors.** That's the concrete win. Structured-data errors don't directly affect rankings, so they weren't costing traffic.
- **No Google rich result either way.** Google fully dropped FAQ rich results on **2026-05-07**, removed FAQPage from Search Console reporting + the Rich Results Test in June 2026, and drops API support in Aug 2026. FAQPage will never render a snippet.
- **We are not giving up a QAPage rich result** — we were never eligible for one. Q&A rich results are still live, but only for genuine user-answerable pages. Keeping QAPage and adding `answerCount`/`author`/`upvoteCount`/`datePublished` would mean knowingly violating a named guideline; misuse risks a manual action where Google ignores our structured data entirely.
- **Still worth doing beyond Google:** valid FAQPage markup is consumed by Bing and by LLM/AI answer engines, which is the more relevant channel here.

Net: this is about **valid markup + clean GSC + removing a guideline violation**, not a traffic win. Merging on correctness grounds.

## Changes
- `article()` now emits FAQPage with `mainEntity` as a list.
- Extracted `_question_entity()` / `_faq_page_json_ld()` so the index and article pages build the same Question shape from one place, instead of duplicating the dict literal.
- Added `test_article_page_emits_faqpage_json_ld` — the existing FAQPage assertion only covered `/`, which is how this shipped unnoticed.

Resulting markup:
```json
{"@context":"https://schema.org","@type":"FAQPage",
 "mainEntity":[{"@type":"Question","name":"…","acceptedAnswer":{"@type":"Answer","text":"…"}}]}
```

## Test plan
- [x] `pytest -k "help_center or faq"` → 93 passed
- [x] New test verified to **fail** against the old QAPage code and pass after the fix (confirmed it's a real regression guard)
- [x] `pyflakes` clean on both changed files
- [ ] CI green
- [ ] After deploy, verify JSON-LD with **`validator.schema.org`** or by viewing source on an `/a/…` URL — **not** Google's Rich Results Test, which no longer supports FAQPage (it will report nothing found; that is expected, not a failure).
- [ ] The 4 items drop off the GSC **Q&A** report after re-crawl (no "validate fix" button for Q&A; URL-Inspect → Request indexing to speed it up).