### PR TITLE
refactor(shopify): make the product cache key a single source of truth

### DIFF
--- a/backend/app/agents/chat_agent.py
+++ b/backend/app/agents/chat_agent.py
@@ -815,7 +815,7 @@ Keep your responses concise and focused. Provide clear, actionable information i
             logger.debug(f"Response content: {response_content}")
 
             # Enrich Shopify response with full product data from Redis
-            response_content = enrich_shopify_response(response_content, session_id, fallback_cache_key=(self.shopify_tools.products_cache_key if getattr(self, 'shopify_tools', None) else None))
+            response_content = enrich_shopify_response(response_content, session_id, fallback_cache_key=self._shopify_fallback_cache_key())
 
             # If shopify_output has products, remove URLs from message
             # (URLs should only be removed when products are being displayed separately)
@@ -1039,6 +1039,18 @@ Keep your responses concise and focused. Provide clear, actionable information i
 
         return updated_response
 
+    def _shopify_fallback_cache_key(self):
+        """Redis key for products a Shopify tool fetched during THIS turn, else None.
+
+        Used to attach products when the model omits shopify_output. Gated on the
+        toolkit having actually cached this turn so a previous turn's still-live
+        cache can never be pinned onto an unrelated reply.
+        """
+        tools = getattr(self, 'shopify_tools', None)
+        if tools and getattr(tools, 'has_cached_products', False):
+            return tools.product_cache_key
+        return None
+
     async def handle_workflow_transfer(self, session_id: str, org_id: str, agent_id: str, customer_id: str, transfer_group_id: str, db, chat_repo: ChatRepository, llm_response: ChatResponse = None) -> ChatResponse:
         """
         Handle transfer to human from workflow with specific group ID.
@@ -1150,7 +1162,7 @@ Keep your responses concise and focused. Provide clear, actionable information i
                 logger.debug(f"Response content: {response_content}")
 
                 # Enrich Shopify response with full product data from Redis
-                response_content = enrich_shopify_response(response_content, session_id, fallback_cache_key=(self.shopify_tools.products_cache_key if getattr(self, 'shopify_tools', None) else None))
+                response_content = enrich_shopify_response(response_content, session_id, fallback_cache_key=self._shopify_fallback_cache_key())
 
                 # If shopify_output has products, remove URLs from message
                 # (URLs should only be removed when products are being displayed separately)

--- a/backend/app/tools/shopify_toolkit.py
+++ b/backend/app/tools/shopify_toolkit.py
@@ -56,10 +56,11 @@ class ShopifyTools(Toolkit):
         self.agent_id = agent_id
         self.org_id = org_id
         self.session_id = session_id
-        # Set to the Redis cache key whenever a product tool returns+caches products
-        # this turn. Lets the backend attach products deterministically even if the LLM
-        # forgets to echo the key in its structured shopify_output. Per-request instance.
-        self.products_cache_key: Optional[str] = None
+        # True once a product tool has fetched+cached products during this turn.
+        # Lets the backend attach products deterministically (via product_cache_key)
+        # even if the LLM forgets to echo the key in its structured shopify_output.
+        # Per-request instance, so this cannot leak across turns.
+        self.has_cached_products: bool = False
 
         # Register the functions
         self.register(self.list_products)
@@ -68,7 +69,18 @@ class ShopifyTools(Toolkit):
         self.register(self.search_orders)
         self.register(self.get_order_status)
         self.register(self.recommend_products)
-    
+
+    @property
+    def product_cache_key(self) -> str:
+        """Redis key holding this session's most recent product result.
+
+        Org-scoped for multi-tenant isolation. Single source of truth: the
+        backend re-hydrates products from this exact key, so every producer must
+        build it here rather than repeating the format.
+        """
+        return f"{self.org_id}:shopify_products:{self.session_id}"
+
+
     def _get_shop_for_agent(self) -> Optional[ShopifyShop]:
         """
         Helper method to get the Shopify shop associated with the agent.
@@ -145,7 +157,7 @@ class ShopifyTools(Toolkit):
                         try:
                             # Use fixed cache key per session with org_id for multi-tenant isolation
                             # Format: {org_id}:shopify_products:{session_id}
-                            product_cache_key = f"{self.org_id}:shopify_products:{self.session_id}"
+                            product_cache_key = self.product_cache_key
 
                             # Store full products in Redis with 5-minute TTL
                             # setex will overwrite any previous value automatically
@@ -158,7 +170,7 @@ class ShopifyTools(Toolkit):
                                 })
                             )
                             logger.debug(f"Cached {len(products)} listed products with key: {product_cache_key}")
-                            self.products_cache_key = product_cache_key
+                            self.has_cached_products = True
                         except Exception as e:
                             logger.error(f"Failed to cache listed products in Redis: {str(e)}")
                             product_cache_key = None
@@ -430,7 +442,7 @@ class ShopifyTools(Toolkit):
                     try:
                         # Use fixed cache key per session with org_id for multi-tenant isolation
                         # Format: {org_id}:shopify_products:{session_id}
-                        product_cache_key = f"{self.org_id}:shopify_products:{self.session_id}"
+                        product_cache_key = self.product_cache_key
 
                         # Store full products in Redis with 5-minute TTL
                         # setex will overwrite any previous value automatically
@@ -446,7 +458,7 @@ class ShopifyTools(Toolkit):
                             })
                         )
                         logger.debug(f"Cached {len(products)} products with key: {product_cache_key}")
-                        self.products_cache_key = product_cache_key
+                        self.has_cached_products = True
                     except Exception as e:
                         logger.error(f"Failed to cache products in Redis: {str(e)}")
                         product_cache_key = None
@@ -1255,7 +1267,7 @@ class ShopifyTools(Toolkit):
                     try:
                         # Use fixed cache key per session with org_id for multi-tenant isolation
                         # Format: {org_id}:shopify_products:{session_id}
-                        product_cache_key = f"{self.org_id}:shopify_products:{self.session_id}"
+                        product_cache_key = self.product_cache_key
 
                         # Store full products in Redis with 5-minute TTL
                         # setex will overwrite any previous value automatically
@@ -1271,7 +1283,7 @@ class ShopifyTools(Toolkit):
                             })
                         )
                         logger.debug(f"Cached {len(products)} recommended products with key: {product_cache_key}")
-                        self.products_cache_key = product_cache_key
+                        self.has_cached_products = True
                     except Exception as e:
                         logger.error(f"Failed to cache recommended products in Redis: {str(e)}")
                         product_cache_key = None


### PR DESCRIPTION
Follow-up from reviewing #220. No behaviour change.

The Redis key `{org_id}:shopify_products:{session_id}` was written out in three separate tool methods. Since #220 the backend re-hydrates products from that exact key, so a drift in any one copy would silently stop product cards appearing again — the same class of bug #220 just fixed. It now lives in one property on the toolkit.

The other change is naming. #220 left the toolkit with `products_cache_key` sitting next to a `product_cache_key` key format — one character apart, easy to confuse later. What the backend actually needs to know is *whether a tool cached during this turn*; the key itself is always derivable. So that attribute becomes a `has_cached_products` flag, and the two `ChatAgent` call sites now share one `_shopify_fallback_cache_key()` helper instead of repeating the same guard expression inline.

The per-turn gating is unchanged and still the important bit: the toolkit is per-request, and the fallback only fires when a tool cached this turn, so a previous turn's still-live cache can't be pinned onto an unrelated reply. The key stays org-scoped, so tenant isolation is untouched.