### PR TITLE
Close the CSAT loop for AI ticketing

### DIFF
--- a/backend/alembic/versions/add_ticket_csat.py
+++ b/backend/alembic/versions/add_ticket_csat.py
@@ -1,0 +1,43 @@
+"""CSAT score linkage on tickets
+
+Revision ID: add_tkt_csat_001
+Revises: add_tkt_row_scope_001
+Create Date: 2026-07-22
+
+The CSAT ask already goes out on close; nothing carried the answer back. These
+columns close the loop: when the customer rates the conversation linked to a
+ticket, the score lands on the ticket itself, so AI-resolved vs human-resolved
+CSAT is a plain query instead of a join through ratings/sessions.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "add_tkt_csat_001"
+down_revision = "add_tkt_row_scope_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("tickets", sa.Column("csat_requested_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("tickets", sa.Column("csat_score", sa.Integer(), nullable=True))
+    op.add_column("tickets", sa.Column("csat_rating_id", sa.UUID(), nullable=True))
+    op.add_column("tickets", sa.Column("csat_responded_at", sa.DateTime(timezone=True), nullable=True))
+    op.create_foreign_key(
+        "fk_tickets_csat_rating_id",
+        "tickets",
+        "ratings",
+        ["csat_rating_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index("ix_tickets_org_csat", "tickets", ["organization_id", "csat_responded_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tickets_org_csat", table_name="tickets")
+    op.drop_constraint("fk_tickets_csat_rating_id", "tickets", type_="foreignkey")
+    op.drop_column("tickets", "csat_responded_at")
+    op.drop_column("tickets", "csat_rating_id")
+    op.drop_column("tickets", "csat_score")
+    op.drop_column("tickets", "csat_requested_at")

--- a/backend/app/api/rating.py
+++ b/backend/app/api/rating.py
@@ -20,6 +20,7 @@ from app.database import get_db
 from app.core.auth import get_current_user, require_permissions
 from app.repositories.rating import RatingRepository
 from app.repositories.session_to_agent import SessionToAgentRepository
+from app.services.ticket_csat import record_conversation_rating
 from app.models.user import User
 from typing import List, Optional
 from pydantic import BaseModel, Field
@@ -82,6 +83,9 @@ async def create_rating(
             rating=rating_data.rating,
             feedback=rating_data.feedback
         )
+
+        # Close the CSAT loop if this conversation belongs to a ticket.
+        record_conversation_rating(db, rating)
 
         return rating
 

--- a/backend/app/api/widget_chat.py
+++ b/backend/app/api/widget_chat.py
@@ -46,6 +46,7 @@ from app.repositories.agent import AgentRepository
 from app.services.lead_capture import record_lead_from_response
 from app.services.message_delivery import deliver_to_customer
 from app.repositories.rating import RatingRepository
+from app.services.ticket_csat import record_conversation_rating
 from app.repositories.jira import JiraRepository
 from app.models.ai_config import AIModelType
 from app.services.workflow_execution import WorkflowExecutionService
@@ -1384,6 +1385,9 @@ async def handle_rating_submission(sid, data):
             rating=rating,
             feedback=feedback
         )
+
+        # Close the CSAT loop if this conversation belongs to a ticket.
+        record_conversation_rating(db, rating_obj)
 
         # Emit success response
         await sio.emit('rating_submitted', {

--- a/backend/app/models/schemas/ticket.py
+++ b/backend/app/models/schemas/ticket.py
@@ -267,6 +267,9 @@ class TicketOut(BaseModel):
     closed_at: Optional[datetime] = None
     confirmation_requested_at: Optional[datetime] = None
     reopened_count: int = 0
+    csat_requested_at: Optional[datetime] = None
+    csat_score: Optional[int] = None
+    csat_responded_at: Optional[datetime] = None
     external_ref_type: Optional[str] = None
     external_ref_id: Optional[str] = None
     external_ref_url: Optional[str] = None
@@ -320,6 +323,12 @@ class TicketStats(BaseModel):
     awaiting_approval: int
     sla_breaching: int
     ai_resolved_pct_7d: Optional[float] = None
+    # CSAT over the trailing csat_window_days, overall and split by resolver.
+    csat_avg: Optional[float] = None
+    csat_ai_avg: Optional[float] = None
+    csat_human_avg: Optional[float] = None
+    csat_responses: int = 0
+    csat_window_days: int = 30
 
 
 class SlaTarget(BaseModel):

--- a/backend/app/models/ticket.py
+++ b/backend/app/models/ticket.py
@@ -203,6 +203,15 @@ class Ticket(Base):
     confirmation_requested_at = Column(DateTime(timezone=True), nullable=True)
     reopened_count = Column(Integer, nullable=False, default=0, server_default="0")
 
+    # CSAT. The ask goes out on close (csat_requested_at); the score arrives
+    # later, when the customer rates the linked conversation — see
+    # app/services/ticket_csat.py for the capture path and why it is
+    # conversation-only.
+    csat_requested_at = Column(DateTime(timezone=True), nullable=True)
+    csat_score = Column(Integer, nullable=True)
+    csat_rating_id = Column(UUID(as_uuid=True), ForeignKey("ratings.id", ondelete="SET NULL"), nullable=True)
+    csat_responded_at = Column(DateTime(timezone=True), nullable=True)
+
     # Optional one-way escalation reference (e.g. 'JIRA' + issue key + URL).
     external_ref_type = Column(String, nullable=True)
     external_ref_id = Column(String, nullable=True)
@@ -232,6 +241,8 @@ class Ticket(Base):
         Index("ix_tickets_org_status", "organization_id", "status"),
         Index("ix_tickets_org_assignee", "organization_id", "assignee_user_id"),
         Index("ix_tickets_org_created", "organization_id", "created_at"),
+        # Drives the CSAT stat (AI- vs human-resolved averages over a window).
+        Index("ix_tickets_org_csat", "organization_id", "csat_responded_at"),
         # NOTE: production also has an HNSW cosine index on embedding — it
         # lives only in the migration (sqlite tests can't compile it).
     )

--- a/backend/app/models/ticket_activity.py
+++ b/backend/app/models/ticket_activity.py
@@ -43,6 +43,7 @@ class TicketActivityType(_ValueStrEnum):
     CUSTOMER_REPLIED = "customer_replied"
     CUSTOMER_LINKED = "customer_linked"
     CSAT_REQUESTED = "csat_requested"
+    CSAT_RECEIVED = "csat_received"
     REOPENED = "reopened"
     JIRA_ESCALATED = "jira_escalated"
 

--- a/backend/app/repositories/ticket.py
+++ b/backend/app/repositories/ticket.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 from uuid import UUID
 
 from sqlalchemy import and_, func, or_, text
@@ -338,6 +338,27 @@ class TicketRepository:
         total = base.scalar() or 0
         ai = base.filter(Ticket.resolved_by_actor == "ai").scalar() or 0
         return ai, total
+
+    def csat_by_resolver(self, organization_id: UUID, days: int = 30) -> Dict[str, Tuple[int, float]]:
+        """{resolver: (responses, average)} over the trailing window, keyed by
+        resolved_by_actor ('ai' | 'user' | '' when the ticket was never
+        formally resolved). Powers the AI- vs human-resolved CSAT split."""
+        since = datetime.now(timezone.utc) - timedelta(days=days)
+        rows = (
+            self.db.query(
+                Ticket.resolved_by_actor,
+                func.count(Ticket.id),
+                func.avg(Ticket.csat_score),
+            )
+            .filter(
+                Ticket.organization_id == organization_id,
+                Ticket.csat_score.isnot(None),
+                Ticket.csat_responded_at >= since,
+            )
+            .group_by(Ticket.resolved_by_actor)
+            .all()
+        )
+        return {(actor or ""): (count, float(avg)) for actor, count, avg in rows}
 
 
 class TicketActivityRepository:

--- a/backend/app/services/ticket.py
+++ b/backend/app/services/ticket.py
@@ -63,6 +63,10 @@ DUPLICATE_SIMILARITY_THRESHOLD = 0.90
 # tickets (Jira sessions keep 'JIRA').
 NATIVE_INTEGRATION_TYPE = "NATIVE"
 
+# Trailing window for the workspace CSAT stat. Wider than the 7-day resolution
+# stats because CSAT responses are sparse.
+CSAT_WINDOW_DAYS = 30
+
 _embedder = None
 
 
@@ -606,6 +610,16 @@ class TicketService:
         await self.send_customer_message(ticket, message)
 
     async def request_csat(self, ticket: Ticket) -> None:
+        """Ask the customer to rate the ticket, reusing the widget's existing
+        conversation rating prompt.
+
+        Conversation-only by design: a rating row is keyed to a session
+        (ratings.session_id is NOT NULL), so a ticket with no linked
+        conversation — manual or email-only — has nothing to rate and no
+        capture path short of a public tokenised rating page. Those tickets
+        are simply never asked; csat_requested_at stays NULL and the UI shows
+        "not requested" rather than a CSAT that will never arrive.
+        """
         session_record = self._primary_session(ticket)
         if session_record is None:
             return
@@ -619,6 +633,7 @@ class TicketService:
                 "type": "chat_response",
                 "request_rating": True,
             })
+            ticket.csat_requested_at = datetime.now(timezone.utc)
             self._add_activity(
                 ticket, TicketActivityType.CSAT_REQUESTED,
                 actor_type=TicketActorType.SYSTEM,
@@ -626,6 +641,26 @@ class TicketService:
             )
         except Exception as e:
             logger.error(f"CSAT request failed for {ticket.display_number}: {e}")
+
+    def record_csat(
+        self, ticket: Ticket, rating_id: UUID, score: int, feedback: Optional[str] = None
+    ) -> Ticket:
+        """Attach a submitted conversation rating to the ticket. The most
+        recent rating wins if a customer rates the same conversation twice."""
+        ticket.csat_score = score
+        ticket.csat_rating_id = rating_id
+        ticket.csat_responded_at = datetime.now(timezone.utc)
+        body = f"Customer rated {score}/5"
+        if feedback:
+            body = f"{body} — {feedback}"
+        self._add_activity(
+            ticket,
+            TicketActivityType.CSAT_RECEIVED,
+            actor_type=TicketActorType.CUSTOMER,
+            body=body,
+            metadata={"rating_id": str(rating_id), "score": score},
+        )
+        return ticket
 
     def _resolve_customer_by_email(
         self, organization_id: UUID, customer_email: str, customer_name: Optional[str]
@@ -833,11 +868,33 @@ class TicketService:
 
         ai_resolved, total_resolved = self.repo.resolved_counts_7d(organization_id)
         pct = round(100.0 * ai_resolved / total_resolved, 1) if total_resolved else None
+
         return {
             "open": open_count,
             "awaiting_approval": awaiting,
             "sla_breaching": breaching,
             "ai_resolved_pct_7d": pct,
+            **self.csat_stats(organization_id),
+        }
+
+    def csat_stats(self, organization_id: UUID, days: int = CSAT_WINDOW_DAYS) -> dict:
+        """Overall CSAT plus the AI-resolved vs human-resolved split. A wider
+        window than the resolution stats — CSAT responses are far sparser, and
+        a 7-day average would be noise for most orgs."""
+        by_resolver = self.repo.csat_by_resolver(organization_id, days=days)
+        total = sum(count for count, _ in by_resolver.values())
+        weighted = sum(count * avg for count, avg in by_resolver.values())
+
+        def side(actor: str) -> Optional[float]:
+            entry = by_resolver.get(actor)
+            return round(entry[1], 2) if entry else None
+
+        return {
+            "csat_responses": total,
+            "csat_avg": round(weighted / total, 2) if total else None,
+            "csat_ai_avg": side("ai"),
+            "csat_human_avg": side("user"),
+            "csat_window_days": days,
         }
 
     # ---------- internals ----------

--- a/backend/app/services/ticket_csat.py
+++ b/backend/app/services/ticket_csat.py
@@ -37,6 +37,7 @@ from sqlalchemy.orm import Session
 
 from app.core.logger import get_logger
 from app.models.rating import Rating
+from app.services.ticket import TicketService
 
 logger = get_logger(__name__)
 
@@ -48,8 +49,6 @@ def record_conversation_rating(db: Session, rating: Rating) -> Optional[UUID]:
     native ticket (the common case for plain chats) or the linkage failed.
     """
     try:
