### PR TITLE
feat(channels): one-click Meta connect for WhatsApp, Messenger and Instagram

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -56,6 +56,10 @@ META_MESSENGER_CONFIG_ID=
 # Instagram app id/secret from the app's Instagram product, NOT the Meta ones.
 INSTAGRAM_APP_ID=
 INSTAGRAM_APP_SECRET=
+# Comma-separated emails allowed to use one-click Meta signup. Empty = everyone.
+# Set this while the Meta app is in App Review so the flow can be exercised in
+# production without offering customers a login that would fail for them.
+SIGNUP_ALLOWED_EMAILS=
 
 VERIFY_SSL_CERTIFICATES=true
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -47,8 +47,11 @@ META_APP_ID=your_meta_app_id
 META_APP_SECRET=your_meta_app_secret
 META_WEBHOOK_VERIFY_TOKEN=any_random_string_you_choose
 META_GRAPH_VERSION=v21.0
-# Only for cloud-hosted WhatsApp Embedded Signup (enterprise); leave blank for self-hosting
+# Only for cloud-hosted one-click onboarding; leave blank for self-hosting.
+# META_CONFIG_ID: WhatsApp Embedded Signup. META_MESSENGER_CONFIG_ID: Facebook
+# Login for Business, for connecting a Page (Messenger + Instagram DM).
 META_CONFIG_ID=
+META_MESSENGER_CONFIG_ID=
 
 VERIFY_SSL_CERTIFICATES=true
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,6 +52,10 @@ META_GRAPH_VERSION=v21.0
 # Login for Business, for connecting a Page (Messenger + Instagram DM).
 META_CONFIG_ID=
 META_MESSENGER_CONFIG_ID=
+# Instagram API with Instagram Login (no Facebook Page needed). These are the
+# Instagram app id/secret from the app's Instagram product, NOT the Meta ones.
+INSTAGRAM_APP_ID=
+INSTAGRAM_APP_SECRET=
 
 VERIFY_SSL_CERTIFICATES=true
 

--- a/backend/app/api/channels/__init__.py
+++ b/backend/app/api/channels/__init__.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter
 from app.api.channels.accounts import router as accounts_router
 from app.api.channels.telegram import router as telegram_router
 from app.api.channels.meta import router as meta_router
+from app.api.channels.whatsapp_messaging import router as whatsapp_messaging_router
 from app.api.channels.slack import router as slack_router
 from app.api.channels.email import router as email_router
 from app.api.channels.sms import router as sms_router
@@ -30,6 +31,8 @@ router = APIRouter()
 router.include_router(accounts_router, tags=["channels"])
 router.include_router(telegram_router, prefix="/telegram", tags=["channels"])
 router.include_router(meta_router, prefix="/meta", tags=["channels"])
+# Same prefix: onboarding and messaging are separate modules, one URL space.
+router.include_router(whatsapp_messaging_router, prefix="/meta", tags=["channels"])
 router.include_router(slack_router, prefix="/slack", tags=["channels"])
 router.include_router(email_router, prefix="/email", tags=["channels"])
 router.include_router(sms_router, prefix="/sms", tags=["channels"])

--- a/backend/app/api/channels/meta.py
+++ b/backend/app/api/channels/meta.py
@@ -172,12 +172,34 @@ def _signup_available(channel: str) -> bool:
     return bool(_signup_config_id(channel))
 
 
-def check_signup_access(channel: str) -> None:
+def _signup_allowed_for(user: User) -> bool:
+    """Whether this account may use one-click signup.
+
+    An empty allowlist means everyone, which is the end state. While the Meta
+    app is in App Review the login only succeeds for people with a role on that
+    app, so the allowlist keeps the button off everyone it would only fail for.
+    Read at call time so the list can be changed without a code deploy.
+    """
+    allowed = {email.strip().lower()
+               for email in settings.SIGNUP_ALLOWED_EMAILS.split(",")
+               if email.strip()}
+    return not allowed or (user.email or "").strip().lower() in allowed
+
+
+def check_signup_access(channel: str, user: User) -> None:
     if not _signup_available(channel):
         raise HTTPException(
             status_code=403,
             detail="Signup is not configured on this deployment for this channel. "
                    "Connect with credentials instead.",
+        )
+    # Separate from the deployment gate so the reason is honest: the flow exists
+    # here, this account just isn't one of the ones it is open to yet.
+    if not _signup_allowed_for(user):
+        raise HTTPException(
+            status_code=403,
+            detail="One-click connect is limited to selected accounts on this "
+                   "deployment. Connect with credentials instead.",
         )
 
 
