### PR TITLE
Relabel reused widget sessions so Shopify chats get their badge

### DIFF
--- a/backend/app/api/widget_chat.py
+++ b/backend/app/api/widget_chat.py
@@ -30,6 +30,7 @@ from app.database import get_db
 from app.repositories.ai_config import AIConfigRepository
 from app.repositories.widget import WidgetRepository
 from app.repositories.agent_shopify_config_repository import AgentShopifyConfigRepository
+from app.channels.constants import is_widget_channel
 from app.core.security import decrypt_api_key
 from app.repositories.session_to_agent import SessionToAgentRepository
 from app.repositories.chat import ChatRepository
@@ -155,6 +156,27 @@ def validate_form_data(form_fields: list, form_data: dict) -> list:
     
     return errors
 
+def widget_channel(db, agent_id) -> str:
+    """Which widget surface this agent serves: a connected Shopify store, or the
+    plain website widget."""
+    config = AgentShopifyConfigRepository(db).get_agent_shopify_config(str(agent_id))
+    return 'shopify' if config and config.enabled else 'web'
+
+
+def restamp_widget_channel(session, desired: str) -> bool:
+    """Relabel a reused session, returning whether anything changed.
+
+    Only ever moves between widget surfaces: a session belonging to Telegram or
+    WhatsApp must never be relabelled by the widget's connect handler, and
+    `channel` is the outbound routing key, so clobbering it would misroute
+    replies.
+    """
+    if session.channel == desired or not is_widget_channel(session.channel):
+        return False
+    session.channel = desired
+    return True
+
+
 @sio.on('connect', namespace='/widget')
 async def widget_connect(sid, environ, auth):
     db = None
@@ -201,6 +223,11 @@ async def widget_connect(sid, environ, auth):
               
         if active_session:
             session_id = str(active_session.session_id)
+            # Widget sessions are long-lived and reused across visits, so a
+            # conversation that began before the store was connected would keep
+            # its old label forever. Re-stamp on reconnect instead.
+            if restamp_widget_channel(active_session, widget_channel(db, widget.agent_id)):
+                db.commit()
             logger.debug(f"Active session: {session_id}")  
         else:
             # Create new session if none exists. Stamp the channel now, the way
@@ -208,15 +235,12 @@ async def widget_connect(sid, environ, auth):
             # serving that storefront, and the inbox labels the conversation
             # accordingly. Still a widget surface — see WIDGET_CHANNELS.
             new_session_id = str(uuid.uuid4())
-            shopify_config = AgentShopifyConfigRepository(db).get_agent_shopify_config(
-                str(widget.agent_id)
-            )
             session_repo.create_session(
                 session_id=new_session_id,
                 agent_id=widget.agent_id,
                 customer_id=customer_id,
                 organization_id=org_id,
-                channel='shopify' if shopify_config and shopify_config.enabled else 'web'
+                channel=widget_channel(db, widget.agent_id)
             )
             session_id = new_session_id
             logger.debug(f"New session: {session_id}")

--- a/backend/tests/api/test_widget_channel_stamp.py
+++ b/backend/tests/api/test_widget_channel_stamp.py
@@ -1,0 +1,53 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.widget_chat import restamp_widget_channel
+
+
+def session(channel):
+    return SimpleNamespace(channel=channel)
+
+
+class TestRestampWidgetChannel:
+    def test_relabels_a_session_that_predates_the_store_connection(self):
+        """The reported bug: widget sessions are reused across visits, so a
+        conversation opened before the store was connected kept 'web' forever."""
+        s = session("web")
+        assert restamp_widget_channel(s, "shopify") is True
+        assert s.channel == "shopify"
+
+    def test_relabels_back_when_the_store_is_disconnected(self):
+        s = session("shopify")
+        assert restamp_widget_channel(s, "web") is True
+        assert s.channel == "web"
+
+    @pytest.mark.parametrize("channel", ["web", "shopify"])
+    def test_no_write_when_already_correct(self, channel):
+        s = session(channel)
+        assert restamp_widget_channel(s, channel) is False
+        assert s.channel == channel
+
+    @pytest.mark.parametrize("channel", ["whatsapp", "telegram", "messenger", "email"])
+    def test_never_touches_an_external_channel(self, channel):
+        """`channel` is the outbound routing key. Relabelling a WhatsApp session
+        from the widget's connect handler would misroute its replies."""
+        s = session(channel)
+        assert restamp_widget_channel(s, "shopify") is False
+        assert s.channel == channel


### PR DESCRIPTION
Follow-up to #229. The channel was only stamped when a session was created, but widget sessions are long-lived and reused across visits — so a Shopify conversation that started before the store was connected (or before #229 shipped) kept `web` and never showed the badge, no matter how often the customer came back. Confirmed in prod: the session serving a live Shopify chat was created hours before the deploy and simply reused.

The connect handler now re-stamps on reconnect, so existing conversations correct themselves on the customer's next message — no backfill needed.

It only ever moves between widget surfaces. `channel` is the outbound routing key, so relabelling a WhatsApp or Telegram session from the widget's connect handler would misroute its replies.