### PR TITLE
docs(infra): certbot renewal is one-shot cron-driven, not a loop

### DIFF
--- a/HELP_CENTER_INFRA.md
+++ b/HELP_CENTER_INFRA.md
@@ -54,12 +54,45 @@ docker run --rm \
   --non-interactive --agree-tos -m <ops-email>
 ```
 
-**Auto-renewal:** the compose `certbot` service (in
-`docker-compose.hostinger.yml`) runs `certbot renew` on a loop. It uses the
-`certbot/dns-route53` image and mounts `/home/chattermate/.aws:/root/.aws:ro`,
-so the wildcard renews unattended (the renewal conf remembers
-`authenticator = dns-route53`). Existing HTTP-01 webroot certs still renew —
-the dns-route53 image is a superset of `certbot/certbot`.
+**Auto-renewal:** a daily cron runs the compose `certbot` service as a
+**one-shot**, then reloads nginx only if a cert actually changed:
+```bash
+docker compose -f docker-compose.hostinger.yml \
+  run --rm --entrypoint certbot certbot \
+  renew --quiet --deploy-hook "echo reload-needed > /var/www/certbot/.reload"
+# ...then, if the flag file appeared: rm it && docker compose exec -T nginx nginx -s reload
+```
+It uses the `certbot/dns-route53` image and mounts
+`/home/chattermate/.aws:/root/.aws:ro`, so the wildcard renews unattended (the
+renewal conf remembers `authenticator = dns-route53`). Existing HTTP-01 webroot
+certs still renew — the dns-route53 image is a superset of `certbot/certbot`.
+`renew` covers every cert in the shared `certbot/conf`, not just the wildcard.
+
+> **The `certbot` service must stay one-shot — never give it a long-running
+> loop entrypoint.** It previously used
+> `sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait ${!}; done;'`,
+> which broke renewal in two non-obvious ways:
+>
+> 1. **`compose run` inherits the entrypoint.** The "one-off" cron run never
+>    exited, so `--rm` never fired (a container leaked *every night*) and the
+>    cron's chained `&& nginx -s reload` never ran at all.
+> 2. **`sh -c '<script>' <args>` silently discards the args** (they land in
+>    `$0`/`$1`…, which the script ignores). So it renewed *without* the
+>    `--deploy-hook`, every 12h — beating the daily cron to the renewal. The
+>    cron's own `renew` then found nothing due, so the hook never fired.
+>
+> Net effect: certs renewed on disk while **nginx kept serving the old ones**,
+> masked only by deploys happening to restart nginx. Left alone that expires a
+> live cert. The service is therefore declared with no `entrypoint:` (the
+> image's default is `certbot`) and `profiles: ["tools"]`, so `compose up -d`
+> never starts it while `compose run` still works (it auto-enables the profile).
+>
+> Regression check — the command must **exit** and leave nothing behind:
+> ```bash
+> timeout 60 docker compose -f docker-compose.hostinger.yml \
+>   run --rm --entrypoint certbot certbot renew --quiet   # ~3s, rc=0
+> docker ps -a --filter name=certbot   # must be empty
+> ```
 
 ### Host nginx server block
 Lives at `~/chattermate/nginx/conf.d/help-center.conf` (mounted read-only into
@@ -133,6 +166,9 @@ whole VPS.
 3. `docker exec chattermate-backend-1 printenv HELP_CENTER_BASE_DOMAIN` → `help.chattermate.chat` (and the backend is `healthy`, not crash-looping on `HELP_CENTER_TARGET_IPS`).
 4. API unaffected: `https://app.chattermate.chat` / `https://api.chattermate.chat/api/v1/...` still route normally.
 5. `POST /ask` from the page returns an answer and appears in `help_center_queries`.
+6. `docker ps -a --filter name=certbot` → **empty**. `compose up -d` must not start a
+   certbot container; one that sticks around means the long-running loop entrypoint is
+   back (see the renewal note in §1) and nginx will stop reloading onto renewed certs.
 
 ## 4. Enterprise (cloud) rollout prerequisite
 


### PR DESCRIPTION
## Summary
`HELP_CENTER_INFRA.md` claimed the compose `certbot` service *"runs `certbot renew` on a loop"*. That design was removed from prod on 2026-07-16 because the loop **broke renewal**, so the runbook documented something that no longer exists — and that must not come back.

Docs-only. No code, no config, no secrets.

## What the loop actually broke
The old entrypoint was `sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait ${!}; done;'`. It failed in two non-obvious ways:

1. **`compose run` inherits the entrypoint.** The cron's "one-off" run never exited → `--rm` never fired (a container leaked *every night*; 23 had accumulated) and the cron's chained `&& nginx -s reload` never ran.
2. **`sh -c '<script>' <args>` silently discards the args** (they land in `$0`/`$1`…, which the script ignores). So it renewed **without** the `--deploy-hook`, every 12h — beating the daily cron to the renewal. The cron's own `renew` then found nothing due, so the hook never fired either.

**Net effect: certs renewed on disk while nginx kept serving the old ones**, masked only by deploys happening to restart nginx. Left alone, that expires a live cert.

The fix (already applied to prod): no `entrypoint:` (the image default is `certbot`) + `profiles: ["tools"]`, so `compose up -d` never starts it while `compose run` still works. This matches the pattern coachiq's `issue-ssl.sh` already used correctly.

## Changes
- Rewrote the **Auto-renewal** note: the real cron command, and a callout explaining why the service must stay one-shot.
- Added a regression check to the §3 post-deploy checklist: `docker ps -a --filter name=certbot` must be **empty**.

## Verification
Every claim in the new text was checked against live prod, not written from memory:

| Claim | Result |
|---|---|
| no `entrypoint:` on the certbot service | OK |
| `profiles: ["tools"]` present | OK |
| cron uses `--entrypoint certbot` | OK |
| cron has `--deploy-hook` + `nginx -s reload` | OK |
| no certbot container running | OK (empty) |
| `dns-route53` image + `.aws` mount still accurate | OK |

Also verified on prod: the documented command exits in ~3s with rc=0 leaving no container (it used to hang forever), `compose up -d` no longer creates a certbot container and is idempotent, and TLS stays valid on api/app/support/coachiq.

## Note
The prod compose file (`docker-compose.hostinger.yml`) deliberately stays **out of this repo** — it's host-specific and documents topology we don't publish. This PR captures the reasoning so the trap isn't reintroduced.