### PR TITLE
chore: ignore Python virtualenvs, not just .venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,12 @@ static/
 logs/
 __pycache__/
 .DS_Store
+# Python virtualenvs. Only .venv/ was listed, so backend/venv — 2GB of
+# site-packages — was one `git add -A` away from being committed. The glob
+# covers the "-old"/"-py313" copies that pile up around a version bump.
 .venv/
+venv/
+venv-*/
 .idea/
 .vscode/
 .pytest_cache/


### PR DESCRIPTION
Only `.venv/` was listed, so `backend/venv` — about 2GB of site-packages — sat untracked but perfectly committable, one `git add -A` away from landing in the repo.

The `venv-*/` glob also covers the "-old"/"-py313" copies that accumulate around a version bump. Verified both globs match at any depth (`backend/venv-py314-test/`, `chattermate-cli/venv/`), and that no tracked file matches either pattern — so this changes no existing file.

No runtime effect; nothing to deploy.