### PR TITLE
fix(tickets): email widget ticket replies + stop re-asking authenticated customers

### DIFF
--- a/backend/app/agents/chat_agent.py
+++ b/backend/app/agents/chat_agent.py
@@ -325,6 +325,24 @@ class ChatAgent(ChatAgentMCPMixin):
             # Load lead-capture config (prompt-driven, like transfer_to_human: a toggle;
             # the agent collects details conversationally and reports structured output).
             # Extract plain values while the session is open so they survive the block.
+            # Known identity of an already-identified customer (authenticated
+            # generate-token visitor, or one whose email/name we captured
+            # earlier). Injected into the ticket instructions so the agent
+            # doesn't ask an identified customer to repeat their email/name.
+            self.known_customer_email = None
+            self.known_customer_name = None
+            if customer_id:
+                try:
+                    from app.repositories.customer import CustomerRepository
+                    cust = CustomerRepository(db).get_by_id(customer_id)
+                    if cust:
+                        if not CustomerRepository.is_placeholder_email(cust.email):
+                            self.known_customer_email = cust.email
+                        if (cust.full_name or "").strip():
+                            self.known_customer_name = cust.full_name.strip()
+                except Exception as e:
+                    logger.error(f"Failed to load customer identity: {e}")
+
             self.lead_capture_enabled = False
             self.lead_capture_fields = []
             self.lead_capture_require_consent = True
@@ -590,7 +608,32 @@ Keep your responses concise and focused. Provide clear, actionable information i
             # Add native ticketing instructions when AI ticketing drives the
             # ticket tools (explicit agent Jira config takes precedence below)
             if self.ticketing_enabled and not self.transfer_to_human and not (self.agent_data and self.agent_data.jira_enabled):
-                ticket_instructions = """
+                # For an already-identified customer, hand the agent their known
+                # email/name so it passes them straight to create_ticket instead
+                # of asking the customer to repeat details we already have.
+                if self.known_customer_email or self.known_customer_name:
+                    known_bits = []
+                    if self.known_customer_name:
+                        known_bits.append(f'name "{self.known_customer_name}"')
+                    if self.known_customer_email:
+                        known_bits.append(f'account email "{self.known_customer_email}"')
+                    identity_instruction = (
+                        "This customer is already identified — " + ", ".join(known_bits) + ". "
+                        "Pass these directly as customer_name and customer_email when calling "
+                        "create_ticket. Do NOT ask the customer to provide or confirm their "
+                        "email or name again."
+                    )
+                else:
+                    identity_instruction = (
+                        "BEFORE creating a ticket, collect the customer's identity so the support "
+                        "AI can look them up in the connected systems: their account email, and "
+                        "their registered name. If they've already given the email or name in this "
+                        "conversation, use those values. If not, ask for them in one short message "
+                        "and wait for the reply before calling create_ticket. Then pass them as "
+                        "customer_email and customer_name. Never invent an email or name; if the "
+                        "customer declines, create the ticket without them."
+                    )
+                ticket_instructions = f"""
                 You have access to native support-ticket tools:
                 1. check_existing_ticket — check if this conversation already has a ticket (always call this first)
                 2. create_ticket — open a support ticket that the team's AI investigator and humans will work on
@@ -602,15 +645,7 @@ Keep your responses concise and focused. Provide clear, actionable information i
                 - You've tried to resolve the issue but were unable to do so
                 - No ticket already exists for this conversation
 
-                BEFORE creating a ticket, collect the customer's identity so the support
-                AI can look them up in the connected systems:
-                - their account email, and
-                - their registered name.
-                If they've already given the email or name in this conversation, use those
-                values. If not, ask for them in one short message and wait for the reply
-                before calling create_ticket. Then pass them as customer_email and
-                customer_name. Never invent an email or name; if the customer declines,
-                create the ticket without them.
+                {identity_instruction}
 
                 After creating a ticket, tell the customer their ticket number and that the team is investigating.
                 Priorities are: urgent, high, medium, low.

