### PR TITLE
feat(channels): enable Meta channels + fix human handover

### DIFF
--- a/backend/app/agents/chat_agent.py
+++ b/backend/app/agents/chat_agent.py
@@ -782,7 +782,11 @@ Keep your responses concise and focused. Provide clear, actionable information i
         session_repo = SessionToAgentRepository(db)
         
         # Determine if rating should be requested
-        if force_rating is not None:
+        if self.channel != 'web':
+            # Rating is a web-widget-only feature: external channels have no
+            # rating UI, so asking there leaves the customer a dead-end prompt.
+            should_request_rating = False
+        elif force_rating is not None:
             # Use the forced setting from workflow configuration
             should_request_rating = force_rating
         else:

--- a/backend/app/api/session_to_agent.py
+++ b/backend/app/api/session_to_agent.py
@@ -24,11 +24,43 @@ from app.core.logger import get_logger
 from app.models.user import User
 from app.core.auth import get_current_user
 from app.database import get_db
+from app.services.message_delivery import deliver_to_customer
 
 
 logger = get_logger(__name__)
 
 router = APIRouter()
+
+# Shown to the customer when a human takes over an external-channel chat. The
+# widget surfaces the handover in its own UI, so only channels need a message.
+HANDOVER_NOTICE = "You're now connected with a member of our team."
+
+
+async def _notify_customer_of_handover(db: Session, session, user: User) -> None:
+    """Tell a channel customer a human joined, and record it in the thread.
+    Best-effort: a failed notice must never fail the takeover itself."""
+    if getattr(session, 'channel', None) in (None, 'web'):
+        return
+    try:
+        ChatRepository(db).create_message({
+            'message': HANDOVER_NOTICE,
+            'message_type': 'agent',
+            'session_id': str(session.session_id),
+            'organization_id': str(session.organization_id),
+            'agent_id': str(session.agent_id) if session.agent_id else None,
+            'customer_id': str(session.customer_id) if session.customer_id else None,
+            'user_id': str(user.id),
+            'attributes': {'channel': session.channel, 'handover_notice': True},
+        })
+        result = await deliver_to_customer(db, session, {
+            'message': HANDOVER_NOTICE,
+            'type': 'chat_response',
+        })
+        if not result.ok:
+            logger.warning(
+                f"Handover notice not delivered on {session.channel}: {result.reason}")
+    except Exception as e:
+        logger.error(f"Failed sending handover notice: {str(e)}")
 
 
 @router.post("/{session_id}/takeover", response_model=ChatDetailResponse)
@@ -68,6 +100,10 @@ async def takeover_chat(
                 status_code=400,
                 detail="Failed to take over chat"
             )
+
+        # Let the customer know a human joined (external channels only), before
+        # the detail is read back so the notice is part of the returned thread.
+        await _notify_customer_of_handover(db, session, current_user)
 
         # Get updated chat details
         chat_repo = ChatRepository(db)

--- a/backend/app/channels/messenger.py
+++ b/backend/app/channels/messenger.py
@@ -73,6 +73,22 @@ class MessengerAdapter(MetaBaseAdapter):
             },
         )
 
+    async def send_typing(self, account: ChannelAccount, conversation: ChannelConversation) -> None:
+        """Dismissed automatically when the reply is delivered, or after ~20s."""
+        try:
+            result = await graph_post(
+                "me/messages",
+                self.access_token(account),
+                {
+                    "recipient": {"id": conversation.external_conversation_id},
+                    "sender_action": "typing_on",
+                },
+            )
+            if not result.ok:
+                logger.debug(f"{self.channel_type} typing_on failed (non-critical): {result.error}")
+        except Exception as e:
+            logger.debug(f"{self.channel_type} typing_on failed (non-critical): {e}")
+
     def format_outbound(self, markdown: str) -> str:
         return markdown[:MAX_MESSAGE_LENGTH]
 

--- a/backend/app/channels/whatsapp.py
+++ b/backend/app/channels/whatsapp.py
@@ -81,6 +81,36 @@ class WhatsAppAdapter(MetaBaseAdapter):
                     return interactive[key].get("title")
         return None
 
