### PR TITLE
Label Shopify chats in the inbox, fix dark-mode product cards

### DIFF
--- a/backend/app/agents/chat_agent.py
+++ b/backend/app/agents/chat_agent.py
@@ -18,6 +18,7 @@ import traceback
 from agno.agent import Agent
 from app.utils.agno_utils import create_model
 from app.core.logger import get_logger
+from app.channels.constants import is_widget_channel
 from app.tools.knowledge_search_byagent import KnowledgeSearchByAgent
 from app.tools.mcp_manager import ChatAgentMCPMixin
 from app.database import get_db, SessionLocal, engine
@@ -868,9 +869,10 @@ Keep your responses concise and focused. Provide clear, actionable information i
         session_repo = SessionToAgentRepository(db)
         
         # Determine if rating should be requested
-        if self.channel != 'web':
-            # Rating is a web-widget-only feature: external channels have no
+        if not is_widget_channel(self.channel):
+            # Rating is a widget-only feature: external channels have no
             # rating UI, so asking there leaves the customer a dead-end prompt.
+            # Shopify counts as the widget — see WIDGET_CHANNELS.
             should_request_rating = False
         elif force_rating is not None:
             # Use the forced setting from workflow configuration

--- a/backend/app/api/widget_chat.py
+++ b/backend/app/api/widget_chat.py
@@ -29,6 +29,7 @@ from app.core.auth_utils import authenticate_socket, authenticate_socket_convers
 from app.database import get_db
 from app.repositories.ai_config import AIConfigRepository
 from app.repositories.widget import WidgetRepository
+from app.repositories.agent_shopify_config_repository import AgentShopifyConfigRepository
 from app.core.security import decrypt_api_key
 from app.repositories.session_to_agent import SessionToAgentRepository
 from app.repositories.chat import ChatRepository
@@ -202,13 +203,20 @@ async def widget_connect(sid, environ, auth):
             session_id = str(active_session.session_id)
             logger.debug(f"Active session: {session_id}")  
         else:
-            # Create new session if none exists
+            # Create new session if none exists. Stamp the channel now, the way
+            # the messaging channels do: an agent wired to a Shopify store is
+            # serving that storefront, and the inbox labels the conversation
+            # accordingly. Still a widget surface — see WIDGET_CHANNELS.
             new_session_id = str(uuid.uuid4())
+            shopify_config = AgentShopifyConfigRepository(db).get_agent_shopify_config(
+                str(widget.agent_id)
+            )
             session_repo.create_session(
                 session_id=new_session_id,
                 agent_id=widget.agent_id,
                 customer_id=customer_id,
-                organization_id=org_id
+                organization_id=org_id,
+                channel='shopify' if shopify_config and shopify_config.enabled else 'web'
             )
             session_id = new_session_id
             logger.debug(f"New session: {session_id}")

--- a/backend/app/channels/constants.py
+++ b/backend/app/channels/constants.py
@@ -21,6 +21,8 @@ default. (It buys no import weight: app/channels/__init__ loads the registry
 regardless. It is about where the value belongs, not what it drags in.)
 """
 
+from typing import Optional
+
 # The language assumed when a caller doesn't name one. Meta has no default —
 # name and language together identify a template, so `order_update` in five
 # languages is five templates — which makes this our choice, and one worth
@@ -30,3 +32,19 @@ regardless. It is about where the value belongs, not what it drags in.)
 # The frontend's DEFAULT_LANGUAGE (utils/whatsappLanguages.ts) is the
 # unavoidable second copy, on the other side of the wire. Keep the two equal.
 DEFAULT_TEMPLATE_LANGUAGE = "en_US"
+
+
+# Channels served by our own chat widget rather than an external messaging
+# platform. They render our UI, so widget-only features (the rating prompt) work
+# there; on Telegram or WhatsApp the same prompt is a dead end.
+#
+# 'shopify' is that widget embedded in a Shopify storefront — a distinct origin
+# worth reporting on, but the same chat surface. Every "is this the widget?"
+# test has to accept both, or Shopify conversations quietly lose widget
+# features the moment they stop being labelled 'web'.
+WIDGET_CHANNELS = frozenset({"web", "shopify"})
+
+
+def is_widget_channel(channel: Optional[str]) -> bool:
+    """True for our own widget surfaces. A missing channel means the widget."""
+    return not channel or channel in WIDGET_CHANNELS

--- a/backend/app/repositories/chat.py
+++ b/backend/app/repositories/chat.py
@@ -25,6 +25,7 @@ from app.models.agent import Agent
 from app.models.session_to_agent import SessionToAgent
 from app.repositories.channels import ChannelConversationRepository
 from app.core.logger import get_logger
+from app.channels.constants import is_widget_channel
 from app.models.user import User
 from app.repositories.customer import CustomerRepository
 from sqlalchemy.orm import joinedload
@@ -162,7 +163,7 @@ class ChatRepository:
         would multiply that query's groups. Only fires for channel sessions,
         and get_chat_detail fetches one session at a time.
         """
-        if not channel or channel == 'web':
+        if is_widget_channel(channel):
             return None
         conversation = ChannelConversationRepository(self.db).get_by_session(session_id)
         return str(conversation.channel_account_id) if conversation else None

