### PR TITLE
Call the enterprise disposable-email check at signup

### DIFF
--- a/backend/app/api/organizations.py
+++ b/backend/app/api/organizations.py
@@ -43,6 +43,16 @@ from uuid import UUID
 from app.core.cors import update_cors_middleware
 from app.core.application import app  # Import the FastAPI app instance from the new location
 
+# Disposable-address rejection lives in the enterprise module: the hosted signup
+# flow is what attracts throwaway signups, and the community edition has no
+# reason to carry an 8k-domain blocklist. Absent, every address is accepted.
+try:
+    from app.enterprise.services.email_validation import ensure_not_disposable
+
+    HAS_EMAIL_VALIDATION = True
+except ImportError:
+    HAS_EMAIL_VALIDATION = False
+
 logger = get_logger(__name__)
 router = APIRouter(
     tags=["organizations"]
@@ -57,6 +67,9 @@ async def create_organization(
 ):
     """Create a new organization with an admin user and default roles"""
     try:
+        if HAS_EMAIL_VALIDATION:
+            ensure_not_disposable(org_data.admin_email)
+
         # Check if any organization exists
         existing_orgs = db.query(Organization).first()
         

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -52,6 +52,16 @@ try:
 except ImportError:
     HAS_ENTERPRISE = False
 
+# Disposable-address rejection lives in the enterprise module: the hosted signup
+# flow is what attracts throwaway signups, and the community edition has no
+# reason to carry an 8k-domain blocklist. Absent, every address is accepted.
+try:
+    from app.enterprise.services.email_validation import ensure_not_disposable
+
+    HAS_EMAIL_VALIDATION = True
+except ImportError:
+    HAS_EMAIL_VALIDATION = False
+
 logger = get_logger(__name__)
 router = APIRouter(
     tags=["users"]
@@ -99,8 +109,11 @@ async def create_user(
 ):
     """Create a new user"""
     try:
+        if HAS_EMAIL_VALIDATION:
+            ensure_not_disposable(user_data.email)
+
         user_repo = UserRepository(db)
-        
+
         # Check if email already exists
         if user_repo.get_user_by_email(user_data.email):
             raise HTTPException(
@@ -755,8 +768,11 @@ async def update_profile(
         if hasattr(data, 'role_id'):
             delattr(data, 'role_id')
         
-        # If updating email, check if it's already taken
+        # If updating email, check it's a real mailbox and not already taken.
+        # Same bounce risk as signup, and otherwise a trivial way around that gate.
         if data.email and data.email != current_user.email:
+            if HAS_EMAIL_VALIDATION:
+                ensure_not_disposable(data.email)
             existing_user = user_repo.get_user_by_email(data.email)
             if existing_user:
                 raise HTTPException(
@@ -824,6 +840,8 @@ async def update_user(
     
     # Check if updating email and if it's already taken
     if user_data.email and user_data.email != user.email:
+        if HAS_EMAIL_VALIDATION:
+            ensure_not_disposable(user_data.email)
         existing_user = user_repo.get_user_by_email(user_data.email)
         if existing_user:
             raise HTTPException(

--- a/backend/tests/api/test_organizations.py
+++ b/backend/tests/api/test_organizations.py
@@ -28,6 +28,21 @@ from app.api import organizations as organizations_router
 from app.core.auth import get_current_user, require_permissions
 from tests.conftest import engine, TestingSessionLocal, create_tables, Base
 
+# The disposable-address gate is enterprise-only; a community checkout has no
+# blocklist and accepts everything.
+try:
+    from app.enterprise.services.email_validation import DISPOSABLE_EMAIL_MESSAGE
+
+    HAS_EMAIL_VALIDATION = True
+except ImportError:
+    DISPOSABLE_EMAIL_MESSAGE = ""
+    HAS_EMAIL_VALIDATION = False
+
+requires_email_validation = pytest.mark.skipif(
+    not HAS_EMAIL_VALIDATION, reason="enterprise email validation not installed"
+)
+
+
 # Create a test FastAPI app
 app = FastAPI()
 app.include_router(
@@ -303,6 +318,41 @@ def test_create_organization_duplicate(client, test_organization):
     response = client.post("/api/v1/organizations", json=org_data)
     assert response.status_code == 403
     assert "Organization already exists" in response.json()["detail"]
+
+@requires_email_validation
+def test_create_organization_rejects_disposable_admin_email(client, db):
+    """Signup with a throwaway admin address is refused and creates nothing"""
+    app.dependency_overrides[get_db] = lambda: db
+
+    db.query(User).delete()
+    db.commit()
+    db.query(Organization).delete()
+    db.commit()
+
+    org_data = {
+        "name": "Throwaway Org",
+        "domain": "throwaway.com",
+        "timezone": "UTC",
+        "business_hours": {
+            "monday": {"start": "09:00", "end": "17:00", "enabled": True},
+            "tuesday": {"start": "09:00", "end": "17:00", "enabled": True},
+            "wednesday": {"start": "09:00", "end": "17:00", "enabled": True},
+            "thursday": {"start": "09:00", "end": "17:00", "enabled": True},
+            "friday": {"start": "09:00", "end": "17:00", "enabled": True},
+            "saturday": {"start": "09:00", "end": "17:00", "enabled": False},
+            "sunday": {"start": "09:00", "end": "17:00", "enabled": False}
+        },
+        "admin_email": "someone@yopmail.com",
+        "admin_name": "Throwaway Admin",
+        "admin_password": "adminpass123"
+    }
+
+    response = client.post("/api/v1/organizations", json=org_data)
+    assert response.status_code == 400
+    assert response.json()["detail"] == DISPOSABLE_EMAIL_MESSAGE
+    assert db.query(Organization).count() == 0
+    assert db.query(User).count() == 0
+
 
 def test_update_organization_invalid_hours(client, test_organization):
     """Test updating organization with invalid business hours"""

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -35,6 +35,21 @@ import json
 from urllib.parse import unquote
 from tests.conftest import engine, TestingSessionLocal, create_tables, test_organization
 
+# The disposable-address gate is enterprise-only; a community checkout has no
+# blocklist and accepts everything.
+try:
+    from app.enterprise.services.email_validation import DISPOSABLE_EMAIL_MESSAGE
+
+    HAS_EMAIL_VALIDATION = True
+except ImportError:
+    DISPOSABLE_EMAIL_MESSAGE = ""
+    HAS_EMAIL_VALIDATION = False
+
+requires_email_validation = pytest.mark.skipif(
+    not HAS_EMAIL_VALIDATION, reason="enterprise email validation not installed"
+)
+
+
 # Create a test FastAPI app
 app = FastAPI()
 app.include_router(
@@ -198,6 +213,31 @@ def test_create_user_duplicate_email(client: TestClient, test_user: User, test_r
     response = client.post("/api/v1/users", json=user_data)
     assert response.status_code == 400  # Bad request for duplicate email
     assert "Email already registered" in response.json()["detail"]
+
+@requires_email_validation
+def test_create_user_rejects_disposable_email(admin_client: TestClient, test_role: Role, test_organization):
+    """Test that an invited teammate cannot be created on a throwaway domain"""
+    user_data = {
+        "email": "someone@yopmail.com",
+        "full_name": "Throwaway User",
+        "password": "testpassword123",
+        "is_active": True,
+        "role_id": test_role.id,
+        "organization_id": str(test_organization.id)
+    }
+    response = admin_client.post("/api/v1/users", json=user_data)
+    assert response.status_code == 400
+    assert response.json()["detail"] == DISPOSABLE_EMAIL_MESSAGE
+
+@requires_email_validation
+def test_update_user_rejects_disposable_email(client: TestClient, test_user: User):
+    """Test that an existing account cannot be moved onto a throwaway domain"""
+    response = client.put(
+        f"/api/v1/users/{test_user.id}",
+        json={"email": "someone@dropmail.me"}
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == DISPOSABLE_EMAIL_MESSAGE
 
 def test_list_users(client: TestClient, test_user: User):
     """Test listing all users in the organization"""


### PR DESCRIPTION
About 7% of the user table is throwaway mailboxes. They hard bounce, and bounces on our shared sending IP cost deliverability for verification and password-reset mail to real customers.

The blocklist and the matching live in the enterprise module — the hosted signup flow is what attracts them, and the community edition has no reason to carry an 8k-domain list.

This PR is only the hook. Org creation, user creation and the two email-change routes call `ensure_not_disposable` when `app.enterprise.services.email_validation` is installed, and accept everything when it isn't. Same `HAS_ENTERPRISE` pattern as the subscription checks. The route tests skip in a community checkout.

Implementation: chattermate/enterprise_backend#24 — merge that first.

Existing users are untouched.