### PR TITLE
Prefill the onboarding teach step with the signup domain

### DIFF
--- a/frontend/src/__tests__/components/StepTeach.prefill.spec.ts
+++ b/frontend/src/__tests__/components/StepTeach.prefill.spec.ts
@@ -4,80 +4,120 @@ import { mount, flushPromises } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 
 const getOrganization = vi.fn()
+const getKnowledgeByAgent = vi.fn()
+const getKnowledgeByOrganization = vi.fn()
 
 vi.mock('@/services/organization', () => ({
   organizationService: { getOrganization: (id: string) => getOrganization(id) }
 }))
 vi.mock('@/services/knowledge', () => ({
   knowledgeService: {
-    getKnowledgeByAgent: vi.fn().mockResolvedValue({ knowledge: [], pagination: { total_pages: 0 } }),
-    getKnowledgeByOrganization: vi
-      .fn()
-      .mockResolvedValue({ knowledge: [], pagination: { total_pages: 0 } }),
+    getKnowledgeByAgent: (...a: unknown[]) => getKnowledgeByAgent(...a),
+    getKnowledgeByOrganization: (...a: unknown[]) => getKnowledgeByOrganization(...a),
     getAgentQueueItems: vi.fn().mockResolvedValue({ queue_items: [] })
   }
 }))
 
 import StepTeach from '@/components/aiagent/onboarding/steps/StepTeach.vue'
 
