### PR TITLE
fix(channels): start a new session when the channel's agent changes

### DIFF
--- a/backend/app/services/channel_chat.py
+++ b/backend/app/services/channel_chat.py
@@ -306,6 +306,30 @@ async def _enrich_customer_name(db: Session, adapter, account: ChannelAccount,
         logger.error(f"Failed to update customer name: {e}")
 
 
+def _agent_changed(session_record, agent_id) -> bool:
+    """Whether this channel now answers with a different agent than the one the
+    open session was started with.
+
+    A session is bound to one agent: its stored history, and the AI runtime's
+    own memory for that session id, belong to that agent. Carrying it over to a
+    newly configured agent makes the new agent answer out of the previous one's
+    retrieved knowledge, and splits the inbox list in two — the conversations
+    query groups by agent *and* session, while the detail view keys on session
+    alone, so the same thread appears twice and neither row opens the other.
+
+    A missing session likewise needs a new one. A human-handled or
+    transferred chat is left alone: rotating it would drop the agent out of a
+    live conversation mid-reply.
+    """
+    if session_record is None:
+        return True
+    if session_record.user_id is not None:
+        return False
+    if session_record.status == SessionStatus.TRANSFERRED:
+        return False
+    return str(session_record.agent_id) != str(agent_id)
+
+
 def _get_or_create_session(db: Session, account: ChannelAccount, inbound: InboundMessage,
                            agent_id, customer_id: str, org_id: str):
     """Find the open session for this platform conversation or start a new one."""
@@ -314,8 +338,17 @@ def _get_or_create_session(db: Session, account: ChannelAccount, inbound: Inboun
 
     conversation = conv_repo.get_active(account.id, inbound.external_conversation_id)
     if conversation is not None:
-        conv_repo.touch_inbound(conversation)
-        return session_repo.get_session(conversation.session_id), conversation
+        session_record = session_repo.get_session(conversation.session_id)
+        if not _agent_changed(session_record, agent_id):
+            conv_repo.touch_inbound(conversation)
+            return session_record, conversation
+        # Retire the thread so the newly configured agent starts clean. Closing
+        # the session is what makes get_active skip it, so the create below
+        # opens a fresh conversation for the same platform thread.
+        logger.info(
+            f"Agent changed for {account.channel_type} account {account.id}; "
+            f"starting a new session for conversation {inbound.external_conversation_id}")
+        session_repo.close_session(conversation.session_id)
 
     session_id = str(uuid.uuid4())
     session_record = session_repo.create_session(

--- a/backend/tests/services/test_channel_chat.py
+++ b/backend/tests/services/test_channel_chat.py
@@ -22,12 +22,14 @@ import pytest
 
 from app.channels.base import InboundMessage
 from app.models.channels import ChannelConversation
+from app.models.agent import AgentType
 from app.models.session_to_agent import SessionToAgent, SessionStatus
 from app.repositories.channels import (
     ChannelAccountRepository,
     ChannelConversationRepository,
     AgentChannelConfigRepository,
 )
+from app.repositories.agent import AgentRepository
 from app.repositories.chat import ChatRepository
 from app.services import channel_chat
 from app.services.channel_chat import process_channel_message
@@ -201,6 +203,87 @@ async def test_reuses_open_session_for_same_conversation(db, routed_account, use
         await process_channel_message(routed_account.id, make_inbound("second"))
 
     assert db.query(ChannelConversation).count() == 1
+
+
+class TestAgentChangeStartsANewSession:
+    """A session belongs to one agent: its history, and the AI runtime's memory
+    for that session id, are that agent's. Reusing it after the channel is
+    pointed at a different agent made the new agent answer out of the previous
+    one's retrieved knowledge, and split the inbox in two — the conversations
+    list groups by agent *and* session while the detail view keys on session
+    alone, so one thread showed twice and neither row opened the other."""
+
+    @staticmethod
+    async def _send(routed_account, text):
+        response = SimpleNamespace(message="ok", transfer_to_human=False,
+                                   end_chat=False, request_lead_capture=False)
+        fake_agent = MagicMock()
+        fake_agent.get_response = AsyncMock(return_value=response)
+        fake_agent.safe_cleanup_mcp_tools = AsyncMock()
+        with patch.object(channel_chat.ChatAgent, "create_async", AsyncMock(return_value=fake_agent)), \
+             patch.object(channel_chat, "deliver_to_customer", AsyncMock()):
+            await process_channel_message(routed_account.id, make_inbound(text))
+
+    @pytest.mark.asyncio
+    async def test_a_new_agent_gets_a_new_session(self, db, routed_account, use_test_db,
+                                                  test_ai_config, test_organization, mock_sio):
+        await self._send(routed_account, "first")
+        first = db.query(ChannelConversation).one()
+
+        other = AgentRepository(db).create_agent(
+            name="Other Agent", agent_type=AgentType.CUSTOMER_SUPPORT,
+            org_id=test_organization.id, instructions=["help"])
+        AgentChannelConfigRepository(db).set_agent(routed_account.id, other.id)
+
+        await self._send(routed_account, "second")
+
+        # Same platform thread, but a second conversation and a second session.
+        conversations = db.query(ChannelConversation).order_by(
+            ChannelConversation.created_at).all()
+        assert len(conversations) == 2
+        assert conversations[0].session_id != conversations[1].session_id
+        assert {c.external_conversation_id for c in conversations} == {"222"}
+
+        # The retired session is closed, so it stops being picked up, and each
+        # session is bound to exactly one agent.
+        old = db.query(SessionToAgent).filter_by(session_id=first.session_id).one()
+        new = db.query(SessionToAgent).filter_by(session_id=conversations[1].session_id).one()
+        assert old.status == SessionStatus.CLOSED
+        assert str(new.agent_id) == str(other.id)
+
+    @pytest.mark.asyncio
+    async def test_the_same_agent_keeps_its_session(self, db, routed_account, use_test_db,
+                                                    test_ai_config, mock_sio):
+        """The guard must not fire on every message — only on a real change."""
+        await self._send(routed_account, "first")
+        await self._send(routed_account, "second")
+
+        assert db.query(ChannelConversation).count() == 1
+        assert db.query(SessionToAgent).filter_by(
+            status=SessionStatus.CLOSED).count() == 0
+
+    @pytest.mark.asyncio
+    async def test_a_human_handled_chat_is_not_rotated(self, db, routed_account, use_test_db,
+                                                       test_ai_config, test_organization,
+                                                       test_user, mock_sio):
+        """Rotating here would drop the human agent out of a live conversation."""
+        await self._send(routed_account, "first")
+        conversation = db.query(ChannelConversation).one()
+        session = db.query(SessionToAgent).filter_by(
+            session_id=conversation.session_id).one()
+        session.user_id = test_user.id
+        db.commit()
+
+        other = AgentRepository(db).create_agent(
+            name="Other Agent 2", agent_type=AgentType.CUSTOMER_SUPPORT,
+            org_id=test_organization.id, instructions=["help"])
+        AgentChannelConfigRepository(db).set_agent(routed_account.id, other.id)
+
+        await self._send(routed_account, "while a human is on it")
+
+        assert db.query(ChannelConversation).count() == 1
+        assert db.query(SessionToAgent).filter_by(
+            session_id=conversation.session_id).one().status != SessionStatus.CLOSED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Repointing a channel at a different AI agent left the open conversation bound to the old agent. Hit in prod on Messenger.

The new agent then answered out of the old agent's knowledge, because the AI runtime keys its per-session memory on session id alone — the retired agent's retrieved documents were still in that session's context and got used instead of a fresh search. Confirmed on prod: one Messenger session held 4 messages stamped with two different agents, and its stored memory still contained the old agent's docs.

The same anomaly split the inbox. `get_recent_chats` groups by agent *and* session, so one session carrying two agents listed twice, while the detail view keys on session alone — both rows opened the same thread, so clicking between them looked like nothing happened.

Fix: if the configured agent differs from the session's, close the old session. That's what makes `get_active` skip it, so the next message opens a fresh conversation on the same platform thread and each session stays bound to one agent. Human-handled and transferred chats are left alone — rotating those would drop the agent out of a live conversation.

Not a data leak: the vector table is per-org and both agents belong to the same org. The knowledge filter itself is fine — running the real search path in prod as the new agent returns only that agent's docs.

487 tests pass. Verified the new tests aren't vacuous: with the fix reverted, `test_a_new_agent_gets_a_new_session` fails.

Note: existing mixed-history sessions in prod aren't repaired by this — it only prevents new ones. Closing the affected session clears it.