### PR TITLE
fix(mobile): light-theme edge shadow and dark flash on launch

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,30 @@
   <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content">
   <meta name="theme-color" content="#0B0C10">
+  <script>
+    /* Applies the saved theme before first paint.
+       useTheme.ts sets data-theme and theme-color too, but only once the bundle
+       has parsed and run — so a light-theme user saw the dark shell, and dark
+       browser chrome, flash on every launch. That is most obvious in the
+       installed PWA, where the launch goes straight from a dark splash into the
+       app. The manifest's own background_color cannot help: it is static and
+       already matches the default (dark) theme.
+       Keep the key and the two colours in step with src/composables/useTheme.ts
+       and src/config/themeColors.ts — a static document cannot import them. */
+    (function () {
+      try {
+        var stored = localStorage.getItem('cm-theme') || 'dark';
+        var resolved = stored === 'system'
+          ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+          : (stored === 'light' ? 'light' : 'dark');
+        document.documentElement.setAttribute('data-theme', resolved);
+        var meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) meta.setAttribute('content', resolved === 'dark' ? '#0B0C10' : '#EEF0F4');
+      } catch (e) {
+        /* Private mode can throw on localStorage; the dark default already applies. */
+      }
+    })();
+  </script>
   <!-- iOS installed-PWA (Add to Home Screen) -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -293,6 +293,13 @@ const handleNavigation = () => {
     .sidebar.collapsed {
         transform: translateX(-100%);
         width: 252px;
+        /* An off-canvas panel must not keep painting its shadow over the page.
+           Sliding it out moves the box, not the shadow's reach: with an 8px
+           offset and 32px blur, roughly 24px of it still lands on the page's
+           left edge, above the content at z-index 1000. On the dark theme that
+           is black on near-black and invisible, which is why it went unnoticed;
+           on the light theme it reads as a grey band down the side. */
+        box-shadow: none;
     }
 
     /* In overlay mode the panel is full-width — restore expanded layout */


### PR DESCRIPTION
Two light-theme fixes on mobile.

**The closed sidebar was painting a shadow over the page.** Sliding it out with `translateX(-100%)` moves the box, not the reach of its shadow — with an 8px offset and 32px blur, roughly 24px still lands on the page's left edge, drawn above content at `z-index: 1000`. On dark it's black on near-black and invisible, which is why it survived; on light it's a grey band down the side.

**The saved theme is now applied before first paint.** `index.html` hardcodes the dark `theme-color` and nothing sets `data-theme` until the bundle runs, so a light-theme user saw the dark shell flash on every launch — most obvious in the installed PWA, going from a dark splash into the app. A small inline script resolves the stored preference (including `system`) and sets both up front; `useTheme` still owns everything after that.

The manifest is deliberately untouched: `background_color` is static, can't follow a preference, and already matches the app's default dark theme — pointing it at light would just move the flash onto everyone who never changed the setting.

256 tests pass, vue-tsc clean. The pre-paint resolution was checked against `useTheme.ts` semantics for all six cases (unset / dark / light / system+prefersDark / system+prefersLight / garbage).

Note: the right-hand strip in the report is **not** addressed here — the app never constrains its own width (`#app` is `width: 100%`, no max-width), and the screenshot's asymmetric strips plus a mid-height drag handle look like DevTools device-mode chrome rather than the app. Worth confirming on-device before chasing it.