--- a/backend/app/services/ticket.py
+++ b/backend/app/services/ticket.py
@@ -55,6 +55,10 @@ from app.repositories.ticket import (
 
 logger = get_logger(__name__)
 
+# Widget sessions carry this channel; their replies reach the browser tab over
+# Socket.IO only, so ticket updates to them are also emailed (see below).
+WEB_CHANNEL = "web"
+
 # Open tickets whose title+description embed this close to an existing open
 # ticket are flagged as possible duplicates.
 DUPLICATE_SIMILARITY_THRESHOLD = 0.90
@@ -770,6 +774,7 @@ class TicketService:
         if session_record is None:
             await self._send_direct_email(ticket, message, record_activity)
             return
+        channel = getattr(session_record, "channel", None) or WEB_CHANNEL
         try:
             from app.services.message_delivery import deliver_to_customer
             from app.repositories.chat import ChatRepository
@@ -789,39 +794,42 @@ class TicketService:
             })
             if ticket.first_response_at is None:
                 ticket.first_response_at = datetime.now(timezone.utc)
-            if not record_activity:
-                return
-            self._add_activity(
-                ticket, TicketActivityType.CUSTOMER_NOTIFIED,
-                actor_type=TicketActorType.SYSTEM,
-                body=message,
-                metadata={
-                    "session_id": str(session_record.session_id),
-                    "channel": getattr(session_record, "channel", "web"),
-                },
-            )
+            if record_activity:
+                self._add_activity(
+                    ticket, TicketActivityType.CUSTOMER_NOTIFIED,
+                    actor_type=TicketActorType.SYSTEM,
+                    body=message,
+                    metadata={
+                        "session_id": str(session_record.session_id),
+                        "channel": channel,
+                    },
+                )
         except Exception as e:
             logger.error(f"Customer notification failed for {ticket.display_number}: {e}")
+
+        # Widget (web) sessions are delivered over Socket.IO to the browser tab
+        # only, but a ticket reply almost always arrives after the visitor has
+        # closed the chat — so it reaches nobody. When we have a real inbox for
+        # them, also email the reply through the org's connected email channel
+        # (their own domain) so async ticket updates actually land. External
+        # channels (WhatsApp/Telegram/email) already deliver asynchronously via
+        # their own adapter, so this supplement is web-only.
+        if channel == WEB_CHANNEL:
+            to_email = self._deliverable_email(ticket)
+            if to_email:
+                await self._email_customer_copy(ticket, message, to_email)
 
     async def _send_direct_email(
         self, ticket: Ticket, message: str, record_activity: bool
     ) -> None:
         """Email fallback for tickets with no linked conversation."""
-        to_email = ticket.customer.email if ticket.customer else None
+        to_email = self._deliverable_email(ticket)
         if not to_email:
             logger.info(
-                f"Ticket {ticket.display_number}: no linked session or customer email to notify"
+                f"Ticket {ticket.display_number}: no linked session or mailable customer email to notify"
             )
             return
-        from app.services.ticket_email import send_ticket_email
-        sent = await send_ticket_email(
-            self.db,
-            ticket.organization_id,
-            to_email,
-            subject=f"[{ticket.display_number}] {ticket.title}",
-            body=message,
-        )
-        if not sent:
+        if not await self._email_customer_copy(ticket, message, to_email):
             return
         if ticket.first_response_at is None:
             ticket.first_response_at = datetime.now(timezone.utc)
@@ -832,6 +840,33 @@ class TicketService:
             actor_type=TicketActorType.SYSTEM,
             body=message,
             metadata={"channel": "email", "to": to_email},
