### PR TITLE
fix(channels): make Messenger connectable, and stop End Chat promising a rating it won't ask for

### DIFF
--- a/backend/app/api/channels/meta.py
+++ b/backend/app/api/channels/meta.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 from app.api.channels.accounts import get_org_account_or_404, to_account_out
 from app.channels import get_adapter
 from app.channels.meta_base import (
+    debug_token,
     exchange_signup_code,
     fetch_message_templates,
     graph_get,
@@ -70,6 +71,20 @@ def _whatsapp_display_name(profile: dict, phone_number_id: str) -> str:
     """How a connected number is labelled in the UI, from its Graph profile."""
     return (f"{profile.get('verified_name', 'WhatsApp')} "
             f"({profile.get('display_phone_number', phone_number_id)})")
+
+
+async def _page_name(page_id: str, access_token: str) -> str:
+    """The Page's name for the UI label, falling back to its id.
+
+    Reading it needs pages_read_engagement, which messaging does not require —
+    so a token without it still connects and simply shows the id.
+    """
+    ok, data = await graph_get(page_id, access_token, params={"fields": "name"})
+    if not ok or not data.get("name"):
+        logger.info(f"No name for page {page_id} (pages_read_engagement not granted); "
+                    f"labelling with the id")
+        return page_id
+    return data["name"]
 
 
 async def _verify_signup_assets(waba_id: str, phone_number_id: str, access_token: str) -> dict:
@@ -323,16 +338,30 @@ async def connect_messenger(
     db: Session = Depends(get_db),
 ):
     """Connect a Facebook Page for Messenger with a page access token."""
-    ok, data = await graph_get("me", request.page_access_token, params={"fields": "id,name"})
-    if not ok or str(data.get("id")) != request.page_id:
-        raise HTTPException(status_code=400,
-                            detail="Could not verify page token (token invalid or not for this page)")
+    # Inspect the token rather than reading the Page node: `me?fields=id,name`
+    # needs pages_read_engagement, which a messaging token has no reason to
+    # carry — it would reject a token that sends perfectly well.
+    ok, info = await debug_token(request.page_access_token)
+    if not ok or not info.get("is_valid"):
+        raise HTTPException(status_code=400, detail=_graph_detail(
+            info, "That token is not valid — generate a fresh Page access token"))
+    if info.get("type") != "PAGE":
+        raise HTTPException(status_code=400, detail=(
+            f"That is a {str(info.get('type', 'user')).lower()} access token, not a Page "
+            f"access token. In the Meta app dashboard go to Messenger → Settings and "
+            f"click Generate on the row for your Page."))
+    if str(info.get("profile_id")) != request.page_id:
+        raise HTTPException(status_code=400, detail=(
+            f"That token is for Page {info.get('profile_id')}, not the Page ID you "
+            f"entered. Webhooks are routed by Page ID, so the two must match."))
 
+    display_name = request.display_name or await _page_name(
+        request.page_id, request.page_access_token)
     account = _upsert_account(
         db, organization, ChannelType.MESSENGER.value,
         external_account_id=request.page_id,
         credentials={"access_token": request.page_access_token},
-        display_name=request.display_name or data.get("name", request.page_id),
+        display_name=display_name,
     )
     if not await subscribe_app(request.page_id, request.page_access_token,
                                subscribed_fields="messages,messaging_postbacks"):

--- a/backend/app/channels/meta_base.py
+++ b/backend/app/channels/meta_base.py
@@ -147,6 +147,27 @@ async def graph_post_json(path: str, access_token: str, payload: dict) -> tuple[
     return await _graph_request("POST", path, access_token, json_body=payload)
 
 
+async def debug_token(input_token: str) -> tuple[bool, dict]:
+    """Inspect a token: what it is, who it belongs to, and whether it is ours.
+
+    Returns Meta's `data` object, which for a Page token carries
+    `type: "PAGE"`, `profile_id` (the page id), `app_id`, `is_valid` and the
+    granted `scopes`.
+
+    This authenticates with app credentials rather than the token being
+    inspected, so it needs no permission on the asset. Reading the Page node
+    directly (`me?fields=id,name`) would instead demand `pages_read_engagement`
+    — unrelated to messaging, and absent from a token that can nonetheless send
+    perfectly well.
+    """
+    app_token = f"{settings.META_APP_ID}|{settings.META_APP_SECRET}"
+    ok, data = await _graph_request("GET", "debug_token", app_token,
+                                    params={"input_token": input_token})
+    if not ok:
+        return False, data
+    return True, data.get("data", {})
+
+
 async def exchange_signup_code(code: str) -> tuple[bool, dict]:
     """Trade an Embedded Signup code for the customer's business access token.
 

--- a/backend/tests/api/test_meta_channels_api.py
+++ b/backend/tests/api/test_meta_channels_api.py
@@ -156,12 +156,63 @@ class TestMetaConnect:
                 "phone_number_id": "PN9", "access_token": "bad"})
         assert r.status_code == 400
 
+    def test_connect_messenger_success(self, client, db):
+        # A real messaging token carries pages_messaging but not
+        # pages_read_engagement, so the page name is unreadable — that must not
+        # block the connect, only the label.
+        inspect = AsyncMock(return_value=(True, {
+            "type": "PAGE", "profile_id": "PAGE9", "is_valid": True,
+            "scopes": ["pages_messaging"]}))
+        name = AsyncMock(return_value=(False, {"error": {"message": "needs pages_read_engagement"}}))
+        with patch("app.api.channels.meta.debug_token", inspect), \
+             patch("app.api.channels.meta.graph_get", name), \
+             patch("app.api.channels.meta.subscribe_app", AsyncMock(return_value=True)):
+            r = client.post(f"{BASE}/messenger", json={
+                "page_id": "PAGE9", "page_access_token": "EAAG-x"})
+        assert r.status_code == 200
+        assert r.json()["display_name"] == "PAGE9"
+        account = ChannelAccountRepository(db).get_by_external_id("messenger", "PAGE9")
+        assert ChannelAccountRepository(db).get_credentials(account)["access_token"] == "EAAG-x"
+
+    def test_connect_messenger_uses_page_name_when_readable(self, client):
+        inspect = AsyncMock(return_value=(True, {
+            "type": "PAGE", "profile_id": "PAGE9", "is_valid": True}))
+        with patch("app.api.channels.meta.debug_token", inspect), \
+             patch("app.api.channels.meta.graph_get", AsyncMock(return_value=(True, {"name": "Acme Support"}))), \
+             patch("app.api.channels.meta.subscribe_app", AsyncMock(return_value=True)):
+            r = client.post(f"{BASE}/messenger", json={
+                "page_id": "PAGE9", "page_access_token": "EAAG-x"})
+        assert r.status_code == 200
+        assert r.json()["display_name"] == "Acme Support"
+
     def test_connect_messenger_token_page_mismatch(self, client):
-        graph = AsyncMock(return_value=(True, {"id": "OTHER_PAGE", "name": "Nope"}))
-        with patch("app.api.channels.meta.graph_get", graph):
+        # Webhooks route on page id; a token for a different page would leave
+        # every inbound message unmatched.
+        inspect = AsyncMock(return_value=(True, {
+            "type": "PAGE", "profile_id": "OTHER_PAGE", "is_valid": True}))
+        with patch("app.api.channels.meta.debug_token", inspect):
             r = client.post(f"{BASE}/messenger", json={
                 "page_id": "PAGE9", "page_access_token": "EAAG-x"})
         assert r.status_code == 400
+        assert "OTHER_PAGE" in r.json()["detail"]
+
+    def test_connect_messenger_rejects_a_user_token(self, client):
+        inspect = AsyncMock(return_value=(True, {
+            "type": "USER", "profile_id": "PAGE9", "is_valid": True}))
+        with patch("app.api.channels.meta.debug_token", inspect):
+            r = client.post(f"{BASE}/messenger", json={
+                "page_id": "PAGE9", "page_access_token": "EAAG-x"})
+        assert r.status_code == 400
+        assert "Page access token" in r.json()["detail"]
+
+    def test_connect_messenger_rejects_an_expired_token(self, client):
+        inspect = AsyncMock(return_value=(True, {
+            "is_valid": False, "error": {"message": "Session has expired"}}))
+        with patch("app.api.channels.meta.debug_token", inspect):
+            r = client.post(f"{BASE}/messenger", json={
+                "page_id": "PAGE9", "page_access_token": "EAAG-x"})
+        assert r.status_code == 400
+        assert "Session has expired" in r.json()["detail"]
 
     def test_connect_instagram_success(self, client, db):
         graph = AsyncMock(return_value=(True, {"id": "IG7", "username": "acme"}))

--- a/frontend/src/components/conversations/ChatInfoPanel.vue
+++ b/frontend/src/components/conversations/ChatInfoPanel.vue
@@ -51,6 +51,10 @@ const loadingUsers = ref(false)
 // Chat action functions
 const currentUserId = userService.getUserId()
 
+// Only the web widget can render a rating; on external channels (WhatsApp,
+// Messenger, ...) the ask is dropped, so the confirmation must not promise it.
+const askRating = computed(() => canRequestRating(props.chatInfo?.channel))
+
 const canTakeOver = computed(() => {
   if (!props.chatInfo) return false
   return (
@@ -125,9 +129,6 @@ const confirmEndChat = async () => {
   try {
     actionLoading.value = true
     
-    // Only the web widget can render a rating; on external channels the ask is
-    // dropped and the closing message says nothing about rating.
-    const askRating = canRequestRating(props.chatInfo.channel)
     const timestamp = new Date().toISOString()
     const endChatMessage = {
       message: endChatMessageFor(props.chatInfo.channel),
@@ -135,7 +136,7 @@ const confirmEndChat = async () => {
       created_at: timestamp,
       session_id: props.chatInfo.session_id,
       end_chat: true,
-      request_rating: askRating,
+      request_rating: askRating.value,
       end_chat_reason: "AGENT_REQUEST",
       end_chat_description: "Agent manually ended the chat"
     }
@@ -147,13 +148,13 @@ const confirmEndChat = async () => {
       message_type: endChatMessage.message_type,
       created_at: timestamp,
       end_chat: true,
-      request_rating: askRating,
+      request_rating: askRating.value,
       end_chat_reason: "AGENT_REQUEST",
       end_chat_description: "Agent manually ended the chat"
     })
 
     toast.success('Chat ended successfully', {
-      description: askRating ? 'Customer will be asked for feedback' : 'Chat has been closed',
+      description: askRating.value ? 'Customer will be asked for feedback' : 'Chat has been closed',
       duration: 4000,
       closeButton: true
     })
@@ -366,11 +367,12 @@ const confirmReassign = async () => {
     <div v-if="showEndChatConfirm" class="end-chat-modal">
       <div class="end-chat-modal-content">
         <h3>End Chat</h3>
-        <p>Are you sure you want to end this chat and request customer feedback?</p>
+        <p v-if="askRating">Are you sure you want to end this chat and request customer feedback?</p>
+        <p v-else>Are you sure you want to end this chat?</p>
         <div class="end-chat-modal-actions">
           <button class="cancel-btn" @click="cancelEndChat">Cancel</button>
           <button class="confirm-btn" @click="confirmEndChat" :disabled="actionLoading">
-            {{ actionLoading ? 'Ending...' : 'End Chat & Request Rating' }}
+            {{ actionLoading ? 'Ending...' : (askRating ? 'End Chat & Request Rating' : 'End Chat') }}
           </button>
         </div>
       </div>

--- a/frontend/src/components/integrations/MetaChannelConnect.vue
+++ b/frontend/src/components/integrations/MetaChannelConnect.vue
@@ -337,7 +337,9 @@ const saveAgent = async () => {
 }
 
 .meta-intro-link {
-  color: var(--accent-solid);
+  /* --accent-ink, not --accent-solid: the latter is the lime fill and stays
+     lime in both themes, which is unreadable as text on a light background. */
+  color: var(--accent-ink);
   text-decoration: underline;
   font-weight: 600;
 }


### PR DESCRIPTION
Three fixes found while connecting a real Facebook Page for the first time. Follows #208.

**Messenger couldn't be connected.** We validated Page tokens by reading the Page node, which needs `pages_read_engagement` — a permission messaging tokens don't carry, and one that's App-Review gated. So valid tokens were rejected as invalid. Now uses `debug_token`, which needs no permission on the asset. The page name is still fetched for the UI label, but a refusal falls back to the page id instead of blocking the connect. Error messages now say what actually went wrong.

**End Chat promised a rating it never asked for.** The dialog said "end this chat and request customer feedback?" on every channel, including Messenger and WhatsApp where there's no rating UI. Only the copy was wrong — `canRequestRating()` already gated the real behaviour. The channel check was a local const inside `confirmEndChat`, invisible to the template, which is how it drifted. Now a computed.

**Connect modal link was invisible in light theme.** It used `--accent-solid` (the lime fill) as text colour. Switched to `--accent-ink`.

Tests: the existing Messenger test would have hit the live Graph API after this change and still passed. Replaced with five that mock `debug_token`. 82 backend, 208 frontend, vue-tsc clean. Verified end-to-end against a real Page.

Messenger Embedded Signup is deliberately not here — it's a different flow, not a flag flip. Separate PR.