### PR TITLE
fix(slack): make the app fit for Marketplace review

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -40,6 +40,14 @@ SHOPIFY_API_KEY=your_shopify_key
 SHOPIFY_API_SECRET=your_shopify_secret
 SHOPIFY_API_VERSION=2025-04
 
+# Slack channel — create an app at api.slack.com/apps. The OAuth redirect URI is
+# derived from BACKEND_URL, so add {BACKEND_URL}/api/v1/channels/slack/callback
+# to the app's Redirect URLs. Without SLACK_SIGNING_SECRET every incoming Slack
+# webhook is rejected with a 403, since signature checks fail closed.
+SLACK_CLIENT_ID=your_slack_client_id
+SLACK_CLIENT_SECRET=your_slack_client_secret
+SLACK_SIGNING_SECRET=your_slack_signing_secret
+
 # Meta channels (WhatsApp Cloud API, Messenger, Instagram) — create an app at
 # developers.facebook.com. META_WEBHOOK_VERIFY_TOKEN is any random string you pick
 # and also enter in the App Dashboard webhook config.

--- a/backend/app/api/channels/slack.py
+++ b/backend/app/api/channels/slack.py
@@ -24,11 +24,12 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
 from app.api.channels.accounts import get_org_account_or_404
+from app.channels.slack import slack_api
 from app.core.auth import get_current_organization, require_permissions
 from app.core.config import settings
 from app.core.redis import get_redis
 from app.database import get_db
-from app.models.channels import ChannelType
+from app.models.channels import ChannelAccount, ChannelType
 from app.models.organization import Organization
 from app.models.user import User
 from app.repositories.channels import ChannelAccountRepository
@@ -37,9 +38,14 @@ from app.core.logger import get_logger
 router = APIRouter()
 logger = get_logger(__name__)
 
-# Bot scopes for the customer-chat use case: receive mentions + DMs, reply,
-# and resolve the sender's real name (users:read) so customers aren't raw U0… ids
-OAUTH_SCOPES = "app_mentions:read,chat:write,im:history,im:read,im:write,users:read"
+# Bot scopes for the customer-chat use case. Keep this minimal — the
+# Marketplace review asks us to justify each one, and once listed the app can
+# only use approved scopes:
+#   app_mentions:read  receive app_mention, so the agent answers when @mentioned
+#   chat:write         post the reply and the "typing…" placeholder
+#   im:history         receive message.im, so the agent answers DMs
+#   users:read         users.info, so a customer shows as a name not a raw U0… id
+OAUTH_SCOPES = "app_mentions:read,chat:write,im:history,users:read"
 STATE_TTL_SECONDS = 60 * 10
 
 # In-process fallback when Redis is disabled (single-worker dev setups)
