### PR TITLE
Meter AI ticket investigations against the message limit

### DIFF
--- a/backend/alembic/versions/add_investigation_metered.py
+++ b/backend/alembic/versions/add_investigation_metered.py
@@ -1,0 +1,41 @@
+"""Add metered flag to investigation_runs
+
+Revision ID: add_tkt_metered_001
+Revises: add_tkt_row_scope_001
+Create Date: 2026-07-21
+
+Marks whether an investigation run's LLM usage counts against the org's message
+budget (hosted model only). Existing rows default to false — nothing is
+retroactively metered on upgrade.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "add_tkt_metered_001"
+down_revision = "add_tkt_row_scope_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "investigation_runs",
+        sa.Column(
+            "metered",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    # The enterprise message-limit check sums llm_calls of metered runs per
+    # billing window — an index on (org, metered, created_at) keeps that cheap.
+    op.create_index(
+        "ix_investigation_runs_metered_period",
+        "investigation_runs",
+        ["organization_id", "metered", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_investigation_runs_metered_period", table_name="investigation_runs")
+    op.drop_column("investigation_runs", "metered")

--- a/backend/app/agents/ticket_investigator.py
+++ b/backend/app/agents/ticket_investigator.py
@@ -162,10 +162,34 @@ class TicketInvestigatorAgent:
         self._use_groq_json_tool = model_type.upper() == "GROQ"
         # Metering hook, fired once per provider call — set by the worker.
         self.on_llm_call: Optional[Callable[[], None]] = None
+        # Token usage accumulated across every phase of this run; the worker
+        # folds these onto the InvestigationRun at finalize time.
+        self.input_tokens = 0
+        self.output_tokens = 0
 
     def _count_call(self) -> None:
         if self.on_llm_call:
             self.on_llm_call()
+
+    def _capture_usage(self, agent, response) -> None:
+        """Accumulate one call's token usage. agno exposes per-phase scalar
+        totals on agent.session_metrics (a fresh Agent is built per phase, so
+        these are this call's totals); fall back to summing the per-message
+        lists on response.metrics. Best-effort — metering must never break a
+        run."""
+        try:
+            metrics = getattr(agent, "session_metrics", None)
+            if metrics is not None and (
+                getattr(metrics, "input_tokens", 0) or getattr(metrics, "output_tokens", 0)
+            ):
+                self.input_tokens += int(metrics.input_tokens or 0)
+                self.output_tokens += int(metrics.output_tokens or 0)
+                return
+            resp_metrics = getattr(response, "metrics", None) or {}
+            self.input_tokens += int(sum(resp_metrics.get("input_tokens", []) or []))
+            self.output_tokens += int(sum(resp_metrics.get("output_tokens", []) or []))
+        except Exception as e:
+            logger.warning(f"Token usage capture failed: {e}")
 
     async def _run_structured(
         self,
@@ -223,6 +247,7 @@ class TicketInvestigatorAgent:
         try:
             self._count_call()
             response = await agent.arun(message)
+            self._capture_usage(agent, response)
         except Exception as e:
             logger.error(f"{name} LLM call failed: {e}")
             return None

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -516,6 +516,16 @@ async def investigate_ticket(
             detail="This ticket is resolved — reopen it before running another investigation",
         )
     payload = payload or InvestigateRequest()
+    # Distinguish "out of credits" (402, actionable — upgrade) from the generic
+    # 409 below, for a human clicking Investigate.
+    if payload.run_type == InvestigationRunType.INVESTIGATION and service._investigation_over_budget(ticket):
+        raise HTTPException(
+            status_code=402,
+            detail=(
+                "Not enough message credits left in your plan to run an AI "
+                "investigation. Upgrade your plan or switch to your own AI model key."
+            ),
+        )
     run = service.enqueue_run(
         ticket,
         run_type=payload.run_type,

--- a/backend/app/models/investigation.py
+++ b/backend/app/models/investigation.py
@@ -108,6 +108,11 @@ class InvestigationRun(Base):
     input_tokens = Column(BigInteger, nullable=False, default=0, server_default="0")
     output_tokens = Column(BigInteger, nullable=False, default=0, server_default="0")
     model_name = Column(String, nullable=True)
+    # True when this run's LLM usage counts against the org's message budget —
+    # set only for the platform-hosted model (own-key orgs pay their provider
+    # directly). Mirrors FAQGenerationJob.metered; summed by the enterprise
+    # message-limit check.
+    metered = Column(Boolean, nullable=False, default=False, server_default="false")
 
     error = Column(Text, nullable=True)
     started_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/app/models/schemas/ticket.py
+++ b/backend/app/models/schemas/ticket.py
@@ -134,6 +134,10 @@ class InvestigationRunOut(BaseModel):
     error: Optional[str] = None
     tool_calls_used: int = 0
     max_tool_calls: int = 25
+    llm_calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    metered: bool = False
     model_name: Optional[str] = None
     started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None

--- a/backend/app/repositories/ticket.py
+++ b/backend/app/repositories/ticket.py
@@ -438,6 +438,24 @@ class InvestigationRepository:
         )
         return [r[0] for r in rows]
 
+    def count_llm_calls_for_period(
+        self, organization_id: UUID, start_date: datetime, end_date: datetime
+    ) -> int:
+        """Metered investigation LLM calls in a billing period — the hosted-
+        model usage the enterprise message-limit check adds to the bot-message
+        count. Mirrors FAQGenerationJobRepository.count_llm_calls_for_period."""
+        total = (
+            self.db.query(func.coalesce(func.sum(InvestigationRun.llm_calls), 0))
+            .filter(
+                InvestigationRun.organization_id == organization_id,
+                InvestigationRun.metered.is_(True),
+                InvestigationRun.created_at >= start_date,
+                InvestigationRun.created_at <= end_date,
+            )
+            .scalar()
+        )
+        return int(total or 0)
+
     def latest_run_of_type(self, ticket_id: UUID, run_type: str) -> Optional[InvestigationRun]:
         return (
             self.db.query(InvestigationRun)

--- a/backend/app/services/faq_usage.py
+++ b/backend/app/services/faq_usage.py
@@ -32,17 +32,20 @@ from app.core.config import settings
 from app.core.logger import get_logger
 from app.knowledge.page_editor import PAGE_ID_EXPR
 from app.models.knowledge import Knowledge
-from app.repositories.ai_config import AIConfigRepository
 from app.repositories.faq import FAQRepository
+# Shared hosted-model metering helpers; re-exported here so existing FAQ
+# callers keep importing them from faq_usage.
+from app.services.usage_metering import (  # noqa: F401
+    HOSTED_MODEL_TYPE,
+    is_hosted_model,
+    remaining_message_credits,
+)
 
 logger = get_logger(__name__)
 
 # Rough pages-per-LLM-call heuristic for the confirm-dialog estimate (matches
 # today's floor batch of ~3 average pages). An estimate, not billing.
 PAGES_PER_CALL = 3
-
-# Model type whose provider costs land on the platform, hence metered.
-HOSTED_MODEL_TYPE = "CHATTERMATE"
 
 OVER_BUDGET_MESSAGE = (
     "Not enough message credits left in your plan for this generation "
@@ -73,13 +76,7 @@ class GenerationEstimate:
 def generation_is_metered(db: Session, organization_id: UUID) -> bool:
     """Generation costs credits only on the hosted model — own-key orgs pay
     their provider directly. FAQ_METER_OWN_KEY flips to always-meter."""
-    if settings.FAQ_METER_OWN_KEY:
-        return True
-    config = AIConfigRepository(db).get_active_config(organization_id)
-    if not config:
-        return False
-    model_type = config.model_type.value if hasattr(config.model_type, "value") else str(config.model_type)
-    return model_type.upper() == HOSTED_MODEL_TYPE
+    return settings.FAQ_METER_OWN_KEY or is_hosted_model(db, organization_id)
 
 
 def count_source_pages(db: Session, knowledge: Knowledge) -> Optional[int]:
@@ -167,21 +164,6 @@ def estimate_generation_calls(
         estimated_calls=agg_calls,
         sources=source_list,
     )
-
-
-def remaining_message_credits(db: Session, organization_id: UUID) -> Optional[int]:
-    """Credits left in the billing period, or None when unlimited (no
-    enterprise module, no subscription cap, or the check errored — fail open,
-    matching check_message_limit's posture)."""
-    try:
-        from app.enterprise.services.message_limit import get_remaining_messages
-    except ImportError:
-        return None
-    try:
-        return get_remaining_messages(db, organization_id)
-    except Exception as e:
-        logger.error(f"Remaining-credit check failed for org {organization_id}: {e}")
-        return None
 
 
 def ensure_generation_budget(db: Session, organization_id: UUID, estimated_calls: int) -> None:

--- a/backend/app/services/ticket.py
+++ b/backend/app/services/ticket.py
@@ -423,6 +423,19 @@ class TicketService:
 
     # ---------- AI runs ----------
 
+    def _investigation_over_budget(self, ticket: Ticket) -> bool:
+        """True when a metered (hosted-model) org has no message credits left.
+        Fails open (never blocks) for own-key orgs, unlimited plans, self-host
+        without the enterprise module, or on any metering error."""
+        from app.services.usage_metering import (
+            is_hosted_model,
+            remaining_message_credits,
+        )
+        if not is_hosted_model(self.db, ticket.organization_id):
+            return False
+        remaining = remaining_message_credits(self.db, ticket.organization_id)
+        return remaining is not None and remaining <= 0
+
     def enqueue_run(
         self,
         ticket: Ticket,
@@ -437,6 +450,22 @@ class TicketService:
             done = self.run_repo.count_for_ticket(ticket.id, InvestigationRunType.INVESTIGATION)
             if done >= settings.max_runs_per_ticket:
                 logger.info(f"Ticket {ticket.display_number}: max investigation runs reached")
+                return None
+            # An investigation makes many metered LLM calls, so a hosted-model
+            # org that's out of message credits can't start one. Triage (cheap,
+            # one call) is never gated, so tickets still get classified.
+            if self._investigation_over_budget(ticket):
+                self._add_activity(
+                    ticket,
+                    TicketActivityType.STATUS_CHANGE,
+                    actor_type=TicketActorType.SYSTEM,
+                    body=(
+                        "AI investigation paused — the organization is out of "
+                        "message credits for this billing period."
+                    ),
+                    metadata={"reason": "message_limit_reached"},
+                )
+                logger.info(f"Ticket {ticket.display_number}: investigation blocked, out of credits")
                 return None
         run = self.run_repo.enqueue(
             InvestigationRun(

--- a/backend/app/services/usage_metering.py
+++ b/backend/app/services/usage_metering.py
@@ -1,0 +1,65 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Shared usage-metering helpers for hosted-model features (FAQ generation, AI
+ticket investigations). Whether a run counts against the org's message budget,
+and how many credits remain, is the same question for every hosted-model
+feature — kept here so each feature doesn't reimplement (or drift from) it.
+
+OSS/self-hosted builds have no enterprise module: nothing is metered and
+nothing is blocked (fail open).
+"""
+
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.logger import get_logger
+from app.repositories.ai_config import AIConfigRepository
+
+logger = get_logger(__name__)
+
+# Model type whose provider costs land on the platform, hence metered. Own-key
+# orgs pay their provider directly and are never metered or blocked.
+HOSTED_MODEL_TYPE = "CHATTERMATE"
+
+
+def is_hosted_model(db: Session, organization_id: UUID) -> bool:
+    """True when the org runs on the platform-hosted model, so its LLM usage is
+    billable against the message budget."""
+    config = AIConfigRepository(db).get_active_config(organization_id)
+    if not config:
+        return False
+    model_type = (
+        config.model_type.value if hasattr(config.model_type, "value")
+        else str(config.model_type)
+    )
+    return model_type.upper() == HOSTED_MODEL_TYPE
+
+
+def remaining_message_credits(db: Session, organization_id: UUID) -> Optional[int]:
+    """Message credits left in the current billing period, or None when
+    unlimited (no enterprise module, no subscription cap, or the check errored
+    — fail open, matching check_message_limit's posture)."""
+    try:
+        from app.enterprise.services.message_limit import get_remaining_messages
+    except ImportError:
+        return None
+    try:
+        return get_remaining_messages(db, organization_id)
+    except Exception as e:
+        logger.error(f"Remaining-credit check failed for org {organization_id}: {e}")
+        return None

--- a/backend/app/workers/ticket_investigator.py
+++ b/backend/app/workers/ticket_investigator.py
@@ -40,8 +40,9 @@ from app.models.ticket_activity import TicketActivityType, TicketActorType
 from app.repositories.ai_config import AIConfigRepository
 from app.repositories.ticket import InvestigationRepository, TicketRepository
 from app.services.ticket import TicketService, embed_ticket_text
-from app.services.ticket_privacy import redact_reference_text
 from app.services.ticket_events import emit_ticket_update
+from app.services.ticket_privacy import redact_reference_text
+from app.services.usage_metering import HOSTED_MODEL_TYPE
 
 logger = get_logger(__name__)
 
@@ -161,18 +162,23 @@ async def process_run(run_id: UUID) -> None:
             {"status": "running", "run_type": str(run.run_type)},
         )
 
+        agent = None
         try:
             config = AIConfigRepository(db).get_active_config(ticket.organization_id)
             if config is None:
                 raise RuntimeError("Organization has no active AI configuration")
 
+            model_type = config.model_type.value if hasattr(config.model_type, "value") else str(config.model_type)
             from app.agents.ticket_investigator import TicketInvestigatorAgent
             agent = TicketInvestigatorAgent(
                 api_key=decrypt_api_key(config.encrypted_api_key),
                 model_name=config.model_name,
-                model_type=config.model_type.value if hasattr(config.model_type, "value") else str(config.model_type),
+                model_type=model_type,
             )
             run.model_name = config.model_name
+            # Metered only on the hosted model — own-key orgs pay their provider
+            # directly. This is what the message-limit check sums.
+            run.metered = model_type.upper() == HOSTED_MODEL_TYPE
 
             def count_call():
                 run.llm_calls = (run.llm_calls or 0) + 1
@@ -191,6 +197,17 @@ async def process_run(run_id: UUID) -> None:
             except Exception:
                 pass
             _fail_run(db, run, ticket, previous_status, str(e))
+        finally:
+            # Record token usage on every path — success, budget-exceeded,
+            # failure or timeout — so partial spend is still metered.
+            if agent is not None and (agent.input_tokens or agent.output_tokens):
+                try:
+                    run.input_tokens = agent.input_tokens
+                    run.output_tokens = agent.output_tokens
+                    db.commit()
+                except Exception as e:
+                    logger.warning(f"Recording token usage failed for run {run_id}: {e}")
+                    db.rollback()
 
 
 async def _process_triage(db, run, service: TicketService, ticket: Ticket, agent, previous_status: str) -> None:

--- a/backend/tests/services/test_ticket_metering.py
+++ b/backend/tests/services/test_ticket_metering.py
@@ -1,0 +1,207 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Investigation metering: per-period llm_call counting, the enqueue budget gate,
+and per-run token capture. The billable unit is one LLM call, mirroring FAQ
+generation; only hosted-model (metered) runs count against the message budget.
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.models.investigation import InvestigationRun, InvestigationRunType, InvestigationTrigger
+from app.models.ticket import Ticket, TicketPriority, TicketSource, TicketStatus
+from app.models.ticket_activity import TicketActivity
+from app.repositories.ticket import InvestigationRepository
+from app.services.ticket import TicketService
+
+
+def _make_ticket(db, org) -> Ticket:
+    t = Ticket(
+        organization_id=org.id,
+        ticket_number=1,
+        title="Payout stuck",
+        description="No payout since yesterday.",
+        status=TicketStatus.OPEN,
+        priority=TicketPriority.HIGH,
+        source=TicketSource.MANUAL,
+    )
+    db.add(t)
+    db.commit()
+    return t
+
+
+def _add_run(db, ticket, *, llm_calls, metered, created_at=None) -> InvestigationRun:
+    r = InvestigationRun(
+        ticket_id=ticket.id,
+        organization_id=ticket.organization_id,
+        run_type="investigation",
+        status="completed",
+        llm_calls=llm_calls,
+        metered=metered,
+    )
+    db.add(r)
+    db.commit()
+    if created_at is not None:
+        # created_at has a server default; override after insert for the window test.
+        r.created_at = created_at
+        db.commit()
+    return r
+
+
+class TestCountLlmCallsForPeriod:
+    def _window(self):
+        now = datetime.now(timezone.utc)
+        return now - timedelta(days=30), now + timedelta(days=1)
+
+    def test_sums_metered_runs(self, db, test_organization):
+        ticket = _make_ticket(db, test_organization)
+        _add_run(db, ticket, llm_calls=5, metered=True)
+        _add_run(db, ticket, llm_calls=7, metered=True)
+        start, end = self._window()
+        total = InvestigationRepository(db).count_llm_calls_for_period(
+            test_organization.id, start, end
+        )
+        assert total == 12
+
+    def test_excludes_unmetered(self, db, test_organization):
+        ticket = _make_ticket(db, test_organization)
+        _add_run(db, ticket, llm_calls=5, metered=True)
+        _add_run(db, ticket, llm_calls=100, metered=False)  # own-key run
+        start, end = self._window()
+        total = InvestigationRepository(db).count_llm_calls_for_period(
+            test_organization.id, start, end
+        )
+        assert total == 5
+
+    def test_excludes_out_of_window(self, db, test_organization):
+        ticket = _make_ticket(db, test_organization)
+        _add_run(db, ticket, llm_calls=5, metered=True)
+        _add_run(
+            db, ticket, llm_calls=9, metered=True,
+            created_at=datetime.now(timezone.utc) - timedelta(days=60),
+        )
+        start, end = self._window()
+        total = InvestigationRepository(db).count_llm_calls_for_period(
+            test_organization.id, start, end
+        )
+        assert total == 5
+
+    def test_zero_when_none(self, db, test_organization):
+        start, end = self._window()
+        assert InvestigationRepository(db).count_llm_calls_for_period(
+            test_organization.id, start, end
+        ) == 0
+
+
+class TestEnqueueBudgetGate:
+    """Investigations are blocked when a hosted-model org is out of credits;
+    triage never is, and own-key / unlimited orgs never are."""
+
+    def _service(self, db):
+        return TicketService(db)
+
+    def _patch(self, hosted, remaining):
+        return (
+            patch("app.services.usage_metering.is_hosted_model", return_value=hosted),
+            patch("app.services.usage_metering.remaining_message_credits", return_value=remaining),
+        )
+
+    def test_investigation_blocked_when_out_of_credits(self, db, test_organization):
+        ticket = _make_ticket(db, test_organization)
+        service = self._service(db)
+        p1, p2 = self._patch(hosted=True, remaining=0)
+        with p1, p2:
+            run = service.enqueue_run(ticket, run_type=InvestigationRunType.INVESTIGATION)
+        assert run is None
+        # A visible activity records why nothing happened.
+        acts = db.query(TicketActivity).filter(TicketActivity.ticket_id == ticket.id).all()
+        assert any("message credits" in (a.body or "") for a in acts)
+        assert any((a.activity_metadata or {}).get("reason") == "message_limit_reached" for a in acts)
+
+    def test_triage_never_blocked(self, db, test_organization):
+        ticket = _make_ticket(db, test_organization)
+        service = self._service(db)
+        p1, p2 = self._patch(hosted=True, remaining=0)
+        with p1, p2:
+            run = service.enqueue_run(ticket, run_type=InvestigationRunType.TRIAGE)
+        assert run is not None
+
+    def test_investigation_allowed_with_credits(self, db, test_organization):
+        ticket = _make_ticket(db, test_organization)
+        service = self._service(db)
+        p1, p2 = self._patch(hosted=True, remaining=50)
+        with p1, p2:
+            run = service.enqueue_run(ticket, run_type=InvestigationRunType.INVESTIGATION)
+        assert run is not None
+
+    def test_own_key_org_never_blocked(self, db, test_organization):
+        ticket = _make_ticket(db, test_organization)
+        service = self._service(db)
+        # is_hosted_model False → gate short-circuits, remaining irrelevant.
+        p1, p2 = self._patch(hosted=False, remaining=0)
+        with p1, p2:
+            run = service.enqueue_run(ticket, run_type=InvestigationRunType.INVESTIGATION)
+        assert run is not None
+
+    def test_unlimited_plan_never_blocked(self, db, test_organization):
+        ticket = _make_ticket(db, test_organization)
+        service = self._service(db)
+        # remaining None = unlimited / self-host / metering error.
+        p1, p2 = self._patch(hosted=True, remaining=None)
+        with p1, p2:
+            run = service.enqueue_run(ticket, run_type=InvestigationRunType.INVESTIGATION)
+        assert run is not None
+
+
+class TestTokenCapture:
+    """The agent accumulates token usage across phases from agno's metrics."""
+
+    def _agent(self):
+        from app.agents.ticket_investigator import TicketInvestigatorAgent
+        return TicketInvestigatorAgent(api_key="x", model_name="m", model_type="openai")
+
+    def test_reads_session_metrics(self):
+        agent = self._agent()
+        fake = SimpleNamespace(session_metrics=SimpleNamespace(input_tokens=100, output_tokens=40))
+        agent._capture_usage(fake, response=SimpleNamespace(metrics=None))
+        assert agent.input_tokens == 100
+        assert agent.output_tokens == 40
+
+    def test_accumulates_across_calls(self):
+        agent = self._agent()
+        for _ in range(3):
+            fake = SimpleNamespace(session_metrics=SimpleNamespace(input_tokens=10, output_tokens=5))
+            agent._capture_usage(fake, response=SimpleNamespace(metrics=None))
+        assert agent.input_tokens == 30
+        assert agent.output_tokens == 15
+
+    def test_falls_back_to_response_metrics(self):
+        agent = self._agent()
+        # No session_metrics → sum the per-message lists on response.metrics.
+        fake_agent = SimpleNamespace(session_metrics=None)
+        resp = SimpleNamespace(metrics={"input_tokens": [3, 4], "output_tokens": [1, 2]})
+        agent._capture_usage(fake_agent, resp)
+        assert agent.input_tokens == 7
+        assert agent.output_tokens == 3
+
+    def test_never_raises(self):
+        agent = self._agent()
+        # Garbage metrics must not break a run.
+        agent._capture_usage(SimpleNamespace(session_metrics="bad"), SimpleNamespace(metrics="bad"))
+        assert agent.input_tokens == 0

--- a/frontend/src/components/tickets/TicketInvestigationPanel.vue
+++ b/frontend/src/components/tickets/TicketInvestigationPanel.vue
@@ -49,6 +49,14 @@ const tickerLine = computed(() => {
 const toolCallCount = computed(
   () => props.investigation.events.filter((e) => e.event_type === 'tool_call').length,
 )
+
+// Compact token total for the run header, e.g. "1.2k tokens". Only shown once
+// the run has recorded usage.
+const tokenLabel = computed(() => {
+  const total = (run.value?.input_tokens || 0) + (run.value?.output_tokens || 0)
+  if (!total) return ''
+  return total >= 1000 ? `${(total / 1000).toFixed(1)}k tokens` : `${total} tokens`
+})
 </script>
 
 <template>
@@ -65,6 +73,8 @@ const toolCallCount = computed(
         <span>{{ investigation.hypotheses.length }} hypotheses</span>
         <span>·</span>
         <span>{{ toolCallCount }}/{{ run.max_tool_calls || '—' }} tool calls</span>
+        <span v-if="run.llm_calls">· {{ run.llm_calls }} LLM calls</span>
+        <span v-if="tokenLabel">· {{ tokenLabel }}</span>
         <span v-if="run.model_name">· {{ run.model_name }}</span>
       </div>
     </div>

--- a/frontend/src/types/ticket.ts
+++ b/frontend/src/types/ticket.ts
@@ -121,6 +121,10 @@ export interface InvestigationRun {
   error?: string | null
   tool_calls_used: number
   max_tool_calls?: number
+  llm_calls?: number
+  input_tokens?: number
+  output_tokens?: number
+  metered?: boolean
   model_name?: string | null
   started_at?: string | null
   finished_at?: string | null


### PR DESCRIPTION
AI ticket investigations run the LLM many times per ticket (triage + hypotheses + per-hypothesis tool tests + RCA), but that usage was **unmetered and unbilled** — the `input_tokens`/`output_tokens` columns were never written and nothing counted investigations against a plan. This makes investigation usage draw from the org's existing **message quota** (`plan.max_messages`) — the same meter chat and FAQ generation use — and blocks new investigations once an org is out of credits.

**Billable unit = one LLM call**, mirroring FAQ generation. Only **hosted-model** runs are metered; own-key orgs pay their provider directly and are never metered or blocked. Self-host (no enterprise module) is unlimited.

### What's here
- **Token capture** — reads agno `session_metrics` after each phase and folds `input/output_tokens` onto the run at finalize (every path: success, budget-exceeded, failure, timeout).
- **`metered` flag** on `investigation_runs` (+ index on `org/metered/created_at`) and `InvestigationRepository.count_llm_calls_for_period` — the period-sum the enterprise meter adds to the bot-message count.
- **Enqueue gate** — a hosted-model org with no credits can't start a full investigation (records a "paused — out of credits" activity); **triage is never gated** so tickets still get classified. Manual *Investigate* returns **402** with an upgrade hint. Fails open for self-host / own-key / unlimited plans.
- **Shared helpers** — extracted `is_hosted_model` / `remaining_message_credits` into `app/services/usage_metering.py`, reused by `faq_usage` and the ticket gate (no duplication).
- **Glass box** — shows LLM calls + token totals.

### Metering model (no new usage table)
Usage stays a live period-count with no stored counter: the enterprise `_used_messages` sums bot messages + Ask-AI + FAQ calls + (now) investigation calls between the subscription's billing dates. Persisting a run row *is* the increment — same pattern as every other feature.

### Pairs with
[enterprise_backend#20](https://github.com/chattermate/enterprise_backend/pull/20) folds investigation calls into `_used_messages`. Merge that alongside; until then this OSS side records usage and self-host stays unlimited.

### Verification
- New unit suite (period-count metered/unmetered/window, enqueue gate block/allow/triage/own-key/unlimited, token capture). Full ticket + FAQ suites pass (the `usage_metering` extraction doesn't break FAQ). `vue-tsc` + vitest green.
- **Live e2e**: a metered 13-call run raised `_used_messages` by exactly 13; an unmetered run was ignored.

### Deploy notes
- OSS migration `add_tkt_metered_001` (off `add_tkt_row_scope_001`), single head.
- No new deps, no new service.