-        from app.services.ticket import TicketService
-
         service = TicketService(db)
         ticket = service.repo.get_by_session(rating.session_id)
         if ticket is None:

--- a/backend/app/services/ticket_csat.py
+++ b/backend/app/services/ticket_csat.py
@@ -1,0 +1,68 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Capture side of the ticket CSAT loop.
+
+TicketService.close() asks the customer for a rating through the widget's
+existing conversation rating prompt. This module carries the answer back: every
+path that creates a Rating calls record_conversation_rating(), which attaches
+the score to the ticket linked to that session, if there is one.
+
+Deliberately conversation-only. ratings.session_id is NOT NULL, so a rating
+cannot exist without a chat session — a manual or email-only ticket has nothing
+to rate. Supporting those would mean a public tokenised rating page and a
+session-less Rating; until that exists, such tickets are never asked and their
+CSAT card reads "not requested".
+
+Best-effort throughout: a rating is a customer-facing success the moment it is
+stored, so a failure to link it must never fail the submission.
+"""
+
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.logger import get_logger
+from app.models.rating import Rating
+
+logger = get_logger(__name__)
+
+
+def record_conversation_rating(db: Session, rating: Rating) -> Optional[UUID]:
+    """Link a just-submitted conversation rating to its ticket.
+
+    Returns the ticket id it was attached to, or None when the session has no
+    native ticket (the common case for plain chats) or the linkage failed.
+    """
+    try:
+        from app.services.ticket import TicketService
+
+        service = TicketService(db)
+        ticket = service.repo.get_by_session(rating.session_id)
+        if ticket is None:
+            return None
+        service.record_csat(ticket, rating.id, rating.rating, rating.feedback)
+        db.commit()
+        return ticket.id
+    except Exception as e:
+        # The rating row itself is already committed by the caller, so rolling
+        # back here only discards the half-applied ticket update.
+        logger.error(f"Failed to link rating {rating.id} to its ticket: {e}")
+        try:
+            db.rollback()
+        except Exception:
+            pass
+        return None

--- a/backend/tests/services/test_ticket_csat.py
+++ b/backend/tests/services/test_ticket_csat.py
@@ -1,0 +1,224 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.models.rating import Rating
+from app.models.session_to_agent import SessionStatus, SessionToAgent
+from app.models.ticket import Ticket, TicketPriority, TicketSource, TicketStatus
+from app.models.ticket_activity import TicketActivityType, TicketActorType
+from app.services.ticket import TicketService
+from app.services.ticket_csat import record_conversation_rating
+
+
+@pytest.fixture(autouse=True)
+def no_embeddings():
+    with patch("app.services.ticket.embed_ticket_text", return_value=None):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def no_delivery():
+    """CSAT asks go out over the widget socket — irrelevant here."""
+    with patch("app.services.message_delivery.deliver_to_customer", new=AsyncMock()):
+        yield
+
+
+@pytest.fixture
+def service(db):
+    return TicketService(db)
+
+
+@pytest.fixture
+def test_session(db, test_organization, test_customer, test_agent) -> SessionToAgent:
+    session = SessionToAgent(
+        session_id=uuid4(),
+        organization_id=test_organization.id,
+        customer_id=test_customer.id,
+        agent_id=test_agent.id,
+        status=SessionStatus.OPEN,
+        channel="web",
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+    return session
+
+
+def make_ticket(service, db, org, **overrides) -> Ticket:
+    kwargs = dict(
+        organization_id=org.id,
+        title="Refund never arrived",
+        priority=TicketPriority.MEDIUM,
+        source=TicketSource.MANUAL,
+    )
+    kwargs.update(overrides)
+    ticket, _dupes = service.create_ticket(**kwargs)
+    db.commit()
+    db.refresh(ticket)
+    return ticket
+
+
+def make_rating(db, session, org, score=5, feedback=None) -> Rating:
+    rating = Rating(
+        session_id=session.session_id,
+        customer_id=session.customer_id,
+        agent_id=session.agent_id,
+        organization_id=org.id,
+        rating=score,
+        feedback=feedback,
+    )
+    db.add(rating)
+    db.commit()
+    db.refresh(rating)
+    return rating
+
+
+class TestCsatRequest:
+    @pytest.mark.asyncio
+    async def test_close_stamps_requested_at(
+        self, service, db, test_organization, test_session
+    ):
+        ticket = make_ticket(
+            service, db, test_organization,
+            session_id=test_session.session_id, source=TicketSource.CHAT_AI,
+        )
+        await service.close(ticket)
+        db.commit()
+        assert ticket.csat_requested_at is not None
+        assert ticket.csat_score is None
+        types = [a.activity_type for a in service.activity_repo.list_for_ticket(ticket.id)]
+        assert TicketActivityType.CSAT_REQUESTED.value in types
+
+    @pytest.mark.asyncio
+    async def test_close_without_session_never_asks(
+        self, service, db, test_organization
+    ):
+        """Conversation-only by design: a ticket with nothing to rate is never
+        asked, so the UI can show "not requested" rather than a pending CSAT
+        that will never arrive."""
+        ticket = make_ticket(service, db, test_organization)
+        await service.close(ticket)
+        db.commit()
+        assert ticket.csat_requested_at is None
+
+    @pytest.mark.asyncio
+    async def test_close_respects_csat_disabled(
+        self, service, db, test_organization, test_session
+    ):
+        settings = service.settings_repo.get_or_create(test_organization.id)
+        settings.csat_enabled = False
+        db.commit()
+        ticket = make_ticket(
+            service, db, test_organization,
+            session_id=test_session.session_id, source=TicketSource.CHAT_AI,
+        )
+        await service.close(ticket)
+        db.commit()
+        assert ticket.csat_requested_at is None
+
+
+class TestCsatCapture:
+    def test_rating_lands_on_the_linked_ticket(
+        self, service, db, test_organization, test_session
+    ):
+        ticket = make_ticket(
+            service, db, test_organization,
+            session_id=test_session.session_id, source=TicketSource.CHAT_AI,
+        )
+        rating = make_rating(db, test_session, test_organization, score=4, feedback="Quick fix")
+
+        assert record_conversation_rating(db, rating) == ticket.id
+        db.refresh(ticket)
+        assert ticket.csat_score == 4
+        assert ticket.csat_rating_id == rating.id
+        assert ticket.csat_responded_at is not None
+
+        received = [
+            a for a in service.activity_repo.list_for_ticket(ticket.id)
+            if a.activity_type == TicketActivityType.CSAT_RECEIVED.value
+        ]
+        assert len(received) == 1
+        assert received[0].actor_type == TicketActorType.CUSTOMER.value
+        assert "4/5" in received[0].body
+        assert "Quick fix" in received[0].body
+
+    def test_rating_without_a_ticket_is_a_noop(self, db, test_organization, test_session):
+        rating = make_rating(db, test_session, test_organization)
+        assert record_conversation_rating(db, rating) is None
+
+    def test_linkage_failure_does_not_raise(self, db, test_organization, test_session):
+        """The rating is already stored by the time we get here — a broken
+        linkage must never surface to the customer."""
+        rating = make_rating(db, test_session, test_organization)
+        with patch(
+            "app.repositories.ticket.TicketRepository.get_by_session",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert record_conversation_rating(db, rating) is None
+
+    def test_second_rating_overwrites(
+        self, service, db, test_organization, test_session
+    ):
+        ticket = make_ticket(
+            service, db, test_organization,
+            session_id=test_session.session_id, source=TicketSource.CHAT_AI,
+        )
+        first = make_rating(db, test_session, test_organization, score=2)
+        record_conversation_rating(db, first)
+        second = make_rating(db, test_session, test_organization, score=5)
+        record_conversation_rating(db, second)
+        db.refresh(ticket)
+        assert ticket.csat_score == 5
+        assert ticket.csat_rating_id == second.id
+
+
+class TestCsatStats:
+    def _scored(self, service, db, org, score, resolver, days_ago=1):
+        ticket = make_ticket(service, db, org)
+        ticket.csat_score = score
+        ticket.resolved_by_actor = resolver
+        ticket.csat_responded_at = datetime.now(timezone.utc) - timedelta(days=days_ago)
+        db.commit()
+        return ticket
+
+    def test_splits_ai_and_human(self, service, db, test_organization):
+        self._scored(service, db, test_organization, 5, "ai")
+        self._scored(service, db, test_organization, 4, "ai")
+        self._scored(service, db, test_organization, 2, "user")
+        stats = service.stats(test_organization.id)
+        assert stats["csat_responses"] == 3
+        assert stats["csat_ai_avg"] == 4.5
+        assert stats["csat_human_avg"] == 2.0
+        assert stats["csat_avg"] == pytest.approx(3.67, abs=0.01)
+
+    def test_ignores_responses_outside_the_window(self, service, db, test_organization):
+        self._scored(service, db, test_organization, 5, "ai", days_ago=90)
+        stats = service.stats(test_organization.id)
+        assert stats["csat_responses"] == 0
+        assert stats["csat_avg"] is None
+        assert stats["csat_window_days"] == 30
+
+    def test_no_responses(self, service, db, test_organization):
+        make_ticket(service, db, test_organization)
+        stats = service.stats(test_organization.id)
+        assert stats["csat_responses"] == 0
+        assert stats["csat_ai_avg"] is None
+        assert stats["csat_human_avg"] is None

--- a/frontend/src/__tests__/components/tickets/TicketSidePanel.spec.ts
+++ b/frontend/src/__tests__/components/tickets/TicketSidePanel.spec.ts
@@ -1,0 +1,77 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }) }))
+vi.mock('@/composables/useUsers', () => ({
+  useUsers: () => ({ users: { value: [] }, fetchUsers: vi.fn().mockResolvedValue([]) }),
+}))
+
+import TicketSidePanel from '../../../components/tickets/TicketSidePanel.vue'
+import type { Ticket } from '../../../types/ticket'
+
+const baseTicket = {
+  id: 't1',
+  ticket_number: 12,
+  display_number: 'TKT-12',
+  organization_id: 'org1',
+  title: 'Refund never arrived',
+  status: 'closed',
+  priority: 'medium',
+  source: 'chat_ai',
+  reopened_count: 0,
+} as Ticket
+
+const createWrapper = (ticket: Partial<Ticket> = {}, linkedSessionIds: string[] = ['s1']) =>
+  mount(TicketSidePanel, {
+    props: {
+      ticket: { ...baseTicket, ...ticket } as Ticket,
+      linkedSessionIds,
+      canManage: false,
+    },
+    global: { stubs: { 'font-awesome-icon': true } },
+  })
+
+const csatCard = (wrapper: ReturnType<typeof createWrapper>) =>
+  wrapper.findAll('.panel-card').find((card) => card.text().startsWith('CSAT'))!
+
+describe('TicketSidePanel CSAT card', () => {
+  it('shows the score once the customer has rated', () => {
+    const card = csatCard(createWrapper({ csat_requested_at: '2026-07-20T10:00:00Z', csat_score: 4 }))
+    expect(card.text()).toContain('4/5')
+    expect(card.findAll('.csat-stars font-awesome-icon-stub')).toHaveLength(5)
+    expect(card.text()).toContain('Rated by the customer')
+  })
+
+  it('shows pending while the ask is out', () => {
+    const card = csatCard(createWrapper({ csat_requested_at: '2026-07-20T10:00:00Z' }))
+    expect(card.text()).toContain('Pending')
+    expect(card.find('.csat-stars').exists()).toBe(false)
+  })
+
+  it('shows not requested before close', () => {
+    const card = csatCard(createWrapper())
+    expect(card.text()).toContain('Not requested')
+    expect(card.text()).toContain('when the ticket is closed')
+  })
+
+  it('explains why a ticket with no conversation is never asked', () => {
+    const card = csatCard(createWrapper({}, []))
+    expect(card.text()).toContain('No linked conversation to rate')
+  })
+})

--- a/frontend/src/__tests__/components/tickets/TicketSidePanel.spec.ts
+++ b/frontend/src/__tests__/components/tickets/TicketSidePanel.spec.ts
@@ -52,7 +52,13 @@ const csatCard = (wrapper: ReturnType<typeof createWrapper>) =>
 
 describe('TicketSidePanel CSAT card', () => {
   it('shows the score once the customer has rated', () => {
-    const card = csatCard(createWrapper({ csat_requested_at: '2026-07-20T10:00:00Z', csat_score: 4 }))
+    const card = csatCard(
+      createWrapper({
+        csat_requested_at: '2026-07-20T10:00:00Z',
+        csat_responded_at: '2026-07-20T11:00:00Z',
+        csat_score: 4,
+      }),
+    )
     expect(card.text()).toContain('4/5')
     expect(card.findAll('.csat-stars font-awesome-icon-stub')).toHaveLength(5)
     expect(card.text()).toContain('Rated by the customer')
@@ -62,6 +68,18 @@ describe('TicketSidePanel CSAT card', () => {
     const card = csatCard(createWrapper({ csat_requested_at: '2026-07-20T10:00:00Z' }))
     expect(card.text()).toContain('Pending')
     expect(card.find('.csat-stars').exists()).toBe(false)
+  })
+
+  it('goes back to pending when a reopened ticket is asked again', () => {
+    const card = csatCard(
+      createWrapper({
+        csat_score: 2,
+        csat_responded_at: '2026-07-20T11:00:00Z',
+        csat_requested_at: '2026-07-21T09:00:00Z',
+      }),
+    )
+    expect(card.text()).toContain('Pending')
+    expect(card.text()).not.toContain('2/5')
   })
 
   it('shows not requested before close', () => {

--- a/frontend/src/components/tickets/TicketSidePanel.vue
+++ b/frontend/src/components/tickets/TicketSidePanel.vue
@@ -63,6 +63,24 @@ const assigneeName = computed(
   () => props.ticket.assignee?.full_name || props.ticket.assignee_name || null,
 )
 
+// CSAT is asked on close, through the linked conversation's rating prompt, so
+// a ticket with no conversation is never asked at all.
+const csat = computed(() => {
+  const score = props.ticket.csat_score
+  if (score != null) {
+    return {
+      state: 'scored' as const,
+      score,
+      label: `${score}/5`,
+      color: score >= 4 ? 'var(--c-positive)' : score >= 3 ? 'var(--c-warn)' : 'var(--c-danger)',
+    }
+  }
+  if (props.ticket.csat_requested_at) {
+    return { state: 'pending' as const, score: 0, label: 'Pending', color: 'var(--muted2)' }
+  }
+  return { state: 'not-requested' as const, score: 0, label: 'Not requested', color: 'var(--faint)' }
+})
+
 function openConversation() {
   if (props.linkedSessionIds.length) {
     router.push({ path: '/conversations', query: { session: props.linkedSessionIds[0] } })
@@ -174,6 +192,26 @@ function pickAssignee(userId: string | null) {
         <span class="sla-label">Resolution</span>
         <span class="sla-value mono" :style="{ color: sla.color }">{{ sla.label }}</span>
       </div>
+    </div>
+
+    <div class="panel-card">
+      <div class="card-label">CSAT</div>
+      <div class="csat-row">
+        <span v-if="csat.state === 'scored'" class="csat-stars" :style="{ color: csat.color }">
+          <font-awesome-icon
+            v-for="star in 5"
+            :key="star"
+            :icon="[star <= csat.score ? 'fas' : 'far', 'star']"
+          />
+        </span>
+        <span class="sla-value" :style="{ color: csat.color }">{{ csat.label }}</span>
+      </div>
+      <p class="csat-note">
+        <template v-if="csat.state === 'scored'">Rated by the customer on the linked conversation.</template>
+        <template v-else-if="csat.state === 'pending'">Asked on close — waiting for the customer to rate.</template>
+        <template v-else-if="linkedSessionIds.length">Asked automatically when the ticket is closed.</template>
+        <template v-else>No linked conversation to rate, so CSAT isn't collected for this ticket.</template>
+      </p>
     </div>
 
     <div v-if="ticket.intent || ticket.ai_summary" class="panel-card">
@@ -392,6 +430,22 @@ function pickAssignee(userId: string | null) {
 .mono {
   font-family: var(--font-mono);
   font-size: 12px;
+}
+.csat-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.csat-stars {
+  display: inline-flex;
+  gap: 3px;
+  font-size: 12px;
+}
+.csat-note {
+  margin: 9px 0 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--faint);
 }
 .triage-summary {
   margin: 10px 0 0;

--- a/frontend/src/components/tickets/TicketSidePanel.vue
+++ b/frontend/src/components/tickets/TicketSidePanel.vue
@@ -64,10 +64,14 @@ const assigneeName = computed(
 )
 
 // CSAT is asked on close, through the linked conversation's rating prompt, so
-// a ticket with no conversation is never asked at all.
+// a ticket with no conversation is never asked at all. A reopened-then-closed
+// ticket is asked again, hence the timestamp comparison rather than a plain
+// "has a score" check — the newest ask is the one being waited on.
 const csat = computed(() => {
-  const score = props.ticket.csat_score
-  if (score != null) {
+  const { csat_score: score, csat_requested_at: asked, csat_responded_at: answered } = props.ticket
+  const awaitingAnswer = !!asked && (!answered || new Date(asked) > new Date(answered))
+
+  if (score != null && !awaitingAnswer) {
     return {
       state: 'scored' as const,
       score,
@@ -75,7 +79,7 @@ const csat = computed(() => {
       color: score >= 4 ? 'var(--c-positive)' : score >= 3 ? 'var(--c-warn)' : 'var(--c-danger)',
     }
   }
-  if (props.ticket.csat_requested_at) {
+  if (awaitingAnswer) {
     return { state: 'pending' as const, score: 0, label: 'Pending', color: 'var(--muted2)' }
   }
   return { state: 'not-requested' as const, score: 0, label: 'Not requested', color: 'var(--faint)' }

--- a/frontend/src/types/ticket.ts
+++ b/frontend/src/types/ticket.ts
@@ -75,6 +75,9 @@ export interface Ticket extends TicketListItem {
   closed_at?: string | null
   confirmation_requested_at?: string | null
   reopened_count: number
+  csat_requested_at?: string | null
+  csat_score?: number | null
+  csat_responded_at?: string | null
   external_ref_type?: string | null
   external_ref_id?: string | null
   external_ref_url?: string | null
@@ -98,6 +101,7 @@ export type TicketActivityType =
   | 'customer_replied'
   | 'customer_linked'
   | 'csat_requested'
+  | 'csat_received'
   | 'reopened'
   | 'jira_escalated'
 
@@ -298,6 +302,11 @@ export interface TicketStats {
   awaiting_approval: number
   sla_breaching: number
   ai_resolved_pct_7d?: number | null
+  csat_avg?: number | null
+  csat_ai_avg?: number | null
+  csat_human_avg?: number | null
+  csat_responses: number
+  csat_window_days: number
 }
 
 export interface TicketListFilters {

--- a/frontend/src/views/TicketsView.vue
+++ b/frontend/src/views/TicketsView.vue
@@ -38,6 +38,24 @@ const {
 const showCreateModal = ref(false)
 const canManage = permissionChecks.canManageTickets()
 
+// "AI 4.6 · human 4.2" when both sides have responses — the split is the point
+// of the chip now that L3 auto-resolve is live.
+const csatSub = computed(() => {
+  const s = stats.value
+  const days = s?.csat_window_days ?? 30
+  if (!s?.csat_responses) return `last ${days} days`
+  const parts: string[] = []
+  if (s.csat_ai_avg != null) parts.push(`AI ${s.csat_ai_avg.toFixed(1)}`)
+  if (s.csat_human_avg != null) parts.push(`human ${s.csat_human_avg.toFixed(1)}`)
+  return parts.length ? parts.join(' · ') : `${s.csat_responses} in ${days} days`
+})
+
+const csatColor = computed(() => {
+  const avg = stats.value?.csat_avg
+  if (avg == null) return 'var(--c-info)'
+  return avg >= 4 ? 'var(--c-positive)' : avg >= 3 ? 'var(--c-warn)' : 'var(--c-danger)'
+})
+
 const statChips = computed(() => [
   { label: 'Open', value: stats.value?.open ?? '—', color: 'var(--c-info)', alert: false },
   { label: 'Awaiting approval', value: stats.value?.awaiting_approval ?? '—', color: 'var(--c-warn)', alert: false },
@@ -53,6 +71,13 @@ const statChips = computed(() => [
     color: 'var(--c-positive)',
     alert: false,
     sub: 'last 7 days',
+  },
+  {
+    label: 'CSAT',
+    value: stats.value?.csat_avg != null ? `${stats.value.csat_avg.toFixed(1)}/5` : '—',
+    color: csatColor.value,
+    alert: false,
+    sub: csatSub.value,
   },
 ])
 

--- a/frontend/src/views/TicketsView.vue
+++ b/frontend/src/views/TicketsView.vue
@@ -42,12 +42,13 @@ const canManage = permissionChecks.canManageTickets()
 // of the chip now that L3 auto-resolve is live.
 const csatSub = computed(() => {
   const s = stats.value
-  const days = s?.csat_window_days ?? 30
-  if (!s?.csat_responses) return `last ${days} days`
+  if (!s) return ''
+  const window = `last ${s.csat_window_days} days`
+  if (!s.csat_responses) return window
   const parts: string[] = []
   if (s.csat_ai_avg != null) parts.push(`AI ${s.csat_ai_avg.toFixed(1)}`)
   if (s.csat_human_avg != null) parts.push(`human ${s.csat_human_avg.toFixed(1)}`)
-  return parts.length ? parts.join(' · ') : `${s.csat_responses} in ${days} days`
+  return parts.length ? parts.join(' · ') : `${s.csat_responses} rated · ${window}`
 })
 
 const csatColor = computed(() => {


### PR DESCRIPTION
We ask the customer to rate a ticket when it closes, but nothing was capturing the answer — the rating landed against the conversation and the ticket never learned the score.

Ratings submitted for a conversation now attach to that conversation's ticket (`csat_score`, `csat_rating_id`, `csat_responded_at`, plus a `csat_received` activity), hooked into both rating-create paths and best-effort so a failed linkage can never break the customer's submission. The ticket side panel gets a CSAT card (pending / score / not requested) and the Tickets stat chips get CSAT split by AI-resolved vs human-resolved over 30 days.

CSAT stays conversation-only on purpose: `ratings.session_id` is NOT NULL, so a manual or email-only ticket has nothing to rate. Those are never asked and the card says so rather than showing a pending CSAT that will never arrive. An email path would need a public tokenised rating page.

New migration `add_tkt_csat_001` (off `add_tkt_row_scope_001`). No config or deploy changes.