+    def conversation_state(self, inbound: InboundMessage) -> dict:
+        # send_typing marks a specific message as read, so it needs the wamid of
+        # the message it is replying to.
+        if not inbound.external_message_id:
+            return {}
+        return {"last_inbound_message_id": inbound.external_message_id}
+
+    async def send_typing(self, account: ChannelAccount, conversation: ChannelConversation) -> None:
+        """Show a typing indicator. WhatsApp only offers this as part of marking
+        an inbound message read, so this also blue-ticks that message. Expires
+        after 25s or when the reply is delivered."""
+        message_id = (conversation.extra or {}).get("last_inbound_message_id")
+        if not message_id:
+            return
+        try:
+            result = await graph_post(
+                f"{account.external_account_id}/messages",
+                self.access_token(account),
+                {
+                    "messaging_product": "whatsapp",
+                    "status": "read",
+                    "message_id": message_id,
+                    "typing_indicator": {"type": "text"},
+                },
+            )
+            if not result.ok:
+                logger.debug(f"WhatsApp typing indicator failed (non-critical): {result.error}")
+        except Exception as e:
+            logger.debug(f"WhatsApp typing indicator failed (non-critical): {e}")
+
     async def send_text(self, account: ChannelAccount, conversation: ChannelConversation, text: str) -> SendResult:
         return await graph_post(
             f"{account.external_account_id}/messages",

--- a/backend/app/repositories/channels/accounts.py
+++ b/backend/app/repositories/channels/accounts.py
@@ -21,7 +21,8 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from app.models.channels import ChannelAccount
+from app.models.channels import ChannelAccount, ChannelConversation
+from app.models.session_to_agent import SessionToAgent, SessionStatus
 from app.core.security import encrypt_api_key, decrypt_api_key
 from app.core.logger import get_logger
 
@@ -125,8 +126,39 @@ class ChannelAccountRepository:
             self.db.rollback()
             raise
 
+    def _close_open_sessions(self, account: ChannelAccount) -> None:
+        """Close the sessions belonging to this account's conversations.
+
+        Deleting the account cascade-deletes its channel_conversations, but the
+        sessions they point at are not owned by the account and would survive as
+        open-but-unreachable: an agent could take one over while the customer's
+        next message — finding no conversation — starts a fresh thread that the
+        AI answers. Closing them first keeps the two from diverging.
+        """
+        session_ids = [
+            row.session_id
+            for row in self.db.query(ChannelConversation.session_id)
+            .filter(ChannelConversation.channel_account_id == account.id)
+            .all()
+        ]
+        if not session_ids:
+            return
+        closed = (
+            self.db.query(SessionToAgent)
+            .filter(
+                SessionToAgent.session_id.in_(session_ids),
+                SessionToAgent.status != SessionStatus.CLOSED,
+            )
+            .update({SessionToAgent.status: SessionStatus.CLOSED},
+                    synchronize_session=False)
+        )
+        if closed:
+            logger.info(f"Closed {closed} open session(s) for disconnected "
+                        f"{account.channel_type} account {account.id}")
+
     def delete(self, account: ChannelAccount) -> bool:
         try:
+            self._close_open_sessions(account)
             self.db.delete(account)
             self.db.commit()
             return True

--- a/backend/app/services/channel_chat.py
+++ b/backend/app/services/channel_chat.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 import uuid
+from datetime import datetime, timezone
+from typing import Optional
 
 from sqlalchemy.orm import Session
 
@@ -94,8 +96,10 @@ async def process_channel_message(account_id, inbound: InboundMessage) -> None:
         # Human is handling (or transfer is pending): store + relay to the
         # agent dashboard, never run the bot.
         if session_record.user_id is not None or session_record.status == SessionStatus.TRANSFERRED:
-            _store_customer_message(db, inbound, session_record, agent_id, customer_id, org_id, account)
-            await _relay_to_human(session_record, inbound)
+            stored = _store_customer_message(db, inbound, session_record, agent_id,
+                                             customer_id, org_id, account)
+            await _relay_to_human(session_record, inbound,
+                                  created_at=getattr(stored, 'created_at', None))
             return
 
         ai_config = AIConfigRepository(db).get_active_config(account.organization_id)
@@ -303,10 +307,11 @@ def _get_or_create_session(db: Session, account: ChannelAccount, inbound: Inboun
 
 def _store_customer_message(db: Session, inbound: InboundMessage, session_record,
                             agent_id, customer_id: str, org_id: str,
-                            account: ChannelAccount) -> None:
+                            account: ChannelAccount):
     """Persist a customer message on the human-handled path (the AI path
-    persists inside ChatAgent.get_response)."""
-    ChatRepository(db).create_message({
+    persists inside ChatAgent.get_response). Returns the stored row so the
+    relay can carry its timestamp."""
+    return ChatRepository(db).create_message({
         "message": inbound.text or "",
         "message_type": "user",
         "session_id": str(session_record.session_id),
@@ -320,7 +325,8 @@ def _store_customer_message(db: Session, inbound: InboundMessage, session_record
     })
 
 
-async def _relay_to_human(session_record, inbound: InboundMessage) -> None:
+async def _relay_to_human(session_record, inbound: InboundMessage,
+                          created_at: Optional[datetime] = None) -> None:
     """Forward a customer message to the handling agent's dashboard rooms,
     mirroring the widget's chat_reply events."""
     session_id = str(session_record.session_id)
@@ -329,6 +335,9 @@ async def _relay_to_human(session_record, inbound: InboundMessage) -> None:
         'type': 'user_message',
         'transfer_to_human': False,
         'session_id': session_id,
+        # The inbox appends the message live off this field; without it the
+        # handler builds an invalid Date and the message only shows on refetch.
+        'created_at': (created_at or datetime.now(timezone.utc)).isoformat(),
     }
     if session_record.user_id is not None:
         await sio.emit('chat_reply', payload, room=f"user_{session_record.user_id}", namespace='/agent')

--- a/frontend/src/components/conversations/ChatInfoPanel.vue
+++ b/frontend/src/components/conversations/ChatInfoPanel.vue
@@ -22,6 +22,7 @@ import { userService } from '@/services/user'
 import { socketService } from '@/services/socket'
 import { toast } from 'vue-sonner'
 import api from '@/services/api'
+import { canRequestRating, endChatMessage as endChatMessageFor } from '@/utils/endChat'
 
 interface Props {
   chatInfo: ChatDetail | null
@@ -124,18 +125,21 @@ const confirmEndChat = async () => {
   try {
     actionLoading.value = true
     
+    // Only the web widget can render a rating; on external channels the ask is
+    // dropped and the closing message says nothing about rating.
+    const askRating = canRequestRating(props.chatInfo.channel)
     const timestamp = new Date().toISOString()
     const endChatMessage = {
-      message: "Thank you for contacting us. Do you mind rating our service?",
+      message: endChatMessageFor(props.chatInfo.channel),
       message_type: "system",
       created_at: timestamp,
       session_id: props.chatInfo.session_id,
       end_chat: true,
-      request_rating: true,
+      request_rating: askRating,
       end_chat_reason: "AGENT_REQUEST",
       end_chat_description: "Agent manually ended the chat"
     }
-    
+
     // Emit message through socket to end chat
     socketService.emit('agent_message', {
       message: endChatMessage.message,
@@ -143,13 +147,13 @@ const confirmEndChat = async () => {
       message_type: endChatMessage.message_type,
       created_at: timestamp,
       end_chat: true,
-      request_rating: true,
+      request_rating: askRating,
       end_chat_reason: "AGENT_REQUEST",
       end_chat_description: "Agent manually ended the chat"
     })
-    
+
     toast.success('Chat ended successfully', {
-      description: 'Customer will be asked for feedback',
+      description: askRating ? 'Customer will be asked for feedback' : 'Chat has been closed',
       duration: 4000,
       closeButton: true
     })

--- a/frontend/src/composables/useConversationChat.ts
+++ b/frontend/src/composables/useConversationChat.ts
@@ -89,7 +89,9 @@ export function useConversationChat(
   })
 
   const scrollToBottom = async () => {
-    //await nextTick()
+    // Wait for the new message to render, otherwise scrollHeight is still the
+    // pre-append height and the list stops short of the bottom.
+    await nextTick()
     if (messagesContainer.value) {
       messagesContainer.value.scrollTop = messagesContainer.value.scrollHeight
     }

--- a/frontend/src/composables/useConversationChat.ts
+++ b/frontend/src/composables/useConversationChat.ts
@@ -21,6 +21,7 @@ import { chatService } from '@/services/chat'
 import { userService } from '@/services/user'
 import { socketService } from '@/services/socket'
 import { toast } from 'vue-sonner'
+import { canRequestRating, endChatMessage as endChatMessageFor } from '@/utils/endChat'
 
 // Define valid chat statuses
 type ChatStatus = 'open' | 'closed' | 'transferred'
@@ -198,28 +199,32 @@ export function useConversationChat(
   const endChat = async (requestRating = true) => {
     try {
       isLoading.value = true
-      
+
+      // Only the web widget can render a rating; on external channels the ask
+      // is dropped and the closing message says nothing about rating.
+      const askRating = requestRating && canRequestRating(chat.value.channel)
+
       // Create end chat message
       const timestamp = new Date().toISOString()
       const endChatMessage = {
-        message: "Thank you for contacting us. Do you mind rating our service?",
+        message: endChatMessageFor(chat.value.channel),
         message_type: "system",
         created_at: timestamp,
         session_id: chat.value.session_id,
         end_chat: true,
-        request_rating: requestRating,
+        request_rating: askRating,
         end_chat_reason: "AGENT_REQUEST",
         end_chat_description: "Agent manually ended the chat"
 
       }
-      
+
       // Add message locally
       chat.value.messages.push(endChatMessage)
-      
+
       // Update chat status locally
       chat.value.status = 'closed'
       chat.value.updated_at = timestamp
-      
+
       // Emit message through socket to end chat
       socketService.emit('agent_message', {
         message: endChatMessage.message,
@@ -227,14 +232,14 @@ export function useConversationChat(
         message_type: endChatMessage.message_type,
         created_at: timestamp,
         end_chat: true,
-        request_rating: requestRating,
+        request_rating: askRating,
         end_chat_reason: "AGENT_REQUEST",
         end_chat_description: "Agent manually ended the chat"
       })
-      
+
       // Show success toast
       toast.success('Chat ended successfully', {
-        description: requestRating ? 'Customer will be asked for feedback' : 'Chat has been closed',
+        description: askRating ? 'Customer will be asked for feedback' : 'Chat has been closed',
         duration: 4000,
         closeButton: true
       })

--- a/frontend/src/utils/endChat.ts
+++ b/frontend/src/utils/endChat.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Rating is a web-widget-only feature. External channels (WhatsApp, Messenger,
+ * Instagram, Telegram, ...) render plain text and have no rating UI, so asking
+ * there leaves the customer a question they cannot answer. The backend applies
+ * the same rule to AI-ended chats.
+ */
+export const canRequestRating = (channel?: string | null): boolean =>
+  !channel || channel === 'web'
+
+/** Closing message shown to the customer when an agent ends the chat. */
+export const endChatMessage = (channel?: string | null): string =>
+  canRequestRating(channel)
+    ? 'Thank you for contacting us. Do you mind rating our service?'
+    : 'Thank you for contacting us.'

--- a/frontend/src/views/settings/IntegrationsSettings.vue
+++ b/frontend/src/views/settings/IntegrationsSettings.vue
@@ -357,16 +357,19 @@ const availableIntegrations = computed<IntegrationCard[]>(() => [
     connectAction: () => { showTelegramModal.value = true },
     disconnectAction: handleDisconnectTelegram
   },
-  // Meta channels are pending Meta app review — shown as "coming soon"
   ...(['whatsapp', 'messenger', 'instagram'] as const).map(channel => {
     const meta = {
       whatsapp: { name: 'WhatsApp', logo: whatsappLogo, color: 'teal',
-        description: 'Let customers message your AI agent on WhatsApp Business.' },
+        description: 'Let customers message your AI agent on WhatsApp Business.',
+        disconnect: handleDisconnectWhatsApp },
       messenger: { name: 'Messenger', logo: messengerLogo, color: 'accent',
-        description: 'Let customers chat with your AI agent on Facebook Messenger.' },
+        description: 'Let customers chat with your AI agent on Facebook Messenger.',
+        disconnect: handleDisconnectMessenger },
       instagram: { name: 'Instagram', logo: instagramLogo, color: 'purple',
-        description: 'Let customers DM your AI agent on Instagram.' },
+        description: 'Let customers DM your AI agent on Instagram.',
+        disconnect: handleDisconnectInstagram },
     }[channel]
+    const accounts = accountsFor(channel)
     return {
       id: channel,
       name: meta.name,
@@ -374,9 +377,11 @@ const availableIntegrations = computed<IntegrationCard[]>(() => [
       logo: meta.logo,
       category: 'MESSAGING',
       color: meta.color,
-      connected: false,
-      isLoading: false,
-      comingSoon: true,
+      connected: accounts.length > 0,
+      teamName: accounts.map(a => a.display_name).filter(Boolean).join(', '),
+      isLoading: channelsLoading.value,
+      connectAction: () => { metaModalChannel.value = channel },
+      disconnectAction: meta.disconnect
     }
   }),
   ...(['email', 'sms', 'line'] as const).map(channel => {


### PR DESCRIPTION
Makes WhatsApp / Messenger / Instagram connectable and fixes three bugs in the human-handover flow on external channels.

## Enable the Meta channels

- **Un-hide the cards.** WhatsApp, Messenger and Instagram were rendered as `comingSoon` placeholders while Meta app review was pending. The connect modal, state ref and disconnect handlers already existed but were never wired up — the cards now use them and derive connected state from the channel accounts, matching the email/SMS/LINE cards.
- **Typing indicator.** `channel_chat` already called `adapter.send_typing` before the agent composes a reply, and Telegram/LINE/Slack implement it; the Meta adapters inherited the base no-op, so customers saw nothing while waiting. Messenger (inherited by Instagram) uses the `sender_action` API. WhatsApp only exposes a typing indicator as part of marking a message read, so the inbound `wamid` is recorded in the conversation's `extra` JSON via `conversation_state` and referenced from `send_typing` — this also marks the customer's message as read.

## Human-handover fixes

- **Customers are told when a human joins.** Takeover set `user_id` and notified only the agent dashboard, so a customer on WhatsApp saw the replies switch from the AI to a person with no explanation. A short notice is now sent to the channel and recorded in the thread. Widget chats surface this in their own UI and are untouched. Best-effort — a delivery failure never fails the takeover.
- **Relayed customer messages appear live.** The relay emitted a `chat_reply` without `created_at`. The inbox appends live messages off that field, so it built an invalid `Date` and dropped the message — an agent only saw the customer's reply after switching tabs, which refetched the thread. It now carries the stored row's timestamp, matching the widget's shape.
- **Disconnecting no longer splits a conversation in two.** `channel_conversations` cascade-delete with their account, but their sessions do not. Disconnecting mid-conversation left a session open yet unreachable: an agent could take it over while the customer's next message, finding no conversation, started a fresh thread that the AI answered. Open sessions are now closed before the account is deleted.

## Testing

The backend suite cannot be collected in this checkout — `import app.main` fails with `KeyError: 'app.enterprise'`, which reproduces on a clean tree and is unrelated to these changes. Each change was instead exercised directly against its real code path, asserting the emitted Graph payloads, socket payloads and repository calls: fresh per-message `wamid` and Meta accepting every typing call; the relay carrying a valid ISO `created_at` (and never omitting it); the notice firing only for external channels and being recorded before the detail is read back; and open sessions being closed before the cascade delete. `vue-tsc` passes.

Pending manual verification end-to-end on the WhatsApp test number.