### PR TITLE
fix(pwa): stop the service worker swallowing non-SPA navigations

### DIFF
--- a/frontend/src/__tests__/utils/swOauthCallback.spec.ts
+++ b/frontend/src/__tests__/utils/swOauthCallback.spec.ts
@@ -1,0 +1,73 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from 'vitest'
+
+import { isDeniedNavigation } from '@/pwa/navigationDenylist'
+import { META_OAUTH_CALLBACK_PATH } from '@/utils/metaSdk'
+
+/**
+ * Workbox matches the denylist against `pathname + search`, so every case here
+ * is written the way the service worker actually sees it — with the query
+ * string attached. An earlier fix anchored on `$` and silently matched nothing
+ * once Meta appended ?code=.
+ */
+describe('service worker navigation denylist', () => {
+  describe('OAuth callbacks are never answered with the SPA shell', () => {
+    it('denies the Meta callback carrying the code and state Meta appends', () => {
+      expect(
+        isDeniedNavigation(`${META_OAUTH_CALLBACK_PATH}?code=AQLe9lcDvOy&state=abc-123`),
+      ).toBe(true)
+    })
+
+    it('denies it bare too', () => {
+      expect(isDeniedNavigation(META_OAUTH_CALLBACK_PATH)).toBe(true)
+    })
+  })
+
+  describe('real SPA routes still get the shell', () => {
+    it.each([
+      '/',
+      '/settings/integrations',
+      '/conversations',
+      '/ai-agents',
+      '/people',
+      '/settings/integrations?tab=messenger',
+    ])('allows %s', (path) => {
+      expect(isDeniedNavigation(path)).toBe(false)
+    })
+
+    it('is not fooled by a dot inside the query string', () => {
+      // The extension rule must look at the path, not the whole string.
+      expect(isDeniedNavigation('/people?search=ada.lovelace%40example.com')).toBe(false)
+    })
+  })
+
+  describe('the pre-existing exclusions still hold', () => {
+    it.each(['/api/v1/users/login', '/widget/abc', '/webclient/chattermate.min.js', '/shopify/inbox'])(
+      'denies %s',
+      (path) => {
+        expect(isDeniedNavigation(path)).toBe(true)
+      },
+    )
+  })
+
+  it('covers any other standalone file in public/, not just the ones we listed', () => {
+    // The point of the extension rule: nothing new has to be enumerated.
+    expect(isDeniedNavigation('/robots.txt')).toBe(true)
+    expect(isDeniedNavigation('/some-future-callback.html?code=x')).toBe(true)
+  })
+})

--- a/frontend/src/pwa/navigationDenylist.ts
+++ b/frontend/src/pwa/navigationDenylist.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Navigations the service worker must NOT answer with the SPA shell.
+ *
+ * Lives outside sw.ts so it can be tested without ServiceWorker globals.
+ *
+ * Workbox matches these against `url.pathname + url.search`, **not** the
+ * pathname alone (see workbox-routing/NavigationRoute `_match`). An anchored
+ * `$` therefore stops matching the moment a provider appends a query string —
+ * which is precisely the case that matters here, since OAuth providers always
+ * redirect back with `?code=…`.
+ */
+export const NAVIGATION_DENYLIST: RegExp[] = [
+  /^\/api\//,
+  /^\/widget/,
+  /^\/webclient/,
+  /^\/shopify/,
+  // Anything carrying a file extension is a real file served from public/,
+  // never an SPA route — no route in the router has one.
+  //
+  // This is what keeps meta-oauth-callback.html working: Meta redirects the
+  // login popup there, and the page exists only to postMessage the code back
+  // to its opener. Answer it with index.html and the SPA boots instead, fails
+  // to route the path, lands on the dashboard, and the connect dies silently.
+  // Being precached does not save it — a precache lookup does not ignore
+  // `?code=&state=`, so the request misses the entry and reaches the fallback.
+  //
+  // `[^?]*` keeps the extension match on the path, so a dot inside a query
+  // string (`/settings?q=a.b`) is not mistaken for a filename.
+  /^[^?]*\.[a-z0-9]+(\?|$)/i,
+]
+
+/**
+ * Whether this navigation should bypass the SPA shell. Mirrors workbox's own
+ * denylist check, so tests exercise the real matching semantics.
+ */
+export function isDeniedNavigation(pathnameAndSearch: string): boolean {
+  return NAVIGATION_DENYLIST.some((pattern) => pattern.test(pathnameAndSearch))
+}

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -31,6 +31,7 @@ import { clientsClaim } from 'workbox-core'
 import { initializeApp } from 'firebase/app'
 import { getMessaging, onBackgroundMessage } from 'firebase/messaging/sw'
 import { SW_MESSAGE, conversationSessionUrl } from './pwa/pushContract'
+import { NAVIGATION_DENYLIST } from './pwa/navigationDenylist'
 
 declare let self: ServiceWorkerGlobalScope
 
@@ -49,10 +50,11 @@ clientsClaim()
 precacheAndRoute(self.__WB_MANIFEST)
 cleanupOutdatedCaches()
 
-// SPA navigation fallback — never for API/widget/Shopify-embedded routes
+// SPA navigation fallback. What it must not swallow lives in
+// ./pwa/navigationDenylist, which is testable without ServiceWorker globals.
 registerRoute(
   new NavigationRoute(createHandlerBoundToURL('index.html'), {
-    denylist: [/^\/api\//, /^\/widget/, /^\/webclient/, /^\/shopify/],
+    denylist: NAVIGATION_DENYLIST,
   }),
 )
 


### PR DESCRIPTION
Connecting a Page or Instagram account broke once the PWA shipped. Meta redirects the login popup to `/meta-oauth-callback.html`, the service worker answered with `index.html`, and the SPA booted, couldn't route that path and landed on the dashboard — so the code never reached `window.opener` and the connect died silently with no error anywhere.

Being precached didn't save it: Meta appends `?code=&state=`, and a precache lookup doesn't ignore those params, so the request missed the entry and hit the navigation fallback.

The rule is general rather than one entry per file — any path with a file extension is a real file in `public/`, never a route (nothing in the router has one). Covers this callback and anything added later.

Worth knowing, because it makes the obvious fix wrong: **workbox matches the denylist against `pathname + search`, not the pathname**. An anchored `/^\/meta-oauth-callback\.html$/` matches nothing once the provider appends its query string — I had exactly that before catching it. The pattern keeps the extension match on the path so a dot inside a query (`/people?q=ada.lovelace@example.com`) isn't mistaken for a filename.

The list moved to `pwa/navigationDenylist.ts` so it can be tested against the URLs the worker really sees; `sw.ts` needs ServiceWorker globals and can't be imported by a test.

Checked the rest while in here: `/shopify/*` are real SPA routes, denylisted on purpose so embedded pages come from network (nginx `try_files` still serves the shell). Slack's callback is under `/api/`. This was the only standalone file in `public/`.

256 frontend tests pass, vue-tsc clean.