### PR TITLE
fix(mobile): stop the closed notification drawer shadowing the page

### DIFF
--- a/frontend/src/components/notifications/NotificationList.vue
+++ b/frontend/src/components/notifications/NotificationList.vue
@@ -183,7 +183,6 @@ onMounted(fetchNotifications)
     height: 100vh;
     background: var(--bg2);
     border-left: 1px solid var(--o08);
-    box-shadow: -20px 0 50px rgba(0, 0, 0, 0.4);
     transition: right 0.3s ease;
     z-index: var(--z-drawer);
     display: flex;
@@ -192,6 +191,12 @@ onMounted(fetchNotifications)
 
 .notification-drawer.open {
     right: 0;
+    /* Only while open. Parked at right:-380px the panel is off-screen, but a
+       shadow cast 20px leftward with a 50px blur still reaches ~45px back onto
+       the page, above the content — and this drawer is mounted by
+       DashboardLayout on every screen, so the band followed you everywhere.
+       Invisible on the dark theme, a grey edge on the light one. */
+    box-shadow: -20px 0 50px rgba(0, 0, 0, 0.4);
 }
 
 .drawer-header {


### PR DESCRIPTION
Follow-up to #215, which fixed the left band. This is the right one — same defect, mirrored.

The notification drawer is parked off-screen at `right: -380px` rather than unmounted, and its shadow is cast 20px *leftward* with a 50px blur. So ~45px of it lands back on the page's right edge, above the content. On a 738px-wide phone that's a band from x=693 to the edge, which matches the screenshot exactly.

`DashboardLayout` mounts this drawer on every screen, so the band followed you everywhere — Conversations, AI Agents, all of it. Invisible on dark (black on near-black), a grey gradient on light.

The shadow now applies only while the drawer is open.

Worth noting for future drawers: `PersonDetailDrawer` is `v-if`'d so it has the same shadow but no bug. The pattern to avoid is a persistently-mounted panel moved off-screen by position or transform — the box moves, the shadow's reach doesn't.

256 tests pass, vue-tsc clean.