-const mountStep = () =>
-  mount(StepTeach, {
+const empty = { knowledge: [], pagination: { total_pages: 0 } }
+
+const mountStep = async () => {
+  const wrapper = mount(StepTeach, {
     props: { agentId: 'agent-1', organizationId: 'org-1' },
     global: { plugins: [createPinia()] }
   })
+  await flushPromises()
+  return wrapper
+}
+
+const urlInput = (wrapper: any) =>
+  wrapper.find('input[type="text"]').element as HTMLInputElement
 
 describe('StepTeach - signup domain prefill', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    getKnowledgeByAgent.mockResolvedValue(empty)
+    getKnowledgeByOrganization.mockResolvedValue(empty)
   })
 
-  it('prefills the URL field with the signup domain, scheme added', async () => {
-    getOrganization.mockResolvedValue({ id: 'org-1', domain: 'paywithatoa.co.uk' })
+  it('stages the signup domain as a source, scheme added', async () => {
+    getOrganization.mockResolvedValue({ id: 'org-1', domain: 'testypo.com' })
 
-    const wrapper = mountStep()
-    await flushPromises()
+    const wrapper = await mountStep()
 
-    expect(getOrganization).toHaveBeenCalledWith('org-1')
-    expect((wrapper.find('input[type="text"]').element as HTMLInputElement).value).toBe(
-      'https://paywithatoa.co.uk'
-    )
+    // Visible as an added source, not parked in the input where it reads as a
+    // placeholder the user must still press "+ Website" to accept.
+    expect(wrapper.find('.source-list').text()).toContain('https://testypo.com')
+    expect(urlInput(wrapper).value).toBe('')
+  })
+
+  it('lets the suggestion be removed', async () => {
+    getOrganization.mockResolvedValue({ id: 'org-1', domain: 'testypo.com' })
+
+    const wrapper = await mountStep()
+    await wrapper.find('.source-remove').trigger('click')
+
+    expect(wrapper.find('.source-list').exists()).toBe(false)
   })
 
   it('leaves a domain that already has a scheme alone', async () => {
     getOrganization.mockResolvedValue({ id: 'org-1', domain: 'https://example.com' })
 
-    const wrapper = mountStep()
-    await flushPromises()
+    const wrapper = await mountStep()
 
-    expect((wrapper.find('input[type="text"]').element as HTMLInputElement).value).toBe(
-      'https://example.com'
-    )
+    expect(wrapper.find('.source-list').text()).toContain('https://example.com')
+  })
+
+  it('does not re-add a domain that is already indexed, or nag about it', async () => {
+    getKnowledgeByAgent.mockResolvedValue({
+      knowledge: [{ id: 1, name: 'https://testypo.com' }],
+      pagination: { total_pages: 1 }
+    })
+    getOrganization.mockResolvedValue({ id: 'org-1', domain: 'testypo.com' })
+
+    const wrapper = await mountStep()
+
+    expect(wrapper.find('.step-error').exists()).toBe(false)
+    // Present once, as the already-indexed entry — not staged a second time.
+    expect(wrapper.findAll('.source-row')).toHaveLength(1)
   })
 
   it('renders normally when the org lookup fails', async () => {
     getOrganization.mockRejectedValue(new Error('boom'))
 
-    const wrapper = mountStep()
-    await flushPromises()
+    const wrapper = await mountStep()
 
-    expect((wrapper.find('input[type="text"]').element as HTMLInputElement).value).toBe('')
+    expect(urlInput(wrapper).value).toBe('')
+    expect(wrapper.find('.source-list').exists()).toBe(false)
     expect(wrapper.text()).toContain('Teach it your business')
   })
 
-  it('stages the prefilled URL on Continue without needing "+ Website"', async () => {
-    getOrganization.mockResolvedValue({ id: 'org-1', domain: 'paywithatoa.co.uk' })
+  it('stages a typed URL on Continue without needing "+ Website"', async () => {
+    getOrganization.mockResolvedValue({ id: 'org-1', domain: '' })
 
-    const wrapper = mountStep()
-    await flushPromises()
+    const wrapper = await mountStep()
+    await wrapper.find('input[type="text"]').setValue('docs.company.com')
 
-    const buttons = wrapper.findAll('button')
-    const cont = buttons.find((b) => b.text().includes('Continue'))!
+    const cont = wrapper.findAll('button').find((b: any) => b.text().includes('Continue'))!
     await cont.trigger('click')
     await flushPromises()
 
-    // It must not be silently dropped just because the user never pressed the
-    // "+ Website" button — the URL was sitting in the box, visibly accepted.
     expect(wrapper.emitted('next')).toBeTruthy()
+  })
+
+  it('does not advance when the typed URL is invalid', async () => {
+    getOrganization.mockResolvedValue({ id: 'org-1', domain: '' })
+
+    const wrapper = await mountStep()
+    await wrapper.find('input[type="text"]').setValue('not a url')
+
+    const cont = wrapper.findAll('button').find((b: any) => b.text().includes('Continue'))!
+    await cont.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.emitted('next')).toBeFalsy()
+    expect(wrapper.find('.step-error').text()).toContain('valid URL')
   })
 })

--- a/frontend/src/__tests__/components/StepTeach.prefill.spec.ts
+++ b/frontend/src/__tests__/components/StepTeach.prefill.spec.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+
+const getOrganization = vi.fn()
+
+vi.mock('@/services/organization', () => ({
+  organizationService: { getOrganization: (id: string) => getOrganization(id) }
+}))
+vi.mock('@/services/knowledge', () => ({
+  knowledgeService: {
+    getKnowledgeByAgent: vi.fn().mockResolvedValue({ knowledge: [], pagination: { total_pages: 0 } }),
+    getKnowledgeByOrganization: vi
+      .fn()
+      .mockResolvedValue({ knowledge: [], pagination: { total_pages: 0 } }),
+    getAgentQueueItems: vi.fn().mockResolvedValue({ queue_items: [] })
+  }
+}))
+
+import StepTeach from '@/components/aiagent/onboarding/steps/StepTeach.vue'
+
+const mountStep = () =>
+  mount(StepTeach, {
+    props: { agentId: 'agent-1', organizationId: 'org-1' },
+    global: { plugins: [createPinia()] }
+  })
+
+describe('StepTeach - signup domain prefill', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('prefills the URL field with the signup domain, scheme added', async () => {
+    getOrganization.mockResolvedValue({ id: 'org-1', domain: 'paywithatoa.co.uk' })
+
+    const wrapper = mountStep()
+    await flushPromises()
+
+    expect(getOrganization).toHaveBeenCalledWith('org-1')
+    expect((wrapper.find('input[type="text"]').element as HTMLInputElement).value).toBe(
+      'https://paywithatoa.co.uk'
+    )
+  })
+
+  it('leaves a domain that already has a scheme alone', async () => {
+    getOrganization.mockResolvedValue({ id: 'org-1', domain: 'https://example.com' })
+
+    const wrapper = mountStep()
+    await flushPromises()
+
+    expect((wrapper.find('input[type="text"]').element as HTMLInputElement).value).toBe(
+      'https://example.com'
+    )
+  })
+
+  it('renders normally when the org lookup fails', async () => {
+    getOrganization.mockRejectedValue(new Error('boom'))
+
+    const wrapper = mountStep()
+    await flushPromises()
+
+    expect((wrapper.find('input[type="text"]').element as HTMLInputElement).value).toBe('')
+    expect(wrapper.text()).toContain('Teach it your business')
+  })
+
+  it('stages the prefilled URL on Continue without needing "+ Website"', async () => {
+    getOrganization.mockResolvedValue({ id: 'org-1', domain: 'paywithatoa.co.uk' })
+
+    const wrapper = mountStep()
+    await flushPromises()
+
+    const buttons = wrapper.findAll('button')
+    const cont = buttons.find((b) => b.text().includes('Continue'))!
+    await cont.trigger('click')
+    await flushPromises()
+
+    // It must not be silently dropped just because the user never pressed the
+    // "+ Website" button — the URL was sitting in the box, visibly accepted.
+    expect(wrapper.emitted('next')).toBeTruthy()
+  })
+})

--- a/frontend/src/__tests__/components/StepTeach.prefill.spec.ts
+++ b/frontend/src/__tests__/components/StepTeach.prefill.spec.ts
@@ -48,7 +48,7 @@ describe('StepTeach - signup domain prefill', () => {
     const wrapper = await mountStep()
 
     // Visible as an added source, not parked in the input where it reads as a
-    // placeholder the user must still press "+ Website" to accept.
+    // placeholder the user must still press "Add" to accept.
     expect(wrapper.find('.source-list').text()).toContain('https://testypo.com')
     expect(urlInput(wrapper).value).toBe('')
   })
@@ -94,7 +94,7 @@ describe('StepTeach - signup domain prefill', () => {
     expect(wrapper.text()).toContain('Teach it your business')
   })
 
-  it('stages a typed URL on Continue without needing "+ Website"', async () => {
+  it('stages a typed URL on Continue without needing "Add"', async () => {
     getOrganization.mockResolvedValue({ id: 'org-1', domain: '' })
 
     const wrapper = await mountStep()

--- a/frontend/src/__tests__/composables/useKnowledgeManagement.url.spec.ts
+++ b/frontend/src/__tests__/composables/useKnowledgeManagement.url.spec.ts
@@ -54,9 +54,14 @@ describe('useKnowledgeManagement - URL handling', () => {
       (url) => expect(isValidUrl(url)).toBe(true)
     )
 
-    it.each(['mailto:someone@x.com', 'foo:bar', 'https://localhost', 'not a url'])(
+    it.each(['mailto:someone@x.com', 'foo:bar', 'not a url', 'https://'])(
       'rejects %s',
       (url) => expect(isValidUrl(url)).toBe(false)
+    )
+
+    it.each(['https://localhost', 'https://wiki', 'http://intranet:8080'])(
+      'accepts the intranet hostnames a self-hosted install indexes: %s',
+      (url) => expect(isValidUrl(url)).toBe(true)
     )
   })
 

--- a/frontend/src/__tests__/composables/useKnowledgeManagement.url.spec.ts
+++ b/frontend/src/__tests__/composables/useKnowledgeManagement.url.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('@/services/knowledge', () => ({
+  knowledgeService: {
+    getKnowledgeByAgent: vi.fn().mockResolvedValue({ knowledge: [], pagination: { total_pages: 0 } }),
+    getKnowledgeByOrganization: vi
+      .fn()
+      .mockResolvedValue({ knowledge: [], pagination: { total_pages: 0 } }),
+    getAgentQueueItems: vi.fn().mockResolvedValue({ queue_items: [] })
+  }
+}))
+
+import { useKnowledgeManagement } from '@/composables/useKnowledgeManagement'
+
+const setup = () => useKnowledgeManagement('agent-1', 'org-1')
+
+describe('useKnowledgeManagement - URL handling', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  describe('withScheme', () => {
+    const { withScheme } = setup()
+
+    it.each([
+      ['docs.company.com', 'https://docs.company.com'],
+      ['company.co.uk', 'https://company.co.uk'],
+      ['  spaced.com  ', 'https://spaced.com'],
+      ['//protocol-relative.com', 'https://protocol-relative.com']
+    ])('defaults the scheme: %s -> %s', (input, expected) => {
+      expect(withScheme(input)).toBe(expected)
+    })
+
+    it.each([
+      'https://already.com',
+      'http://plain.com',
+      'HTTPS://shouty.com'
+    ])('leaves an existing scheme alone: %s', (input) => {
+      expect(withScheme(input)).toBe(input)
+    })
+
+    it('leaves an empty value empty', () => {
+      expect(withScheme('   ')).toBe('')
+    })
+  })
+
+  describe('isValidUrl', () => {
+    const { isValidUrl } = setup()
+
+    it.each(['https://docs.company.com', 'http://a.co', 'https://x.com/path?q=1'])(
+      'accepts %s',
+      (url) => expect(isValidUrl(url)).toBe(true)
+    )
+
+    it.each(['mailto:someone@x.com', 'foo:bar', 'https://localhost', 'not a url'])(
+      'rejects %s',
+      (url) => expect(isValidUrl(url)).toBe(false)
+    )
+  })
+
+  describe('handleUrlAdd', () => {
+    it('stages a scheme-less URL instead of rejecting it', () => {
+      const { newUrl, urls, urlFormError, handleUrlAdd } = setup()
+      newUrl.value = 'docs.company.com'
+
+      handleUrlAdd()
+
+      expect(urls.value).toEqual(['https://docs.company.com'])
+      expect(urlFormError.value).toBeNull()
+      expect(newUrl.value).toBe('')
+    })
+
+    it('still rejects input that is not a URL at all', () => {
+      const { newUrl, urls, urlFormError, handleUrlAdd } = setup()
+      newUrl.value = 'not a url'
+
+      handleUrlAdd()
+
+      expect(urls.value).toEqual([])
+      expect(urlFormError.value).toBe('Please enter a valid URL')
+    })
+
+    it('clears a previous error when a later attempt succeeds', () => {
+      const { newUrl, urls, urlFormError, handleUrlAdd } = setup()
+
+      newUrl.value = 'not a url'
+      handleUrlAdd()
+      expect(urlFormError.value).toBe('Please enter a valid URL')
+
+      newUrl.value = 'docs.company.com'
+      handleUrlAdd()
+
+      expect(urlFormError.value).toBeNull()
+      expect(urls.value).toEqual(['https://docs.company.com'])
+    })
+
+    it('does not stage the same URL twice', () => {
+      const { newUrl, urls, urlFormError, handleUrlAdd } = setup()
+
+      newUrl.value = 'docs.company.com'
+      handleUrlAdd()
+      newUrl.value = 'https://docs.company.com'
+      handleUrlAdd()
+
+      expect(urls.value).toEqual(['https://docs.company.com'])
+      expect(urlFormError.value).toBe('This URL has already been added to the current batch')
+    })
+  })
+})

--- a/frontend/src/components/aiagent/onboarding/steps/StepTeach.vue
+++ b/frontend/src/components/aiagent/onboarding/steps/StepTeach.vue
@@ -55,7 +55,7 @@ const advancing = ref(false)
 // The site they gave us at signup is almost always what they want indexed
 // first. Stage it as a source rather than dropping it in the input: sitting in
 // the box it looks like a placeholder, and nothing says you must press
-// "+ Website" for it to count. In the list it reads as added, with an × to
+// "Add" for it to count. In the list it reads as added, with an × to
 // drop it.
 const prefillFromOrgDomain = async () => {
   try {
@@ -83,7 +83,7 @@ onMounted(async () => {
 // background — we don't block the wizard on it.
 const handleContinue = async () => {
   // A URL sitting in the box (the prefill, or one they typed without pressing
-  // "+ Website") reads as accepted. Stage it rather than silently dropping it.
+  // "Add") reads as accepted. Stage it rather than silently dropping it.
   if (newUrl.value.trim()) {
     handleUrlAdd()
     if (urlFormError.value) return
@@ -120,8 +120,11 @@ const removeFile = (index: number) => {
         :disabled="isUploading"
         @keydown.enter.prevent="handleUrlAdd"
       />
-      <button type="button" class="btn-soft" :disabled="isUploading" @click="handleUrlAdd">+ Website</button>
-      <button type="button" class="btn-soft" :disabled="isUploading" @click="triggerFileInput">+ PDF</button>
+      <!-- "Add" acts on the URL beside it, so the object is implicit. The PDF
+           button opens a file picker, a different action — it keeps its own
+           label rather than reading as a second way to add the same thing. -->
+      <button type="button" class="btn-soft" :disabled="isUploading" @click="handleUrlAdd">Add</button>
+      <button type="button" class="btn-soft" :disabled="isUploading" @click="triggerFileInput">Upload PDF</button>
       <input
         ref="fileInput"
         type="file"

--- a/frontend/src/components/aiagent/onboarding/steps/StepTeach.vue
+++ b/frontend/src/components/aiagent/onboarding/steps/StepTeach.vue
@@ -17,6 +17,7 @@ limitations under the License.
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { useKnowledgeManagement } from '@/composables/useKnowledgeManagement'
+import { organizationService } from '@/services/organization'
 
 const props = defineProps<{
   agentId: string
@@ -46,17 +47,40 @@ const {
   handleUrlUpload,
   handleFileUpload,
   fetchKnowledge,
+  withScheme,
 } = useKnowledgeManagement(props.agentId, props.organizationId)
 
 const advancing = ref(false)
 
+// The site they gave us at signup is almost always what they want indexed
+// first, so offer it rather than making them retype it. Only a suggestion —
+// it stays editable, and we never overwrite something already typed.
+const prefillFromOrgDomain = async () => {
+  try {
+    const org = await organizationService.getOrganization(props.organizationId)
+    if (org?.domain && !newUrl.value) {
+      newUrl.value = withScheme(org.domain)
+    }
+  } catch {
+    // A missing prefill is not worth blocking or alarming the user over.
+  }
+}
+
 onMounted(() => {
   fetchKnowledge()
+  prefillFromOrgDomain()
 })
 
 // Flush any staged URLs/files, then advance. Ingestion runs async in the
 // background — we don't block the wizard on it.
 const handleContinue = async () => {
+  // A URL sitting in the box (the prefill, or one they typed without pressing
+  // "+ Website") reads as accepted. Stage it rather than silently dropping it.
+  if (newUrl.value.trim()) {
+    handleUrlAdd()
+    if (urlFormError.value) return
+  }
+
   advancing.value = true
   try {
     if (urls.value.length) await handleUrlUpload()

--- a/frontend/src/components/aiagent/onboarding/steps/StepTeach.vue
+++ b/frontend/src/components/aiagent/onboarding/steps/StepTeach.vue
@@ -53,22 +53,30 @@ const {
 const advancing = ref(false)
 
 // The site they gave us at signup is almost always what they want indexed
-// first, so offer it rather than making them retype it. Only a suggestion —
-// it stays editable, and we never overwrite something already typed.
+// first. Stage it as a source rather than dropping it in the input: sitting in
+// the box it looks like a placeholder, and nothing says you must press
+// "+ Website" for it to count. In the list it reads as added, with an × to
+// drop it.
 const prefillFromOrgDomain = async () => {
   try {
     const org = await organizationService.getOrganization(props.organizationId)
-    if (org?.domain && !newUrl.value) {
-      newUrl.value = withScheme(org.domain)
-    }
+    if (!org?.domain || newUrl.value || urls.value.length) return
+
+    newUrl.value = withScheme(org.domain)
+    handleUrlAdd()
+    // handleUrlAdd flags an already-indexed URL. That is worth saying when a
+    // person typed it, but not for a suggestion they never asked for — it just
+    // ends up not staged.
+    urlFormError.value = null
   } catch {
     // A missing prefill is not worth blocking or alarming the user over.
   }
 }
 
-onMounted(() => {
-  fetchKnowledge()
-  prefillFromOrgDomain()
+onMounted(async () => {
+  // Prefill after the fetch so the dedupe check can see what is already indexed.
+  await fetchKnowledge()
+  await prefillFromOrgDomain()
 })
 
 // Flush any staged URLs/files, then advance. Ingestion runs async in the

--- a/frontend/src/composables/useKnowledgeManagement.ts
+++ b/frontend/src/composables/useKnowledgeManagement.ts
@@ -88,13 +88,14 @@ export function useKnowledgeManagement(agentId: string, organizationId: string) 
         fetchQueueItems(),
       ])
 
-      // Update agent knowledge
-      knowledgeItems.value = agentResponse.knowledge
-      totalPages.value = agentResponse.pagination.total_pages
+      // Default to empty: a partial response used to leave these undefined,
+      // and every later .some()/.length on them threw.
+      knowledgeItems.value = agentResponse?.knowledge || []
+      totalPages.value = agentResponse?.pagination?.total_pages || 0
 
       // Update org knowledge
-      orgKnowledgeItems.value = orgResponse.knowledge
-      orgTotalPages.value = orgResponse.pagination.total_pages
+      orgKnowledgeItems.value = orgResponse?.knowledge || []
+      orgTotalPages.value = orgResponse?.pagination?.total_pages || 0
     } catch (err) {
       error.value = 'Failed to load knowledge sources'
       console.error(err)
@@ -160,11 +161,24 @@ export function useKnowledgeManagement(agentId: string, organizationId: string) 
     )
   }
 
+  // People type "docs.company.com", not "https://docs.company.com". Without a
+  // scheme new URL() throws and they get "Please enter a valid URL" for an
+  // address that is perfectly fine, so default the scheme before validating.
+  const withScheme = (url: string): string => {
+    const trimmed = url.trim()
+    if (!trimmed) return trimmed
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return trimmed
+    // Leading slashes would produce https:////host — drop them first.
+    return `https://${trimmed.replace(/^\/+/, '')}`
+  }
+
   // URL validation
   const isValidUrl = (url: string): boolean => {
     try {
-      new URL(url)
-      return true
+      const parsed = new URL(url)
+      // new URL() accepts things like "mailto:x" and "foo:bar"; a crawlable
+      // source has to be http(s) with an actual host.
+      return /^https?:$/.test(parsed.protocol) && parsed.hostname.includes('.')
     } catch {
       return false
     }
@@ -216,8 +230,12 @@ export function useKnowledgeManagement(agentId: string, organizationId: string) 
   const handleUrlAdd = () => {
     if (!newUrl.value) return
 
-    // Clean the URL
-    const cleanUrl = newUrl.value.trim()
+    // Start clean so the outcome of this attempt is the only thing on screen,
+    // and so callers can read urlFormError to tell whether it succeeded.
+    urlFormError.value = null
+
+    // Clean the URL, defaulting the scheme when the user left it off
+    const cleanUrl = withScheme(newUrl.value)
 
     // Basic URL validation
     if (!isValidUrl(cleanUrl)) {
@@ -446,6 +464,7 @@ export function useKnowledgeManagement(agentId: string, organizationId: string) 
 
     getFirstCreated,
     isValidUrl,
+    withScheme,
     triggerFileInput,
     handleFileSelect,
     handleFileUpload,

--- a/frontend/src/composables/useKnowledgeManagement.ts
+++ b/frontend/src/composables/useKnowledgeManagement.ts
@@ -177,8 +177,9 @@ export function useKnowledgeManagement(agentId: string, organizationId: string) 
     try {
       const parsed = new URL(url)
       // new URL() accepts things like "mailto:x" and "foo:bar"; a crawlable
-      // source has to be http(s) with an actual host.
-      return /^https?:$/.test(parsed.protocol) && parsed.hostname.includes('.')
+      // source has to be http(s). Deliberately not requiring a dot in the host:
+      // self-hosted installs index intranet names like https://wiki.
+      return /^https?:$/.test(parsed.protocol) && !!parsed.hostname
     } catch {
       return false
     }


### PR DESCRIPTION
The site given at signup is almost always the first thing to index, so the teach step now offers it instead of asking again. It's staged as a source (visible in the list with an × to remove) rather than parked in the input, where it read as a placeholder you still had to press a button to accept. Already-indexed domains are skipped quietly.

URLs no longer need a scheme — people type `docs.company.com`, which `new URL()` rejected, so they got "Please enter a valid URL" for a good address. https is defaulted before validating, everywhere knowledge URLs are added. Validation in exchange requires http(s), so `mailto:x` no longer passes; intranet names like `https://wiki` still do.

Also: a URL left in the box is staged on Continue instead of dropped, and the knowledge lists default to empty — a partial fetch left them undefined and the next add threw.

`+ Website` / `+ PDF` are now `Add` / `Upload PDF`.