--- a/backend/tests/core/test_widget_channels.py
+++ b/backend/tests/core/test_widget_channels.py
@@ -1,0 +1,43 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+
+from app.channels.constants import WIDGET_CHANNELS, is_widget_channel
+
+
+class TestIsWidgetChannel:
+    @pytest.mark.parametrize("channel", ["web", "shopify"])
+    def test_our_own_widget_surfaces(self, channel):
+        assert is_widget_channel(channel) is True
+
+    @pytest.mark.parametrize("channel", [None, ""])
+    def test_absent_channel_means_the_widget(self, channel):
+        """Sessions predating the column, and anything that omits it."""
+        assert is_widget_channel(channel) is True
+
+    @pytest.mark.parametrize(
+        "channel",
+        ["telegram", "whatsapp", "messenger", "instagram", "slack", "email", "sms", "line"],
+    )
+    def test_external_platforms_are_not_the_widget(self, channel):
+        assert is_widget_channel(channel) is False
+
+    def test_shopify_is_a_widget_channel(self):
+        """The whole point: labelling Shopify separately must not cost it the
+        widget features that 'web' gets — the rating prompt above all."""
+        assert "shopify" in WIDGET_CHANNELS
+        assert is_widget_channel("shopify") is True

--- a/frontend/src/components/common/ChannelBadge.vue
+++ b/frontend/src/components/common/ChannelBadge.vue
@@ -22,6 +22,7 @@ const props = defineProps<{
 }>()
 
 const CHANNEL_LABELS: Record<string, string> = {
+  shopify: 'Shopify',
   telegram: 'Telegram',
   whatsapp: 'WhatsApp',
   messenger: 'Messenger',

--- a/frontend/src/components/conversations/ConversationChat.vue
+++ b/frontend/src/components/conversations/ConversationChat.vue
@@ -1045,7 +1045,7 @@ watch(() => currentChat.value?.session_id, () => refreshLinkedTicket())
   margin: var(--space-xs) 0;
   width: 100%;
   padding: var(--space-xs);
-  background: rgba(0, 0, 0, 0.02);
+  background: var(--o03);
   border-radius: 20px;
 }
 
@@ -1064,7 +1064,7 @@ watch(() => currentChat.value?.session_id, () => refreshLinkedTicket())
   scroll-snap-type: x mandatory;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: thin;
-  scrollbar-color: rgba(0, 0, 0, 0.3) rgba(0, 0, 0, 0.1);
+  scrollbar-color: var(--o25) var(--o08);
 }
 
 .product-card-compact {
@@ -1120,7 +1120,7 @@ watch(() => currentChat.value?.session_id, () => refreshLinkedTicket())
   line-clamp: 2;
   -webkit-box-orient: vertical;
   min-height: 2.8em;
-  color: black;
+  color: var(--text);
 }
 
 .product-variant-compact {
@@ -1131,7 +1131,7 @@ watch(() => currentChat.value?.session_id, () => refreshLinkedTicket())
 .product-price-compact {
   font-size: var(--text-sm);
   font-weight: 600;
-  color: black;
+  color: var(--text);
 }
 
 .view-details-button-compact {

--- a/frontend/src/utils/endChat.ts
+++ b/frontend/src/utils/endChat.ts
@@ -15,13 +15,21 @@ limitations under the License.
 */
 
 /**
- * Rating is a web-widget-only feature. External channels (WhatsApp, Messenger,
+ * Channels served by our own widget rather than an external messaging platform.
+ * Mirrors WIDGET_CHANNELS in backend/app/channels/constants.py — keep the two
+ * in step. 'shopify' is the widget embedded in a storefront: a separate label
+ * in the inbox, the same chat surface.
+ */
+const WIDGET_CHANNELS = ['web', 'shopify']
+
+/**
+ * Rating is a widget-only feature. External channels (WhatsApp, Messenger,
  * Instagram, Telegram, ...) render plain text and have no rating UI, so asking
  * there leaves the customer a question they cannot answer. The backend applies
  * the same rule to AI-ended chats.
  */
 export const canRequestRating = (channel?: string | null): boolean =>
-  !channel || channel === 'web'
+  !channel || WIDGET_CHANNELS.includes(channel)
 
 /** Closing message shown to the customer when an agent ends the chat. */
 export const endChatMessage = (channel?: string | null): string =>


### PR DESCRIPTION
Two inbox fixes.

**Dark mode.** The product card title and price were hardcoded `color: black` — 1.15:1 contrast on the dark card, effectively invisible. Now `--text`: 16.9:1 in dark, light unchanged. The carousel background and scrollbar were fixed black-alpha too.

**Shopify label.** Widget sessions stamp `channel='shopify'` when the agent is wired to a Shopify store, the same way the messaging channels stamp their type at session creation. The existing ChannelBadge then labels it like WhatsApp — no new column, no migration.

Two places read the channel as "web, or an external platform", which would have quietly cost Shopify chats their widget features: the rating gate in `chat_agent` (Shopify would stop asking for CSAT) and `_channel_account_id`. Both now ask `is_widget_channel()`, with web and shopify as the widget. `canRequestRating` on the frontend mirrors it.

Existing Shopify conversations stay `web` — the stamp only applies to new sessions. An agent serving both a storefront and a plain website widget labels both as Shopify.

The dark-mode half has a twin in enterprise_frontend (InboxTab).