@@ -148,6 +154,22 @@ async def slack_oauth_callback(
     return _settings_redirect("success")
 
 
+async def _revoke_token(repo: ChannelAccountRepository, account: ChannelAccount) -> None:
+    """Best-effort: tell Slack to invalidate the bot token before we drop it.
+
+    Never blocks the disconnect — an already-revoked token, an undecryptable
+    blob, or an unreachable Slack must still leave the workspace disconnected
+    on our side.
+    """
+    try:
+        token = repo.get_credentials(account).get("access_token")
+        if not token:
+            return
+        await slack_api("auth.revoke", token, {}, form=True)
+    except Exception as e:
+        logger.warning(f"Slack auth.revoke failed, disconnecting anyway: {e}")
+
+
 @router.delete("/{account_id}")
 async def disconnect_slack(
     account_id: UUID,
@@ -158,5 +180,7 @@ async def disconnect_slack(
     account = get_org_account_or_404(db, account_id, organization)
     if account.channel_type != ChannelType.SLACK.value:
         raise HTTPException(status_code=404, detail="Channel account not found")
-    ChannelAccountRepository(db).delete(account)
+    repo = ChannelAccountRepository(db)
+    await _revoke_token(repo, account)
+    repo.delete(account)
     return {"status": "disconnected"}

--- a/backend/app/api/webhooks/slack.py
+++ b/backend/app/api/webhooks/slack.py
@@ -29,6 +29,51 @@ from app.services.channel_chat import process_channel_message
 router = APIRouter()
 logger = get_logger(__name__)
 
+# Workspace-level events that end our access: the app was removed, or its
+# tokens were revoked. Both mean the stored credentials are dead.
+LIFECYCLE_EVENT_TYPES = frozenset({"app_uninstalled", "tokens_revoked"})
+
+
+def _revokes_bot_access(event: dict) -> bool:
+    """Whether the event actually kills the credentials we hold.
+
+    An uninstall always does. tokens_revoked also fires when a *user* token
+    is revoked, which leaves the bot working — we only ever store a bot
+    token, so acting on those would disconnect a healthy workspace.
+    """
+    if event.get("type") == "app_uninstalled":
+        return True
+    return bool((event.get("tokens") or {}).get("bot"))
+
+
+def _handle_lifecycle_event(payload: dict, account_repo: ChannelAccountRepository) -> None:
+    """Drop the workspace's stored credentials after an uninstall or revoke.
+
+    Deleting the account closes any open sessions and cascades to its
+    conversations and agent config, so no agent is left holding a
+    conversation on a channel we can no longer reach.
+    """
+    if not _revokes_bot_access(payload.get("event") or {}):
+        logger.info("Slack tokens_revoked without a bot token; keeping the account")
+        return
+
+    team_id = payload.get("team_id", "")
+    if not team_id:
+        logger.warning("Slack lifecycle event without a team_id; ignoring")
+        return
+
+    account = account_repo.get_by_external_id(ChannelType.SLACK.value, team_id)
+    if account is None:
+        # Already disconnected our side, or a workspace we never stored.
+        logger.info(f"Slack lifecycle event for unknown team {team_id}")
+        return
+
+    # delete() reports failure by returning False rather than raising.
+    if account_repo.delete(account):
+        logger.info(f"Removed Slack account for team {team_id} after lifecycle event")
+    else:
+        logger.error(f"Failed to remove Slack account for team {team_id}")
+
 
 @router.post("")
 async def slack_webhook(
@@ -53,8 +98,15 @@ async def slack_webhook(
     if payload.get("type") != "event_callback":
         return {"status": "ignored"}
 
-    adapter = get_adapter(ChannelType.SLACK.value)
     account_repo = ChannelAccountRepository(db)
+
+    # Lifecycle events carry no message, so parse_inbound drops them — resolve
+    # the workspace off the envelope instead, before the message loop.
+    if (payload.get("event") or {}).get("type") in LIFECYCLE_EVENT_TYPES:
+        _handle_lifecycle_event(payload, account_repo)
+        return {"status": "ok"}
+
+    adapter = get_adapter(ChannelType.SLACK.value)
 
     for inbound in adapter.parse_inbound(payload):
         account = account_repo.get_by_external_id(ChannelType.SLACK.value, inbound.external_account_id)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -75,13 +75,12 @@ class Settings(BaseSettings):
     # Shopify
     SHOPIFY_API_KEY: str = os.getenv("SHOPIFY_API_KEY", "")
     SHOPIFY_API_SECRET: str = os.getenv("SHOPIFY_API_SECRET", "")
+    SHOPIFY_API_VERSION: str = os.getenv("SHOPIFY_API_VERSION", "2025-10")
 
-    # Slack
+    # Slack. The OAuth redirect URI is derived from BACKEND_URL, not configured.
     SLACK_CLIENT_ID: str = os.getenv("SLACK_CLIENT_ID", "")
     SLACK_CLIENT_SECRET: str = os.getenv("SLACK_CLIENT_SECRET", "")
     SLACK_SIGNING_SECRET: str = os.getenv("SLACK_SIGNING_SECRET", "")
-    SLACK_REDIRECT_URI: str = os.getenv("SLACK_REDIRECT_URI", "")
-    SHOPIFY_API_VERSION: str = os.getenv("SHOPIFY_API_VERSION", "2025-10")
 
     # Meta (WhatsApp Cloud API, Messenger, Instagram) — one app, shared webhook.
     # Self-hosters supply their own app; the cloud supplies its approved app.

--- a/backend/tests/channels/test_slack_adapter.py
+++ b/backend/tests/channels/test_slack_adapter.py
@@ -17,9 +17,11 @@ limitations under the License.
 import hashlib
 import hmac
 import time
+from unittest.mock import MagicMock
 
 import pytest
 
+from app.api.webhooks.slack import _handle_lifecycle_event
 from app.channels import get_adapter
 from app.channels.slack import SlackAdapter, verify_slack_signature
 from app.core.config import settings
@@ -91,6 +93,58 @@ def test_split_conversation():
 
 def test_format_outbound_mrkdwn(adapter):
     assert adapter.format_outbound("**bold** text") == "*bold* text"
+
+
+class TestLifecycleEvents:
+    """app_uninstalled / tokens_revoked must drop the workspace's credentials,
+    but only when it's really our bot token that died."""
+
+    @pytest.fixture
+    def repo(self):
+        repo = MagicMock()
+        repo.get_by_external_id.return_value = MagicMock(name="account")
+        repo.delete.return_value = True
+        return repo
+
+    def test_uninstall_deletes_account(self, repo):
+        _handle_lifecycle_event(make_event({"type": "app_uninstalled"}), repo)
+        repo.get_by_external_id.assert_called_once_with("slack", "T111")
+        repo.delete.assert_called_once()
+
+    def test_bot_token_revoked_deletes_account(self, repo):
+        payload = make_event({"type": "tokens_revoked", "tokens": {"bot": ["B123"]}})
+        _handle_lifecycle_event(payload, repo)
+        repo.delete.assert_called_once()
+
+    def test_user_token_revoke_keeps_account(self, repo):
+        """We only ever store a bot token — a user-token revoke leaves the
+        workspace working, so deleting it would disconnect a healthy install."""
+        payload = make_event({"type": "tokens_revoked", "tokens": {"oauth": ["U123"]}})
+        _handle_lifecycle_event(payload, repo)
+        repo.delete.assert_not_called()
+
+    def test_unknown_team_is_noop(self, repo):
+        repo.get_by_external_id.return_value = None
+        _handle_lifecycle_event(make_event({"type": "app_uninstalled"}), repo)
+        repo.delete.assert_not_called()
+
+    def test_missing_team_id_is_noop(self, repo):
+        payload = make_event({"type": "app_uninstalled"}, team_id="")
+        _handle_lifecycle_event(payload, repo)
+        repo.get_by_external_id.assert_not_called()
+        repo.delete.assert_not_called()
+
+    def test_failed_delete_does_not_raise(self, repo):
+        """delete() reports failure by returning False; Slack still needs a 200."""
+        repo.delete.return_value = False
+        _handle_lifecycle_event(make_event({"type": "app_uninstalled"}), repo)
+        repo.delete.assert_called_once()
+
+    def test_lifecycle_events_are_not_messages(self, adapter):
+        """They must stay out of the message path — parse_inbound yields nothing,
+        which is why the route resolves the team off the envelope instead."""
+        assert adapter.parse_inbound(make_event({"type": "app_uninstalled"})) == []
+        assert adapter.parse_inbound(make_event({"type": "tokens_revoked"})) == []
 
 
 class TestSignature:

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -15,14 +15,13 @@ limitations under the License.
 -->
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { authService } from '@/services/auth'
 import { permissionChecks } from '@/utils/permissions'
 import { useEnterpriseFeatures } from '@/composables/useEnterpriseFeatures'
 import { useForgotPassword } from '@/composables/useForgotPassword'
 import InstallPrompt from '@/components/pwa/InstallPrompt.vue'
-import api from '@/services/api'
 import type { AxiosError } from 'axios'
 interface ErrorResponse {
     detail: string
@@ -46,10 +45,6 @@ const { hasEnterpriseModule } = useEnterpriseFeatures()
 // Forgot password composable - only initialize if enterprise module is available
 const showForgotPasswordModal = ref(false)
 const forgotPassword = hasEnterpriseModule ? useForgotPassword() : null
-
-// Check for pending Slack installation from marketplace
-const pendingSlackTeam = computed(() => router.currentRoute.value.query.slack_team as string || null)
-const hasPendingSlackInstall = computed(() => !!router.currentRoute.value.query.slack_install)
 
 // Destructure with fallbacks for when enterprise module is not available
 const isForgotPasswordLoading = forgotPassword?.isLoading ?? ref(false)
@@ -206,24 +201,6 @@ const handleLogin = async () => {
             }
         }
 
-        // Check for Slack marketplace installation pending
-        const slackInstallKey = router.currentRoute.value.query.slack_install as string
-        if (slackInstallKey) {
-            console.log('🔗 Slack marketplace installation detected, completing install...')
-            try {
-                const response = await api.post(`/slack/complete-install?install_key=${slackInstallKey}`)
-                console.log('✅ Slack installation completed:', response.data)
-                // Redirect to integrations with success
-                router.push('/settings/integrations?status=success&integration=slack')
-                return
-            } catch (slackError: any) {
-                console.error('❌ Failed to complete Slack installation:', slackError)
-                const errorMsg = slackError.response?.data?.detail || 'Failed to complete Slack installation'
-                router.push(`/settings/integrations?status=failure&reason=${encodeURIComponent(errorMsg)}`)
-                return
-            }
-        }
-
         // Check for redirect query parameter (internal frontend route)
         const redirectPath = router.currentRoute.value.query.redirect as string
         if (redirectPath) {
@@ -252,14 +229,12 @@ const handleLogin = async () => {
 }
 
 const navigateToSignup = () => {
-    // Preserve embedded, shop_id, return_to, redirect, slack_install query params if present
+    // Preserve embedded, shop_id, return_to, redirect query params if present
     const isEmbedded = router.currentRoute.value.query.embedded
     const shopId = router.currentRoute.value.query.shop_id
     const returnTo = router.currentRoute.value.query.return_to
     const shopifyFlow = router.currentRoute.value.query.shopify_flow
     const redirect = router.currentRoute.value.query.redirect
-    const slackInstall = router.currentRoute.value.query.slack_install
-    const slackTeam = router.currentRoute.value.query.slack_team
 
     const query: any = {}
 
@@ -268,8 +243,6 @@ const navigateToSignup = () => {
     if (returnTo) query.return_to = returnTo
     if (shopifyFlow) query.shopify_flow = shopifyFlow
     if (redirect) query.redirect = redirect
-    if (slackInstall) query.slack_install = slackInstall
-    if (slackTeam) query.slack_team = slackTeam
 
     if (Object.keys(query).length > 0) {
         console.log('Navigating to signup with params:', query)
@@ -326,18 +299,6 @@ const handleVerifyAndResetPassword = async () => {
 
             <h1 class="auth-title">Welcome back</h1>
             <p class="auth-sub">Sign in to continue to your dashboard</p>
-
-            <!-- Slack Installation Banner -->
-            <div v-if="hasPendingSlackInstall" class="slack-banner">
-                <svg viewBox="0 0 24 24" width="18" height="18" fill="var(--accent-ink)">
-                    <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zM6.313 15.165a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313zM8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312zM18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312zM15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z"/>
-                </svg>
-                <div>
-                    <strong>Connect Slack Workspace</strong>
-                    <span v-if="pendingSlackTeam"> — connect <em>{{ pendingSlackTeam }}</em></span>
-                    <span v-else> — complete your Slack installation</span>
-                </div>
-            </div>
 
             <form @submit.prevent="handleLogin" class="auth-form">
                 <div class="field">
@@ -616,23 +577,6 @@ const handleVerifyAndResetPassword = async () => {
     font-size: 15px;
     margin-bottom: 36px;
 }
-
-/* Slack banner */
-.slack-banner {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 12px 16px;
-    background: color-mix(in srgb, var(--accent-solid) 6%, transparent);
-    border: 1px solid color-mix(in srgb, var(--accent-ink) 20%, transparent);
-    border-radius: 10px;
-    margin-bottom: 24px;
-    font-size: 13.5px;
-    color: var(--text3);
-}
-
-.slack-banner strong { color: var(--text); }
-.slack-banner em { color: var(--accent-ink); font-style: normal; }
 
 /* Form */
 .auth-form {

--- a/frontend/src/views/settings/IntegrationsSettings.vue
+++ b/frontend/src/views/settings/IntegrationsSettings.vue
@@ -468,6 +468,14 @@ const intSummary = computed(() => {
   return `${connected}/${total} connected`
 })
 
+// Display name for an ?integration= id, taken from the card list so a new
+// integration never has to be named twice. Jira's callback predates the param,
+// so a missing id means Jira.
+const integrationName = (id?: string) => {
+  const integrationId = id || 'jira'
+  return availableIntegrations.value.find(it => it.id === integrationId)?.name || integrationId
+}
+
 onMounted(async () => {
   await Promise.all([
     fetchJiraStatus(),
@@ -491,7 +499,7 @@ onMounted(async () => {
         }
       }
       else {
-        toast.success('Jira connected successfully!')
+        toast.success(`${integrationName(route.query.integration as string)} connected successfully!`)
       }
       lastConnectionError.value = null
     } else if (route.query.status === 'failure') {


### PR DESCRIPTION
Prep for the Slack Marketplace submission. The app config declared features we never built, and we held onto credentials after an uninstall. This brings the code in line with what the integration actually does — @mention and DM answering.

- Handle `app_uninstalled` and `tokens_revoked`. These carry no message, so `parse_inbound` drops them and the account was never found; the team is now resolved off the envelope before the message loop. Only acts on `tokens_revoked` when a bot token is named — a user-token revoke leaves the bot working, and deleting then would disconnect a healthy workspace.
- Revoke the bot token with `auth.revoke` on disconnect instead of leaving a live token behind. Best-effort, never blocks the disconnect.
- Trim `OAUTH_SCOPES` to the four that have real call sites. `im:read` and `im:write` had none.
- Drop the dead `SLACK_REDIRECT_URI`, and document the Slack vars in `.env.example` — without a signing secret every webhook 403s with no hint.
- Remove the frontend `/slack/complete-install` flow. That endpoint doesn't exist, so the path only ever produced a 404.

Tests: 7 new cases for the lifecycle branch; 143 pass across the Slack-touching suites. Frontend type-check clean.

Note the Slack dashboard still points at three URLs that 404 in production — that's a separate config change, not code.