+        )
+
+    def _deliverable_email(self, ticket: Ticket) -> Optional[str]:
+        """The customer's real, mailable address, or None for anonymous /
+        placeholder records: …@noemail.com widget visitors, …@<channel>.channel
+        identity keys, and generate-token …@<org>.local anonymous stand-ins —
+        none of which can receive mail."""
+        from app.repositories.customer import CustomerRepository
+        email = ticket.customer.email if ticket.customer else None
+        if not email or CustomerRepository.is_placeholder_email(email) or email.endswith(".local"):
+            return None
+        return email
+
+    async def _email_customer_copy(self, ticket: Ticket, message: str, to_email: str) -> bool:
+        """Email a ticket reply to a customer through the org's email channel.
+        The single send point for both the widget (web) supplement and the
+        no-session fallback. Returns whether the mail was sent.
+
+        Best-effort — send_ticket_email swallows SMTP errors and returns False,
+        so a mail hiccup never fails the surrounding ticket mutation."""
+        from app.services.ticket_email import send_ticket_email
+        return await send_ticket_email(
+            self.db,
+            ticket.organization_id,
+            to_email,
+            subject=f"[{ticket.display_number}] {ticket.title}",
+            body=message,
         )
 
     def _primary_session(self, ticket: Ticket) -> Optional[SessionToAgent]:

--- a/backend/tests/services/test_ticket_service.py
+++ b/backend/tests/services/test_ticket_service.py
@@ -251,6 +251,45 @@ class TestCustomerEmailPath:
         assert ticket.first_response_at is not None
 
     @pytest.mark.asyncio
+    async def test_web_session_reply_is_also_emailed(
+        self, service, db, test_organization, test_session
+    ):
+        """A widget (web) reply is emitted over the socket to the browser tab
+        only; when the customer has a real inbox it must also be emailed so a
+        ticket update reaches them after they've closed the chat."""
+        ticket = make_ticket(
+            service, db, test_organization, session_id=test_session.session_id
+        )
+        with patch(
+            "app.services.message_delivery.deliver_to_customer"
+        ) as deliver, patch(
+            "app.services.ticket_email.send_ticket_email", return_value=True
+        ) as send:
+            await service.send_customer_message(ticket, "Update on your ticket")
+        deliver.assert_awaited_once()
+        send.assert_awaited_once()
+        assert send.await_args.args[2] == test_session.customer.email
+
+    @pytest.mark.asyncio
+    async def test_web_session_reply_not_emailed_for_placeholder(
+        self, service, db, test_organization, test_session, test_customer
+    ):
+        """Anonymous widget visitors (…@noemail.com) have no real inbox — the
+        socket emit is the only delivery, no email is attempted."""
+        test_customer.email = "visitor@noemail.com"
+        db.commit()
+        ticket = make_ticket(
+            service, db, test_organization, session_id=test_session.session_id
+        )
+        with patch(
+            "app.services.message_delivery.deliver_to_customer"
+        ), patch(
+            "app.services.ticket_email.send_ticket_email", return_value=True
+        ) as send:
+            await service.send_customer_message(ticket, "Update on your ticket")
+        send.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_no_contact_is_a_silent_noop(self, service, db, test_organization):
         ticket = make_ticket(service, db, test_organization)
         with patch(


### PR DESCRIPTION
Two ticketing bugs hit on prod (CoachIQ, Gmail SMTP configured).

**1. Ticket replies never reach widget customers by email.** A ticket linked to a widget (`web`) session was delivered only over the Socket.IO widget room, so any reply sent after the visitor closed the chat reached no one — even with a connected email channel and a real customer inbox. Web-session replies are now also emailed through the org's email channel when the customer has a mailable address. The no-session fallback and the new supplement share one send path, and both now skip non-mailable placeholder addresses (`…@noemail.com`, `.channel`, anonymous `…@<org>.local`).

**2. Authenticated flow re-asks for email + name.** The chat agent never got the already-known customer identity, so it asked authenticated (generate-token) visitors to repeat details already on their record. It now loads the known email/name and, when the customer is identified, passes them straight to `create_ticket` instead of asking.

Behavior note: every web-session ticket reply now also emails the customer (if live in the widget they get both the socket message and the email) — the intended reliable path for async ticket updates.

No migration, no new deps. Added tests for the web-session email supplement and the placeholder skip.