@@ -302,7 +324,10 @@ async def get_embedded_signup_config(
     never leaks on another's request."""
     if channel not in SIGNUP_CHANNELS:
         raise HTTPException(status_code=404, detail="No signup flow for this channel")
-    enabled = _signup_available(channel)
+    # Both halves of the same gate the connect endpoints enforce, so an account
+    # outside the allowlist is shown the manual form rather than a button that
+    # would 403 on click.
+    enabled = _signup_available(channel) and _signup_allowed_for(current_user)
     return EmbeddedSignupConfigOut(
         enabled=enabled,
         # Instagram Login has no configuration id, only an app id.
@@ -354,7 +379,7 @@ async def connect_whatsapp_embedded_signup(
     Only the way the credentials are obtained differs from connect_whatsapp —
     everything after that is the same upsert and webhook subscribe.
     """
-    check_signup_access(ChannelType.WHATSAPP.value)
+    check_signup_access(ChannelType.WHATSAPP.value, current_user)
 
     ok, data = await exchange_signup_code(request.code)
     access_token = data.get("access_token") if ok else None
@@ -449,7 +474,7 @@ async def list_messenger_signup_pages(
     The Page tokens are sealed into signup_token and never reach the browser;
     only the ids and names come back for the picker.
     """
-    check_signup_access(ChannelType.MESSENGER.value)
+    check_signup_access(ChannelType.MESSENGER.value, current_user)
     user_token = await _signup_user_token(request)
 
     pages = await _list_manageable_pages(user_token, "id,name,access_token")
@@ -479,7 +504,7 @@ async def connect_messenger_signup(
     equivalent of _verify_signup_assets, and matters for the same reason —
     webhooks resolve accounts by external id with no org scoping.
     """
-    check_signup_access(ChannelType.MESSENGER.value)
+    check_signup_access(ChannelType.MESSENGER.value, current_user)
     pages = _open_signup_pages(request.signup_token, organization)
 
     page = next((p for p in pages if p.get("id") == request.page_id), None)
@@ -512,7 +537,7 @@ async def connect_instagram_login(
     nothing to pick. The token is an Instagram user token, used against
     graph.instagram.com rather than the Facebook graph.
     """
-    check_signup_access(ChannelType.INSTAGRAM.value)
+    check_signup_access(ChannelType.INSTAGRAM.value, current_user)
 
     ok, data = await exchange_instagram_code(request.code, request.redirect_uri)
     token_data = instagram_token_payload(data) if ok else {}

--- a/backend/app/api/channels/meta.py
+++ b/backend/app/api/channels/meta.py
@@ -239,6 +239,28 @@ async def _list_manageable_pages(user_token: str, fields: str) -> list[dict]:
     return data
 
 
+async def _signup_user_token(request: MessengerSignupRequest) -> str:
+    """Trade a Login-for-Business code for a long-lived user token.
+
+    Shared by the Messenger and Instagram flows — everything up to listing the
+    customer's Pages is identical. Page tokens inherit the user token's lifetime,
+    so it is extended first (best-effort; a failure only risks earlier expiry).
+    """
+    ok, data = await exchange_signup_code(request.code, redirect_uri=request.redirect_uri)
+    user_token = data.get("access_token") if ok else None
+    if not user_token:
+        # The code is short-lived (~10 minutes) and single-use, so a stale or
+        # replayed one lands here rather than on a Graph error later.
+        raise HTTPException(status_code=400, detail=_graph_detail(
+            data, "Could not complete signup — please try connecting again"))
+
+    ok, extended = await exchange_for_long_lived_token(user_token)
+    if ok and extended.get("access_token"):
+        return extended["access_token"]
+    logger.warning("Could not extend the signup token; page tokens may expire early")
+    return user_token
+
+
 def _graph_detail(data: dict, fallback: str) -> str:
     """Meta's own error text where it has one, so the UI can show the real
     reason (e.g. a template that cannot be deleted) rather than a generic
@@ -480,27 +502,7 @@ async def list_messenger_signup_pages(
     only the ids and names come back for the picker.
     """
     check_signup_access(ChannelType.MESSENGER.value)
-
-    # The OAuth popup bound the code to its callback URL; the exchange must send
-    # that exact value back or Graph rejects the code as a mismatch. The client
-    # used it and it is a registered Valid OAuth Redirect URI, so it is trusted
-    # only as far as Meta's own redirect-match check allows.
-    ok, data = await exchange_signup_code(request.code, redirect_uri=request.redirect_uri)
-    user_token = data.get("access_token") if ok else None
-    if not user_token:
-        # The code is short-lived (~10 minutes) and single-use, so a stale or
-        # replayed one lands here rather than on a Graph error later.
-        raise HTTPException(status_code=400, detail=_graph_detail(
-            data, "Could not complete signup — please try connecting again"))
-
-    # Page tokens inherit the user token's lifetime; extend it first so the ones
-    # we store keep working for months. Best-effort — an already-long-lived
-    # token comes back unchanged, and a failure only risks earlier expiry.
-    ok, extended = await exchange_for_long_lived_token(user_token)
-    if ok and extended.get("access_token"):
-        user_token = extended["access_token"]
-    else:
-        logger.warning("Could not extend the Messenger signup token; page tokens may expire early")
+    user_token = await _signup_user_token(request)
 
     pages = await _list_manageable_pages(user_token, "id,name,access_token")
     if not pages:
@@ -545,6 +547,77 @@ async def connect_messenger_signup(
     if not await subscribe_app(page["id"], page["access_token"],
                                subscribed_fields=MESSENGER_SUBSCRIBED_FIELDS):
         logger.warning(f"Page subscribe failed for {page['id']} after signup")
+    return to_account_out(db, account)
+
+
+# A Page carries its linked Instagram professional account inline, so one
+# /me/accounts call lists both the Page tokens and the IG ids to connect.
+INSTAGRAM_PAGE_FIELDS = "id,name,access_token,instagram_business_account{id,username}"
+
+
+@router.post("/instagram/signup/pages", response_model=MessengerSignupPagesOut)
+async def list_instagram_signup_pages(
+    request: MessengerSignupRequest,
+    current_user: User = Depends(require_permissions("manage_organization")),
+    organization: Organization = Depends(get_current_organization),
+):
+    """Step 1 for Instagram: same Login-for-Business popup as Messenger, but the
+    picker offers the Instagram account linked to each Page, not the Page."""
+    check_signup_access(ChannelType.INSTAGRAM.value)
+    user_token = await _signup_user_token(request)
+
+    pages = await _list_manageable_pages(user_token, INSTAGRAM_PAGE_FIELDS)
+    # Only Pages with a linked professional account can receive Instagram DMs.
+    ig_pages = [p for p in pages if p.get("instagram_business_account")]
+    if not ig_pages:
+        raise HTTPException(status_code=400, detail=(
+            "None of your Facebook Pages has an Instagram professional account "
+            "linked. Link one in the Page's settings, then connect again."))
+
+    return MessengerSignupPagesOut(
+        signup_token=_seal_signup_pages(organization.id, ig_pages),
+        pages=[MessengerPageOut(
+            id=p["id"],
+            name="@" + (p["instagram_business_account"].get("username") or p["id"]),
+        ) for p in ig_pages],
+    )
+
+
+@router.post("/instagram/signup/connect", response_model=ChannelAccountOut)
+async def connect_instagram_signup(
+    request: MessengerSignupConnectRequest,
+    current_user: User = Depends(require_permissions("manage_organization")),
+    organization: Organization = Depends(get_current_organization),
+    db: Session = Depends(get_db),
+):
+    """Step 2 for Instagram: connect the account the customer picked.
+
+    page_id selects a Page out of the list we fetched; the account stored is its
+    linked Instagram business account, keyed by that account's own id (webhooks
+    route Instagram events by it), with the Page token that sends its DMs.
+    """
+    check_signup_access(ChannelType.INSTAGRAM.value)
+    pages = _open_signup_pages(request.signup_token, organization)
+
+    page = next((p for p in pages if p.get("id") == request.page_id), None)
+    if page is None or not page.get("access_token"):
+        raise HTTPException(status_code=400, detail="That account was not part of this signup")
+
+    ig = page.get("instagram_business_account") or {}
+    ig_id = ig.get("id")
+    if not ig_id:
+        raise HTTPException(status_code=400, detail="That Page has no linked Instagram account")
+
+    account = _upsert_account(
+        db, organization, ChannelType.INSTAGRAM.value,
+        external_account_id=str(ig_id),
+        credentials={"access_token": page["access_token"]},
+        display_name=request.display_name or ("@" + (ig.get("username") or str(ig_id))),
+    )
+    # Instagram DMs are delivered through the linked Page's app subscription.
+    if not await subscribe_app(page["id"], page["access_token"],
+                               subscribed_fields=MESSENGER_SUBSCRIBED_FIELDS):
+        logger.warning(f"Page subscribe failed for {page['id']} after Instagram signup")
     return to_account_out(db, account)
 
 

--- a/backend/app/api/channels/meta.py
+++ b/backend/app/api/channels/meta.py
@@ -481,7 +481,11 @@ async def list_messenger_signup_pages(
     """
     check_signup_access(ChannelType.MESSENGER.value)
 
-    ok, data = await exchange_signup_code(request.code)
+    # The OAuth popup bound the code to its callback URL; the exchange must send
+    # that exact value back or Graph rejects the code as a mismatch. The client
+    # used it and it is a registered Valid OAuth Redirect URI, so it is trusted
+    # only as far as Meta's own redirect-match check allows.
+    ok, data = await exchange_signup_code(request.code, redirect_uri=request.redirect_uri)
     user_token = data.get("access_token") if ok else None
     if not user_token:
         # The code is short-lived (~10 minutes) and single-use, so a stale or

--- a/backend/app/api/channels/meta.py
+++ b/backend/app/api/channels/meta.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 from app.api.channels.accounts import get_org_account_or_404, to_account_out
 from app.channels import get_adapter
 from app.channels.meta_base import (
+    debug_token,
     exchange_signup_code,
     fetch_message_templates,
     graph_get,
@@ -70,6 +71,20 @@ def _whatsapp_display_name(profile: dict, phone_number_id: str) -> str:
     """How a connected number is labelled in the UI, from its Graph profile."""
     return (f"{profile.get('verified_name', 'WhatsApp')} "
             f"({profile.get('display_phone_number', phone_number_id)})")
+
+
+async def _page_name(page_id: str, access_token: str) -> str:
+    """The Page's name for the UI label, falling back to its id.
+
+    Reading it needs pages_read_engagement, which messaging does not require —
+    so a token without it still connects and simply shows the id.
+    """
+    ok, data = await graph_get(page_id, access_token, params={"fields": "name"})
+    if not ok or not data.get("name"):
+        logger.info(f"No name for page {page_id} (pages_read_engagement not granted); "
+                    f"labelling with the id")
+        return page_id
+    return data["name"]
 
 
 async def _verify_signup_assets(waba_id: str, phone_number_id: str, access_token: str) -> dict:
@@ -323,16 +338,30 @@ async def connect_messenger(
     db: Session = Depends(get_db),
 ):
     """Connect a Facebook Page for Messenger with a page access token."""
-    ok, data = await graph_get("me", request.page_access_token, params={"fields": "id,name"})
-    if not ok or str(data.get("id")) != request.page_id:
-        raise HTTPException(status_code=400,
-                            detail="Could not verify page token (token invalid or not for this page)")
+    # Inspect the token rather than reading the Page node: `me?fields=id,name`
+    # needs pages_read_engagement, which a messaging token has no reason to
+    # carry — it would reject a token that sends perfectly well.
+    ok, info = await debug_token(request.page_access_token)
+    if not ok or not info.get("is_valid"):
+        raise HTTPException(status_code=400, detail=_graph_detail(
+            info, "That token is not valid — generate a fresh Page access token"))
+    if info.get("type") != "PAGE":
+        raise HTTPException(status_code=400, detail=(
+            f"That is a {str(info.get('type', 'user')).lower()} access token, not a Page "
+            f"access token. In the Meta app dashboard go to Messenger → Settings and "
+            f"click Generate on the row for your Page."))
+    if str(info.get("profile_id")) != request.page_id:
+        raise HTTPException(status_code=400, detail=(
+            f"That token is for Page {info.get('profile_id')}, not the Page ID you "
+            f"entered. Webhooks are routed by Page ID, so the two must match."))
 
+    display_name = request.display_name or await _page_name(
+        request.page_id, request.page_access_token)
     account = _upsert_account(
         db, organization, ChannelType.MESSENGER.value,
         external_account_id=request.page_id,
         credentials={"access_token": request.page_access_token},
-        display_name=request.display_name or data.get("name", request.page_id),
+        display_name=display_name,
     )
     if not await subscribe_app(request.page_id, request.page_access_token,
                                subscribed_fields="messages,messaging_postbacks"):

--- a/backend/app/api/channels/meta.py
+++ b/backend/app/api/channels/meta.py
@@ -28,12 +28,17 @@ from app.channels import get_adapter
 from app.channels.meta_base import (
     debug_token,
     exchange_for_long_lived_token,
+    exchange_instagram_code,
+    exchange_instagram_long_lived,
     exchange_signup_code,
     fetch_message_templates,
     graph_get,
     graph_list_all,
+    instagram_token_payload,
     register_phone_number,
     subscribe_app,
+    subscribe_instagram_app,
+    GRAPH_INSTAGRAM_BASE,
 )
 from app.core.security import decrypt_api_key, encrypt_api_key
 from app.core.auth import (
@@ -58,6 +63,7 @@ from app.models.schemas.channel import (
     MessengerSignupRequest,
     MessengerPageOut,
     InstagramConnectRequest,
+    InstagramLoginRequest,
     OutboundConversationOut,
     OutboundConversationRequest,
     TemplateLibraryOut,
@@ -136,8 +142,8 @@ def _generate_verification_pin() -> str:
 
 
 # Channels that can be onboarded through a Meta login popup, each with the Meta
-# configuration that drives it. Messenger and Instagram DM both ride on a Page's
-# token, so one Facebook Login for Business configuration serves both.
+# configuration that drives it. WhatsApp and Messenger run Facebook logins;
+# Instagram runs Instagram Login, which needs no Facebook Page at all.
 SIGNUP_CHANNELS = (
     ChannelType.WHATSAPP.value,
     ChannelType.MESSENGER.value,
@@ -149,23 +155,35 @@ MESSENGER_SUBSCRIBED_FIELDS = "messages,messaging_postbacks"
 
 
 def _signup_config_id(channel: str) -> str:
-    """The Meta configuration id that onboards this channel, read at call time so
-    a settings override (tests, reloads) is always seen."""
+    """The Facebook Login-for-Business configuration that onboards this channel,
+    read at call time so a settings override (tests, reloads) is always seen.
+
+    Instagram Login has no configuration — it is gated on its own app id.
+    """
     return {
         ChannelType.WHATSAPP.value: settings.META_CONFIG_ID,
         ChannelType.MESSENGER.value: settings.META_MESSENGER_CONFIG_ID,
-        ChannelType.INSTAGRAM.value: settings.META_MESSENGER_CONFIG_ID,
     }.get(channel, "")
+
+
+def _signup_app_id(channel: str) -> str:
+    """The app the login popup authenticates against. Instagram Login uses the
+    Instagram app; the Facebook flows use the Meta app."""
+    if channel == ChannelType.INSTAGRAM.value:
+        return settings.INSTAGRAM_APP_ID
+    return settings.META_APP_ID
 
 
 def _signup_available(channel: str) -> bool:
     """Whether this deployment can offer the login flow for this channel.
 
-    Onboarding happens under *our* approved Meta app, so without a config id it
-    structurally cannot work — a self-hoster has no such app and gets the manual
+    Onboarding happens under *our* app, so without its credentials it
+    structurally cannot work — a self-hoster has none and gets the manual
     credentials form instead. That is the whole gate: like every other
     integration, signup is not restricted by plan.
     """
+    if channel == ChannelType.INSTAGRAM.value:
+        return bool(settings.INSTAGRAM_APP_ID and settings.INSTAGRAM_APP_SECRET)
     return bool(_signup_config_id(channel))
 
 
@@ -240,11 +258,11 @@ async def _list_manageable_pages(user_token: str, fields: str) -> list[dict]:
 
 
 async def _signup_user_token(request: MessengerSignupRequest) -> str:
-    """Trade a Login-for-Business code for a long-lived user token.
+    """Trade a Facebook Login-for-Business code for a long-lived user token.
 
-    Shared by the Messenger and Instagram flows — everything up to listing the
-    customer's Pages is identical. Page tokens inherit the user token's lifetime,
-    so it is extended first (best-effort; a failure only risks earlier expiry).
+    Page tokens inherit the user token's lifetime, so it is extended first
+    (best-effort; a failure only risks earlier expiry). Instagram does not come
+    through here — Instagram Login is its own OAuth against its own host.
     """
     ok, data = await exchange_signup_code(request.code, redirect_uri=request.redirect_uri)
     user_token = data.get("access_token") if ok else None
@@ -358,8 +376,9 @@ async def get_embedded_signup_config(
     enabled = _signup_available(channel)
     return EmbeddedSignupConfigOut(
         enabled=enabled,
-        config_id=_signup_config_id(channel) if enabled else None,
-        app_id=settings.META_APP_ID if enabled else None,
+        # Instagram Login has no configuration id, only an app id.
+        config_id=(_signup_config_id(channel) or None) if enabled else None,
+        app_id=_signup_app_id(channel) if enabled else None,
         graph_version=settings.META_GRAPH_VERSION,
     )
 
@@ -550,74 +569,58 @@ async def connect_messenger_signup(
     return to_account_out(db, account)
 
 
-# A Page carries its linked Instagram professional account inline, so one
-# /me/accounts call lists both the Page tokens and the IG ids to connect.
-INSTAGRAM_PAGE_FIELDS = "id,name,access_token,instagram_business_account{id,username}"
-
-
-@router.post("/instagram/signup/pages", response_model=MessengerSignupPagesOut)
-async def list_instagram_signup_pages(
-    request: MessengerSignupRequest,
-    current_user: User = Depends(require_permissions("manage_organization")),
-    organization: Organization = Depends(get_current_organization),
-):
-    """Step 1 for Instagram: same Login-for-Business popup as Messenger, but the
-    picker offers the Instagram account linked to each Page, not the Page."""
-    check_signup_access(ChannelType.INSTAGRAM.value)
-    user_token = await _signup_user_token(request)
-
-    pages = await _list_manageable_pages(user_token, INSTAGRAM_PAGE_FIELDS)
-    # Only Pages with a linked professional account can receive Instagram DMs.
-    ig_pages = [p for p in pages if p.get("instagram_business_account")]
-    if not ig_pages:
-        raise HTTPException(status_code=400, detail=(
-            "None of your Facebook Pages has an Instagram professional account "
-            "linked. Link one in the Page's settings, then connect again."))
-
-    return MessengerSignupPagesOut(
-        signup_token=_seal_signup_pages(organization.id, ig_pages),
-        pages=[MessengerPageOut(
-            id=p["id"],
-            name="@" + (p["instagram_business_account"].get("username") or p["id"]),
-        ) for p in ig_pages],
-    )
-
-
-@router.post("/instagram/signup/connect", response_model=ChannelAccountOut)
-async def connect_instagram_signup(
-    request: MessengerSignupConnectRequest,
+@router.post("/instagram/login/connect", response_model=ChannelAccountOut)
+async def connect_instagram_login(
+    request: InstagramLoginRequest,
     current_user: User = Depends(require_permissions("manage_organization")),
     organization: Organization = Depends(get_current_organization),
     db: Session = Depends(get_db),
 ):
-    """Step 2 for Instagram: connect the account the customer picked.
+    """Connect an Instagram professional account through Instagram Login.
 
-    page_id selects a Page out of the list we fetched; the account stored is its
-    linked Instagram business account, keyed by that account's own id (webhooks
-    route Instagram events by it), with the Page token that sends its DMs.
+    Unlike Messenger this needs no Facebook Page: the business signs in with
+    Instagram itself, so the login returns exactly one account and there is
+    nothing to pick. The token is an Instagram user token, used against
+    graph.instagram.com rather than the Facebook graph.
     """
     check_signup_access(ChannelType.INSTAGRAM.value)
-    pages = _open_signup_pages(request.signup_token, organization)
 
-    page = next((p for p in pages if p.get("id") == request.page_id), None)
-    if page is None or not page.get("access_token"):
-        raise HTTPException(status_code=400, detail="That account was not part of this signup")
+    ok, data = await exchange_instagram_code(request.code, request.redirect_uri)
+    token_data = instagram_token_payload(data) if ok else {}
+    access_token = token_data.get("access_token")
+    user_id = token_data.get("user_id")
+    if not access_token or not user_id:
+        # The code is single-use and short-lived, so a stale or replayed one
+        # lands here rather than on a Graph error later.
+        raise HTTPException(status_code=400, detail=_graph_detail(
+            data, "Could not complete Instagram login — please try connecting again"))
 
-    ig = page.get("instagram_business_account") or {}
-    ig_id = ig.get("id")
-    if not ig_id:
-        raise HTTPException(status_code=400, detail="That Page has no linked Instagram account")
+    # The login token lasts about an hour; without extending it the connection
+    # dies silently mid-conversation. Best-effort, like the Page flow.
+    ok, extended = await exchange_instagram_long_lived(access_token)
+    if ok and extended.get("access_token"):
+        access_token = extended["access_token"]
+    else:
+        logger.warning("Could not extend the Instagram token; it may expire within the hour")
+
+    ok, profile = await graph_get("me", access_token,
+                                  params={"fields": "user_id,username"},
+                                  base=GRAPH_INSTAGRAM_BASE)
+    username = profile.get("username") if ok else None
+    # Webhooks route Instagram events by the professional account id, which /me
+    # reports as user_id. The login response also carries a user_id but it can
+    # be app-scoped, and keying on the wrong one means inbound DMs never match
+    # any account — silently, with no error. Prefer the authoritative one.
+    account_id = str((profile.get("user_id") if ok else None) or user_id)
 
     account = _upsert_account(
         db, organization, ChannelType.INSTAGRAM.value,
-        external_account_id=str(ig_id),
-        credentials={"access_token": page["access_token"]},
-        display_name=request.display_name or ("@" + (ig.get("username") or str(ig_id))),
+        external_account_id=account_id,
+        credentials={"access_token": access_token},
+        display_name=request.display_name or ("@" + (username or account_id)),
     )
-    # Instagram DMs are delivered through the linked Page's app subscription.
-    if not await subscribe_app(page["id"], page["access_token"],
-                               subscribed_fields=MESSENGER_SUBSCRIBED_FIELDS):
-        logger.warning(f"Page subscribe failed for {page['id']} after Instagram signup")
+    if not await subscribe_instagram_app(access_token):
+        logger.warning(f"Instagram webhook subscribe failed for {account_id}; DMs may not arrive")
     return to_account_out(db, account)
 
 

--- a/backend/app/api/channels/meta.py
+++ b/backend/app/api/channels/meta.py
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import json
 import secrets
+import time
 from urllib.parse import urlencode
 from uuid import UUID
 
@@ -25,12 +27,15 @@ from app.api.channels.accounts import get_org_account_or_404, to_account_out
 from app.channels import get_adapter
 from app.channels.meta_base import (
     debug_token,
+    exchange_for_long_lived_token,
     exchange_signup_code,
     fetch_message_templates,
     graph_get,
+    graph_list_all,
     register_phone_number,
     subscribe_app,
 )
+from app.core.security import decrypt_api_key, encrypt_api_key
 from app.core.auth import (
     INBOX_PERMISSIONS,
     get_current_organization,
@@ -48,6 +53,10 @@ from app.models.schemas.channel import (
     EmbeddedSignupRequest,
     WhatsAppConnectRequest,
     MessengerConnectRequest,
+    MessengerSignupConnectRequest,
+    MessengerSignupPagesOut,
+    MessengerSignupRequest,
+    MessengerPageOut,
     InstagramConnectRequest,
     OutboundConversationOut,
     OutboundConversationRequest,
@@ -167,6 +176,67 @@ def check_signup_access(channel: str) -> None:
             detail="Signup is not configured on this deployment for this channel. "
                    "Connect with credentials instead.",
         )
+
+
+# The signup code is single-use and lives ~10 minutes; the sealed page list it
+# produces should not outlive it, so a stale one fails cleanly with a retry.
+SIGNUP_TOKEN_TTL_SECONDS = 600
+# 500 Pages; an agency ceiling, not a limit a real customer reaches.
+PAGE_LIST_MAX_PAGES = 5
+
+
+def _seal_signup_pages(organization_id, pages: list[dict]) -> str:
+    """Carry a signup's Page tokens through the picker without the browser ever
+    holding them in the clear.
+
+    The tokens go back to the client as ciphertext only we can open, so step 2
+    needs no server-side session — which matters because the two requests are
+    not guaranteed to hit the same worker. Binding the org and an expiry inside
+    means a leaked blob cannot be replayed by another tenant, or after the
+    signup's own code would already have died.
+    """
+    payload = {
+        "org": str(organization_id),
+        "exp": int(time.time()) + SIGNUP_TOKEN_TTL_SECONDS,
+        "pages": pages,
+    }
+    return encrypt_api_key(json.dumps(payload))
+
+
+def _open_signup_pages(signup_token: str, organization: Organization) -> list[dict]:
+    """The sealed page list, or 400 if it is forged, expired or another org's.
+
+    One generic message across every reject path, so it is not an oracle for
+    which check tripped.
+    """
+    invalid = HTTPException(status_code=400,
+                            detail="That signup has expired — please connect again")
+    try:
+        # decrypt raises ValueError on a bad token; json.loads raises
+        # JSONDecodeError, a ValueError subclass — one except covers both.
+        payload = json.loads(decrypt_api_key(signup_token))
+    except ValueError:
+        raise invalid
+    if not isinstance(payload, dict) or payload.get("org") != str(organization.id):
+        raise invalid
+    if float(payload.get("exp", 0)) <= time.time():
+        raise invalid
+    pages = payload.get("pages")
+    if not isinstance(pages, list):
+        raise invalid
+    return pages
+
+
+async def _list_manageable_pages(user_token: str, fields: str) -> list[dict]:
+    """The Pages this signup granted us, each with its own Page access token."""
+    ok, data = await graph_list_all(
+        "me/accounts", user_token, {"fields": fields, "limit": 100},
+        max_pages=PAGE_LIST_MAX_PAGES)
+    if not ok:
+        raise HTTPException(
+            status_code=400,
+            detail=_graph_detail(data, "Could not list your Facebook Pages"))
+    return data
 
 
 def _graph_detail(data: dict, fallback: str) -> str:
@@ -394,6 +464,83 @@ async def connect_messenger(
     if not await subscribe_app(request.page_id, request.page_access_token,
                                subscribed_fields=MESSENGER_SUBSCRIBED_FIELDS):
         logger.warning(f"Page subscribe failed for {request.page_id}; webhook may need manual subscription")
+    return to_account_out(db, account)
+
+
+@router.post("/messenger/signup/pages", response_model=MessengerSignupPagesOut)
+async def list_messenger_signup_pages(
+    request: MessengerSignupRequest,
+    current_user: User = Depends(require_permissions("manage_organization")),
+    organization: Organization = Depends(get_current_organization),
+):
+    """Step 1 of Facebook Login for Business: trade the code for the customer's
+    Pages so they can pick which to connect.
+
+    The Page tokens are sealed into signup_token and never reach the browser;
+    only the ids and names come back for the picker.
+    """
+    check_signup_access(ChannelType.MESSENGER.value)
+
+    ok, data = await exchange_signup_code(request.code)
+    user_token = data.get("access_token") if ok else None
+    if not user_token:
+        # The code is short-lived (~10 minutes) and single-use, so a stale or
+        # replayed one lands here rather than on a Graph error later.
+        raise HTTPException(status_code=400, detail=_graph_detail(
+            data, "Could not complete signup — please try connecting again"))
+
+    # Page tokens inherit the user token's lifetime; extend it first so the ones
+    # we store keep working for months. Best-effort — an already-long-lived
+    # token comes back unchanged, and a failure only risks earlier expiry.
+    ok, extended = await exchange_for_long_lived_token(user_token)
+    if ok and extended.get("access_token"):
+        user_token = extended["access_token"]
+    else:
+        logger.warning("Could not extend the Messenger signup token; page tokens may expire early")
+
+    pages = await _list_manageable_pages(user_token, "id,name,access_token")
+    if not pages:
+        raise HTTPException(status_code=400, detail=(
+            "No Facebook Pages were shared with ChatterMate. Run the connect "
+            "again and tick the Page you want to use."))
+
+    return MessengerSignupPagesOut(
+        signup_token=_seal_signup_pages(organization.id, pages),
+        pages=[MessengerPageOut(id=p["id"], name=p.get("name") or p["id"]) for p in pages],
+    )
+
+
+@router.post("/messenger/signup/connect", response_model=ChannelAccountOut)
+async def connect_messenger_signup(
+    request: MessengerSignupConnectRequest,
+    current_user: User = Depends(require_permissions("manage_organization")),
+    organization: Organization = Depends(get_current_organization),
+    db: Session = Depends(get_db),
+):
+    """Step 2: connect the Page the customer picked in step 1.
+
+    page_id is a selector into the list we fetched ourselves, never a caller
+    claim: the token stored is the one /me/accounts returned for that Page, so a
+    caller cannot connect a Page they do not administer. This is the Messenger
+    equivalent of _verify_signup_assets, and matters for the same reason —
+    webhooks resolve accounts by external id with no org scoping.
+    """
+    check_signup_access(ChannelType.MESSENGER.value)
+    pages = _open_signup_pages(request.signup_token, organization)
+
+    page = next((p for p in pages if p.get("id") == request.page_id), None)
+    if page is None or not page.get("access_token"):
+        raise HTTPException(status_code=400, detail="That Page was not part of this signup")
+
+    account = _upsert_account(
+        db, organization, ChannelType.MESSENGER.value,
+        external_account_id=page["id"],
+        credentials={"access_token": page["access_token"]},
+        display_name=request.display_name or page.get("name") or page["id"],
+    )
+    if not await subscribe_app(page["id"], page["access_token"],
+                               subscribed_fields=MESSENGER_SUBSCRIBED_FIELDS):
+        logger.warning(f"Page subscribe failed for {page['id']} after signup")
     return to_account_out(db, account)
 
 

--- a/backend/app/api/channels/meta.py
+++ b/backend/app/api/channels/meta.py
@@ -126,23 +126,46 @@ def _generate_verification_pin() -> str:
     return f"{secrets.randbelow(1_000_000):06d}"
 
 
-def _embedded_signup_available() -> bool:
-    """Whether this deployment can offer Embedded Signup at all.
+# Channels that can be onboarded through a Meta login popup, each with the Meta
+# configuration that drives it. Messenger and Instagram DM both ride on a Page's
+# token, so one Facebook Login for Business configuration serves both.
+SIGNUP_CHANNELS = (
+    ChannelType.WHATSAPP.value,
+    ChannelType.MESSENGER.value,
+    ChannelType.INSTAGRAM.value,
+)
 
-    It onboards a customer's number under *our* approved Meta app, so without a
-    config id it structurally cannot work — a self-hoster has no such app and
-    gets the manual credentials form instead. That is the whole gate: like every
-    other integration, Embedded Signup is not restricted by plan.
+# Webhook fields a Page must subscribe our app to for Messenger to work.
+MESSENGER_SUBSCRIBED_FIELDS = "messages,messaging_postbacks"
+
+
+def _signup_config_id(channel: str) -> str:
+    """The Meta configuration id that onboards this channel, read at call time so
+    a settings override (tests, reloads) is always seen."""
+    return {
+        ChannelType.WHATSAPP.value: settings.META_CONFIG_ID,
+        ChannelType.MESSENGER.value: settings.META_MESSENGER_CONFIG_ID,
+        ChannelType.INSTAGRAM.value: settings.META_MESSENGER_CONFIG_ID,
+    }.get(channel, "")
+
+
+def _signup_available(channel: str) -> bool:
+    """Whether this deployment can offer the login flow for this channel.
+
+    Onboarding happens under *our* approved Meta app, so without a config id it
+    structurally cannot work — a self-hoster has no such app and gets the manual
+    credentials form instead. That is the whole gate: like every other
+    integration, signup is not restricted by plan.
     """
-    return bool(settings.META_CONFIG_ID)
+    return bool(_signup_config_id(channel))
 
 
-def check_embedded_signup_access() -> None:
-    if not _embedded_signup_available():
+def check_signup_access(channel: str) -> None:
+    if not _signup_available(channel):
         raise HTTPException(
             status_code=403,
-            detail="WhatsApp Embedded Signup is not configured on this deployment. "
-                   "Connect your number with its credentials instead.",
+            detail="Signup is not configured on this deployment for this channel. "
+                   "Connect with credentials instead.",
         )
 
 
@@ -230,15 +253,20 @@ def _upsert_account(db: Session, organization: Organization, channel_type: str,
 
 @router.get("/embedded-signup-config", response_model=EmbeddedSignupConfigOut)
 async def get_embedded_signup_config(
+    channel: str = ChannelType.WHATSAPP.value,
     current_user: User = Depends(require_permissions("manage_organization")),
 ):
-    """What the connect UI needs to decide between Embedded Signup and the
-    manual credentials form. The app id is returned here rather than baked into
-    the frontend build, so a self-hoster can point at their own app."""
-    enabled = _embedded_signup_available()
+    """What the connect UI needs to decide between a Meta login flow and the
+    manual credentials form, for the given channel. The app id is returned here
+    rather than baked into the frontend build, so a self-hoster can point at
+    their own app. A disabled channel returns no ids, so one channel's config
+    never leaks on another's request."""
+    if channel not in SIGNUP_CHANNELS:
+        raise HTTPException(status_code=404, detail="No signup flow for this channel")
+    enabled = _signup_available(channel)
     return EmbeddedSignupConfigOut(
         enabled=enabled,
-        config_id=settings.META_CONFIG_ID if enabled else None,
+        config_id=_signup_config_id(channel) if enabled else None,
         app_id=settings.META_APP_ID if enabled else None,
         graph_version=settings.META_GRAPH_VERSION,
     )
@@ -286,7 +314,7 @@ async def connect_whatsapp_embedded_signup(
     Only the way the credentials are obtained differs from connect_whatsapp —
     everything after that is the same upsert and webhook subscribe.
     """
-    check_embedded_signup_access()
+    check_signup_access(ChannelType.WHATSAPP.value)
 
     ok, data = await exchange_signup_code(request.code)
     access_token = data.get("access_token") if ok else None
@@ -364,7 +392,7 @@ async def connect_messenger(
         display_name=display_name,
     )
     if not await subscribe_app(request.page_id, request.page_access_token,
-                               subscribed_fields="messages,messaging_postbacks"):
+                               subscribed_fields=MESSENGER_SUBSCRIBED_FIELDS):
         logger.warning(f"Page subscribe failed for {request.page_id}; webhook may need manual subscription")
     return to_account_out(db, account)
 

--- a/backend/app/api/channels/meta.py
+++ b/backend/app/api/channels/meta.py
@@ -44,7 +44,6 @@ from app.core.security import decrypt_api_key, encrypt_api_key
 from app.core.auth import (
     INBOX_PERMISSIONS,
     get_current_organization,
-    get_current_user,
     require_any_permission,
     require_permissions,
 )

--- a/backend/app/api/channels/meta.py
+++ b/backend/app/api/channels/meta.py
@@ -17,22 +17,20 @@ limitations under the License.
 import json
 import secrets
 import time
-from urllib.parse import urlencode
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from app.api.channels.accounts import get_org_account_or_404, to_account_out
-from app.channels import get_adapter
 from app.channels.meta_base import (
     debug_token,
     exchange_for_long_lived_token,
     exchange_instagram_code,
     exchange_instagram_long_lived,
     exchange_signup_code,
-    fetch_message_templates,
     graph_get,
+    graph_detail,
     graph_list_all,
     instagram_token_payload,
     register_phone_number,
@@ -42,9 +40,7 @@ from app.channels.meta_base import (
 )
 from app.core.security import decrypt_api_key, encrypt_api_key
 from app.core.auth import (
-    INBOX_PERMISSIONS,
     get_current_organization,
-    require_any_permission,
     require_permissions,
 )
 from app.core.config import settings
@@ -63,23 +59,13 @@ from app.models.schemas.channel import (
     MessengerPageOut,
     InstagramConnectRequest,
     InstagramLoginRequest,
-    OutboundConversationOut,
-    OutboundConversationRequest,
-    TemplateLibraryOut,
-    TemplateOut,
-    TemplateSendRequest,
 )
 from app.models.user import User
-from app.repositories.channels import ChannelAccountRepository, ChannelConversationRepository
-from app.services.whatsapp_outbound import OutboundError, start_outbound_conversation
+from app.repositories.channels import ChannelAccountRepository
 from app.core.logger import get_logger
 
 router = APIRouter()
 logger = get_logger(__name__)
-
-# Meta's own template authoring UI, which is where we send people to write one.
-TEMPLATE_LIBRARY_URL = "https://business.facebook.com/latest/whatsapp_manager/template_library"
-
 
 def _whatsapp_display_name(profile: dict, phone_number_id: str) -> str:
     """How a connected number is labelled in the UI, from its Graph profile."""
@@ -118,7 +104,7 @@ async def _verify_signup_assets(waba_id: str, phone_number_id: str, access_token
     if not ok:
         raise HTTPException(
             status_code=400,
-            detail=_graph_detail(data, "Could not read that WhatsApp Business Account"))
+            detail=graph_detail(data, "Could not read that WhatsApp Business Account"))
 
     numbers = data.get("data")
     if not isinstance(numbers, list):
@@ -252,7 +238,7 @@ async def _list_manageable_pages(user_token: str, fields: str) -> list[dict]:
     if not ok:
         raise HTTPException(
             status_code=400,
-            detail=_graph_detail(data, "Could not list your Facebook Pages"))
+            detail=graph_detail(data, "Could not list your Facebook Pages"))
     return data
 
 
@@ -268,7 +254,7 @@ async def _signup_user_token(request: MessengerSignupRequest) -> str:
     if not user_token:
         # The code is short-lived (~10 minutes) and single-use, so a stale or
         # replayed one lands here rather than on a Graph error later.
-        raise HTTPException(status_code=400, detail=_graph_detail(
+        raise HTTPException(status_code=400, detail=graph_detail(
             data, "Could not complete signup — please try connecting again"))
 
     ok, extended = await exchange_for_long_lived_token(user_token)
@@ -276,62 +262,6 @@ async def _signup_user_token(request: MessengerSignupRequest) -> str:
         return extended["access_token"]
     logger.warning("Could not extend the signup token; page tokens may expire early")
     return user_token
-
-
-def _graph_detail(data: dict, fallback: str) -> str:
-    """Meta's own error text where it has one, so the UI can show the real
-    reason (e.g. a template that cannot be deleted) rather than a generic
-    failure.
-
-    error_user_msg first: `message` is often a generic OAuth string that says
-    nothing actionable — Graph will pair a `message` of "Application does not
-    have permission for this action" with an error_user_msg that names the
-    actual asset and rule. Only one of those is a clue.
-    """
-    error = data.get("error", {})
-    if not isinstance(error, dict):
-        return fallback
-    return error.get("error_user_msg") or error.get("message") or fallback
-
-
-def _whatsapp_account_or_404(db: Session, account_id: UUID, organization: Organization):
-    account = get_org_account_or_404(db, account_id, organization)
-    if account.channel_type != ChannelType.WHATSAPP.value:
-        raise HTTPException(status_code=404, detail="Channel account not found")
-    return account
-
-
-# Template sending is inbox work — reopening a window, starting a conversation
-# — done by support agents, not org admins. INBOX_PERMISSIONS is shared with
-# the People page so the two surfaces can't disagree about who works the inbox.
-require_inbox_agent = require_any_permission(*INBOX_PERMISSIONS)
-
-
-async def _fetch_all_templates(waba_id: str, access_token: str) -> list[TemplateOut]:
-    """Every template on the WABA (transport lives in meta_base; this wrapper
-    owns the HTTP error surface)."""
-    ok, data = await fetch_message_templates(waba_id, access_token)
-    if not ok:
-        raise HTTPException(status_code=502,
-                            detail=_graph_detail(data, "Could not list templates"))
-    return [TemplateOut(**template) for template in data]
-
-
-def _waba_credentials(db: Session, account) -> tuple[str, str]:
-    """(waba_id, access_token) for a WhatsApp account.
-
-    Templates live on the WhatsApp Business Account, not the phone number, and
-    the WABA id is optional in the credential blob — accounts connected without
-    it can send and receive but cannot manage templates.
-    """
-    credentials = ChannelAccountRepository(db).get_credentials(account)
-    waba_id = credentials.get("waba_id")
-    if not waba_id:
-        raise HTTPException(
-            status_code=400,
-            detail="Reconnect this number with its WhatsApp Business Account ID to manage templates",
-        )
-    return waba_id, credentials["access_token"]
 
 
 def _upsert_account(db: Session, organization: Organization, channel_type: str,
@@ -433,7 +363,7 @@ async def connect_whatsapp_embedded_signup(
         # replayed one lands here rather than on a Graph error later.
         raise HTTPException(
             status_code=400,
-            detail=_graph_detail(data, "Could not complete signup — please try connecting again"),
+            detail=graph_detail(data, "Could not complete signup — please try connecting again"),
         )
 
     profile = await _verify_signup_assets(
@@ -447,7 +377,7 @@ async def connect_whatsapp_embedded_signup(
     if not registered:
         logger.warning(
             f"Phone {request.phone_number_id} not registered after signup: "
-            f"{_graph_detail(register_data, 'unknown error')}")
+            f"{graph_detail(register_data, 'unknown error')}")
 
     credentials = {"access_token": access_token, "waba_id": request.waba_id}
     # Only keep the PIN we actually set on the number. Storing one from a failed
@@ -481,7 +411,7 @@ async def connect_messenger(
     # carry — it would reject a token that sends perfectly well.
     ok, info = await debug_token(request.page_access_token)
     if not ok or not info.get("is_valid"):
-        raise HTTPException(status_code=400, detail=_graph_detail(
+        raise HTTPException(status_code=400, detail=graph_detail(
             info, "That token is not valid — generate a fresh Page access token"))
     if info.get("type") != "PAGE":
         raise HTTPException(status_code=400, detail=(
@@ -591,7 +521,7 @@ async def connect_instagram_login(
     if not access_token or not user_id:
         # The code is single-use and short-lived, so a stale or replayed one
         # lands here rather than on a Graph error later.
-        raise HTTPException(status_code=400, detail=_graph_detail(
+        raise HTTPException(status_code=400, detail=graph_detail(
             data, "Could not complete Instagram login — please try connecting again"))
 
     # The login token lasts about an hour; without extending it the connection
@@ -667,107 +597,3 @@ async def disconnect_meta_account(
         raise HTTPException(status_code=404, detail="Channel account not found")
     ChannelAccountRepository(db).delete(account)
     return {"status": "disconnected"}
-
-
-@router.post("/whatsapp/{account_id}/conversations", response_model=OutboundConversationOut)
-async def start_whatsapp_conversation(
-    account_id: UUID,
-    request: OutboundConversationRequest,
-    current_user: User = Depends(require_inbox_agent),
-    organization: Organization = Depends(get_current_organization),
-    db: Session = Depends(get_db),
-):
-    """Start a WhatsApp conversation with a phone number via an approved
-    Utility/Authentication template. The thin route: policy lives in the
-    service so the Phase-2 scheduler can call the same function."""
-    account = _whatsapp_account_or_404(db, account_id, organization)
-    try:
-        session_id = await start_outbound_conversation(
-            db, account,
-            to=request.to,
-            template_name=request.template_name,
-            language=request.language,
-            components=request.components,
-            customer_id=request.customer_id,
-            customer_name=request.customer_name,
-        )
-    except OutboundError as e:
-        raise HTTPException(status_code=e.status_code, detail=e.detail)
-    return OutboundConversationOut(session_id=session_id)
-
-
-@router.post("/whatsapp/{account_id}/send-template")
-async def send_whatsapp_template(
-    account_id: UUID,
-    request: TemplateSendRequest,
-    current_user: User = Depends(require_inbox_agent),
-    organization: Organization = Depends(get_current_organization),
-    db: Session = Depends(get_db),
-):
-    """Send an approved template message to reopen an expired 24h window."""
-    account = _whatsapp_account_or_404(db, account_id, organization)
-
-    conversation = ChannelConversationRepository(db).get_by_session(request.session_id)
-    if conversation is None or conversation.channel_account_id != account.id:
-        raise HTTPException(status_code=404, detail="Conversation not found for this account")
-
-    adapter = get_adapter(ChannelType.WHATSAPP.value)
-    result = await adapter.send_template(
-        account, conversation,
-        template_name=request.template_name,
-        language=request.language,
-        components=request.components,
-    )
-    if not result.ok:
-        raise HTTPException(status_code=502, detail=result.error or "Template send failed")
-    return {"status": "sent", "external_message_id": result.external_message_id}
-
-
-@router.get("/whatsapp/{account_id}/templates", response_model=list[TemplateOut])
-async def list_whatsapp_templates(
-    account_id: UUID,
-    # Inbox-agent, not org-admin: this is what the send-template picker and the
-    # New-conversation modal read. Gating it tighter than the send it feeds made
-    # the loosening of those endpoints a no-op — the agent could send a template
-    # but never see one to pick.
-    current_user: User = Depends(require_inbox_agent),
-    organization: Organization = Depends(get_current_organization),
-    db: Session = Depends(get_db),
-):
-    """List the message templates on this number's WhatsApp Business Account."""
-    account = _whatsapp_account_or_404(db, account_id, organization)
-    waba_id, access_token = _waba_credentials(db, account)
-    return await _fetch_all_templates(waba_id, access_token)
-
-
-@router.get("/whatsapp/{account_id}/template-library", response_model=TemplateLibraryOut)
-async def get_whatsapp_template_library(
-    account_id: UUID,
-    current_user: User = Depends(require_permissions("manage_organization")),
-    organization: Organization = Depends(get_current_organization),
-    db: Session = Depends(get_db),
-):
-    """Where to go to write a template: Meta's own Template Library, opened on
-    this number's WhatsApp Business Account.
-
-    Templates are not authored here. Meta's library holds ~150 pre-written,
-    pre-localised utility templates plus its authentication ones, all shaped to
-    pass its own review — a form of ours could only ever be a worse version of
-    that, and every rule it encodes (categories, variable numbering, which
-    buttons may be mixed) is Meta's to change without telling us.
-
-    The link is built per account rather than hardcoded: business_id scopes the
-    page to the right portfolio. It is best-effort — a business we cannot read
-    gives a link that lands less precisely, not a dead button.
-    """
-    account = _whatsapp_account_or_404(db, account_id, organization)
-    waba_id, access_token = _waba_credentials(db, account)
-
-    params = {"asset_id": waba_id}
-    ok, data = await graph_get(waba_id, access_token, params={"fields": "owner_business_info"})
-    if ok:
-        business_id = (data.get("owner_business_info") or {}).get("id")
-        if business_id:
-            params["business_id"] = business_id
-
-    return TemplateLibraryOut(url=f"{TEMPLATE_LIBRARY_URL}?{urlencode(params)}")

--- a/backend/app/api/channels/whatsapp_messaging.py
+++ b/backend/app/api/channels/whatsapp_messaging.py
@@ -1,0 +1,201 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Sending on an already-connected WhatsApp number: templates and outbound
+conversations.
+
+Separate from meta.py, which onboards accounts. These routes are inbox work
+done by support agents on a live number, not org-admin onboarding, and they are
+the only ones that care about WhatsApp Business Accounts and templates. They
+mount under the same /meta prefix, so the URLs are unchanged.
+"""
+
+from urllib.parse import urlencode
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.api.channels.accounts import get_org_account_or_404
+from app.channels import get_adapter
+from app.channels.meta_base import fetch_message_templates, graph_detail, graph_get
+from app.core.auth import (
+    INBOX_PERMISSIONS,
+    get_current_organization,
+    require_any_permission,
+    require_permissions,
+)
+from app.database import get_db
+from app.models.channels import ChannelType
+from app.models.organization import Organization
+from app.models.schemas.channel import (
+    OutboundConversationOut,
+    OutboundConversationRequest,
+    TemplateLibraryOut,
+    TemplateOut,
+    TemplateSendRequest,
+)
+from app.models.user import User
+from app.repositories.channels import ChannelAccountRepository, ChannelConversationRepository
+from app.services.whatsapp_outbound import OutboundError, start_outbound_conversation
+
+router = APIRouter()
+
+# Meta's own template authoring UI, which is where we send people to write one.
+TEMPLATE_LIBRARY_URL = "https://business.facebook.com/latest/whatsapp_manager/template_library"
+
+# Template sending is inbox work — reopening a window, starting a conversation
+# — done by support agents, not org admins. INBOX_PERMISSIONS is shared with
+# the People page so the two surfaces can't disagree about who works the inbox.
+require_inbox_agent = require_any_permission(*INBOX_PERMISSIONS)
+
+
+def _whatsapp_account_or_404(db: Session, account_id: UUID, organization: Organization):
+    account = get_org_account_or_404(db, account_id, organization)
+    if account.channel_type != ChannelType.WHATSAPP.value:
+        raise HTTPException(status_code=404, detail="Channel account not found")
+    return account
+
+
+async def _fetch_all_templates(waba_id: str, access_token: str) -> list[TemplateOut]:
+    """Every template on the WABA (transport lives in meta_base; this wrapper
+    owns the HTTP error surface)."""
+    ok, data = await fetch_message_templates(waba_id, access_token)
+    if not ok:
+        raise HTTPException(status_code=502,
+                            detail=graph_detail(data, "Could not list templates"))
+    return [TemplateOut(**template) for template in data]
+
+
+def _waba_credentials(db: Session, account) -> tuple[str, str]:
+    """(waba_id, access_token) for a WhatsApp account.
+
+    Templates live on the WhatsApp Business Account, not the phone number, and
+    the WABA id is optional in the credential blob — accounts connected without
+    it can send and receive but cannot manage templates.
+    """
+    credentials = ChannelAccountRepository(db).get_credentials(account)
+    waba_id = credentials.get("waba_id")
+    if not waba_id:
+        raise HTTPException(
+            status_code=400,
+            detail="Reconnect this number with its WhatsApp Business Account ID to manage templates",
+        )
+    return waba_id, credentials["access_token"]
+
+
+@router.post("/whatsapp/{account_id}/conversations", response_model=OutboundConversationOut)
+async def start_whatsapp_conversation(
+    account_id: UUID,
+    request: OutboundConversationRequest,
+    current_user: User = Depends(require_inbox_agent),
+    organization: Organization = Depends(get_current_organization),
+    db: Session = Depends(get_db),
+):
+    """Start a WhatsApp conversation with a phone number via an approved
+    Utility/Authentication template. The thin route: policy lives in the
+    service so the Phase-2 scheduler can call the same function."""
+    account = _whatsapp_account_or_404(db, account_id, organization)
+    try:
+        session_id = await start_outbound_conversation(
+            db, account,
+            to=request.to,
+            template_name=request.template_name,
+            language=request.language,
+            components=request.components,
+            customer_id=request.customer_id,
+            customer_name=request.customer_name,
+        )
+    except OutboundError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.detail)
+    return OutboundConversationOut(session_id=session_id)
+
+
+@router.post("/whatsapp/{account_id}/send-template")
+async def send_whatsapp_template(
+    account_id: UUID,
+    request: TemplateSendRequest,
+    current_user: User = Depends(require_inbox_agent),
+    organization: Organization = Depends(get_current_organization),
+    db: Session = Depends(get_db),
+):
+    """Send an approved template message to reopen an expired 24h window."""
+    account = _whatsapp_account_or_404(db, account_id, organization)
+
+    conversation = ChannelConversationRepository(db).get_by_session(request.session_id)
+    if conversation is None or conversation.channel_account_id != account.id:
+        raise HTTPException(status_code=404, detail="Conversation not found for this account")
+
+    adapter = get_adapter(ChannelType.WHATSAPP.value)
+    result = await adapter.send_template(
+        account, conversation,
+        template_name=request.template_name,
+        language=request.language,
+        components=request.components,
+    )
+    if not result.ok:
+        raise HTTPException(status_code=502, detail=result.error or "Template send failed")
+    return {"status": "sent", "external_message_id": result.external_message_id}
+
+
+@router.get("/whatsapp/{account_id}/templates", response_model=list[TemplateOut])
+async def list_whatsapp_templates(
+    account_id: UUID,
+    # Inbox-agent, not org-admin: this is what the send-template picker and the
+    # New-conversation modal read. Gating it tighter than the send it feeds made
+    # the loosening of those endpoints a no-op — the agent could send a template
+    # but never see one to pick.
+    current_user: User = Depends(require_inbox_agent),
+    organization: Organization = Depends(get_current_organization),
+    db: Session = Depends(get_db),
+):
+    """List the message templates on this number's WhatsApp Business Account."""
+    account = _whatsapp_account_or_404(db, account_id, organization)
+    waba_id, access_token = _waba_credentials(db, account)
+    return await _fetch_all_templates(waba_id, access_token)
+
+
+@router.get("/whatsapp/{account_id}/template-library", response_model=TemplateLibraryOut)
+async def get_whatsapp_template_library(
+    account_id: UUID,
+    current_user: User = Depends(require_permissions("manage_organization")),
+    organization: Organization = Depends(get_current_organization),
+    db: Session = Depends(get_db),
+):
+    """Where to go to write a template: Meta's own Template Library, opened on
+    this number's WhatsApp Business Account.
+
+    Templates are not authored here. Meta's library holds ~150 pre-written,
+    pre-localised utility templates plus its authentication ones, all shaped to
+    pass its own review — a form of ours could only ever be a worse version of
+    that, and every rule it encodes (categories, variable numbering, which
+    buttons may be mixed) is Meta's to change without telling us.
+
+    The link is built per account rather than hardcoded: business_id scopes the
+    page to the right portfolio. It is best-effort — a business we cannot read
+    gives a link that lands less precisely, not a dead button.
+    """
+    account = _whatsapp_account_or_404(db, account_id, organization)
+    waba_id, access_token = _waba_credentials(db, account)
+
+    params = {"asset_id": waba_id}
+    ok, data = await graph_get(waba_id, access_token, params={"fields": "owner_business_info"})
+    if ok:
+        business_id = (data.get("owner_business_info") or {}).get("id")
+        if business_id:
+            params["business_id"] = business_id
+
+    return TemplateLibraryOut(url=f"{TEMPLATE_LIBRARY_URL}?{urlencode(params)}")

--- a/backend/app/api/webhooks/meta.py
+++ b/backend/app/api/webhooks/meta.py
@@ -72,10 +72,6 @@ async def meta_webhook(
         raise HTTPException(status_code=403, detail="Invalid signature")
 
     payload = await request.json()
-    # TODO(debug): remove once Instagram delivery is confirmed in production.
-    # Ids only — the body carries customer message text.
-    logger.info(f"Meta webhook: object={payload.get('object')} "
-                f"entries={[e.get('id') for e in payload.get('entry', []) if isinstance(e, dict)]}")
     channel_type = _OBJECT_TO_CHANNEL.get(payload.get("object"))
     if channel_type is None:
         # Unknown product subscription — ack so Meta doesn't retry forever

--- a/backend/app/api/webhooks/meta.py
+++ b/backend/app/api/webhooks/meta.py
@@ -65,7 +65,12 @@ async def meta_webhook(
     background.
     """
     raw_body = await request.body()
-    if not verify_meta_signature(raw_body, request.headers.get("x-hub-signature-256", "")):
+    signature_ok = verify_meta_signature(raw_body, request.headers.get("x-hub-signature-256", ""))
+    # TODO(debug): remove once Instagram delivery is confirmed. Logs before the
+    # signature gate so a rejected payload is distinguishable from one that
+    # never arrived at all.
+    logger.info(f"Meta webhook in: signature_ok={signature_ok} body={raw_body[:500]!r}")
+    if not signature_ok:
         raise HTTPException(status_code=403, detail="Invalid signature")
 
     payload = await request.json()

--- a/backend/app/api/webhooks/meta.py
+++ b/backend/app/api/webhooks/meta.py
@@ -65,15 +65,17 @@ async def meta_webhook(
     background.
     """
     raw_body = await request.body()
-    signature_ok = verify_meta_signature(raw_body, request.headers.get("x-hub-signature-256", ""))
-    # TODO(debug): remove once Instagram delivery is confirmed. Logs before the
-    # signature gate so a rejected payload is distinguishable from one that
-    # never arrived at all.
-    logger.info(f"Meta webhook in: signature_ok={signature_ok} body={raw_body[:500]!r}")
-    if not signature_ok:
+    if not verify_meta_signature(raw_body, request.headers.get("x-hub-signature-256", "")):
+        # Logged so a rejected delivery is distinguishable from one that never
+        # arrived; the body is untrusted and unlogged.
+        logger.warning(f"Meta webhook rejected: bad signature ({len(raw_body)} bytes)")
         raise HTTPException(status_code=403, detail="Invalid signature")
 
     payload = await request.json()
+    # TODO(debug): remove once Instagram delivery is confirmed in production.
+    # Ids only — the body carries customer message text.
+    logger.info(f"Meta webhook: object={payload.get('object')} "
+                f"entries={[e.get('id') for e in payload.get('entry', []) if isinstance(e, dict)]}")
     channel_type = _OBJECT_TO_CHANNEL.get(payload.get("object"))
     if channel_type is None:
         # Unknown product subscription — ack so Meta doesn't retry forever

--- a/backend/app/channels/instagram.py
+++ b/backend/app/channels/instagram.py
@@ -27,6 +27,12 @@ from app.models.channels import ChannelType
 
 class InstagramAdapter(MessengerAdapter):
     channel_type: ClassVar[str] = ChannelType.INSTAGRAM.value
+    # An IG user node exposes name/username, not the Messenger first/last name.
+    profile_fields: ClassVar[str] = "name,username"
+
+    @staticmethod
+    def _display_name(data: dict) -> str:
+        return (data.get("name") or data.get("username") or "").strip()
 
 
 register_adapter(InstagramAdapter())

--- a/backend/app/channels/instagram.py
+++ b/backend/app/channels/instagram.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import ClassVar
+from typing import ClassVar, List
 
 from app.channels.messenger import MessengerAdapter
 from app.channels.meta_base import GRAPH_INSTAGRAM_BASE
@@ -38,6 +38,19 @@ class InstagramAdapter(MessengerAdapter):
     # Instagram's send body is just {recipient, message} — messaging_type is a
     # Messenger-only parameter and has no meaning here.
     send_extras: ClassVar[dict] = {}
+
+    def _events(self, entry: dict) -> List[dict]:
+        """Instagram delivers a DM either as messaging[] or, depending on the
+        API version, as changes[] with field=messages and the same event under
+        `value`. Reading only one shape drops every message on the other, and
+        silently — the payload parses to nothing and the webhook still acks.
+        """
+        events = super()._events(entry)
+        if events:
+            return events
+        return [change.get("value") or {}
+                for change in entry.get("changes") or []
+                if change.get("field") == "messages"]
 
     @staticmethod
     def _display_name(data: dict) -> str:

--- a/backend/app/channels/instagram.py
+++ b/backend/app/channels/instagram.py
@@ -17,18 +17,27 @@ limitations under the License.
 from typing import ClassVar
 
 from app.channels.messenger import MessengerAdapter
+from app.channels.meta_base import GRAPH_INSTAGRAM_BASE
 from app.channels.registry import register_adapter
 from app.models.channels import ChannelType
 
 # Instagram DM uses the same Messenger Platform envelope (entry[].messaging[],
-# sender.id = IGSID) and the same `me/messages` Graph send with the linked
-# page token, so the only difference from Messenger is the channel identity.
+# sender.id = IGSID) and the same `me/messages` send shape, so it subclasses
+# Messenger. What differs is the host and the credential: accounts connect
+# through Instagram Login, which yields an Instagram user token rather than a
+# Facebook Page token.
 
 
 class InstagramAdapter(MessengerAdapter):
     channel_type: ClassVar[str] = ChannelType.INSTAGRAM.value
+    # An Instagram user token is only accepted by graph.instagram.com; the
+    # Facebook graph rejects it, so sends and profile lookups go here instead.
+    graph_base: ClassVar[str] = GRAPH_INSTAGRAM_BASE
     # An IG user node exposes name/username, not the Messenger first/last name.
     profile_fields: ClassVar[str] = "name,username"
+    # Instagram's send body is just {recipient, message} — messaging_type is a
+    # Messenger-only parameter and has no meaning here.
+    send_extras: ClassVar[dict] = {}
 
     @staticmethod
     def _display_name(data: dict) -> str:

--- a/backend/app/channels/messenger.py
+++ b/backend/app/channels/messenger.py
@@ -17,7 +17,7 @@ limitations under the License.
 from typing import ClassVar, List
 
 from app.channels.base import InboundMessage, SendResult
-from app.channels.meta_base import MetaBaseAdapter, graph_get, graph_post
+from app.channels.meta_base import GRAPH_BASE, MetaBaseAdapter, graph_get, graph_post
 from app.channels.registry import register_adapter
 from app.models.channels import ChannelAccount, ChannelConversation, ChannelType
 from app.core.logger import get_logger
@@ -30,12 +30,19 @@ MAX_MESSAGE_LENGTH = 2000
 
 class MessengerAdapter(MetaBaseAdapter):
     """Facebook Messenger. Instagram DM shares the same entry[].messaging[]
-    envelope and Graph send, so InstagramAdapter subclasses this."""
+    envelope and send shape, so InstagramAdapter subclasses this — overriding
+    only the host it talks to and the fields that name a sender."""
 
     channel_type: ClassVar[str] = ChannelType.MESSENGER.value
+    # Instagram Login accounts hold an Instagram user token, which only
+    # graph.instagram.com accepts; Page tokens only work on the Facebook graph.
+    graph_base: ClassVar[str] = GRAPH_BASE
     # Graph fields on the sender node that carry a display name. Instagram user
     # nodes expose different ones, so it overrides this and _display_name.
     profile_fields: ClassVar[str] = "first_name,last_name"
+    # Extra keys on a send. messaging_type is a Messenger Platform parameter and
+    # is not part of Instagram's documented send body, so Instagram sends none.
+    send_extras: ClassVar[dict] = {"messaging_type": "RESPONSE"}
 
     def parse_inbound(self, payload: dict) -> List[InboundMessage]:
         """Normalize entry[].messaging[] events. Echoes, delivery/read receipts
@@ -71,9 +78,10 @@ class MessengerAdapter(MetaBaseAdapter):
             self.access_token(account),
             {
                 "recipient": {"id": conversation.external_conversation_id},
-                "messaging_type": "RESPONSE",
+                **self.send_extras,
                 "message": {"text": text},
             },
+            base=self.graph_base,
         )
 
     async def send_typing(self, account: ChannelAccount, conversation: ChannelConversation) -> None:
@@ -86,6 +94,7 @@ class MessengerAdapter(MetaBaseAdapter):
                     "recipient": {"id": conversation.external_conversation_id},
                     "sender_action": "typing_on",
                 },
+                base=self.graph_base,
             )
             if not result.ok:
                 logger.debug(f"{self.channel_type} typing_on failed (non-critical): {result.error}")
@@ -105,7 +114,8 @@ class MessengerAdapter(MetaBaseAdapter):
         sender's name needs no permission beyond messaging them.
         """
         ok, data = await graph_get(external_user_id, self.access_token(account),
-                                   params={"fields": self.profile_fields})
+                                   params={"fields": self.profile_fields},
+                                   base=self.graph_base)
         if not ok:
             return {}
         name = self._display_name(data)

--- a/backend/app/channels/messenger.py
+++ b/backend/app/channels/messenger.py
@@ -17,7 +17,7 @@ limitations under the License.
 from typing import ClassVar, List
 
 from app.channels.base import InboundMessage, SendResult
-from app.channels.meta_base import MetaBaseAdapter, graph_post
+from app.channels.meta_base import MetaBaseAdapter, graph_get, graph_post
 from app.channels.registry import register_adapter
 from app.models.channels import ChannelAccount, ChannelConversation, ChannelType
 from app.core.logger import get_logger
@@ -33,6 +33,9 @@ class MessengerAdapter(MetaBaseAdapter):
     envelope and Graph send, so InstagramAdapter subclasses this."""
 
     channel_type: ClassVar[str] = ChannelType.MESSENGER.value
+    # Graph fields on the sender node that carry a display name. Instagram user
+    # nodes expose different ones, so it overrides this and _display_name.
+    profile_fields: ClassVar[str] = "first_name,last_name"
 
     def parse_inbound(self, payload: dict) -> List[InboundMessage]:
         """Normalize entry[].messaging[] events. Echoes, delivery/read receipts
@@ -91,6 +94,26 @@ class MessengerAdapter(MetaBaseAdapter):
 
     def format_outbound(self, markdown: str) -> str:
         return markdown[:MAX_MESSAGE_LENGTH]
+
+    async def fetch_profile(self, account: ChannelAccount, external_user_id: str) -> dict:
+        """The customer's name, which the webhook never carries — Messenger
+        sends only a PSID, so without this every customer shows as
+        "Messenger user 2742…" in People.
+
+        Best-effort: a lookup failure must not cost us the message, so it
+        degrades to {} (the placeholder stays) rather than raising. Reading a
+        sender's name needs no permission beyond messaging them.
+        """
+        ok, data = await graph_get(external_user_id, self.access_token(account),
+                                   params={"fields": self.profile_fields})
+        if not ok:
+            return {}
+        name = self._display_name(data)
+        return {"name": name} if name else {}
+
+    @staticmethod
+    def _display_name(data: dict) -> str:
+        return " ".join(p for p in (data.get("first_name"), data.get("last_name")) if p).strip()
 
 
 register_adapter(MessengerAdapter())

--- a/backend/app/channels/messenger.py
+++ b/backend/app/channels/messenger.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import ClassVar, List
+from typing import ClassVar, List, Optional
 
 from app.channels.base import InboundMessage, SendResult
 from app.channels.meta_base import GRAPH_BASE, MetaBaseAdapter, graph_get, graph_post
@@ -44,13 +44,34 @@ class MessengerAdapter(MetaBaseAdapter):
     # is not part of Instagram's documented send body, so Instagram sends none.
     send_extras: ClassVar[dict] = {"messaging_type": "RESPONSE"}
 
+    @staticmethod
+    def _event_seconds(raw) -> Optional[int]:
+        """Event time in seconds, or None if absent/unparseable.
+
+        Messenger sends milliseconds as a number; Instagram's changes payload
+        sends seconds as a string, which the old `// 1000` raised a TypeError on
+        — crashing the whole webhook rather than dropping one timestamp.
+        """
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return None
+        # 13-digit values are milliseconds; 10-digit ones are already seconds.
+        return value // 1000 if value > 10_000_000_000 else value
+
+    def _events(self, entry: dict) -> List[dict]:
+        """The messaging events on one entry. Messenger always uses messaging[];
+        Instagram overrides this because it can deliver the same event under
+        changes[] instead."""
+        return entry.get("messaging") or []
+
     def parse_inbound(self, payload: dict) -> List[InboundMessage]:
-        """Normalize entry[].messaging[] events. Echoes, delivery/read receipts
+        """Normalize per-entry messaging events. Echoes, delivery/read receipts
         and attachment-only messages yield nothing."""
         messages: List[InboundMessage] = []
         for entry in payload.get("entry", []):
             account_id = str(entry.get("id", ""))
-            for event in entry.get("messaging", []):
+            for event in self._events(entry):
                 message = event.get("message")
                 if not message or message.get("is_echo"):
                     continue
@@ -67,7 +88,7 @@ class MessengerAdapter(MetaBaseAdapter):
                     external_message_id=str(message.get("mid", "")),
                     text=text,
                     profile={},
-                    timestamp=self._timestamp(event.get("timestamp") and event["timestamp"] // 1000),
+                    timestamp=self._timestamp(self._event_seconds(event.get("timestamp"))),
                 ))
         return messages
 

--- a/backend/app/channels/meta_base.py
+++ b/backend/app/channels/meta_base.py
@@ -147,6 +147,27 @@ async def graph_post_json(path: str, access_token: str, payload: dict) -> tuple[
     return await _graph_request("POST", path, access_token, json_body=payload)
 
 
+async def debug_token(input_token: str) -> tuple[bool, dict]:
+    """Inspect a token: what it is, who it belongs to, and whether it is ours.
+
+    Returns Meta's `data` object, which for a Page token carries
+    `type: "PAGE"`, `profile_id` (the page id), `app_id`, `is_valid` and the
+    granted `scopes`.
+
+    This authenticates with app credentials rather than the token being
+    inspected, so it needs no permission on the asset. Reading the Page node
+    directly (`me?fields=id,name`) would instead demand `pages_read_engagement`
+    — unrelated to messaging, and absent from a token that can nonetheless send
+    perfectly well.
+    """
+    app_token = f"{settings.META_APP_ID}|{settings.META_APP_SECRET}"
+    ok, data = await _graph_request("GET", "debug_token", app_token,
+                                    params={"input_token": input_token})
+    if not ok:
+        return False, data
+    return True, data.get("data", {})
+
+
 async def exchange_signup_code(code: str) -> tuple[bool, dict]:
     """Trade an Embedded Signup code for the customer's business access token.
 

--- a/backend/app/channels/meta_base.py
+++ b/backend/app/channels/meta_base.py
@@ -32,6 +32,11 @@ from app.core.logger import get_logger
 logger = get_logger(__name__)
 
 GRAPH_BASE = "https://graph.facebook.com"
+# Instagram API with Instagram Login speaks to its own host with an Instagram
+# user token; the Facebook graph rejects those. Page-based channels keep using
+# GRAPH_BASE, so every helper below takes the base rather than assuming one.
+GRAPH_INSTAGRAM_BASE = "https://graph.instagram.com"
+INSTAGRAM_OAUTH_BASE = "https://api.instagram.com"
 REQUEST_TIMEOUT_SECONDS = 15.0
 SEND_RETRIES = 2
 # Meta customer-service window: free-form replies allowed for 24h after the
@@ -50,26 +55,32 @@ def _get_http_client() -> httpx.AsyncClient:
     return _http_client
 
 
-def graph_url(path: str) -> str:
-    return f"{GRAPH_BASE}/{settings.META_GRAPH_VERSION}/{path}"
+def graph_url(path: str, base: str = GRAPH_BASE) -> str:
+    return f"{base}/{settings.META_GRAPH_VERSION}/{path}"
 
 
 def verify_meta_signature(raw_body: bytes, signature_header: str) -> bool:
-    """Validate the X-Hub-Signature-256 header against META_APP_SECRET.
+    """Validate the X-Hub-Signature-256 header against our app secrets.
 
     The signature covers the raw request body; it must be checked before the
     body is parsed. Uses a constant-time comparison.
+
+    Instagram Login webhooks are signed with the Instagram app secret rather
+    than the Meta one, and the only thing that would say which product sent this
+    is inside the body we have not authenticated yet. So this tries each secret
+    we own instead of trusting unverified content to choose one; an attacker
+    still has to forge one of them.
     """
-    app_secret = settings.META_APP_SECRET
-    if not app_secret or not signature_header:
+    if not signature_header or not signature_header.startswith("sha256="):
         return False
-    if not signature_header.startswith("sha256="):
-        return False
-    expected = hmac.new(
-        app_secret.encode(), raw_body, hashlib.sha256
-    ).hexdigest()
     provided = signature_header[len("sha256="):]
-    return hmac.compare_digest(expected, provided)
+    for app_secret in (settings.META_APP_SECRET, settings.INSTAGRAM_APP_SECRET):
+        if not app_secret:
+            continue
+        expected = hmac.new(app_secret.encode(), raw_body, hashlib.sha256).hexdigest()
+        if hmac.compare_digest(expected, provided):
+            return True
+    return False
 
 
 def verify_challenge(mode: Optional[str], token: Optional[str], challenge: Optional[str]) -> Optional[str]:
@@ -83,13 +94,15 @@ def verify_challenge(mode: Optional[str], token: Optional[str], challenge: Optio
     return None
 
 
-async def graph_post(path: str, access_token: str, payload: dict) -> SendResult:
+async def graph_post(path: str, access_token: str, payload: dict,
+                     base: str = GRAPH_BASE) -> SendResult:
     """POST to the Graph API with small exponential backoff on transient errors.
 
     Returns a SendResult; 4xx errors are terminal (no retry), network/5xx are
-    retried up to SEND_RETRIES times.
+    retried up to SEND_RETRIES times. `base` selects the host — Instagram Login
+    accounts send via graph.instagram.com, everything else via graph.facebook.com.
     """
-    url = graph_url(path)
+    url = graph_url(path, base)
     headers = {"Authorization": f"Bearer {access_token}"}
     last_error = "unknown error"
     for attempt in range(SEND_RETRIES + 1):
@@ -112,7 +125,8 @@ async def graph_post(path: str, access_token: str, payload: dict) -> SendResult:
 
 async def _graph_request(method: str, path: str, access_token: Optional[str],
                          params: Optional[dict] = None,
-                         json_body: Optional[dict] = None) -> tuple[bool, dict]:
+                         json_body: Optional[dict] = None,
+                         base: str = GRAPH_BASE) -> tuple[bool, dict]:
     """Issue a Graph call and return (ok, decoded-json).
 
     Unlike graph_post this keeps the whole response body, for calls where the
@@ -125,7 +139,7 @@ async def _graph_request(method: str, path: str, access_token: Optional[str],
     try:
         response = await _get_http_client().request(
             method,
-            graph_url(path),
+            graph_url(path, base),
             params=params or None,
             json=json_body,
             headers={"Authorization": f"Bearer {access_token}"} if access_token else {},
@@ -136,9 +150,10 @@ async def _graph_request(method: str, path: str, access_token: Optional[str],
         return (False, {"error": {"message": str(e)}})
 
 
-async def graph_get(path: str, access_token: str, params: Optional[dict] = None) -> tuple[bool, dict]:
+async def graph_get(path: str, access_token: str, params: Optional[dict] = None,
+                    base: str = GRAPH_BASE) -> tuple[bool, dict]:
     """GET a Graph node (validating tokens during onboarding, listing templates)."""
-    return await _graph_request("GET", path, access_token, params=params)
+    return await _graph_request("GET", path, access_token, params=params, base=base)
 
 
 async def graph_post_json(path: str, access_token: str, payload: dict) -> tuple[bool, dict]:
@@ -207,6 +222,79 @@ async def exchange_for_long_lived_token(short_lived_token: str) -> tuple[bool, d
         "client_secret": settings.META_APP_SECRET,
         "fb_exchange_token": short_lived_token,
     })
+
+
+def instagram_token_payload(data: dict) -> dict:
+    """The token object out of an Instagram Login exchange response.
+
+    Instagram has returned this both flat and wrapped in a single-element `data`
+    list depending on the API version, and the difference is invisible until it
+    silently yields no token — so accept either shape.
+    """
+    entries = data.get("data")
+    if isinstance(entries, list) and entries and isinstance(entries[0], dict):
+        return entries[0]
+    return data
+
+
+async def exchange_instagram_code(code: str, redirect_uri: str) -> tuple[bool, dict]:
+    """Trade an Instagram Business Login code for a short-lived user token.
+
+    Instagram Login is a separate OAuth from the Facebook graph: its own host,
+    its own app credentials, form-encoded rather than query params, and it
+    returns an Instagram user token plus the account's user_id — no Page and no
+    Page token anywhere in the flow.
+    """
+    try:
+        response = await _get_http_client().request(
+            "POST",
+            f"{INSTAGRAM_OAUTH_BASE}/oauth/access_token",
+            data={
+                "client_id": settings.INSTAGRAM_APP_ID,
+                "client_secret": settings.INSTAGRAM_APP_SECRET,
+                "grant_type": "authorization_code",
+                "redirect_uri": redirect_uri,
+                "code": code,
+            },
+        )
+        return (response.status_code < 300, response.json())
+    except Exception as e:
+        logger.error(f"Instagram code exchange failed: {e}")
+        return (False, {"error": {"message": str(e)}})
+
+
+async def exchange_instagram_long_lived(short_lived_token: str) -> tuple[bool, dict]:
+    """Trade a short-lived Instagram token (~1 hour) for a 60-day one.
+
+    Without this the connection dies about an hour after onboarding, with no
+    signal beyond messages quietly failing.
+    """
+    try:
+        response = await _get_http_client().request(
+            "GET",
+            f"{GRAPH_INSTAGRAM_BASE}/access_token",
+            params={
+                "grant_type": "ig_exchange_token",
+                "client_secret": settings.INSTAGRAM_APP_SECRET,
+                "access_token": short_lived_token,
+            },
+        )
+        return (response.status_code < 300, response.json())
+    except Exception as e:
+        logger.error(f"Instagram long-lived exchange failed: {e}")
+        return (False, {"error": {"message": str(e)}})
+
+
+async def subscribe_instagram_app(access_token: str) -> bool:
+    """Subscribe our app to this Instagram account's message webhooks.
+
+    Best-effort, like subscribe_app: onboarding still succeeds if it fails, and
+    it can be retried by reconnecting.
+    """
+    ok, _ = await _graph_request("POST", "me/subscribed_apps", access_token,
+                                 params={"subscribed_fields": "messages"},
+                                 base=GRAPH_INSTAGRAM_BASE)
+    return ok
 
 
 async def register_phone_number(phone_number_id: str, access_token: str, pin: str) -> tuple[bool, dict]:

--- a/backend/app/channels/meta_base.py
+++ b/backend/app/channels/meta_base.py
@@ -168,19 +168,27 @@ async def debug_token(input_token: str) -> tuple[bool, dict]:
     return True, data.get("data", {})
 
 
-async def exchange_signup_code(code: str) -> tuple[bool, dict]:
-    """Trade an Embedded Signup code for the customer's business access token.
+async def exchange_signup_code(code: str, redirect_uri: Optional[str] = None) -> tuple[bool, dict]:
+    """Trade a login code for the customer's access token.
 
     The app credentials authenticate this call, so it is the one Graph request
-    that carries no bearer token. There is no redirect_uri: Embedded Signup
-    hands the code back through the JS SDK rather than a redirect, so none was
-    ever issued and sending one is rejected as a mismatch.
+    that carries no bearer token.
+
+    redirect_uri must match whatever the login dialog used, or Graph rejects the
+    code as a mismatch:
+      - WhatsApp Embedded Signup issues its code through the JS SDK with no
+        redirect_uri, so it passes None and we omit the param.
+      - Facebook Login for Business runs as a first-party OAuth popup bound to
+        our own callback URL, so that flow passes that exact callback URL.
     """
-    return await _graph_request("GET", "oauth/access_token", None, params={
+    params = {
         "client_id": settings.META_APP_ID,
         "client_secret": settings.META_APP_SECRET,
         "code": code,
-    })
+    }
+    if redirect_uri is not None:
+        params["redirect_uri"] = redirect_uri
+    return await _graph_request("GET", "oauth/access_token", None, params=params)
 
 
 async def exchange_for_long_lived_token(short_lived_token: str) -> tuple[bool, dict]:

--- a/backend/app/channels/meta_base.py
+++ b/backend/app/channels/meta_base.py
@@ -156,6 +156,22 @@ async def graph_get(path: str, access_token: str, params: Optional[dict] = None,
     return await _graph_request("GET", path, access_token, params=params, base=base)
 
 
+def graph_detail(data: dict, fallback: str) -> str:
+    """Meta's own error text where it has one, so the UI can show the real
+    reason (e.g. a template that cannot be deleted) rather than a generic
+    failure.
+
+    error_user_msg first: `message` is often a generic OAuth string that says
+    nothing actionable — Graph will pair a `message` of "Application does not
+    have permission for this action" with an error_user_msg that names the
+    actual asset and rule. Only one of those is a clue.
+    """
+    error = data.get("error", {})
+    if not isinstance(error, dict):
+        return fallback
+    return error.get("error_user_msg") or error.get("message") or fallback
+
+
 async def graph_post_json(path: str, access_token: str, payload: dict) -> tuple[bool, dict]:
     """POST to a Graph node, keeping the response body (e.g. creating a message
     template returns its id, status and category)."""

--- a/backend/app/channels/meta_base.py
+++ b/backend/app/channels/meta_base.py
@@ -203,32 +203,42 @@ TEMPLATE_PAGE_LIMIT = 100
 TEMPLATE_MAX_PAGES = 10
 
 
-async def fetch_message_templates(waba_id: str, access_token: str) -> tuple[bool, list | dict]:
-    """Every template on the WABA, following Graph's cursor.
+async def graph_list_all(path: str, access_token: str, params: dict,
+                         max_pages: int = TEMPLATE_MAX_PAGES) -> tuple[bool, list | dict]:
+    """Every node on a Graph edge, following its cursor.
 
-    A template that exists but isn't listed is an invisible failure — an agent
-    picking one would never see it — so this pages rather than showing the
-    first hundred and stopping. Returns (True, [template dicts]) or
-    (False, graph error body), matching the other helpers here.
+    A node that exists but isn't listed is an invisible failure — a Page the
+    customer administers but never sees offered, a template an agent cannot pick
+    — so this pages rather than stopping at the first page. Returns
+    (True, [node dicts]) or (False, graph error body), matching the other
+    helpers here. A `limit` in params lets a short final page end the walk one
+    round-trip early; without one it stops when Graph offers no `after` cursor.
     """
-    templates: list = []
-    params = {"fields": TEMPLATE_FIELDS, "limit": TEMPLATE_PAGE_LIMIT}
-    for _ in range(TEMPLATE_MAX_PAGES):
-        ok, data = await graph_get(f"{waba_id}/message_templates", access_token, params=params)
+    items: list = []
+    limit = params.get("limit")
+    for _ in range(max_pages):
+        ok, data = await graph_get(path, access_token, params=params)
         if not ok:
             return False, data
         page = data.get("data")
         if not isinstance(page, list):
             return False, data
-        templates.extend(page)
+        items.extend(page)
 
         after = (data.get("paging") or {}).get("cursors", {}).get("after")
-        if not after or len(page) < TEMPLATE_PAGE_LIMIT:
-            return True, templates
+        if not after or (limit is not None and len(page) < limit):
+            return True, items
         params = {**params, "after": after}
 
-    logger.warning(f"Stopped paging templates for WABA {waba_id} at {TEMPLATE_MAX_PAGES} pages")
-    return True, templates
+    logger.warning(f"Stopped paging {path} at {max_pages} pages")
+    return True, items
+
+
+async def fetch_message_templates(waba_id: str, access_token: str) -> tuple[bool, list | dict]:
+    """Every template on the WABA (see graph_list_all for the paging rationale)."""
+    return await graph_list_all(
+        f"{waba_id}/message_templates", access_token,
+        {"fields": TEMPLATE_FIELDS, "limit": TEMPLATE_PAGE_LIMIT})
 
 
 async def subscribe_app(node_id: str, access_token: str, subscribed_fields: Optional[str] = None) -> bool:

--- a/backend/app/channels/meta_base.py
+++ b/backend/app/channels/meta_base.py
@@ -183,6 +183,24 @@ async def exchange_signup_code(code: str) -> tuple[bool, dict]:
     })
 
 
+async def exchange_for_long_lived_token(short_lived_token: str) -> tuple[bool, dict]:
+    """Trade a user token for a 60-day one.
+
+    Page tokens inherit their lifetime from the user token they were read with:
+    from a short-lived one they die in about an hour, from a long-lived one they
+    never expire. We store the Page token and send with it for months, so this
+    runs before /me/accounts. An already-long-lived token comes back unchanged,
+    so it is safe to call unconditionally. App credentials authenticate it, so
+    like exchange_signup_code it carries no bearer token.
+    """
+    return await _graph_request("GET", "oauth/access_token", None, params={
+        "grant_type": "fb_exchange_token",
+        "client_id": settings.META_APP_ID,
+        "client_secret": settings.META_APP_SECRET,
+        "fb_exchange_token": short_lived_token,
+    })
+
+
 async def register_phone_number(phone_number_id: str, access_token: str, pin: str) -> tuple[bool, dict]:
     """Enable a number for Cloud API sending.
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -97,6 +97,11 @@ class Settings(BaseSettings):
     # META_CONFIG_ID: it requests pages_messaging + pages_show_list and returns a
     # user token, not a WhatsApp signup.
     META_MESSENGER_CONFIG_ID: str = os.getenv("META_MESSENGER_CONFIG_ID", "")
+    # Instagram API with Instagram Login: its own app id/secret, separate from
+    # the Facebook ones above. This flow needs no Facebook Page — the business
+    # signs in with Instagram and we get an Instagram user token.
+    INSTAGRAM_APP_ID: str = os.getenv("INSTAGRAM_APP_ID", "")
+    INSTAGRAM_APP_SECRET: str = os.getenv("INSTAGRAM_APP_SECRET", "")
 
     VERIFY_SSL_CERTIFICATES: bool = os.getenv("VERIFY_SSL_CERTIFICATES", "true").lower() == "true"
     ENVIRONMENT: str = os.getenv("ENVIRONMENT", "development")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -90,8 +90,13 @@ class Settings(BaseSettings):
     # Our own random token echoed back during webhook GET verification
     META_WEBHOOK_VERIFY_TOKEN: str = os.getenv("META_WEBHOOK_VERIFY_TOKEN", "")
     META_GRAPH_VERSION: str = os.getenv("META_GRAPH_VERSION", "v21.0")
-    # Embedded Signup config id (cloud onboarding convenience; enterprise)
+    # WhatsApp Embedded Signup config id (cloud onboarding convenience)
     META_CONFIG_ID: str = os.getenv("META_CONFIG_ID", "")
+    # Facebook Login for Business config id, for connecting a Page (Messenger and
+    # Instagram DM both ride on the Page's token). A separate configuration from
+    # META_CONFIG_ID: it requests pages_messaging + pages_show_list and returns a
+    # user token, not a WhatsApp signup.
+    META_MESSENGER_CONFIG_ID: str = os.getenv("META_MESSENGER_CONFIG_ID", "")
 
     VERIFY_SSL_CERTIFICATES: bool = os.getenv("VERIFY_SSL_CERTIFICATES", "true").lower() == "true"
     ENVIRONMENT: str = os.getenv("ENVIRONMENT", "development")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -102,6 +102,11 @@ class Settings(BaseSettings):
     # signs in with Instagram and we get an Instagram user token.
     INSTAGRAM_APP_ID: str = os.getenv("INSTAGRAM_APP_ID", "")
     INSTAGRAM_APP_SECRET: str = os.getenv("INSTAGRAM_APP_SECRET", "")
+    # Comma-separated emails allowed to use one-click Meta signup. Empty means
+    # everyone, which is the end state — this exists so the flow can be exercised
+    # in production while the Meta app is still in App Review, since until it is
+    # approved the login only works for people with a role on the app anyway.
+    SIGNUP_ALLOWED_EMAILS: str = os.getenv("SIGNUP_ALLOWED_EMAILS", "")
 
     VERIFY_SSL_CERTIFICATES: bool = os.getenv("VERIFY_SSL_CERTIFICATES", "true").lower() == "true"
     ENVIRONMENT: str = os.getenv("ENVIRONMENT", "development")

--- a/backend/app/models/schemas/channel.py
+++ b/backend/app/models/schemas/channel.py
@@ -113,6 +113,18 @@ class MessengerSignupRequest(BaseModel):
     redirect_uri: str
 
 
+class InstagramLoginRequest(BaseModel):
+    """What Instagram Business Login hands back. No Page and no asset ids — the
+    token itself identifies the single account that signed in, so unlike the
+    Messenger flow there is nothing to list or pick.
+
+    redirect_uri is the OAuth callback the popup used; the code is bound to it,
+    so the token exchange must send the exact same value back."""
+    code: str
+    redirect_uri: str
+    display_name: Optional[str] = None
+
+
 class MessengerPageOut(BaseModel):
     """A Page offered in the picker. Its access token is deliberately absent:
     it travels back inside the opaque signup_token instead."""

--- a/backend/app/models/schemas/channel.py
+++ b/backend/app/models/schemas/channel.py
@@ -104,8 +104,13 @@ class EmbeddedSignupRequest(BaseModel):
 
 class MessengerSignupRequest(BaseModel):
     """The code Facebook Login for Business hands back. Unlike WhatsApp's
-    Embedded Signup it names no assets — the Pages are ours to look up."""
+    Embedded Signup it names no assets — the Pages are ours to look up.
+
+    redirect_uri is the OAuth callback URL the login popup used; the code is
+    bound to it, so the token exchange must send the exact same value back. The
+    client owns it (it must also be a registered Valid OAuth Redirect URI)."""
     code: str
+    redirect_uri: str
 
 
 class MessengerPageOut(BaseModel):

--- a/backend/app/models/schemas/channel.py
+++ b/backend/app/models/schemas/channel.py
@@ -102,6 +102,34 @@ class EmbeddedSignupRequest(BaseModel):
     display_name: Optional[str] = None
 
 
+class MessengerSignupRequest(BaseModel):
+    """The code Facebook Login for Business hands back. Unlike WhatsApp's
+    Embedded Signup it names no assets — the Pages are ours to look up."""
+    code: str
+
+
+class MessengerPageOut(BaseModel):
+    """A Page offered in the picker. Its access token is deliberately absent:
+    it travels back inside the opaque signup_token instead."""
+    id: str
+    name: str
+
+
+class MessengerSignupPagesOut(BaseModel):
+    """Step 1's result: the Pages to choose from, plus an opaque token that
+    carries their access tokens (encrypted) into step 2."""
+    pages: list[MessengerPageOut]
+    signup_token: str
+
+
+class MessengerSignupConnectRequest(BaseModel):
+    """Step 2: the Page picked out of step 1's list. page_id is a selector into
+    that list, not a credential — the token is the one we sealed."""
+    signup_token: str
+    page_id: str
+    display_name: Optional[str] = None
+
+
 class EmbeddedSignupConfigOut(BaseModel):
     """Tells the connect UI whether to offer Embedded Signup. Everything but
     `enabled` is None when it isn't, so nothing leaks to orgs without it."""

--- a/backend/tests/api/test_meta_channels_api.py
+++ b/backend/tests/api/test_meta_channels_api.py
@@ -399,6 +399,66 @@ class TestEmbeddedSignupConfig:
         assert client.get(f"{BASE}/embedded-signup-config?channel=carrier-pigeon").status_code == 404
 
 
+class TestSignupAllowlist:
+    """While the Meta app is in App Review its login only works for people with
+    a role on the app, so SIGNUP_ALLOWED_EMAILS keeps the button off every
+    account it would only fail for. Empty means everyone — the end state, and
+    what every other test in this file relies on."""
+
+    def test_open_to_everyone_when_unset(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "SIGNUP_ALLOWED_EMAILS", "")
+        monkeypatch.setattr(settings, "META_CONFIG_ID", "CFG1")
+        assert client.get(f"{BASE}/embedded-signup-config").json()["enabled"] is True
+
+    def test_disabled_for_an_account_not_on_the_list(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "META_CONFIG_ID", "CFG1")
+        monkeypatch.setattr(settings, "META_APP_ID", "APP1")
+        monkeypatch.setattr(settings, "SIGNUP_ALLOWED_EMAILS", "someone.else@example.com")
+        body = client.get(f"{BASE}/embedded-signup-config").json()
+
+        assert body["enabled"] is False
+        # The ids are what make the popup possible, so a gated-out account must
+        # not receive them either.
+        assert body["config_id"] is None
+        assert body["app_id"] is None
+
+    def test_enabled_for_an_account_on_the_list(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "META_CONFIG_ID", "CFG1")
+        monkeypatch.setattr(settings, "SIGNUP_ALLOWED_EMAILS",
+                            "first@example.com, test.user@example.com")
+        assert client.get(f"{BASE}/embedded-signup-config").json()["enabled"] is True
+
+    def test_matching_ignores_case_and_padding(self, client, monkeypatch):
+        """The list is hand-edited in an env var, so stray spacing or a
+        capitalised address must not silently lock the account out."""
+        monkeypatch.setattr(settings, "META_CONFIG_ID", "CFG1")
+        monkeypatch.setattr(settings, "SIGNUP_ALLOWED_EMAILS", "  Test.User@Example.COM  ,")
+        assert client.get(f"{BASE}/embedded-signup-config").json()["enabled"] is True
+
+    def test_connect_is_refused_for_an_account_not_on_the_list(self, client, monkeypatch):
+        """The gate is enforced server-side, not just hidden in the UI — the
+        config endpoint only decides which pane is shown."""
+        monkeypatch.setattr(settings, "META_CONFIG_ID", "CFG1")
+        monkeypatch.setattr(settings, "SIGNUP_ALLOWED_EMAILS", "someone.else@example.com")
+        exchange = AsyncMock(return_value=(True, {"access_token": "T"}))
+        with patch("app.api.channels.meta.exchange_signup_code", exchange):
+            r = client.post(f"{BASE}/whatsapp/embedded-signup", json={
+                "code": "CODE", "waba_id": "W1", "phone_number_id": "P1"})
+
+        assert r.status_code == 403
+        # Refused before the code is spent, so a retry once allowed still works.
+        exchange.assert_not_awaited()
+
+    def test_messenger_signup_is_refused_for_an_account_not_on_the_list(
+            self, client, monkeypatch):
+        monkeypatch.setattr(settings, "META_MESSENGER_CONFIG_ID", "MCFG")
+        monkeypatch.setattr(settings, "SIGNUP_ALLOWED_EMAILS", "someone.else@example.com")
+        r = client.post(f"{BASE}/messenger/signup/pages",
+                        json={"code": "CODE", "redirect_uri": "https://x/cb"})
+
+        assert r.status_code == 403
+
+
 class TestEmbeddedSignupConnect:
     ES = f"{BASE}/whatsapp/embedded-signup"
     PAYLOAD = {"code": "AQD-code", "waba_id": "WABA9", "phone_number_id": "PN555"}

--- a/backend/tests/api/test_meta_channels_api.py
+++ b/backend/tests/api/test_meta_channels_api.py
@@ -779,28 +779,28 @@ class TestGraphErrorDetail:
     }}
 
     def test_prefers_metas_human_readable_reason(self):
-        from app.api.channels.meta import _graph_detail
+        from app.channels.meta_base import graph_detail
 
         # Not the useless "Application does not have permission for this action"
-        assert _graph_detail(self.UNVERIFIED, "fallback") == (
+        assert graph_detail(self.UNVERIFIED, "fallback") == (
             "This WhatsApp Business account does not have permission to create message template"
         )
 
     def test_falls_back_to_message_when_there_is_no_user_msg(self):
-        from app.api.channels.meta import _graph_detail
+        from app.channels.meta_base import graph_detail
 
-        assert _graph_detail({"error": {"message": "Invalid parameter"}}, "fallback") == (
+        assert graph_detail({"error": {"message": "Invalid parameter"}}, "fallback") == (
             "Invalid parameter")
 
     def test_falls_back_to_our_own_text_when_graph_says_nothing(self):
-        from app.api.channels.meta import _graph_detail
+        from app.channels.meta_base import graph_detail
 
-        assert _graph_detail({}, "Could not read templates") == "Could not read templates"
+        assert graph_detail({}, "Could not read templates") == "Could not read templates"
 
     def test_survives_an_error_that_is_not_an_object(self):
-        from app.api.channels.meta import _graph_detail
+        from app.channels.meta_base import graph_detail
 
-        assert _graph_detail({"error": "boom"}, "fallback") == "fallback"
+        assert graph_detail({"error": "boom"}, "fallback") == "fallback"
 
 
 class TestTemplateLibraryLink:
@@ -813,7 +813,7 @@ class TestTemplateLibraryLink:
     OWNER = (True, {"owner_business_info": {"id": "BIZ1", "name": "Acme"}})
 
     def test_links_to_the_library_for_this_waba_and_business(self, client, waba_account):
-        with patch("app.api.channels.meta.graph_get", AsyncMock(return_value=self.OWNER)):
+        with patch("app.api.channels.whatsapp_messaging.graph_get", AsyncMock(return_value=self.OWNER)):
             r = self._url(client, waba_account)
 
         assert r.status_code == 200
@@ -824,7 +824,7 @@ class TestTemplateLibraryLink:
 
     def test_still_links_when_the_business_cannot_be_read(self, client, waba_account):
         # A worse link, not a dead button: Meta resolves the page from asset_id.
-        with patch("app.api.channels.meta.graph_get",
+        with patch("app.api.channels.whatsapp_messaging.graph_get",
                    AsyncMock(return_value=(False, {"error": {"message": "nope"}}))):
             r = self._url(client, waba_account)
 
@@ -833,7 +833,7 @@ class TestTemplateLibraryLink:
         assert "business_id" not in r.json()["url"]
 
     def test_omits_business_id_when_graph_returns_none(self, client, waba_account):
-        with patch("app.api.channels.meta.graph_get", AsyncMock(return_value=(True, {}))):
+        with patch("app.api.channels.whatsapp_messaging.graph_get", AsyncMock(return_value=(True, {}))):
             r = self._url(client, waba_account)
 
         assert "business_id" not in r.json()["url"]
@@ -1092,7 +1092,7 @@ class TestInboxAgentCanActuallyReachTheFeature:
         templates = [{"name": "order_update", "language": "en_US",
                       "status": "APPROVED", "category": "UTILITY",
                       "components": [{"type": "BODY", "text": "Hi {{1}}"}]}]
-        with patch("app.api.channels.meta.fetch_message_templates",
+        with patch("app.api.channels.whatsapp_messaging.fetch_message_templates",
                    AsyncMock(return_value=(True, templates))):
             r = inbox_client.get(f"{BASE}/whatsapp/{waba_account.id}/templates")
         assert r.status_code == 200

--- a/backend/tests/api/test_meta_channels_api.py
+++ b/backend/tests/api/test_meta_channels_api.py
@@ -561,7 +561,8 @@ class TestMessengerSignup:
              patch("app.api.channels.meta.exchange_for_long_lived_token",
                    AsyncMock(return_value=long_lived)), \
              patch("app.api.channels.meta.graph_list_all", lister):
-            r = client.post(self.PAGES, json={"code": "FB-code"})
+            r = client.post(self.PAGES, json={
+                "code": "FB-code", "redirect_uri": "https://app.test/meta-oauth-callback.html"})
         return r, lister
 
     def _signup_token(self, client):
@@ -629,7 +630,8 @@ class TestMessengerSignup:
     def test_stale_code_is_400(self, client):
         with patch("app.api.channels.meta.exchange_signup_code",
                    AsyncMock(return_value=(False, {"error": {"message": "Code expired"}}))):
-            r = client.post(self.PAGES, json={"code": "FB-code"})
+            r = client.post(self.PAGES, json={
+                "code": "FB-code", "redirect_uri": "https://app.test/meta-oauth-callback.html"})
         assert r.status_code == 400
         assert r.json()["detail"] == "Code expired"
 
@@ -649,7 +651,8 @@ class TestMessengerSignup:
         monkeypatch.setattr(settings, "META_MESSENGER_CONFIG_ID", "")
         exchange = AsyncMock()
         with patch("app.api.channels.meta.exchange_signup_code", exchange):
-            r = client.post(self.PAGES, json={"code": "FB-code"})
+            r = client.post(self.PAGES, json={
+                "code": "FB-code", "redirect_uri": "https://app.test/meta-oauth-callback.html"})
         assert r.status_code == 403
         exchange.assert_not_awaited()
 

--- a/backend/tests/api/test_meta_channels_api.py
+++ b/backend/tests/api/test_meta_channels_api.py
@@ -156,12 +156,63 @@ class TestMetaConnect:
                 "phone_number_id": "PN9", "access_token": "bad"})
         assert r.status_code == 400
 
+    def test_connect_messenger_success(self, client, db):
+        # A real messaging token carries pages_messaging but not
+        # pages_read_engagement, so the page name is unreadable — that must not
+        # block the connect, only the label.
+        inspect = AsyncMock(return_value=(True, {
+            "type": "PAGE", "profile_id": "PAGE9", "is_valid": True,
+            "scopes": ["pages_messaging"]}))
+        name = AsyncMock(return_value=(False, {"error": {"message": "needs pages_read_engagement"}}))
+        with patch("app.api.channels.meta.debug_token", inspect), \
+             patch("app.api.channels.meta.graph_get", name), \
+             patch("app.api.channels.meta.subscribe_app", AsyncMock(return_value=True)):
+            r = client.post(f"{BASE}/messenger", json={
+                "page_id": "PAGE9", "page_access_token": "EAAG-x"})
+        assert r.status_code == 200
+        assert r.json()["display_name"] == "PAGE9"
+        account = ChannelAccountRepository(db).get_by_external_id("messenger", "PAGE9")
+        assert ChannelAccountRepository(db).get_credentials(account)["access_token"] == "EAAG-x"
+
+    def test_connect_messenger_uses_page_name_when_readable(self, client):
+        inspect = AsyncMock(return_value=(True, {
+            "type": "PAGE", "profile_id": "PAGE9", "is_valid": True}))
+        with patch("app.api.channels.meta.debug_token", inspect), \
+             patch("app.api.channels.meta.graph_get", AsyncMock(return_value=(True, {"name": "Acme Support"}))), \
+             patch("app.api.channels.meta.subscribe_app", AsyncMock(return_value=True)):
+            r = client.post(f"{BASE}/messenger", json={
+                "page_id": "PAGE9", "page_access_token": "EAAG-x"})
+        assert r.status_code == 200
+        assert r.json()["display_name"] == "Acme Support"
+
     def test_connect_messenger_token_page_mismatch(self, client):
-        graph = AsyncMock(return_value=(True, {"id": "OTHER_PAGE", "name": "Nope"}))
-        with patch("app.api.channels.meta.graph_get", graph):
+        # Webhooks route on page id; a token for a different page would leave
+        # every inbound message unmatched.
+        inspect = AsyncMock(return_value=(True, {
+            "type": "PAGE", "profile_id": "OTHER_PAGE", "is_valid": True}))
+        with patch("app.api.channels.meta.debug_token", inspect):
             r = client.post(f"{BASE}/messenger", json={
                 "page_id": "PAGE9", "page_access_token": "EAAG-x"})
         assert r.status_code == 400
+        assert "OTHER_PAGE" in r.json()["detail"]
+
+    def test_connect_messenger_rejects_a_user_token(self, client):
+        inspect = AsyncMock(return_value=(True, {
+            "type": "USER", "profile_id": "PAGE9", "is_valid": True}))
+        with patch("app.api.channels.meta.debug_token", inspect):
+            r = client.post(f"{BASE}/messenger", json={
+                "page_id": "PAGE9", "page_access_token": "EAAG-x"})
+        assert r.status_code == 400
+        assert "Page access token" in r.json()["detail"]
+
+    def test_connect_messenger_rejects_an_expired_token(self, client):
+        inspect = AsyncMock(return_value=(True, {
+            "is_valid": False, "error": {"message": "Session has expired"}}))
+        with patch("app.api.channels.meta.debug_token", inspect):
+            r = client.post(f"{BASE}/messenger", json={
+                "page_id": "PAGE9", "page_access_token": "EAAG-x"})
+        assert r.status_code == 400
+        assert "Session has expired" in r.json()["detail"]
 
     def test_connect_instagram_success(self, client, db):
         graph = AsyncMock(return_value=(True, {"id": "IG7", "username": "acme"}))

--- a/backend/tests/api/test_meta_channels_api.py
+++ b/backend/tests/api/test_meta_channels_api.py
@@ -28,6 +28,7 @@ from app.core.application import app
 from app.core.auth import get_current_user, get_current_organization
 from app.core.config import settings
 from app.database import get_db
+from app.api.channels.meta import _seal_signup_pages
 from app.channels.base import SendResult
 from app.repositories.channels import ChannelAccountRepository
 
@@ -379,6 +380,24 @@ class TestEmbeddedSignupConfig:
         monkeypatch.setattr(settings, "META_CONFIG_ID", "CFG1")
         assert client.get(f"{BASE}/embedded-signup-config").json()["enabled"] is True
 
+    def test_messenger_config_id_returned_for_messenger(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "META_MESSENGER_CONFIG_ID", "MCFG")
+        monkeypatch.setattr(settings, "META_APP_ID", "APP1")
+        body = client.get(f"{BASE}/embedded-signup-config?channel=messenger").json()
+        assert (body["enabled"], body["config_id"], body["app_id"]) == (True, "MCFG", "APP1")
+
+    def test_whatsapp_config_id_not_served_to_messenger(self, client, monkeypatch):
+        """The WhatsApp config id must not leak on a Messenger request: Messenger
+        has its own config, and an unset one means the manual form, not WhatsApp's."""
+        monkeypatch.setattr(settings, "META_CONFIG_ID", "CFG1")
+        monkeypatch.setattr(settings, "META_MESSENGER_CONFIG_ID", "")
+        body = client.get(f"{BASE}/embedded-signup-config?channel=messenger").json()
+        assert body["enabled"] is False
+        assert body["config_id"] is None
+
+    def test_unknown_channel_404(self, client):
+        assert client.get(f"{BASE}/embedded-signup-config?channel=carrier-pigeon").status_code == 404
+
 
 class TestEmbeddedSignupConnect:
     ES = f"{BASE}/whatsapp/embedded-signup"
@@ -513,6 +532,126 @@ class TestEmbeddedSignupConnect:
         assert credentials["access_token"] == "EAAG-rotated"
         assert credentials["verification_pin"] == pin
         assert credentials["waba_id"] == "WABA9"
+
+
+class TestMessengerSignup:
+    """Facebook Login for Business: the code exchanges to a user token, we list
+    the customer's Pages, and connect the one they pick. The Page tokens ride
+    back to step 2 sealed in signup_token, never through the browser."""
+
+    PAGES = f"{BASE}/messenger/signup/pages"
+    CONNECT = f"{BASE}/messenger/signup/connect"
+
+    # As /me/accounts lists them for the exchanged user token
+    TWO_PAGES = [
+        {"id": "PAGE1", "name": "Acme Support", "access_token": "EAAG-page1"},
+        {"id": "PAGE2", "name": "Acme Sales", "access_token": "EAAG-page2"},
+    ]
+
+    @pytest.fixture(autouse=True)
+    def enabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "META_MESSENGER_CONFIG_ID", "MCFG")
+
+    def _list_pages(self, client, pages=None,
+                    long_lived=(True, {"access_token": "LONGLIVED"})):
+        """Drive step 1, returning (response, graph_list_all mock)."""
+        lister = AsyncMock(return_value=(True, self.TWO_PAGES if pages is None else pages))
+        with patch("app.api.channels.meta.exchange_signup_code",
+                   AsyncMock(return_value=(True, {"access_token": "USERTOKEN"}))), \
+             patch("app.api.channels.meta.exchange_for_long_lived_token",
+                   AsyncMock(return_value=long_lived)), \
+             patch("app.api.channels.meta.graph_list_all", lister):
+            r = client.post(self.PAGES, json={"code": "FB-code"})
+        return r, lister
+
+    def _signup_token(self, client):
+        return self._list_pages(client)[0].json()["signup_token"]
+
+    def test_lists_pages_without_leaking_their_tokens(self, client):
+        r, _ = self._list_pages(client)
+        assert r.status_code == 200
+        body = r.json()
+        assert [p["id"] for p in body["pages"]] == ["PAGE1", "PAGE2"]
+        assert all(set(p.keys()) == {"id", "name"} for p in body["pages"])
+        # The whole point of the sealed token: no page token in the wire response
+        assert "EAAG-page1" not in r.text and "EAAG-page2" not in r.text
+
+    def test_connect_stores_the_token_meta_gave_us_for_that_page(self, client, db):
+        token = self._signup_token(client)
+        subscribe = AsyncMock(return_value=True)
+        with patch("app.api.channels.meta.subscribe_app", subscribe):
+            r = client.post(self.CONNECT, json={"signup_token": token, "page_id": "PAGE2"})
+
+        assert r.status_code == 200
+        assert r.json()["display_name"] == "Acme Sales"
+        repo = ChannelAccountRepository(db)
+        account = repo.get_by_external_id("messenger", "PAGE2")
+        assert repo.get_credentials(account)["access_token"] == "EAAG-page2"
+        subscribe.assert_awaited_once_with(
+            "PAGE2", "EAAG-page2", subscribed_fields="messages,messaging_postbacks")
+
+    def test_rejects_a_page_that_was_not_in_the_signup(self, client, db):
+        """page_id is a selector into a list we fetched, not a claim — a Page the
+        signup never offered cannot be connected, and its token is unknown to us."""
+        token = self._signup_token(client)
+        with patch("app.api.channels.meta.subscribe_app", AsyncMock()) as subscribe:
+            r = client.post(self.CONNECT, json={"signup_token": token, "page_id": "PAGE_I_DO_NOT_OWN"})
+
+        assert r.status_code == 400
+        subscribe.assert_not_awaited()
+        assert ChannelAccountRepository(db).get_by_external_id("messenger", "PAGE_I_DO_NOT_OWN") is None
+
+    def test_rejects_another_orgs_signup_token(self, client, db):
+        """A blob sealed for one org must not connect under another — it is bound
+        to the org id inside the ciphertext, not just handed to the browser."""
+        foreign = _seal_signup_pages(uuid4(), self.TWO_PAGES)
+        r = client.post(self.CONNECT, json={"signup_token": foreign, "page_id": "PAGE1"})
+
+        assert r.status_code == 400
+        assert ChannelAccountRepository(db).get_by_external_id("messenger", "PAGE1") is None
+
+    def test_rejects_an_expired_signup_token(self, client, monkeypatch):
+        monkeypatch.setattr("app.api.channels.meta.SIGNUP_TOKEN_TTL_SECONDS", -10)
+        token = self._signup_token(client)
+        r = client.post(self.CONNECT, json={"signup_token": token, "page_id": "PAGE1"})
+        assert r.status_code == 400
+
+    def test_rejects_a_forged_signup_token(self, client):
+        """A garbage token is a clean 400, not a 500 — decrypt's ValueError is caught."""
+        r = client.post(self.CONNECT, json={"signup_token": "not-a-real-token", "page_id": "PAGE1"})
+        assert r.status_code == 400
+
+    def test_no_pages_is_a_clear_400(self, client):
+        r, _ = self._list_pages(client, pages=[])
+        assert r.status_code == 400
+        assert "No Facebook Pages" in r.json()["detail"]
+
+    def test_stale_code_is_400(self, client):
+        with patch("app.api.channels.meta.exchange_signup_code",
+                   AsyncMock(return_value=(False, {"error": {"message": "Code expired"}}))):
+            r = client.post(self.PAGES, json={"code": "FB-code"})
+        assert r.status_code == 400
+        assert r.json()["detail"] == "Code expired"
+
+    def test_signup_uses_the_long_lived_token_for_page_lookup(self, client):
+        """Page tokens inherit the user token's life, so the lookup must use the
+        extended token — otherwise every Page dies about an hour after launch."""
+        _, lister = self._list_pages(client)
+        assert lister.await_args.args[0] == "me/accounts"
+        assert lister.await_args.args[1] == "LONGLIVED"
+
+    def test_pages_still_listed_when_extension_fails(self, client):
+        r, lister = self._list_pages(client, long_lived=(False, {"error": {"message": "nope"}}))
+        assert r.status_code == 200
+        assert lister.await_args.args[1] == "USERTOKEN"
+
+    def test_rejected_without_messenger_config_id(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "META_MESSENGER_CONFIG_ID", "")
+        exchange = AsyncMock()
+        with patch("app.api.channels.meta.exchange_signup_code", exchange):
+            r = client.post(self.PAGES, json={"code": "FB-code"})
+        assert r.status_code == 403
+        exchange.assert_not_awaited()
 
 
 class TestGraphErrorDetail:

--- a/backend/tests/api/test_meta_channels_api.py
+++ b/backend/tests/api/test_meta_channels_api.py
@@ -657,64 +657,104 @@ class TestMessengerSignup:
         exchange.assert_not_awaited()
 
 
-class TestInstagramSignup:
-    """Same Login-for-Business popup as Messenger, but the picker offers the
-    Instagram account linked to each Page and connects it by its own id."""
+class TestInstagramLogin:
+    """Instagram Login needs no Facebook Page: the business signs in with
+    Instagram, so one account comes back and there is nothing to pick."""
 
-    PAGES = f"{BASE}/instagram/signup/pages"
-    CONNECT = f"{BASE}/instagram/signup/connect"
-
-    # /me/accounts with the IG fields: one Page has a linked account, one doesn't.
-    PAGES_WITH_IG = [
-        {"id": "PAGE1", "name": "Acme", "access_token": "EAAG-page1",
-         "instagram_business_account": {"id": "IG100", "username": "acme"}},
-        {"id": "PAGE2", "name": "No IG", "access_token": "EAAG-page2"},
-    ]
+    CONNECT = f"{BASE}/instagram/login/connect"
+    PAYLOAD = {"code": "IG-code", "redirect_uri": "https://app.test/meta-oauth-callback.html"}
 
     @pytest.fixture(autouse=True)
     def enabled(self, monkeypatch):
-        monkeypatch.setattr(settings, "META_MESSENGER_CONFIG_ID", "MCFG")
+        monkeypatch.setattr(settings, "INSTAGRAM_APP_ID", "IGAPP")
+        monkeypatch.setattr(settings, "INSTAGRAM_APP_SECRET", "IGSECRET")
 
-    def _list_pages(self, client, pages=None):
-        lister = AsyncMock(return_value=(True, self.PAGES_WITH_IG if pages is None else pages))
-        with patch("app.api.channels.meta.exchange_signup_code",
-                   AsyncMock(return_value=(True, {"access_token": "USERTOKEN"}))), \
-             patch("app.api.channels.meta.exchange_for_long_lived_token",
-                   AsyncMock(return_value=(True, {"access_token": "LONGLIVED"}))), \
-             patch("app.api.channels.meta.graph_list_all", lister):
-            r = client.post(self.PAGES, json={
-                "code": "FB-code", "redirect_uri": "https://app.test/meta-oauth-callback.html"})
-        return r, lister
+    def _connect(self, client, exchange=None, long_lived=(True, {"access_token": "IGLong"})):
+        exchange = exchange or AsyncMock(
+            return_value=(True, {"access_token": "IGShort", "user_id": "17841400"}))
+        with patch("app.api.channels.meta.exchange_instagram_code", exchange), \
+             patch("app.api.channels.meta.exchange_instagram_long_lived",
+                   AsyncMock(return_value=long_lived)), \
+             patch("app.api.channels.meta.graph_get",
+                   AsyncMock(return_value=(True, {"username": "acme"}))), \
+             patch("app.api.channels.meta.subscribe_instagram_app",
+                   AsyncMock(return_value=True)):
+            return client.post(self.CONNECT, json=self.PAYLOAD), exchange
 
-    def test_only_offers_pages_with_a_linked_ig_account(self, client):
-        r, _ = self._list_pages(client)
+    def test_connects_the_account_that_logged_in(self, client, db):
+        r, exchange = self._connect(client)
+
         assert r.status_code == 200
-        pages = r.json()["pages"]
-        # PAGE2 has no linked IG account, so it must not be offered.
-        assert [p["id"] for p in pages] == ["PAGE1"]
-        assert pages[0]["name"] == "@acme"
-        assert "EAAG-page1" not in r.text  # token stays sealed
+        assert r.json()["display_name"] == "@acme"
+        repo = ChannelAccountRepository(db)
+        account = repo.get_by_external_id("instagram", "17841400")
+        assert account is not None
+        # The long-lived token is what gets stored, not the ~1h login token.
+        assert repo.get_credentials(account)["access_token"] == "IGLong"
+        exchange.assert_awaited_once_with("IG-code", "https://app.test/meta-oauth-callback.html")
 
-    def test_connect_stores_the_ig_account_id_not_the_page_id(self, client, db):
-        token = self._list_pages(client)[0].json()["signup_token"]
-        subscribe = AsyncMock(return_value=True)
-        with patch("app.api.channels.meta.subscribe_app", subscribe):
-            r = client.post(self.CONNECT, json={"signup_token": token, "page_id": "PAGE1"})
+    def test_keys_the_account_on_the_id_webhooks_route_by(self, client, db):
+        """/me's user_id is the professional account id that arrives as the
+        webhook's entry.id; the login response's can be app-scoped. Keying on
+        the wrong one drops every inbound DM silently."""
+        with patch("app.api.channels.meta.exchange_instagram_code",
+                   AsyncMock(return_value=(True, {"access_token": "IGShort", "user_id": "APPSCOPED"}))), \
+             patch("app.api.channels.meta.exchange_instagram_long_lived",
+                   AsyncMock(return_value=(True, {"access_token": "IGLong"}))), \
+             patch("app.api.channels.meta.graph_get",
+                   AsyncMock(return_value=(True, {"user_id": "17841400", "username": "acme"}))), \
+             patch("app.api.channels.meta.subscribe_instagram_app", AsyncMock(return_value=True)):
+            r = client.post(self.CONNECT, json=self.PAYLOAD)
 
         assert r.status_code == 200
         repo = ChannelAccountRepository(db)
-        # Keyed by the IG account id (webhooks route on it), with the Page token.
-        account = repo.get_by_external_id("instagram", "IG100")
-        assert account is not None
-        assert repo.get_credentials(account)["access_token"] == "EAAG-page1"
-        assert account.display_name == "@acme"
-        subscribe.assert_awaited_once_with(
-            "PAGE1", "EAAG-page1", subscribed_fields="messages,messaging_postbacks")
+        assert repo.get_by_external_id("instagram", "17841400") is not None
+        assert repo.get_by_external_id("instagram", "APPSCOPED") is None
 
-    def test_no_linked_ig_account_is_a_clear_400(self, client):
-        r, _ = self._list_pages(client, pages=[self.PAGES_WITH_IG[1]])
+    def test_accepts_the_wrapped_token_response_shape(self, client, db):
+        """Instagram also returns the token inside a `data` list."""
+        wrapped = AsyncMock(return_value=(True, {
+            "data": [{"access_token": "IGShort", "user_id": "17841400"}]}))
+        r, _ = self._connect(client, exchange=wrapped)
+
+        assert r.status_code == 200
+        assert ChannelAccountRepository(db).get_by_external_id("instagram", "17841400") is not None
+
+    def test_falls_back_to_the_short_token_when_extension_fails(self, client, db):
+        r, _ = self._connect(client, long_lived=(False, {"error": {"message": "nope"}}))
+
+        assert r.status_code == 200
+        repo = ChannelAccountRepository(db)
+        account = repo.get_by_external_id("instagram", "17841400")
+        assert repo.get_credentials(account)["access_token"] == "IGShort"
+
+    def test_stale_code_is_400(self, client, db):
+        stale = AsyncMock(return_value=(False, {"error": {"message": "Code expired"}}))
+        r, _ = self._connect(client, exchange=stale)
+
         assert r.status_code == 400
-        assert "Instagram professional account" in r.json()["detail"]
+        assert r.json()["detail"] == "Code expired"
+        assert ChannelAccountRepository(db).get_by_external_id("instagram", "17841400") is None
+
+    def test_a_response_without_a_token_is_400(self, client):
+        empty = AsyncMock(return_value=(True, {}))
+        r, _ = self._connect(client, exchange=empty)
+        assert r.status_code == 400
+
+    def test_rejected_without_instagram_app_credentials(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "INSTAGRAM_APP_ID", "")
+        exchange = AsyncMock()
+        with patch("app.api.channels.meta.exchange_instagram_code", exchange):
+            r = client.post(self.CONNECT, json=self.PAYLOAD)
+        assert r.status_code == 403
+        exchange.assert_not_awaited()
+
+    def test_config_serves_the_instagram_app_id_and_no_config_id(self, client, monkeypatch):
+        """The frontend builds the Instagram authorize URL from the Instagram
+        app id; the Facebook config id is meaningless here."""
+        monkeypatch.setattr(settings, "META_APP_ID", "FBAPP")
+        body = client.get(f"{BASE}/embedded-signup-config?channel=instagram").json()
+        assert (body["enabled"], body["app_id"], body["config_id"]) == (True, "IGAPP", None)
 
 
 class TestGraphErrorDetail:

--- a/backend/tests/api/test_meta_channels_api.py
+++ b/backend/tests/api/test_meta_channels_api.py
@@ -657,6 +657,66 @@ class TestMessengerSignup:
         exchange.assert_not_awaited()
 
 
+class TestInstagramSignup:
+    """Same Login-for-Business popup as Messenger, but the picker offers the
+    Instagram account linked to each Page and connects it by its own id."""
+
+    PAGES = f"{BASE}/instagram/signup/pages"
+    CONNECT = f"{BASE}/instagram/signup/connect"
+
+    # /me/accounts with the IG fields: one Page has a linked account, one doesn't.
+    PAGES_WITH_IG = [
+        {"id": "PAGE1", "name": "Acme", "access_token": "EAAG-page1",
+         "instagram_business_account": {"id": "IG100", "username": "acme"}},
+        {"id": "PAGE2", "name": "No IG", "access_token": "EAAG-page2"},
+    ]
+
+    @pytest.fixture(autouse=True)
+    def enabled(self, monkeypatch):
+        monkeypatch.setattr(settings, "META_MESSENGER_CONFIG_ID", "MCFG")
+
+    def _list_pages(self, client, pages=None):
+        lister = AsyncMock(return_value=(True, self.PAGES_WITH_IG if pages is None else pages))
+        with patch("app.api.channels.meta.exchange_signup_code",
+                   AsyncMock(return_value=(True, {"access_token": "USERTOKEN"}))), \
+             patch("app.api.channels.meta.exchange_for_long_lived_token",
+                   AsyncMock(return_value=(True, {"access_token": "LONGLIVED"}))), \
+             patch("app.api.channels.meta.graph_list_all", lister):
+            r = client.post(self.PAGES, json={
+                "code": "FB-code", "redirect_uri": "https://app.test/meta-oauth-callback.html"})
+        return r, lister
+
+    def test_only_offers_pages_with_a_linked_ig_account(self, client):
+        r, _ = self._list_pages(client)
+        assert r.status_code == 200
+        pages = r.json()["pages"]
+        # PAGE2 has no linked IG account, so it must not be offered.
+        assert [p["id"] for p in pages] == ["PAGE1"]
+        assert pages[0]["name"] == "@acme"
+        assert "EAAG-page1" not in r.text  # token stays sealed
+
+    def test_connect_stores_the_ig_account_id_not_the_page_id(self, client, db):
+        token = self._list_pages(client)[0].json()["signup_token"]
+        subscribe = AsyncMock(return_value=True)
+        with patch("app.api.channels.meta.subscribe_app", subscribe):
+            r = client.post(self.CONNECT, json={"signup_token": token, "page_id": "PAGE1"})
+
+        assert r.status_code == 200
+        repo = ChannelAccountRepository(db)
+        # Keyed by the IG account id (webhooks route on it), with the Page token.
+        account = repo.get_by_external_id("instagram", "IG100")
+        assert account is not None
+        assert repo.get_credentials(account)["access_token"] == "EAAG-page1"
+        assert account.display_name == "@acme"
+        subscribe.assert_awaited_once_with(
+            "PAGE1", "EAAG-page1", subscribed_fields="messages,messaging_postbacks")
+
+    def test_no_linked_ig_account_is_a_clear_400(self, client):
+        r, _ = self._list_pages(client, pages=[self.PAGES_WITH_IG[1]])
+        assert r.status_code == 400
+        assert "Instagram professional account" in r.json()["detail"]
+
+
 class TestGraphErrorDetail:
     """Meta's `message` is often a generic OAuth string; error_user_msg is the
     one that names the actual asset and rule.

--- a/backend/tests/channels/test_meta_adapters.py
+++ b/backend/tests/channels/test_meta_adapters.py
@@ -17,7 +17,7 @@ limitations under the License.
 import hashlib
 import hmac
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -177,6 +177,47 @@ class TestMessengerInstagramParse:
         assert len(messages) == 1
         assert messages[0].external_account_id == "IG7"
         assert messages[0].external_conversation_id == "IGSID2"
+
+
+class TestProfileEnrichment:
+    """The inbound payload carries only a sender id, so the customer's real name
+    is looked up on demand — otherwise everyone shows as 'Messenger user 2742…'."""
+
+    def _adapter(self, channel, monkeypatch, graph_return):
+        adapter = get_adapter(channel)
+        monkeypatch.setattr(adapter, "access_token", lambda account: "PAGE_TOKEN")
+        graph = AsyncMock(return_value=graph_return)
+        monkeypatch.setattr("app.channels.messenger.graph_get", graph)
+        return adapter, graph
+
+    @pytest.mark.asyncio
+    async def test_messenger_resolves_the_senders_name(self, monkeypatch):
+        adapter, graph = self._adapter(
+            "messenger", monkeypatch, (True, {"first_name": "Ada", "last_name": "Lovelace"}))
+        assert await adapter.fetch_profile(MagicMock(), "PSID1") == {"name": "Ada Lovelace"}
+        graph.assert_awaited_once_with(
+            "PSID1", "PAGE_TOKEN", params={"fields": "first_name,last_name"})
+
+    @pytest.mark.asyncio
+    async def test_a_graph_failure_degrades_to_no_name(self, monkeypatch):
+        """A lookup failure must not lose the message — it keeps the placeholder."""
+        adapter, _ = self._adapter(
+            "messenger", monkeypatch, (False, {"error": {"message": "rate limited"}}))
+        assert await adapter.fetch_profile(MagicMock(), "PSID1") == {}
+
+    @pytest.mark.asyncio
+    async def test_instagram_uses_the_ig_name_fields(self, monkeypatch):
+        adapter, graph = self._adapter(
+            "instagram", monkeypatch, (True, {"name": "Ada", "username": "ada_l"}))
+        assert await adapter.fetch_profile(MagicMock(), "IGSID1") == {"name": "Ada"}
+        graph.assert_awaited_once_with(
+            "IGSID1", "PAGE_TOKEN", params={"fields": "name,username"})
+
+    @pytest.mark.asyncio
+    async def test_instagram_falls_back_to_username(self, monkeypatch):
+        adapter, _ = self._adapter(
+            "instagram", monkeypatch, (True, {"username": "ada_l"}))
+        assert await adapter.fetch_profile(MagicMock(), "IGSID1") == {"name": "ada_l"}
 
 
 class TestDeliveryWindow:

--- a/backend/tests/channels/test_meta_adapters.py
+++ b/backend/tests/channels/test_meta_adapters.py
@@ -27,9 +27,13 @@ from app.channels.meta_base import (
     verify_meta_signature,
     verify_challenge,
     exchange_for_long_lived_token,
+    exchange_instagram_code,
+    exchange_instagram_long_lived,
     graph_get,
     graph_list_all,
     graph_post_json,
+    instagram_token_payload,
+    GRAPH_INSTAGRAM_BASE,
     WINDOW_HOURS,
 )
 from app.core.config import settings
@@ -112,7 +116,24 @@ class TestSignatureAndChallenge:
 
     def test_signature_rejected_without_configured_secret(self, monkeypatch):
         monkeypatch.setattr(settings, "META_APP_SECRET", "")
+        monkeypatch.setattr(settings, "INSTAGRAM_APP_SECRET", "")
         assert verify_meta_signature(b"{}", "sha256=anything") is False
+
+    def test_accepts_a_payload_signed_with_the_instagram_secret(self, monkeypatch):
+        """Instagram Login webhooks are signed with the Instagram app secret;
+        rejecting those would drop every Instagram DM at the door."""
+        monkeypatch.setattr(settings, "META_APP_SECRET", "fb-secret")
+        monkeypatch.setattr(settings, "INSTAGRAM_APP_SECRET", "ig-secret")
+        body = b'{"object":"instagram"}'
+        sig = "sha256=" + hmac.new(b"ig-secret", body, hashlib.sha256).hexdigest()
+        assert verify_meta_signature(body, sig) is True
+
+    def test_a_signature_from_neither_secret_is_rejected(self, monkeypatch):
+        monkeypatch.setattr(settings, "META_APP_SECRET", "fb-secret")
+        monkeypatch.setattr(settings, "INSTAGRAM_APP_SECRET", "ig-secret")
+        body = b'{"object":"instagram"}'
+        sig = "sha256=" + hmac.new(b"attacker", body, hashlib.sha256).hexdigest()
+        assert verify_meta_signature(body, sig) is False
 
     def test_challenge(self, monkeypatch):
         monkeypatch.setattr(settings, "META_WEBHOOK_VERIFY_TOKEN", "vtok")
@@ -179,6 +200,40 @@ class TestMessengerInstagramParse:
         assert messages[0].external_conversation_id == "IGSID2"
 
 
+class TestInstagramTransport:
+    """Instagram Login accounts hold an Instagram user token, which the Facebook
+    graph rejects — every call for them must go to graph.instagram.com."""
+
+    @pytest.mark.asyncio
+    async def test_instagram_sends_via_graph_instagram(self, graph_client, monkeypatch):
+        adapter = get_adapter("instagram")
+        monkeypatch.setattr(adapter, "access_token", lambda account: "IGTOKEN")
+        graph_client.response = _FakeResponse(200, {"message_id": "m1"})
+        conversation = MagicMock()
+        conversation.external_conversation_id = "IGSID1"
+
+        await adapter.send_text(MagicMock(), conversation, "hi")
+
+        call = graph_client.calls[0]
+        assert call["url"].startswith(GRAPH_INSTAGRAM_BASE)
+        # messaging_type is Messenger-only; Instagram's send body omits it.
+        assert "messaging_type" not in call["json"]
+
+    @pytest.mark.asyncio
+    async def test_messenger_still_sends_via_graph_facebook(self, graph_client, monkeypatch):
+        adapter = get_adapter("messenger")
+        monkeypatch.setattr(adapter, "access_token", lambda account: "PAGETOKEN")
+        graph_client.response = _FakeResponse(200, {"message_id": "m1"})
+        conversation = MagicMock()
+        conversation.external_conversation_id = "PSID1"
+
+        await adapter.send_text(MagicMock(), conversation, "hi")
+
+        call = graph_client.calls[0]
+        assert call["url"].startswith("https://graph.facebook.com")
+        assert call["json"]["messaging_type"] == "RESPONSE"
+
+
 class TestProfileEnrichment:
     """The inbound payload carries only a sender id, so the customer's real name
     is looked up on demand — otherwise everyone shows as 'Messenger user 2742…'."""
@@ -196,7 +251,8 @@ class TestProfileEnrichment:
             "messenger", monkeypatch, (True, {"first_name": "Ada", "last_name": "Lovelace"}))
         assert await adapter.fetch_profile(MagicMock(), "PSID1") == {"name": "Ada Lovelace"}
         graph.assert_awaited_once_with(
-            "PSID1", "PAGE_TOKEN", params={"fields": "first_name,last_name"})
+            "PSID1", "PAGE_TOKEN", params={"fields": "first_name,last_name"},
+            base="https://graph.facebook.com")
 
     @pytest.mark.asyncio
     async def test_a_graph_failure_degrades_to_no_name(self, monkeypatch):
@@ -211,7 +267,8 @@ class TestProfileEnrichment:
             "instagram", monkeypatch, (True, {"name": "Ada", "username": "ada_l"}))
         assert await adapter.fetch_profile(MagicMock(), "IGSID1") == {"name": "Ada"}
         graph.assert_awaited_once_with(
-            "IGSID1", "PAGE_TOKEN", params={"fields": "name,username"})
+            "IGSID1", "PAGE_TOKEN", params={"fields": "name,username"},
+            base="https://graph.instagram.com")
 
     @pytest.mark.asyncio
     async def test_instagram_falls_back_to_username(self, monkeypatch):
@@ -267,12 +324,16 @@ class _RecordingClient:
         self.error = None
         self.calls = []
 
-    async def request(self, method, url, params=None, json=None, headers=None):
+    async def request(self, method, url, params=None, json=None, headers=None, data=None):
         self.calls.append({"method": method, "url": url, "params": params,
-                           "json": json, "headers": headers})
+                           "json": json, "headers": headers, "data": data})
         if self.error:
             raise self.error
         return self.response
+
+    async def post(self, url, json=None, headers=None):
+        """graph_post sends through .post rather than .request."""
+        return await self.request("POST", url, json=json, headers=headers)
 
 
 @pytest.fixture
@@ -341,6 +402,47 @@ class TestGraphHelpers:
         assert call["params"]["grant_type"] == "fb_exchange_token"
         assert call["params"]["fb_exchange_token"] == "short-token"
         assert "SEKRET" not in call["url"]
+
+    @pytest.mark.asyncio
+    async def test_instagram_code_exchange_uses_the_instagram_app_and_host(
+            self, graph_client, monkeypatch):
+        """Instagram Login is its own OAuth: Instagram app credentials, its own
+        host, form-encoded — the Facebook app id here would be rejected."""
+        monkeypatch.setattr(settings, "INSTAGRAM_APP_ID", "IGAPP")
+        monkeypatch.setattr(settings, "INSTAGRAM_APP_SECRET", "IGSECRET")
+        monkeypatch.setattr(settings, "META_APP_ID", "FBAPP")
+        graph_client.response = _FakeResponse(200, {"access_token": "IGShort", "user_id": 178})
+
+        ok, body = await exchange_instagram_code("CODE", "https://app.test/cb.html")
+
+        assert (ok, body["access_token"]) == (True, "IGShort")
+        call = graph_client.calls[0]
+        assert call["url"] == "https://api.instagram.com/oauth/access_token"
+        assert call["data"]["client_id"] == "IGAPP"
+        assert call["data"]["grant_type"] == "authorization_code"
+        assert call["data"]["redirect_uri"] == "https://app.test/cb.html"
+
+    @pytest.mark.asyncio
+    async def test_instagram_long_lived_exchange_hits_graph_instagram(self, graph_client, monkeypatch):
+        monkeypatch.setattr(settings, "INSTAGRAM_APP_SECRET", "IGSECRET")
+        graph_client.response = _FakeResponse(200, {"access_token": "IGLong", "expires_in": 5183944})
+
+        ok, body = await exchange_instagram_long_lived("IGShort")
+
+        assert (ok, body["access_token"]) == (True, "IGLong")
+        call = graph_client.calls[0]
+        assert call["url"] == f"{GRAPH_INSTAGRAM_BASE}/access_token"
+        assert call["params"]["grant_type"] == "ig_exchange_token"
+
+    def test_token_payload_accepts_both_response_shapes(self):
+        """Instagram has returned the token flat and wrapped in `data`; reading
+        only one shape yields no token and looks like a login failure."""
+        flat = {"access_token": "A", "user_id": 1}
+        wrapped = {"data": [{"access_token": "A", "user_id": 1}]}
+        assert instagram_token_payload(flat)["access_token"] == "A"
+        assert instagram_token_payload(wrapped)["access_token"] == "A"
+        # An empty/malformed `data` falls back rather than raising
+        assert instagram_token_payload({"data": []}) == {"data": []}
 
     @pytest.mark.asyncio
     async def test_graph_list_all_follows_the_cursor(self, graph_client):

--- a/backend/tests/channels/test_meta_adapters.py
+++ b/backend/tests/channels/test_meta_adapters.py
@@ -18,6 +18,7 @@ import hashlib
 import hmac
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
+from urllib.parse import urlparse
 
 import pytest
 
@@ -33,10 +34,21 @@ from app.channels.meta_base import (
     graph_list_all,
     graph_post_json,
     instagram_token_payload,
+    GRAPH_BASE,
     GRAPH_INSTAGRAM_BASE,
     WINDOW_HOURS,
 )
 from app.core.config import settings
+
+
+def _host(url: str) -> str:
+    """The host a request actually went to.
+
+    Compared rather than prefix-matched: `startswith(GRAPH_BASE)` is also
+    satisfied by `https://graph.facebook.com.evil.example/...`, so it does not
+    really pin down where a token was sent.
+    """
+    return urlparse(url).hostname or ""
 
 
 WHATSAPP_PAYLOAD = {
@@ -247,7 +259,7 @@ class TestInstagramTransport:
         await adapter.send_text(MagicMock(), conversation, "hi")
 
         call = graph_client.calls[0]
-        assert call["url"].startswith(GRAPH_INSTAGRAM_BASE)
+        assert _host(call["url"]) == _host(GRAPH_INSTAGRAM_BASE)
         # messaging_type is Messenger-only; Instagram's send body omits it.
         assert "messaging_type" not in call["json"]
 
@@ -262,7 +274,7 @@ class TestInstagramTransport:
         await adapter.send_text(MagicMock(), conversation, "hi")
 
         call = graph_client.calls[0]
-        assert call["url"].startswith("https://graph.facebook.com")
+        assert _host(call["url"]) == _host(GRAPH_BASE)
         assert call["json"]["messaging_type"] == "RESPONSE"
 
 

--- a/backend/tests/channels/test_meta_adapters.py
+++ b/backend/tests/channels/test_meta_adapters.py
@@ -199,6 +199,38 @@ class TestMessengerInstagramParse:
         assert messages[0].external_account_id == "IG7"
         assert messages[0].external_conversation_id == "IGSID2"
 
+    def test_parse_instagram_changes_shape(self):
+        """Instagram also delivers a DM under changes[] with field=messages
+        (this is the shape Meta's own webhook sample sends). Reading only
+        messaging[] drops the message silently — the webhook still acks."""
+        payload = {
+            "object": "instagram",
+            "entry": [{
+                "id": "IG7",
+                "changes": [{
+                    "field": "messages",
+                    "value": {
+                        "sender": {"id": "IGSID2"},
+                        "recipient": {"id": "IG7"},
+                        "timestamp": "1527459824",
+                        "message": {"mid": "mid.9", "text": "hello from changes"},
+                    },
+                }],
+            }],
+        }
+        messages = get_adapter("instagram").parse_inbound(payload)
+        assert len(messages) == 1
+        assert messages[0].external_account_id == "IG7"
+        assert messages[0].external_conversation_id == "IGSID2"
+        assert messages[0].text == "hello from changes"
+
+    def test_messenger_ignores_the_changes_shape(self):
+        """Only Instagram delivers messaging events that way."""
+        payload = {"object": "page", "entry": [{"id": "PAGE9", "changes": [
+            {"field": "messages", "value": {"sender": {"id": "PSID5"},
+                                            "message": {"mid": "m", "text": "x"}}}]}]}
+        assert get_adapter("messenger").parse_inbound(payload) == []
+
 
 class TestInstagramTransport:
     """Instagram Login accounts hold an Instagram user token, which the Facebook

--- a/backend/tests/channels/test_meta_adapters.py
+++ b/backend/tests/channels/test_meta_adapters.py
@@ -26,7 +26,9 @@ from app.channels.base import WindowStatus
 from app.channels.meta_base import (
     verify_meta_signature,
     verify_challenge,
+    exchange_for_long_lived_token,
     graph_get,
+    graph_list_all,
     graph_post_json,
     WINDOW_HOURS,
 )
@@ -281,3 +283,44 @@ class TestGraphHelpers:
 
         assert ok is False
         assert "connection reset" in body["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_long_lived_exchange_uses_app_credentials_not_a_bearer(self, graph_client, monkeypatch):
+        """Like the signup-code exchange, this authenticates with the app secret
+        in the query, so it must carry no Authorization header."""
+        monkeypatch.setattr(settings, "META_APP_ID", "APP1")
+        monkeypatch.setattr(settings, "META_APP_SECRET", "SEKRET")
+        graph_client.response = _FakeResponse(200, {"access_token": "LONGLIVED"})
+
+        ok, body = await exchange_for_long_lived_token("short-token")
+
+        assert (ok, body["access_token"]) == (True, "LONGLIVED")
+        call = graph_client.calls[0]
+        assert call["headers"].get("Authorization") is None
+        assert call["params"]["grant_type"] == "fb_exchange_token"
+        assert call["params"]["fb_exchange_token"] == "short-token"
+        assert "SEKRET" not in call["url"]
+
+    @pytest.mark.asyncio
+    async def test_graph_list_all_follows_the_cursor(self, graph_client):
+        """Two full pages then a short one: it must return every node, not stop
+        at the first page."""
+        pages = [
+            _FakeResponse(200, {"data": [{"id": "1"}, {"id": "2"}],
+                                "paging": {"cursors": {"after": "c1"}}}),
+            _FakeResponse(200, {"data": [{"id": "3"}]}),
+        ]
+        call_count = {"n": 0}
+
+        async def request(method, url, params=None, json=None, headers=None):
+            graph_client.calls.append({"method": method, "url": url, "params": params})
+            r = pages[call_count["n"]]
+            call_count["n"] += 1
+            return r
+
+        graph_client.request = request
+        ok, items = await graph_list_all("me/accounts", "tok", {"limit": 2})
+
+        assert ok is True
+        assert [i["id"] for i in items] == ["1", "2", "3"]
+        assert graph_client.calls[1]["params"]["after"] == "c1"

--- a/frontend/public/meta-oauth-callback.html
+++ b/frontend/public/meta-oauth-callback.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<!--
+  OAuth redirect target for Facebook Login for Business (Messenger/Instagram).
+
+  Meta redirects the login popup here with ?code&state; this relays them to the
+  opener and closes. It's a static file (not the SPA) so the popup stays light,
+  and it must be registered as a Valid OAuth Redirect URI on the Meta app.
+-->
+<html>
+  <head><meta charset="utf-8" /><title>Connecting…</title></head>
+  <body>
+    Connecting…
+    <script>
+      (function () {
+        var params = new URLSearchParams(window.location.search)
+        var message = {
+          source: 'meta-oauth',
+          code: params.get('code'),
+          state: params.get('state'),
+          error: params.get('error_description') || params.get('error'),
+        }
+        if (window.opener) {
+          window.opener.postMessage(message, window.location.origin)
+        }
+        window.close()
+      })()
+    </script>
+  </body>
+</html>

--- a/frontend/src/__tests__/components/integrations/MessengerPagePicker.spec.ts
+++ b/frontend/src/__tests__/components/integrations/MessengerPagePicker.spec.ts
@@ -1,0 +1,52 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import MessengerPagePicker from '../../../components/integrations/MessengerPagePicker.vue'
+
+const PAGES = [
+  { id: 'PAGE1', name: 'Acme Support' },
+  { id: 'PAGE2', name: 'Acme Sales' },
+]
+
+const mountPicker = (connecting = false) =>
+  mount(MessengerPagePicker, {
+    props: { pages: PAGES, connecting },
+    global: { stubs: { 'font-awesome-icon': true } },
+  })
+
+describe('MessengerPagePicker', () => {
+  it('renders one row per Page', () => {
+    const wrapper = mountPicker()
+    expect(wrapper.findAll('.picker-row')).toHaveLength(2)
+    expect(wrapper.text()).toContain('Acme Support')
+    expect(wrapper.text()).toContain('Acme Sales')
+  })
+
+  it('emits select with the picked Page id', async () => {
+    const wrapper = mountPicker()
+    await wrapper.findAll('.picker-row')[1].trigger('click')
+    expect(wrapper.emitted('select')).toEqual([['PAGE2']])
+  })
+
+  it('locks every row while a connect is in flight', () => {
+    const wrapper = mountPicker(true)
+    const rows = wrapper.findAll('.picker-row')
+    expect(rows.every((row) => row.attributes('disabled') !== undefined)).toBe(true)
+  })
+})

--- a/frontend/src/__tests__/utils/metaSdk.spec.ts
+++ b/frontend/src/__tests__/utils/metaSdk.spec.ts
@@ -75,4 +75,14 @@ describe('signupLoginOptions', () => {
       extras: { setup: {} },
     })
   })
+
+  it('sends the WhatsApp setup extra for WhatsApp', () => {
+    expect(signupLoginOptions('CFG1', 'whatsapp').extras).toEqual({ setup: {} })
+  })
+
+  it('omits the setup extra for Facebook Login for Business', () => {
+    // extras.setup opens Embedded Signup; Messenger/Instagram must not send it.
+    expect(signupLoginOptions('CFG1', 'messenger')).not.toHaveProperty('extras')
+    expect(signupLoginOptions('CFG1', 'instagram')).not.toHaveProperty('extras')
+  })
 })

--- a/frontend/src/__tests__/utils/metaSdk.spec.ts
+++ b/frontend/src/__tests__/utils/metaSdk.spec.ts
@@ -14,8 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { describe, it, expect } from 'vitest'
-import { parseSignupMessage, signupLoginOptions } from '../../utils/metaSdk'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  parseSignupMessage,
+  signupLoginOptions,
+  runInstagramLogin,
+  runBusinessLogin,
+} from '../../utils/metaSdk'
 
 const message = (data: unknown, origin = 'https://www.facebook.com') =>
   ({ origin, data: typeof data === 'string' ? data : JSON.stringify(data) }) as MessageEvent
@@ -84,5 +89,54 @@ describe('signupLoginOptions', () => {
     // extras.setup opens Embedded Signup; Messenger/Instagram must not send it.
     expect(signupLoginOptions('CFG1', 'messenger')).not.toHaveProperty('extras')
     expect(signupLoginOptions('CFG1', 'instagram')).not.toHaveProperty('extras')
+  })
+})
+
+describe('OAuth login popups', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  /** Capture the URL the popup is opened with, without completing the login. */
+  const capturePopupUrl = (run: () => Promise<unknown>) => {
+    let opened = ''
+    vi.stubGlobal('open', (url: string) => {
+      opened = url
+      return { closed: false, close: () => {} }
+    })
+    // The promise stays pending (no callback message); we only want the URL.
+    void run().catch(() => {})
+    return new URL(opened)
+  }
+
+  it('sends Instagram to its own authorize endpoint, not a Facebook dialog', () => {
+    const url = capturePopupUrl(() =>
+      runInstagramLogin({ appId: 'IGAPP', redirectUri: 'https://app.test/cb.html' }))
+
+    expect(url.origin + url.pathname).toBe('https://www.instagram.com/oauth/authorize')
+    expect(url.searchParams.get('client_id')).toBe('IGAPP')
+    expect(url.searchParams.get('response_type')).toBe('code')
+    expect(url.searchParams.get('redirect_uri')).toBe('https://app.test/cb.html')
+    // Must stay an Instagram sign-in — no Page, no Facebook fallback.
+    expect(url.searchParams.get('enable_fb_login')).toBe('0')
+    expect(url.searchParams.get('scope')).toContain('instagram_business_manage_messages')
+    expect(url.searchParams.get('state')).toBeTruthy()
+  })
+
+  it('sends Messenger to the Facebook dialog with its configuration', () => {
+    const url = capturePopupUrl(() =>
+      runBusinessLogin({
+        appId: 'FBAPP', configId: 'CFG1', graphVersion: 'v21.0',
+        redirectUri: 'https://app.test/cb.html',
+      }))
+
+    expect(url.hostname).toBe('www.facebook.com')
+    expect(url.searchParams.get('config_id')).toBe('CFG1')
+    expect(url.searchParams.get('client_id')).toBe('FBAPP')
+  })
+
+  it('rejects when the browser blocks the popup', async () => {
+    vi.stubGlobal('open', () => null)
+    await expect(
+      runInstagramLogin({ appId: 'IGAPP', redirectUri: 'https://app.test/cb.html' }),
+    ).rejects.toThrow(/Popup blocked/)
   })
 })

--- a/frontend/src/__tests__/utils/metaSdk.spec.ts
+++ b/frontend/src/__tests__/utils/metaSdk.spec.ts
@@ -115,9 +115,11 @@ describe('OAuth login popups', () => {
     expect(url.searchParams.get('client_id')).toBe('IGAPP')
     expect(url.searchParams.get('response_type')).toBe('code')
     expect(url.searchParams.get('redirect_uri')).toBe('https://app.test/cb.html')
-    // Must stay an Instagram sign-in — no Page, no Facebook fallback.
-    expect(url.searchParams.get('enable_fb_login')).toBe('0')
+    expect(url.searchParams.get('force_reauth')).toBe('true')
     expect(url.searchParams.get('scope')).toContain('instagram_business_manage_messages')
+    // Least privilege: we only read the account and handle DMs, so no
+    // comments/publishing/insights scopes to enlarge App Review.
+    expect(url.searchParams.get('scope')).not.toContain('content_publish')
     expect(url.searchParams.get('state')).toBeTruthy()
   })
 

--- a/frontend/src/components/conversations/ChatInfoPanel.vue
+++ b/frontend/src/components/conversations/ChatInfoPanel.vue
@@ -51,6 +51,10 @@ const loadingUsers = ref(false)
 // Chat action functions
 const currentUserId = userService.getUserId()
 
+// Only the web widget can render a rating; on external channels (WhatsApp,
+// Messenger, ...) the ask is dropped, so the confirmation must not promise it.
+const askRating = computed(() => canRequestRating(props.chatInfo?.channel))
+
 const canTakeOver = computed(() => {
   if (!props.chatInfo) return false
   return (
@@ -125,9 +129,6 @@ const confirmEndChat = async () => {
   try {
     actionLoading.value = true
     
-    // Only the web widget can render a rating; on external channels the ask is
-    // dropped and the closing message says nothing about rating.
-    const askRating = canRequestRating(props.chatInfo.channel)
     const timestamp = new Date().toISOString()
     const endChatMessage = {
       message: endChatMessageFor(props.chatInfo.channel),
@@ -135,7 +136,7 @@ const confirmEndChat = async () => {
       created_at: timestamp,
       session_id: props.chatInfo.session_id,
       end_chat: true,
-      request_rating: askRating,
+      request_rating: askRating.value,
       end_chat_reason: "AGENT_REQUEST",
       end_chat_description: "Agent manually ended the chat"
     }
@@ -147,13 +148,13 @@ const confirmEndChat = async () => {
       message_type: endChatMessage.message_type,
       created_at: timestamp,
       end_chat: true,
-      request_rating: askRating,
+      request_rating: askRating.value,
       end_chat_reason: "AGENT_REQUEST",
       end_chat_description: "Agent manually ended the chat"
     })
 
     toast.success('Chat ended successfully', {
-      description: askRating ? 'Customer will be asked for feedback' : 'Chat has been closed',
+      description: askRating.value ? 'Customer will be asked for feedback' : 'Chat has been closed',
       duration: 4000,
       closeButton: true
     })
@@ -366,11 +367,12 @@ const confirmReassign = async () => {
     <div v-if="showEndChatConfirm" class="end-chat-modal">
       <div class="end-chat-modal-content">
         <h3>End Chat</h3>
-        <p>Are you sure you want to end this chat and request customer feedback?</p>
+        <p v-if="askRating">Are you sure you want to end this chat and request customer feedback?</p>
+        <p v-else>Are you sure you want to end this chat?</p>
         <div class="end-chat-modal-actions">
           <button class="cancel-btn" @click="cancelEndChat">Cancel</button>
           <button class="confirm-btn" @click="confirmEndChat" :disabled="actionLoading">
-            {{ actionLoading ? 'Ending...' : 'End Chat & Request Rating' }}
+            {{ actionLoading ? 'Ending...' : (askRating ? 'End Chat & Request Rating' : 'End Chat') }}
           </button>
         </div>
       </div>

--- a/frontend/src/components/integrations/MessengerPagePicker.vue
+++ b/frontend/src/components/integrations/MessengerPagePicker.vue
@@ -43,7 +43,7 @@ const choose = (pageId: string) => {
 
 <template>
   <div class="picker">
-    <p class="picker-intro">Choose the Facebook Page to connect:</p>
+    <p class="picker-intro">Choose the account to connect:</p>
     <ul class="picker-list">
       <li v-for="page in pages" :key="page.id">
         <button

--- a/frontend/src/components/integrations/MessengerPagePicker.vue
+++ b/frontend/src/components/integrations/MessengerPagePicker.vue
@@ -1,0 +1,126 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!--
+  Facebook Login for Business can grant several Pages at once, so the customer
+  chooses which one this channel answers. WhatsApp Embedded Signup never needs
+  this — it creates the single number itself.
+-->
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { MessengerSignupPage } from '@/services/channels'
+
+defineProps<{
+  pages: MessengerSignupPage[]
+  connecting: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'select', pageId: string): void
+}>()
+
+// Which row is being connected, so only it shows a spinner (and the rest lock).
+const pendingId = ref('')
+
+const choose = (pageId: string) => {
+  pendingId.value = pageId
+  emit('select', pageId)
+}
+</script>
+
+<template>
+  <div class="picker">
+    <p class="picker-intro">Choose the Facebook Page to connect:</p>
+    <ul class="picker-list">
+      <li v-for="page in pages" :key="page.id">
+        <button
+          type="button"
+          class="picker-row"
+          :disabled="connecting"
+          @click="choose(page.id)"
+        >
+          <span class="picker-name">{{ page.name }}</span>
+          <font-awesome-icon
+            v-if="connecting && pendingId === page.id"
+            icon="fa-solid fa-spinner"
+            spin
+          />
+          <font-awesome-icon v-else icon="fa-solid fa-chevron-right" class="picker-chevron" />
+        </button>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.picker {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.picker-intro {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.picker-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.picker-row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-btn, 8px);
+  background: var(--background-soft);
+  color: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: left;
+}
+
+.picker-row:hover:not(:disabled) {
+  border-color: var(--accent-solid);
+}
+
+.picker-row:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.picker-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.picker-chevron {
+  color: var(--muted);
+  flex-shrink: 0;
+}
+</style>

--- a/frontend/src/components/integrations/MetaChannelConnect.vue
+++ b/frontend/src/components/integrations/MetaChannelConnect.vue
@@ -17,15 +17,43 @@ limitations under the License.
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { toast } from 'vue-sonner'
-import channelsService, { type ChannelAccount } from '@/services/channels'
+import channelsService, {
+  type ChannelAccount,
+  type MessengerSignupPage,
+} from '@/services/channels'
 import { agentService } from '@/services/agent'
 import type { Agent } from '@/types/agent'
+import MessengerPagePicker from './MessengerPagePicker.vue'
 import {
   loadMetaSdk,
   parseSignupMessage,
   signupLoginOptions,
+  type SignupChannel,
   type SignupSession,
 } from '@/utils/metaSdk'
+
+// Channels this modal offers one-click connect for. WhatsApp uses Embedded
+// Signup; Messenger uses Facebook Login for Business. (Instagram rides on the
+// same Page login but isn't wired here yet.)
+const SIGNUP_CHANNELS: SignupChannel[] = ['whatsapp', 'messenger']
+const isSignupChannel = (c: string): c is SignupChannel =>
+  (SIGNUP_CHANNELS as string[]).includes(c)
+
+// Copy for the one-click pane, per channel.
+const SIGNUP_COPY: Record<SignupChannel, { intro: string; cta: string }> = {
+  whatsapp: {
+    intro: 'Connect your WhatsApp Business number with Meta — no API credentials to copy.',
+    cta: 'Continue with Facebook',
+  },
+  messenger: {
+    intro: 'Connect your Facebook Page with Meta — no API credentials to copy.',
+    cta: 'Continue with Facebook',
+  },
+  instagram: {
+    intro: 'Connect your Instagram professional account with Meta — no API credentials to copy.',
+    cta: 'Continue with Facebook',
+  },
+}
 
 const props = defineProps<{
   channel: 'whatsapp' | 'messenger' | 'instagram'
@@ -83,15 +111,22 @@ const agents = ref<Agent[]>([])
 const selectedAgentId = ref('')
 const savingAgent = ref(false)
 
-// Embedded Signup: only offered for WhatsApp, and only when the server says
-// this deployment has a Meta app to onboard under and a plan that allows it.
-// Everyone else keeps the manual credentials form.
+// One-click signup is offered only when the server says this deployment has a
+// Meta app to onboard under (a config id for the channel). Everyone else keeps
+// the manual credentials form.
 const signupEnabled = ref(false)
 const signupConfigId = ref('')
 const signingUp = ref(false)
-/** The signup's two halves arrive separately and are joined once both land. */
+/** WhatsApp only: its two halves arrive separately and are joined once both land. */
 const signupSession = ref<SignupSession | null>(null)
 const showManualForm = ref(false)
+
+// Messenger's Login for Business can grant several Pages; the customer picks one.
+const messengerPages = ref<MessengerSignupPage[]>([])
+const messengerSignupToken = ref('')
+const connectingPage = ref(false)
+
+const signupCopy = computed(() => SIGNUP_COPY[props.channel])
 
 const handleSignupMessage = (event: MessageEvent) => {
   const session = parseSignupMessage(event)
@@ -107,55 +142,92 @@ onMounted(async () => {
     console.error('Error loading agents:', error)
   }
 
-  if (props.channel !== 'whatsapp' || props.existingAccount) return
+  if (!isSignupChannel(props.channel) || props.existingAccount) return
   try {
-    const config = await channelsService.getEmbeddedSignupConfig()
+    const config = await channelsService.getEmbeddedSignupConfig(props.channel)
     if (!config.enabled || !config.config_id || !config.app_id) return
     await loadMetaSdk(config.app_id, config.graph_version)
     signupConfigId.value = config.config_id
     signupEnabled.value = true
-    window.addEventListener('message', handleSignupMessage)
+    // Only Embedded Signup reports its result out of band via postMessage;
+    // Facebook Login for Business returns everything through the login callback.
+    if (props.channel === 'whatsapp') window.addEventListener('message', handleSignupMessage)
   } catch (error) {
     // Falling back to the manual form is a working path, not an error worth
     // interrupting the user for.
-    console.error('Embedded Signup unavailable:', error)
+    console.error('One-click signup unavailable:', error)
   }
 })
 
 onBeforeUnmount(() => window.removeEventListener('message', handleSignupMessage))
 
-const completeEmbeddedSignup = async (response: { authResponse?: { code?: string } }) => {
-  const code = response.authResponse?.code
+const finishWhatsAppSignup = async (code: string) => {
   const session = signupSession.value
-  if (!code) {
-    // The popup was dismissed — not an error worth a toast.
-    signingUp.value = false
-    return
-  }
   if (!session) {
     // Signed in, but Meta never reported which number was set up, so there
     // is nothing to connect. Say so rather than appearing to do nothing.
     toast.error('WhatsApp signup did not complete', {
       description: 'No number was set up. Try again, or enter credentials manually.',
     })
+    return
+  }
+  account.value = await channelsService.connectWhatsAppEmbeddedSignup({
+    code,
+    waba_id: session.waba_id,
+    phone_number_id: session.phone_number_id,
+  })
+  toast.success(`Connected ${account.value.display_name || 'WhatsApp'}`)
+}
+
+const finishMessengerSignup = async (code: string) => {
+  const { pages, signup_token } = await channelsService.listMessengerSignupPages(code)
+  messengerSignupToken.value = signup_token
+  // One Page needs no picker — connect it and go straight to agent assignment.
+  if (pages.length === 1) {
+    await connectMessengerPage(pages[0].id)
+  } else {
+    messengerPages.value = pages
+  }
+}
+
+const connectMessengerPage = async (pageId: string) => {
+  account.value = await channelsService.connectMessengerSignup({
+    signup_token: messengerSignupToken.value,
+    page_id: pageId,
+  })
+  toast.success(`Connected ${account.value.display_name || 'Messenger'}`)
+}
+
+/** The picker's choice — its own loading state, since the login popup is long gone. */
+const onPageSelected = async (pageId: string) => {
+  try {
+    connectingPage.value = true
+    await connectMessengerPage(pageId)
+  } catch (error: any) {
+    toast.error(error?.response?.data?.detail || 'Could not connect that Page')
+  } finally {
+    connectingPage.value = false
+  }
+}
+
+const completeSignup = async (response: { authResponse?: { code?: string } }) => {
+  const code = response.authResponse?.code
+  if (!code) {
+    // The popup was dismissed — not an error worth a toast.
     signingUp.value = false
     return
   }
   try {
-    account.value = await channelsService.connectWhatsAppEmbeddedSignup({
-      code,
-      waba_id: session.waba_id,
-      phone_number_id: session.phone_number_id,
-    })
-    toast.success(`Connected ${account.value.display_name || 'WhatsApp'}`)
+    if (props.channel === 'messenger') await finishMessengerSignup(code)
+    else await finishWhatsAppSignup(code)
   } catch (error: any) {
-    toast.error(error?.response?.data?.detail || 'Could not finish WhatsApp signup')
+    toast.error(error?.response?.data?.detail || 'Could not finish connecting')
   } finally {
     signingUp.value = false
   }
 }
 
-const startEmbeddedSignup = () => {
+const startSignup = () => {
   if (!window.FB || signingUp.value) return
   signupSession.value = null
   signingUp.value = true
@@ -164,8 +236,8 @@ const startEmbeddedSignup = () => {
   // ("Expression is of type asyncfunction, not function"), so hand the async
   // work off from a plain function rather than passing `async` here.
   window.FB.login(
-    (response) => { void completeEmbeddedSignup(response) },
-    signupLoginOptions(signupConfigId.value),
+    (response) => { void completeSignup(response) },
+    signupLoginOptions(signupConfigId.value, props.channel),
   )
 }
 
@@ -222,15 +294,22 @@ const saveAgent = async () => {
 
       <!-- Step 1: credentials -->
       <div v-if="!account" class="meta-modal-body">
+        <!-- Login for Business can grant several Pages at once; the customer
+             picks which one this channel answers. -->
+        <MessengerPagePicker
+          v-if="messengerPages.length"
+          :pages="messengerPages"
+          :connecting="connectingPage"
+          @select="onPageSelected"
+        />
+
         <!-- One-click signup under ChatterMate's Meta app; the manual form
              stays available for anyone who already has their own credentials. -->
-        <div v-if="signupEnabled && !showManualForm" class="meta-signup">
-          <p class="meta-intro">
-            Connect your WhatsApp Business number with Meta — no API credentials to copy.
-          </p>
-          <button class="meta-btn meta-btn-primary meta-signup-btn" :disabled="signingUp" @click="startEmbeddedSignup">
+        <div v-else-if="signupEnabled && !showManualForm" class="meta-signup">
+          <p class="meta-intro">{{ signupCopy.intro }}</p>
+          <button class="meta-btn meta-btn-primary meta-signup-btn" :disabled="signingUp" @click="startSignup">
             <font-awesome-icon v-if="signingUp" icon="fa-solid fa-spinner" spin />
-            {{ signingUp ? 'Waiting for Meta…' : 'Continue with Facebook' }}
+            {{ signingUp ? 'Waiting for Meta…' : signupCopy.cta }}
           </button>
           <button class="meta-link-btn" @click="showManualForm = true">
             Enter credentials manually instead

--- a/frontend/src/components/integrations/MetaChannelConnect.vue
+++ b/frontend/src/components/integrations/MetaChannelConnect.vue
@@ -15,48 +15,13 @@ limitations under the License.
 -->
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { toast } from 'vue-sonner'
-import channelsService, {
-  type ChannelAccount,
-  type MessengerSignupPage,
-} from '@/services/channels'
+import channelsService, { type ChannelAccount } from '@/services/channels'
 import { agentService } from '@/services/agent'
 import type { Agent } from '@/types/agent'
 import MessengerPagePicker from './MessengerPagePicker.vue'
-import {
-  loadMetaSdk,
-  parseSignupMessage,
-  runBusinessLogin,
-  runInstagramLogin,
-  signupLoginOptions,
-  META_OAUTH_CALLBACK_PATH,
-  type SignupChannel,
-  type SignupSession,
-} from '@/utils/metaSdk'
-
-// Channels this modal offers one-click connect for. Each uses a different Meta
-// login: WhatsApp its Embedded Signup SDK, Messenger Facebook Login for
-// Business (a Page), Instagram its own Instagram Login (no Page at all).
-const SIGNUP_CHANNELS: SignupChannel[] = ['whatsapp', 'messenger', 'instagram']
-const isSignupChannel = (c: string): c is SignupChannel =>
-  (SIGNUP_CHANNELS as string[]).includes(c)
-
-// Copy for the one-click pane, per channel.
-const SIGNUP_COPY: Record<SignupChannel, { intro: string; cta: string }> = {
-  whatsapp: {
-    intro: 'Sign in with Facebook to connect your WhatsApp Business number.',
-    cta: 'Continue with Facebook',
-  },
-  messenger: {
-    intro: 'Sign in with Facebook to connect your Page.',
-    cta: 'Continue with Facebook',
-  },
-  instagram: {
-    intro: 'Sign in with Instagram to connect your professional account.',
-    cta: 'Continue with Instagram',
-  },
-}
+import { useMetaSignup } from '@/composables/useMetaSignup'
 
 const props = defineProps<{
   channel: 'whatsapp' | 'messenger' | 'instagram'
@@ -114,29 +79,22 @@ const agents = ref<Agent[]>([])
 const selectedAgentId = ref('')
 const savingAgent = ref(false)
 
-// One-click signup is offered only when the server says this deployment has a
-// Meta app to onboard under (a config id for the channel). Everyone else keeps
-// the manual credentials form.
-const signupEnabled = ref(false)
-const signupConfigId = ref('')
-const signupAppId = ref('')
-const signupGraphVersion = ref('')
-const signingUp = ref(false)
-/** WhatsApp only: its two halves arrive separately and are joined once both land. */
-const signupSession = ref<SignupSession | null>(null)
-const showManualForm = ref(false)
-
-// Login for Business can grant several accounts; the customer picks one.
-const signupPages = ref<MessengerSignupPage[]>([])
-const signupToken = ref('')
-const connectingPage = ref(false)
-
-const signupCopy = computed(() => SIGNUP_COPY[props.channel])
-
-const handleSignupMessage = (event: MessageEvent) => {
-  const session = parseSignupMessage(event)
-  if (session) signupSession.value = session
-}
+// The three one-click logins live in their own composable; this component owns
+// the manual credentials form and agent assignment.
+const {
+  signupEnabled,
+  signingUp,
+  showManualForm,
+  signupPages,
+  connectingPage,
+  copy: signupCopy,
+  startSignup,
+  onPageSelected,
+} = useMetaSignup({
+  channel: props.channel,
+  existingAccount: props.existingAccount,
+  onConnected: (connected) => { account.value = connected },
+})
 
 onMounted(async () => {
   try {
@@ -146,154 +104,7 @@ onMounted(async () => {
   } catch (error) {
     console.error('Error loading agents:', error)
   }
-
-  if (!isSignupChannel(props.channel) || props.existingAccount) return
-  try {
-    const config = await channelsService.getEmbeddedSignupConfig(props.channel)
-    if (!config.enabled || !config.app_id) return
-    // The Facebook logins are driven by a Login-for-Business configuration;
-    // Instagram Login has none, so requiring one here would hide its button.
-    if (props.channel !== 'instagram' && !config.config_id) return
-    // Empty for Instagram Login, which authorizes with the app id alone.
-    signupConfigId.value = config.config_id ?? ''
-    signupAppId.value = config.app_id
-    signupGraphVersion.value = config.graph_version
-    signupEnabled.value = true
-    // WhatsApp uses the JS SDK (Embedded Signup, which also reports its result
-    // out of band via postMessage). Messenger drives its own OAuth popup, so it
-    // needs neither the SDK nor the message listener.
-    if (props.channel === 'whatsapp') {
-      await loadMetaSdk(config.app_id, config.graph_version)
-      window.addEventListener('message', handleSignupMessage)
-    }
-  } catch (error) {
-    // Falling back to the manual form is a working path, not an error worth
-    // interrupting the user for.
-    console.error('One-click signup unavailable:', error)
-  }
 })
-
-onBeforeUnmount(() => window.removeEventListener('message', handleSignupMessage))
-
-const finishWhatsAppSignup = async (code: string) => {
-  const session = signupSession.value
-  if (!session) {
-    // Signed in, but Meta never reported which number was set up, so there
-    // is nothing to connect. Say so rather than appearing to do nothing.
-    toast.error('WhatsApp signup did not complete', {
-      description: 'No number was set up. Try again, or enter credentials manually.',
-    })
-    return
-  }
-  account.value = await channelsService.connectWhatsAppEmbeddedSignup({
-    code,
-    waba_id: session.waba_id,
-    phone_number_id: session.phone_number_id,
-  })
-  toast.success(`Connected ${account.value.display_name || 'WhatsApp'}`)
-}
-
-const finishMessengerSignup = async (code: string, redirectUri: string) => {
-  const { pages, signup_token } = await channelsService.listMessengerSignupPages(code, redirectUri)
-  signupToken.value = signup_token
-  // One Page needs no picker — connect it and go straight to agent assignment.
-  if (pages.length === 1) {
-    await connectPickedPage(pages[0].id)
-  } else {
-    signupPages.value = pages
-  }
-}
-
-const connectPickedPage = async (pageId: string) => {
-  account.value = await channelsService.connectMessengerSignup({
-    signup_token: signupToken.value,
-    page_id: pageId,
-  })
-  toast.success(`Connected ${account.value.display_name || 'Messenger'}`)
-}
-
-/** The picker's choice — its own loading state, since the login popup is long gone. */
-const onPageSelected = async (pageId: string) => {
-  try {
-    connectingPage.value = true
-    await connectPickedPage(pageId)
-  } catch (error: any) {
-    toast.error(error?.response?.data?.detail || 'Could not connect that account')
-  } finally {
-    connectingPage.value = false
-  }
-}
-
-// WhatsApp: the JS SDK's login callback.
-const completeWhatsAppSignup = async (response: { authResponse?: { code?: string } }) => {
-  const code = response.authResponse?.code
-  if (!code) {
-    // The popup was dismissed — not an error worth a toast.
-    signingUp.value = false
-    return
-  }
-  try {
-    await finishWhatsAppSignup(code)
-  } catch (error: any) {
-    toast.error(error?.response?.data?.detail || 'Could not finish connecting')
-  } finally {
-    signingUp.value = false
-  }
-}
-
-/** Shared shape of the two popup logins: run it, connect, surface failures. */
-const runPopupConnect = async (connect: (redirectUri: string) => Promise<void>) => {
-  signingUp.value = true
-  const redirectUri = window.location.origin + META_OAUTH_CALLBACK_PATH
-  try {
-    await connect(redirectUri)
-  } catch (error: any) {
-    // The user closing the popup is not an error worth a toast.
-    if (error?.message !== 'cancelled') {
-      toast.error(error?.response?.data?.detail || error?.message || 'Could not finish connecting')
-    }
-  } finally {
-    signingUp.value = false
-  }
-}
-
-// Messenger: Facebook Login for Business, then pick a Page.
-const startMessengerLogin = () => runPopupConnect(async (redirectUri) => {
-  const code = await runBusinessLogin({
-    appId: signupAppId.value,
-    configId: signupConfigId.value,
-    graphVersion: signupGraphVersion.value,
-    redirectUri,
-  })
-  await finishMessengerSignup(code, redirectUri)
-})
-
-// Instagram: Instagram Login — one account, so it connects in a single step.
-const startInstagramLogin = () => runPopupConnect(async (redirectUri) => {
-  const code = await runInstagramLogin({ appId: signupAppId.value, redirectUri })
-  account.value = await channelsService.connectInstagramLogin(code, redirectUri)
-  toast.success(`Connected ${account.value.display_name || 'Instagram'}`)
-})
-
-const startSignup = () => {
-  if (signingUp.value) return
-
-  // Both popups must open synchronously in the click handler or the browser
-  // blocks them.
-  if (props.channel === 'messenger') { void startMessengerLogin(); return }
-  if (props.channel === 'instagram') { void startInstagramLogin(); return }
-
-  if (!window.FB) return
-  signupSession.value = null
-  signingUp.value = true
-  // The SDK type-checks its callback and rejects an AsyncFunction outright
-  // ("Expression is of type asyncfunction, not function"), so hand the async
-  // work off from a plain function rather than passing `async` here.
-  window.FB.login(
-    (response) => { void completeWhatsAppSignup(response) },
-    signupLoginOptions(signupConfigId.value, props.channel),
-  )
-}
 
 const connect = async () => {
   const missing = form.value.fields.filter(f => !f.label.includes('optional') && !values.value[f.key]?.trim())

--- a/frontend/src/components/integrations/MetaChannelConnect.vue
+++ b/frontend/src/components/integrations/MetaChannelConnect.vue
@@ -337,7 +337,9 @@ const saveAgent = async () => {
 }
 
 .meta-intro-link {
-  color: var(--accent-solid);
+  /* --accent-ink, not --accent-solid: the latter is the lime fill and stays
+     lime in both themes, which is unreadable as text on a light background. */
+  color: var(--accent-ink);
   text-decoration: underline;
   font-weight: 600;
 }

--- a/frontend/src/components/integrations/MetaChannelConnect.vue
+++ b/frontend/src/components/integrations/MetaChannelConnect.vue
@@ -53,9 +53,7 @@ const SIGNUP_COPY: Record<SignupChannel, { intro: string; cta: string }> = {
     cta: 'Continue with Facebook',
   },
   instagram: {
-    // Instagram Login involves no Facebook Page or account at all, so the copy
-    // must not imply one — that is the whole reason this flow exists.
-    intro: 'Connect your Instagram professional account — no Facebook Page, and no API credentials to copy.',
+    intro: 'Sign in with Instagram to connect your professional account.',
     cta: 'Continue with Instagram',
   },
 }

--- a/frontend/src/components/integrations/MetaChannelConnect.vue
+++ b/frontend/src/components/integrations/MetaChannelConnect.vue
@@ -27,7 +27,9 @@ import MessengerPagePicker from './MessengerPagePicker.vue'
 import {
   loadMetaSdk,
   parseSignupMessage,
+  runBusinessLogin,
   signupLoginOptions,
+  META_OAUTH_CALLBACK_PATH,
   type SignupChannel,
   type SignupSession,
 } from '@/utils/metaSdk'
@@ -116,6 +118,8 @@ const savingAgent = ref(false)
 // the manual credentials form.
 const signupEnabled = ref(false)
 const signupConfigId = ref('')
+const signupAppId = ref('')
+const signupGraphVersion = ref('')
 const signingUp = ref(false)
 /** WhatsApp only: its two halves arrive separately and are joined once both land. */
 const signupSession = ref<SignupSession | null>(null)
@@ -146,12 +150,17 @@ onMounted(async () => {
   try {
     const config = await channelsService.getEmbeddedSignupConfig(props.channel)
     if (!config.enabled || !config.config_id || !config.app_id) return
-    await loadMetaSdk(config.app_id, config.graph_version)
     signupConfigId.value = config.config_id
+    signupAppId.value = config.app_id
+    signupGraphVersion.value = config.graph_version
     signupEnabled.value = true
-    // Only Embedded Signup reports its result out of band via postMessage;
-    // Facebook Login for Business returns everything through the login callback.
-    if (props.channel === 'whatsapp') window.addEventListener('message', handleSignupMessage)
+    // WhatsApp uses the JS SDK (Embedded Signup, which also reports its result
+    // out of band via postMessage). Messenger drives its own OAuth popup, so it
+    // needs neither the SDK nor the message listener.
+    if (props.channel === 'whatsapp') {
+      await loadMetaSdk(config.app_id, config.graph_version)
+      window.addEventListener('message', handleSignupMessage)
+    }
   } catch (error) {
     // Falling back to the manual form is a working path, not an error worth
     // interrupting the user for.
@@ -179,8 +188,8 @@ const finishWhatsAppSignup = async (code: string) => {
   toast.success(`Connected ${account.value.display_name || 'WhatsApp'}`)
 }
 
-const finishMessengerSignup = async (code: string) => {
-  const { pages, signup_token } = await channelsService.listMessengerSignupPages(code)
+const finishMessengerSignup = async (code: string, redirectUri: string) => {
+  const { pages, signup_token } = await channelsService.listMessengerSignupPages(code, redirectUri)
   messengerSignupToken.value = signup_token
   // One Page needs no picker — connect it and go straight to agent assignment.
   if (pages.length === 1) {
@@ -210,7 +219,8 @@ const onPageSelected = async (pageId: string) => {
   }
 }
 
-const completeSignup = async (response: { authResponse?: { code?: string } }) => {
+// WhatsApp: the JS SDK's login callback.
+const completeWhatsAppSignup = async (response: { authResponse?: { code?: string } }) => {
   const code = response.authResponse?.code
   if (!code) {
     // The popup was dismissed — not an error worth a toast.
@@ -218,8 +228,7 @@ const completeSignup = async (response: { authResponse?: { code?: string } }) =>
     return
   }
   try {
-    if (props.channel === 'messenger') await finishMessengerSignup(code)
-    else await finishWhatsAppSignup(code)
+    await finishWhatsAppSignup(code)
   } catch (error: any) {
     toast.error(error?.response?.data?.detail || 'Could not finish connecting')
   } finally {
@@ -227,16 +236,45 @@ const completeSignup = async (response: { authResponse?: { code?: string } }) =>
   }
 }
 
+// Messenger: our own OAuth popup (not FB.login — see runBusinessLogin).
+const startMessengerLogin = async () => {
+  signingUp.value = true
+  const redirectUri = window.location.origin + META_OAUTH_CALLBACK_PATH
+  try {
+    const code = await runBusinessLogin({
+      appId: signupAppId.value,
+      configId: signupConfigId.value,
+      graphVersion: signupGraphVersion.value,
+      redirectUri,
+    })
+    await finishMessengerSignup(code, redirectUri)
+  } catch (error: any) {
+    // The user closing the popup is not an error worth a toast.
+    if (error?.message !== 'cancelled') {
+      toast.error(error?.response?.data?.detail || error?.message || 'Could not finish connecting')
+    }
+  } finally {
+    signingUp.value = false
+  }
+}
+
 const startSignup = () => {
-  if (!window.FB || signingUp.value) return
+  if (signingUp.value) return
+
+  if (props.channel === 'messenger') {
+    // Must open synchronously in the click handler or the browser blocks it.
+    void startMessengerLogin()
+    return
+  }
+
+  if (!window.FB) return
   signupSession.value = null
   signingUp.value = true
-
   // The SDK type-checks its callback and rejects an AsyncFunction outright
   // ("Expression is of type asyncfunction, not function"), so hand the async
   // work off from a plain function rather than passing `async` here.
   window.FB.login(
-    (response) => { void completeSignup(response) },
+    (response) => { void completeWhatsAppSignup(response) },
     signupLoginOptions(signupConfigId.value, props.channel),
   )
 }

--- a/frontend/src/components/integrations/MetaChannelConnect.vue
+++ b/frontend/src/components/integrations/MetaChannelConnect.vue
@@ -45,11 +45,11 @@ const isSignupChannel = (c: string): c is SignupChannel =>
 // Copy for the one-click pane, per channel.
 const SIGNUP_COPY: Record<SignupChannel, { intro: string; cta: string }> = {
   whatsapp: {
-    intro: 'Connect your WhatsApp Business number with Meta — no API credentials to copy.',
+    intro: 'Sign in with Facebook to connect your WhatsApp Business number.',
     cta: 'Continue with Facebook',
   },
   messenger: {
-    intro: 'Connect your Facebook Page with Meta — no API credentials to copy.',
+    intro: 'Sign in with Facebook to connect your Page.',
     cta: 'Continue with Facebook',
   },
   instagram: {

--- a/frontend/src/components/integrations/MetaChannelConnect.vue
+++ b/frontend/src/components/integrations/MetaChannelConnect.vue
@@ -28,22 +28,19 @@ import {
   loadMetaSdk,
   parseSignupMessage,
   runBusinessLogin,
+  runInstagramLogin,
   signupLoginOptions,
   META_OAUTH_CALLBACK_PATH,
   type SignupChannel,
   type SignupSession,
 } from '@/utils/metaSdk'
 
-// Channels this modal offers one-click connect for. WhatsApp uses Embedded
-// Signup (the JS SDK); Messenger and Instagram use Facebook Login for Business
-// (our own OAuth popup).
+// Channels this modal offers one-click connect for. Each uses a different Meta
+// login: WhatsApp its Embedded Signup SDK, Messenger Facebook Login for
+// Business (a Page), Instagram its own Instagram Login (no Page at all).
 const SIGNUP_CHANNELS: SignupChannel[] = ['whatsapp', 'messenger', 'instagram']
 const isSignupChannel = (c: string): c is SignupChannel =>
   (SIGNUP_CHANNELS as string[]).includes(c)
-// The two channels that go through the Login-for-Business popup rather than the
-// WhatsApp SDK.
-const isBusinessLoginChannel = (c: string): c is 'messenger' | 'instagram' =>
-  c === 'messenger' || c === 'instagram'
 
 // Copy for the one-click pane, per channel.
 const SIGNUP_COPY: Record<SignupChannel, { intro: string; cta: string }> = {
@@ -56,8 +53,10 @@ const SIGNUP_COPY: Record<SignupChannel, { intro: string; cta: string }> = {
     cta: 'Continue with Facebook',
   },
   instagram: {
-    intro: 'Connect your Instagram professional account with Meta — no API credentials to copy.',
-    cta: 'Continue with Facebook',
+    // Instagram Login involves no Facebook Page or account at all, so the copy
+    // must not imply one — that is the whole reason this flow exists.
+    intro: 'Connect your Instagram professional account — no Facebook Page, and no API credentials to copy.',
+    cta: 'Continue with Instagram',
   },
 }
 
@@ -153,8 +152,12 @@ onMounted(async () => {
   if (!isSignupChannel(props.channel) || props.existingAccount) return
   try {
     const config = await channelsService.getEmbeddedSignupConfig(props.channel)
-    if (!config.enabled || !config.config_id || !config.app_id) return
-    signupConfigId.value = config.config_id
+    if (!config.enabled || !config.app_id) return
+    // The Facebook logins are driven by a Login-for-Business configuration;
+    // Instagram Login has none, so requiring one here would hide its button.
+    if (props.channel !== 'instagram' && !config.config_id) return
+    // Empty for Instagram Login, which authorizes with the app id alone.
+    signupConfigId.value = config.config_id ?? ''
     signupAppId.value = config.app_id
     signupGraphVersion.value = config.graph_version
     signupEnabled.value = true
@@ -192,31 +195,30 @@ const finishWhatsAppSignup = async (code: string) => {
   toast.success(`Connected ${account.value.display_name || 'WhatsApp'}`)
 }
 
-const finishBusinessSignup = async (channel: 'messenger' | 'instagram', code: string, redirectUri: string) => {
-  const { pages, signup_token } = await channelsService.listSignupPages(channel, code, redirectUri)
+const finishMessengerSignup = async (code: string, redirectUri: string) => {
+  const { pages, signup_token } = await channelsService.listMessengerSignupPages(code, redirectUri)
   signupToken.value = signup_token
-  // One account needs no picker — connect it and go straight to agent assignment.
+  // One Page needs no picker — connect it and go straight to agent assignment.
   if (pages.length === 1) {
-    await connectSignupPage(pages[0].id)
+    await connectPickedPage(pages[0].id)
   } else {
     signupPages.value = pages
   }
 }
 
-const connectSignupPage = async (pageId: string) => {
-  const channel = props.channel as 'messenger' | 'instagram'
-  account.value = await channelsService.connectSignupPage(channel, {
+const connectPickedPage = async (pageId: string) => {
+  account.value = await channelsService.connectMessengerSignup({
     signup_token: signupToken.value,
     page_id: pageId,
   })
-  toast.success(`Connected ${account.value.display_name || form.value.title.replace('Connect ', '')}`)
+  toast.success(`Connected ${account.value.display_name || 'Messenger'}`)
 }
 
 /** The picker's choice — its own loading state, since the login popup is long gone. */
 const onPageSelected = async (pageId: string) => {
   try {
     connectingPage.value = true
-    await connectSignupPage(pageId)
+    await connectPickedPage(pageId)
   } catch (error: any) {
     toast.error(error?.response?.data?.detail || 'Could not connect that account')
   } finally {
@@ -241,18 +243,12 @@ const completeWhatsAppSignup = async (response: { authResponse?: { code?: string
   }
 }
 
-// Messenger + Instagram: our own OAuth popup (not FB.login — see runBusinessLogin).
-const startBusinessLogin = async (channel: 'messenger' | 'instagram') => {
+/** Shared shape of the two popup logins: run it, connect, surface failures. */
+const runPopupConnect = async (connect: (redirectUri: string) => Promise<void>) => {
   signingUp.value = true
   const redirectUri = window.location.origin + META_OAUTH_CALLBACK_PATH
   try {
-    const code = await runBusinessLogin({
-      appId: signupAppId.value,
-      configId: signupConfigId.value,
-      graphVersion: signupGraphVersion.value,
-      redirectUri,
-    })
-    await finishBusinessSignup(channel, code, redirectUri)
+    await connect(redirectUri)
   } catch (error: any) {
     // The user closing the popup is not an error worth a toast.
     if (error?.message !== 'cancelled') {
@@ -263,14 +259,31 @@ const startBusinessLogin = async (channel: 'messenger' | 'instagram') => {
   }
 }
 
+// Messenger: Facebook Login for Business, then pick a Page.
+const startMessengerLogin = () => runPopupConnect(async (redirectUri) => {
+  const code = await runBusinessLogin({
+    appId: signupAppId.value,
+    configId: signupConfigId.value,
+    graphVersion: signupGraphVersion.value,
+    redirectUri,
+  })
+  await finishMessengerSignup(code, redirectUri)
+})
+
+// Instagram: Instagram Login — one account, so it connects in a single step.
+const startInstagramLogin = () => runPopupConnect(async (redirectUri) => {
+  const code = await runInstagramLogin({ appId: signupAppId.value, redirectUri })
+  account.value = await channelsService.connectInstagramLogin(code, redirectUri)
+  toast.success(`Connected ${account.value.display_name || 'Instagram'}`)
+})
+
 const startSignup = () => {
   if (signingUp.value) return
 
-  if (isBusinessLoginChannel(props.channel)) {
-    // Must open synchronously in the click handler or the browser blocks it.
-    void startBusinessLogin(props.channel)
-    return
-  }
+  // Both popups must open synchronously in the click handler or the browser
+  // blocks them.
+  if (props.channel === 'messenger') { void startMessengerLogin(); return }
+  if (props.channel === 'instagram') { void startInstagramLogin(); return }
 
   if (!window.FB) return
   signupSession.value = null

--- a/frontend/src/components/integrations/MetaChannelConnect.vue
+++ b/frontend/src/components/integrations/MetaChannelConnect.vue
@@ -35,11 +35,15 @@ import {
 } from '@/utils/metaSdk'
 
 // Channels this modal offers one-click connect for. WhatsApp uses Embedded
-// Signup; Messenger uses Facebook Login for Business. (Instagram rides on the
-// same Page login but isn't wired here yet.)
-const SIGNUP_CHANNELS: SignupChannel[] = ['whatsapp', 'messenger']
+// Signup (the JS SDK); Messenger and Instagram use Facebook Login for Business
+// (our own OAuth popup).
+const SIGNUP_CHANNELS: SignupChannel[] = ['whatsapp', 'messenger', 'instagram']
 const isSignupChannel = (c: string): c is SignupChannel =>
   (SIGNUP_CHANNELS as string[]).includes(c)
+// The two channels that go through the Login-for-Business popup rather than the
+// WhatsApp SDK.
+const isBusinessLoginChannel = (c: string): c is 'messenger' | 'instagram' =>
+  c === 'messenger' || c === 'instagram'
 
 // Copy for the one-click pane, per channel.
 const SIGNUP_COPY: Record<SignupChannel, { intro: string; cta: string }> = {
@@ -125,9 +129,9 @@ const signingUp = ref(false)
 const signupSession = ref<SignupSession | null>(null)
 const showManualForm = ref(false)
 
-// Messenger's Login for Business can grant several Pages; the customer picks one.
-const messengerPages = ref<MessengerSignupPage[]>([])
-const messengerSignupToken = ref('')
+// Login for Business can grant several accounts; the customer picks one.
+const signupPages = ref<MessengerSignupPage[]>([])
+const signupToken = ref('')
 const connectingPage = ref(false)
 
 const signupCopy = computed(() => SIGNUP_COPY[props.channel])
@@ -188,32 +192,33 @@ const finishWhatsAppSignup = async (code: string) => {
   toast.success(`Connected ${account.value.display_name || 'WhatsApp'}`)
 }
 
-const finishMessengerSignup = async (code: string, redirectUri: string) => {
-  const { pages, signup_token } = await channelsService.listMessengerSignupPages(code, redirectUri)
-  messengerSignupToken.value = signup_token
-  // One Page needs no picker — connect it and go straight to agent assignment.
+const finishBusinessSignup = async (channel: 'messenger' | 'instagram', code: string, redirectUri: string) => {
+  const { pages, signup_token } = await channelsService.listSignupPages(channel, code, redirectUri)
+  signupToken.value = signup_token
+  // One account needs no picker — connect it and go straight to agent assignment.
   if (pages.length === 1) {
-    await connectMessengerPage(pages[0].id)
+    await connectSignupPage(pages[0].id)
   } else {
-    messengerPages.value = pages
+    signupPages.value = pages
   }
 }
 
-const connectMessengerPage = async (pageId: string) => {
-  account.value = await channelsService.connectMessengerSignup({
-    signup_token: messengerSignupToken.value,
+const connectSignupPage = async (pageId: string) => {
+  const channel = props.channel as 'messenger' | 'instagram'
+  account.value = await channelsService.connectSignupPage(channel, {
+    signup_token: signupToken.value,
     page_id: pageId,
   })
-  toast.success(`Connected ${account.value.display_name || 'Messenger'}`)
+  toast.success(`Connected ${account.value.display_name || form.value.title.replace('Connect ', '')}`)
 }
 
 /** The picker's choice — its own loading state, since the login popup is long gone. */
 const onPageSelected = async (pageId: string) => {
   try {
     connectingPage.value = true
-    await connectMessengerPage(pageId)
+    await connectSignupPage(pageId)
   } catch (error: any) {
-    toast.error(error?.response?.data?.detail || 'Could not connect that Page')
+    toast.error(error?.response?.data?.detail || 'Could not connect that account')
   } finally {
     connectingPage.value = false
   }
@@ -236,8 +241,8 @@ const completeWhatsAppSignup = async (response: { authResponse?: { code?: string
   }
 }
 
-// Messenger: our own OAuth popup (not FB.login — see runBusinessLogin).
-const startMessengerLogin = async () => {
+// Messenger + Instagram: our own OAuth popup (not FB.login — see runBusinessLogin).
+const startBusinessLogin = async (channel: 'messenger' | 'instagram') => {
   signingUp.value = true
   const redirectUri = window.location.origin + META_OAUTH_CALLBACK_PATH
   try {
@@ -247,7 +252,7 @@ const startMessengerLogin = async () => {
       graphVersion: signupGraphVersion.value,
       redirectUri,
     })
-    await finishMessengerSignup(code, redirectUri)
+    await finishBusinessSignup(channel, code, redirectUri)
   } catch (error: any) {
     // The user closing the popup is not an error worth a toast.
     if (error?.message !== 'cancelled') {
@@ -261,9 +266,9 @@ const startMessengerLogin = async () => {
 const startSignup = () => {
   if (signingUp.value) return
 
-  if (props.channel === 'messenger') {
+  if (isBusinessLoginChannel(props.channel)) {
     // Must open synchronously in the click handler or the browser blocks it.
-    void startMessengerLogin()
+    void startBusinessLogin(props.channel)
     return
   }
 
@@ -332,11 +337,11 @@ const saveAgent = async () => {
 
       <!-- Step 1: credentials -->
       <div v-if="!account" class="meta-modal-body">
-        <!-- Login for Business can grant several Pages at once; the customer
+        <!-- Login for Business can grant several accounts at once; the customer
              picks which one this channel answers. -->
         <MessengerPagePicker
-          v-if="messengerPages.length"
-          :pages="messengerPages"
+          v-if="signupPages.length"
+          :pages="signupPages"
           :connecting="connectingPage"
           @select="onPageSelected"
         />

--- a/frontend/src/composables/useMetaSignup.ts
+++ b/frontend/src/composables/useMetaSignup.ts
@@ -1,0 +1,256 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * One-click connect for the Meta channels.
+ *
+ * Three different logins hide behind one button: WhatsApp uses Meta's Embedded
+ * Signup SDK, Messenger uses Facebook Login for Business and then picks a Page,
+ * and Instagram uses Instagram Login, which involves no Facebook Page at all.
+ * Kept out of the connect modal so that component stays presentation plus the
+ * manual credentials form.
+ */
+
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { toast } from 'vue-sonner'
+import channelsService, {
+  type ChannelAccount,
+  type MessengerSignupPage,
+} from '@/services/channels'
+import {
+  loadMetaSdk,
+  parseSignupMessage,
+  runBusinessLogin,
+  runInstagramLogin,
+  signupLoginOptions,
+  META_OAUTH_CALLBACK_PATH,
+  type SignupChannel,
+  type SignupSession,
+} from '@/utils/metaSdk'
+
+/** Copy for the one-click pane, per channel. */
+const SIGNUP_COPY: Record<SignupChannel, { intro: string; cta: string }> = {
+  whatsapp: {
+    intro: 'Sign in with Facebook to connect your WhatsApp Business number.',
+    cta: 'Continue with Facebook',
+  },
+  messenger: {
+    intro: 'Sign in with Facebook to connect your Page.',
+    cta: 'Continue with Facebook',
+  },
+  instagram: {
+    intro: 'Sign in with Instagram to connect your professional account.',
+    cta: 'Continue with Instagram',
+  },
+}
+
+export interface MetaSignupOptions {
+  channel: SignupChannel
+  /** Manage mode: an already-connected account has nothing to sign up for. */
+  existingAccount?: ChannelAccount | null
+  /** Called with the account once a login completes. */
+  onConnected: (account: ChannelAccount) => void
+}
+
+export function useMetaSignup({ channel, existingAccount, onConnected }: MetaSignupOptions) {
+  // Offered only when the server says this deployment has a Meta app to onboard
+  // under. Everyone else keeps the manual credentials form.
+  const signupEnabled = ref(false)
+  const signingUp = ref(false)
+  const showManualForm = ref(false)
+
+  const configId = ref('')
+  const appId = ref('')
+  const graphVersion = ref('')
+
+  /** WhatsApp only: its two halves arrive separately and are joined once both land. */
+  const signupSession = ref<SignupSession | null>(null)
+
+  // Facebook Login for Business can grant several Pages; the customer picks one.
+  const signupPages = ref<MessengerSignupPage[]>([])
+  const signupToken = ref('')
+  const connectingPage = ref(false)
+
+  const copy = SIGNUP_COPY[channel]
+
+  const handleSignupMessage = (event: MessageEvent) => {
+    const session = parseSignupMessage(event)
+    if (session) signupSession.value = session
+  }
+
+  onMounted(async () => {
+    if (existingAccount) return
+    try {
+      const config = await channelsService.getEmbeddedSignupConfig(channel)
+      if (!config.enabled || !config.app_id) return
+      // The Facebook logins are driven by a Login-for-Business configuration;
+      // Instagram Login has none, so requiring one here would hide its button.
+      if (channel !== 'instagram' && !config.config_id) return
+      // Empty for Instagram Login, which authorizes with the app id alone.
+      configId.value = config.config_id ?? ''
+      appId.value = config.app_id
+      graphVersion.value = config.graph_version
+      signupEnabled.value = true
+      // WhatsApp uses the JS SDK (Embedded Signup, which also reports its
+      // result out of band via postMessage). The other two drive their own
+      // OAuth popup, so they need neither the SDK nor the message listener.
+      if (channel === 'whatsapp') {
+        await loadMetaSdk(config.app_id, config.graph_version)
+        window.addEventListener('message', handleSignupMessage)
+      }
+    } catch (error) {
+      // Falling back to the manual form is a working path, not an error worth
+      // interrupting the user for.
+      console.error('One-click signup unavailable:', error)
+    }
+  })
+
+  onBeforeUnmount(() => window.removeEventListener('message', handleSignupMessage))
+
+  const finishWhatsAppSignup = async (code: string) => {
+    const session = signupSession.value
+    if (!session) {
+      // Signed in, but Meta never reported which number was set up, so there
+      // is nothing to connect. Say so rather than appearing to do nothing.
+      toast.error('WhatsApp signup did not complete', {
+        description: 'No number was set up. Try again, or enter credentials manually.',
+      })
+      return
+    }
+    const account = await channelsService.connectWhatsAppEmbeddedSignup({
+      code,
+      waba_id: session.waba_id,
+      phone_number_id: session.phone_number_id,
+    })
+    onConnected(account)
+    toast.success(`Connected ${account.display_name || 'WhatsApp'}`)
+  }
+
+  const connectPickedPage = async (pageId: string) => {
+    const account = await channelsService.connectMessengerSignup({
+      signup_token: signupToken.value,
+      page_id: pageId,
+    })
+    onConnected(account)
+    toast.success(`Connected ${account.display_name || 'Messenger'}`)
+  }
+
+  const finishMessengerSignup = async (code: string, redirectUri: string) => {
+    const { pages, signup_token } = await channelsService.listMessengerSignupPages(code, redirectUri)
+    signupToken.value = signup_token
+    // One Page needs no picker — connect it and go straight to agent assignment.
+    if (pages.length === 1) {
+      await connectPickedPage(pages[0].id)
+    } else {
+      signupPages.value = pages
+    }
+  }
+
+  /** The picker's choice — its own loading state, since the login popup is long gone. */
+  const onPageSelected = async (pageId: string) => {
+    try {
+      connectingPage.value = true
+      await connectPickedPage(pageId)
+    } catch (error: any) {
+      toast.error(error?.response?.data?.detail || 'Could not connect that account')
+    } finally {
+      connectingPage.value = false
+    }
+  }
+
+  // WhatsApp: the JS SDK's login callback.
+  const completeWhatsAppSignup = async (response: { authResponse?: { code?: string } }) => {
+    const code = response.authResponse?.code
+    if (!code) {
+      // The popup was dismissed — not an error worth a toast.
+      signingUp.value = false
+      return
+    }
+    try {
+      await finishWhatsAppSignup(code)
+    } catch (error: any) {
+      toast.error(error?.response?.data?.detail || 'Could not finish connecting')
+    } finally {
+      signingUp.value = false
+    }
+  }
+
+  /** Shared shape of the two popup logins: run it, connect, surface failures. */
+  const runPopupConnect = async (connect: (redirectUri: string) => Promise<void>) => {
+    signingUp.value = true
+    const redirectUri = window.location.origin + META_OAUTH_CALLBACK_PATH
+    try {
+      await connect(redirectUri)
+    } catch (error: any) {
+      // The user closing the popup is not an error worth a toast.
+      if (error?.message !== 'cancelled') {
+        toast.error(error?.response?.data?.detail || error?.message || 'Could not finish connecting')
+      }
+    } finally {
+      signingUp.value = false
+    }
+  }
+
+  // Messenger: Facebook Login for Business, then pick a Page.
+  const startMessengerLogin = () => runPopupConnect(async (redirectUri) => {
+    const code = await runBusinessLogin({
+      appId: appId.value,
+      configId: configId.value,
+      graphVersion: graphVersion.value,
+      redirectUri,
+    })
+    await finishMessengerSignup(code, redirectUri)
+  })
+
+  // Instagram: Instagram Login — one account, so it connects in a single step.
+  const startInstagramLogin = () => runPopupConnect(async (redirectUri) => {
+    const code = await runInstagramLogin({ appId: appId.value, redirectUri })
+    const account = await channelsService.connectInstagramLogin(code, redirectUri)
+    onConnected(account)
+    toast.success(`Connected ${account.display_name || 'Instagram'}`)
+  })
+
+  const startSignup = () => {
+    if (signingUp.value) return
+
+    // Both popups must open synchronously in the click handler or the browser
+    // blocks them.
+    if (channel === 'messenger') { void startMessengerLogin(); return }
+    if (channel === 'instagram') { void startInstagramLogin(); return }
+
+    if (!window.FB) return
+    signupSession.value = null
+    signingUp.value = true
+    // The SDK type-checks its callback and rejects an AsyncFunction outright
+    // ("Expression is of type asyncfunction, not function"), so hand the async
+    // work off from a plain function rather than passing `async` here.
+    window.FB.login(
+      (response) => { void completeWhatsAppSignup(response) },
+      signupLoginOptions(configId.value, channel),
+    )
+  }
+
+  return {
+    signupEnabled,
+    signingUp,
+    showManualForm,
+    signupPages,
+    connectingPage,
+    copy,
+    startSignup,
+    onPageSelected,
+  }
+}

--- a/frontend/src/services/channels.ts
+++ b/frontend/src/services/channels.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import api from './api'
+import type { SignupChannel } from '@/utils/metaSdk'
 
 // Types
 export type ChannelType =
@@ -87,6 +88,19 @@ export interface EmbeddedSignupConfig {
   graph_version: string
 }
 
+/** A Facebook Page offered in the Messenger signup picker (no token — that
+ * stays sealed in signup_token on the server). */
+export interface MessengerSignupPage {
+  id: string
+  name: string
+}
+
+export interface MessengerSignupPages {
+  pages: MessengerSignupPage[]
+  /** Opaque blob carrying the Pages' access tokens back to the connect step */
+  signup_token: string
+}
+
 export interface ChannelAccount {
   id: string
   channel_type: ChannelType
@@ -145,9 +159,9 @@ const channelsService = {
     return response.data
   },
 
-  /** Whether to offer Embedded Signup, and the ids the Meta SDK needs */
-  async getEmbeddedSignupConfig(): Promise<EmbeddedSignupConfig> {
-    const response = await api.get('/channels/meta/embedded-signup-config')
+  /** Whether to offer a Meta login flow for this channel, and the ids the SDK needs */
+  async getEmbeddedSignupConfig(channel: SignupChannel = 'whatsapp'): Promise<EmbeddedSignupConfig> {
+    const response = await api.get('/channels/meta/embedded-signup-config', { params: { channel } })
     return response.data
   },
 
@@ -161,9 +175,22 @@ const channelsService = {
     return response.data
   },
 
-  /** Connect a Facebook Page for Messenger */
+  /** Connect a Facebook Page for Messenger (manual page token) */
   async connectMessenger(payload: { page_id: string; page_access_token: string }): Promise<ChannelAccount> {
     const response = await api.post('/channels/meta/messenger', payload)
+    return response.data
+  },
+
+  /** Step 1 of Facebook Login for Business: trade the code for the Pages the
+   * customer can connect. Their tokens stay sealed in signup_token. */
+  async listMessengerSignupPages(code: string): Promise<MessengerSignupPages> {
+    const response = await api.post('/channels/meta/messenger/signup/pages', { code })
+    return response.data
+  },
+
+  /** Step 2: connect the picked Page; the backend uses the token it sealed, not ours */
+  async connectMessengerSignup(payload: { signup_token: string; page_id: string }): Promise<ChannelAccount> {
+    const response = await api.post('/channels/meta/messenger/signup/connect', payload)
     return response.data
   },
 

--- a/frontend/src/services/channels.ts
+++ b/frontend/src/services/channels.ts
@@ -181,27 +181,29 @@ const channelsService = {
     return response.data
   },
 
-  /** Step 1 of Facebook Login for Business: trade the code for the accounts the
-   * customer can connect. Their Page tokens stay sealed in signup_token.
-   * Messenger offers Pages; Instagram offers the account linked to each Page. */
-  async listSignupPages(
-    channel: 'messenger' | 'instagram',
-    code: string,
-    redirectUri: string,
-  ): Promise<MessengerSignupPages> {
-    const response = await api.post(`/channels/meta/${channel}/signup/pages`, {
+  /** Step 1 of Facebook Login for Business: trade the code for the Pages the
+   * customer can connect. Their tokens stay sealed in signup_token. */
+  async listMessengerSignupPages(code: string, redirectUri: string): Promise<MessengerSignupPages> {
+    const response = await api.post('/channels/meta/messenger/signup/pages', {
       code,
       redirect_uri: redirectUri,
     })
     return response.data
   },
 
-  /** Step 2: connect the picked account; the backend uses the token it sealed, not ours */
-  async connectSignupPage(
-    channel: 'messenger' | 'instagram',
-    payload: { signup_token: string; page_id: string },
-  ): Promise<ChannelAccount> {
-    const response = await api.post(`/channels/meta/${channel}/signup/connect`, payload)
+  /** Step 2: connect the picked Page; the backend uses the token it sealed, not ours */
+  async connectMessengerSignup(payload: { signup_token: string; page_id: string }): Promise<ChannelAccount> {
+    const response = await api.post('/channels/meta/messenger/signup/connect', payload)
+    return response.data
+  },
+
+  /** Connect an Instagram account via Instagram Login. One account per login,
+   * so unlike Messenger this is a single step with nothing to pick. */
+  async connectInstagramLogin(code: string, redirectUri: string): Promise<ChannelAccount> {
+    const response = await api.post('/channels/meta/instagram/login/connect', {
+      code,
+      redirect_uri: redirectUri,
+    })
     return response.data
   },
 

--- a/frontend/src/services/channels.ts
+++ b/frontend/src/services/channels.ts
@@ -181,19 +181,27 @@ const channelsService = {
     return response.data
   },
 
-  /** Step 1 of Facebook Login for Business: trade the code for the Pages the
-   * customer can connect. Their tokens stay sealed in signup_token. */
-  async listMessengerSignupPages(code: string, redirectUri: string): Promise<MessengerSignupPages> {
-    const response = await api.post('/channels/meta/messenger/signup/pages', {
+  /** Step 1 of Facebook Login for Business: trade the code for the accounts the
+   * customer can connect. Their Page tokens stay sealed in signup_token.
+   * Messenger offers Pages; Instagram offers the account linked to each Page. */
+  async listSignupPages(
+    channel: 'messenger' | 'instagram',
+    code: string,
+    redirectUri: string,
+  ): Promise<MessengerSignupPages> {
+    const response = await api.post(`/channels/meta/${channel}/signup/pages`, {
       code,
       redirect_uri: redirectUri,
     })
     return response.data
   },
 
-  /** Step 2: connect the picked Page; the backend uses the token it sealed, not ours */
-  async connectMessengerSignup(payload: { signup_token: string; page_id: string }): Promise<ChannelAccount> {
-    const response = await api.post('/channels/meta/messenger/signup/connect', payload)
+  /** Step 2: connect the picked account; the backend uses the token it sealed, not ours */
+  async connectSignupPage(
+    channel: 'messenger' | 'instagram',
+    payload: { signup_token: string; page_id: string },
+  ): Promise<ChannelAccount> {
+    const response = await api.post(`/channels/meta/${channel}/signup/connect`, payload)
     return response.data
   },
 

--- a/frontend/src/services/channels.ts
+++ b/frontend/src/services/channels.ts
@@ -183,8 +183,11 @@ const channelsService = {
 
   /** Step 1 of Facebook Login for Business: trade the code for the Pages the
    * customer can connect. Their tokens stay sealed in signup_token. */
-  async listMessengerSignupPages(code: string): Promise<MessengerSignupPages> {
-    const response = await api.post('/channels/meta/messenger/signup/pages', { code })
+  async listMessengerSignupPages(code: string, redirectUri: string): Promise<MessengerSignupPages> {
+    const response = await api.post('/channels/meta/messenger/signup/pages', {
+      code,
+      redirect_uri: redirectUri,
+    })
     return response.data
   },
 

--- a/frontend/src/utils/metaSdk.ts
+++ b/frontend/src/utils/metaSdk.ts
@@ -17,6 +17,11 @@ limitations under the License.
 const SDK_SRC = 'https://connect.facebook.net/en_US/sdk.js'
 const SDK_SCRIPT_ID = 'facebook-jssdk'
 
+/** Where each provider's OAuth dialog lives. Instagram Login is a different
+ * provider, not a Facebook dialog, so it has its own endpoint. */
+const FACEBOOK_DIALOG_BASE = 'https://www.facebook.com'
+const INSTAGRAM_AUTHORIZE_URL = 'https://www.instagram.com/oauth/authorize'
+
 /**
  * Static page Meta redirects the Login-for-Business popup to (see
  * public/meta-oauth-callback.html). Its full URL — origin + this path — is the
@@ -217,7 +222,7 @@ const runOAuthPopup = (buildUrl: (state: string) => string): Promise<string> =>
  */
 export const runBusinessLogin = (config: BusinessLoginConfig): Promise<string> =>
   runOAuthPopup((state) =>
-    `https://www.facebook.com/${config.graphVersion}/dialog/oauth?` +
+    `${FACEBOOK_DIALOG_BASE}/${config.graphVersion}/dialog/oauth?` +
     new URLSearchParams({
       client_id: config.appId,
       config_id: config.configId,
@@ -235,7 +240,7 @@ export const runBusinessLogin = (config: BusinessLoginConfig): Promise<string> =
  */
 export const runInstagramLogin = (config: InstagramLoginConfig): Promise<string> =>
   runOAuthPopup((state) =>
-    'https://www.instagram.com/oauth/authorize?' +
+    `${INSTAGRAM_AUTHORIZE_URL}?` +
     new URLSearchParams({
       client_id: config.appId,
       redirect_uri: config.redirectUri,

--- a/frontend/src/utils/metaSdk.ts
+++ b/frontend/src/utils/metaSdk.ts
@@ -155,36 +155,33 @@ export interface BusinessLoginConfig {
   redirectUri: string
 }
 
-/**
- * Run Facebook Login for Business as a first-party OAuth popup and resolve the
- * returned code.
- *
- * Why not FB.login: the JS SDK binds the code to an internal xd_arbiter
- * redirect that regenerates every login, so it can never be a registered Valid
- * OAuth Redirect URI — fatal once the app enforces Strict Mode (which it does,
- * non-negotiably). Driving the dialog ourselves with our own callback URL means
- * the code is bound to a value we control and the server can reproduce.
- *
- * The same redirectUri must go to the token exchange, so the caller passes it
- * on to the server. Resolves with the code, rejects on error, popup-block, or
- * the user closing the window ('cancelled').
- */
-export const runBusinessLogin = (config: BusinessLoginConfig): Promise<string> =>
-  new Promise((resolve, reject) => {
-    // CSRF: Meta echoes state back on the redirect; we only accept a match.
-    const state = crypto.randomUUID()
-    const url = `https://www.facebook.com/${config.graphVersion}/dialog/oauth?` +
-      new URLSearchParams({
-        client_id: config.appId,
-        config_id: config.configId,
-        response_type: 'code',
-        override_default_response_type: 'true',
-        redirect_uri: config.redirectUri,
-        state,
-        display: 'popup',
-      }).toString()
+export interface InstagramLoginConfig {
+  /** The Instagram app id — not the Meta one; Instagram Login is its own app. */
+  appId: string
+  /** window.location.origin + META_OAUTH_CALLBACK_PATH */
+  redirectUri: string
+}
 
-    const popup = window.open(url, 'meta-login', 'width=600,height=720')
+/** What Instagram Login must grant us: read the account, and handle its DMs. */
+const INSTAGRAM_SCOPES = 'instagram_business_basic,instagram_business_manage_messages'
+
+/**
+ * Run an OAuth authorization in a popup and resolve the code it returns.
+ *
+ * Why we drive the dialog ourselves rather than use FB.login: the JS SDK binds
+ * the code to an internal xd_arbiter redirect that regenerates every login, so
+ * it can never be a registered Valid OAuth Redirect URI — fatal once the app
+ * enforces Strict Mode (which it does, non-negotiably). Owning the callback URL
+ * means the code is bound to a value the server can reproduce at exchange time.
+ *
+ * `buildUrl` receives the CSRF state to embed; the provider echoes it back on
+ * the redirect and we accept only a match. Resolves with the code, rejects on
+ * error, popup-block, or the user closing the window ('cancelled').
+ */
+const runOAuthPopup = (buildUrl: (state: string) => string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const state = crypto.randomUUID()
+    const popup = window.open(buildUrl(state), 'meta-login', 'width=600,height=720')
     if (!popup) {
       reject(new Error('Popup blocked — allow pop-ups for this site and try again'))
       return
@@ -211,3 +208,41 @@ export const runBusinessLogin = (config: BusinessLoginConfig): Promise<string> =
     }, 500)
     window.addEventListener('message', onMessage)
   })
+
+/**
+ * Facebook Login for Business — used by Messenger, which connects a Page.
+ *
+ * The same redirectUri must go to the token exchange, so the caller passes it
+ * on to the server.
+ */
+export const runBusinessLogin = (config: BusinessLoginConfig): Promise<string> =>
+  runOAuthPopup((state) =>
+    `https://www.facebook.com/${config.graphVersion}/dialog/oauth?` +
+    new URLSearchParams({
+      client_id: config.appId,
+      config_id: config.configId,
+      response_type: 'code',
+      override_default_response_type: 'true',
+      redirect_uri: config.redirectUri,
+      state,
+      display: 'popup',
+    }).toString())
+
+/**
+ * Instagram Business Login — a different provider entirely, not a Facebook
+ * dialog: the business signs in with Instagram, so no Facebook Page is involved
+ * and the resulting token is an Instagram user token.
+ */
+export const runInstagramLogin = (config: InstagramLoginConfig): Promise<string> =>
+  runOAuthPopup((state) =>
+    'https://www.instagram.com/oauth/authorize?' +
+    new URLSearchParams({
+      client_id: config.appId,
+      redirect_uri: config.redirectUri,
+      response_type: 'code',
+      scope: INSTAGRAM_SCOPES,
+      state,
+      // Keep it an Instagram sign-in rather than falling through to Facebook.
+      enable_fb_login: '0',
+      force_authentication: '1',
+    }).toString())

--- a/frontend/src/utils/metaSdk.ts
+++ b/frontend/src/utils/metaSdk.ts
@@ -18,6 +18,14 @@ const SDK_SRC = 'https://connect.facebook.net/en_US/sdk.js'
 const SDK_SCRIPT_ID = 'facebook-jssdk'
 
 /**
+ * Static page Meta redirects the Login-for-Business popup to (see
+ * public/meta-oauth-callback.html). Its full URL — origin + this path — is the
+ * redirect_uri, so it must be registered as a Valid OAuth Redirect URI and is
+ * sent to the server to exchange the code against.
+ */
+export const META_OAUTH_CALLBACK_PATH = '/meta-oauth-callback.html'
+
+/**
  * Origins Embedded Signup posts its result from.
  *
  * Meta's own sample checks `origin.endsWith('facebook.com')`, which any
@@ -138,3 +146,68 @@ export const signupLoginOptions = (configId: string, channel: SignupChannel = 'w
   override_default_response_type: true,
   ...(channel === 'whatsapp' ? { extras: { setup: {} } } : {}),
 })
+
+export interface BusinessLoginConfig {
+  appId: string
+  configId: string
+  graphVersion: string
+  /** window.location.origin + META_OAUTH_CALLBACK_PATH */
+  redirectUri: string
+}
+
+/**
+ * Run Facebook Login for Business as a first-party OAuth popup and resolve the
+ * returned code.
+ *
+ * Why not FB.login: the JS SDK binds the code to an internal xd_arbiter
+ * redirect that regenerates every login, so it can never be a registered Valid
+ * OAuth Redirect URI — fatal once the app enforces Strict Mode (which it does,
+ * non-negotiably). Driving the dialog ourselves with our own callback URL means
+ * the code is bound to a value we control and the server can reproduce.
+ *
+ * The same redirectUri must go to the token exchange, so the caller passes it
+ * on to the server. Resolves with the code, rejects on error, popup-block, or
+ * the user closing the window ('cancelled').
+ */
+export const runBusinessLogin = (config: BusinessLoginConfig): Promise<string> =>
+  new Promise((resolve, reject) => {
+    // CSRF: Meta echoes state back on the redirect; we only accept a match.
+    const state = crypto.randomUUID()
+    const url = `https://www.facebook.com/${config.graphVersion}/dialog/oauth?` +
+      new URLSearchParams({
+        client_id: config.appId,
+        config_id: config.configId,
+        response_type: 'code',
+        override_default_response_type: 'true',
+        redirect_uri: config.redirectUri,
+        state,
+        display: 'popup',
+      }).toString()
+
+    const popup = window.open(url, 'meta-login', 'width=600,height=720')
+    if (!popup) {
+      reject(new Error('Popup blocked — allow pop-ups for this site and try again'))
+      return
+    }
+
+    const cleanup = () => {
+      window.removeEventListener('message', onMessage)
+      window.clearInterval(closedTimer)
+    }
+    const onMessage = (event: MessageEvent) => {
+      // The callback page is same-origin, so anything else is not our reply.
+      if (event.origin !== window.location.origin) return
+      const data = event.data
+      if (!data || data.source !== 'meta-oauth') return
+      cleanup()
+      try { popup.close() } catch { /* already closed */ }
+      if (data.state !== state) reject(new Error('Login could not be verified'))
+      else if (data.error) reject(new Error(data.error))
+      else if (!data.code) reject(new Error('Login did not return a code'))
+      else resolve(data.code)
+    }
+    const closedTimer = window.setInterval(() => {
+      if (popup.closed) { cleanup(); reject(new Error('cancelled')) }
+    }, 500)
+    window.addEventListener('message', onMessage)
+  })

--- a/frontend/src/utils/metaSdk.ts
+++ b/frontend/src/utils/metaSdk.ts
@@ -30,6 +30,9 @@ const TRUSTED_ORIGINS = [
   'https://business.facebook.com',
 ]
 
+/** Channels connectable through a Meta login popup. */
+export type SignupChannel = 'whatsapp' | 'messenger' | 'instagram'
+
 export interface SignupSession {
   waba_id: string
   phone_number_id: string
@@ -101,9 +104,11 @@ export const loadMetaSdk = (appId: string, graphVersion: string): Promise<Facebo
 /**
  * Read a signup result out of a postMessage, or null if it isn't one.
  *
- * The SDK reports the created WABA and phone number through postMessage while
- * the authorization code comes back via the FB.login callback, so the two
- * halves must be correlated by the caller.
+ * WhatsApp Embedded Signup only: it reports the created WABA and phone number
+ * through postMessage while the authorization code comes back via the FB.login
+ * callback, so the two halves must be correlated by the caller. Facebook Login
+ * for Business (Messenger/Instagram) has no postMessage — its code alone is
+ * enough — so this is not part of that flow.
  */
 export const parseSignupMessage = (event: MessageEvent): SignupSession | null => {
   if (!TRUSTED_ORIGINS.includes(event.origin)) return null
@@ -120,10 +125,16 @@ export const parseSignupMessage = (event: MessageEvent): SignupSession | null =>
   }
 }
 
-/** Options for the Embedded Signup popup. */
-export const signupLoginOptions = (configId: string) => ({
+/**
+ * Options for the Meta login popup that onboards a channel.
+ *
+ * `extras.setup` is WhatsApp Embedded Signup's own parameter — Facebook Login
+ * for Business is a plain permissions grant and takes none, so passing it would
+ * open the wrong flow.
+ */
+export const signupLoginOptions = (configId: string, channel: SignupChannel = 'whatsapp') => ({
   config_id: configId,
   response_type: 'code',
   override_default_response_type: true,
-  extras: { setup: {} },
+  ...(channel === 'whatsapp' ? { extras: { setup: {} } } : {}),
 })

--- a/frontend/src/utils/metaSdk.ts
+++ b/frontend/src/utils/metaSdk.ts
@@ -242,7 +242,7 @@ export const runInstagramLogin = (config: InstagramLoginConfig): Promise<string>
       response_type: 'code',
       scope: INSTAGRAM_SCOPES,
       state,
-      // Keep it an Instagram sign-in rather than falling through to Facebook.
-      enable_fb_login: '0',
-      force_authentication: '1',
+      // Make the business pick the account deliberately rather than silently
+      // reusing whoever is already signed in on this browser.
+      force_reauth: 'true',
     }).toString())


### PR DESCRIPTION
Lets cloud customers connect WhatsApp, Messenger and Instagram without creating their own Meta app or pasting tokens. The manual credentials form stays for self-hosters.

Supersedes #209 — this branch is stacked on it, so its three commits are included. Close #209 or merge it first, but not both.

WhatsApp uses Embedded Signup (already shipped). Messenger uses Facebook Login for Business plus a Page picker; Page tokens never reach the browser, and `page_id` is a selector into a list we fetched ourselves, not a caller claim — webhook routing resolves accounts by external id with no org scoping, so accepting a caller-supplied id would cross orgs. Instagram uses Instagram Business Login against `graph.instagram.com`, no Facebook Page involved.

Two things worth a look: we can't use `FB.login` because it binds the code to a regenerating `xd_arbiter` redirect the server can't reproduce, which is fatal under Strict Mode — so Messenger and Instagram drive a first-party OAuth popup with CSRF state. And Instagram DMs arrive as `entry[].changes[]`, not `entry[].messaging[]`; the inherited parser silently dropped them.

The last commit adds `SIGNUP_ALLOWED_EMAILS` to limit one-click connect while the Meta app is in App Review, since until it's approved the login only works for people with a role on the app. Empty means everyone.

**Deploy:** new env vars `META_MESSENGER_CONFIG_ID`, `INSTAGRAM_APP_ID`, `INSTAGRAM_APP_SECRET`, `SIGNUP_ALLOWED_EMAILS` — flow is off wherever unset. Webhook signature check now accepts either app secret. `frontend/public/meta-oauth-callback.html` is a new static asset, so the frontend volume needs repopulating or the popup 404s.

177 backend, 194 frontend tests pass. Verified against a live Meta app.