### PR TITLE
fix(tickets): stop duplicate resolution message on repeat resolve

### DIFF
--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -134,9 +134,13 @@ def _activity_out(activity) -> TicketActivityOut:
     return out
 
 
-def _get_ticket_or_404(db: Session, ticket_id: UUID, user: User) -> Ticket:
+def _get_ticket_or_404(
+    db: Session, ticket_id: UUID, user: User, for_update: bool = False
+) -> Ticket:
     from app.repositories.ticket import TicketRepository
-    ticket = TicketRepository(db).get_by_id(ticket_id, user.organization_id)
+    ticket = TicketRepository(db).get_by_id(
+        ticket_id, user.organization_id, for_update=for_update
+    )
     if ticket is None:
         raise HTTPException(status_code=404, detail="Ticket not found")
     return ticket
@@ -454,7 +458,10 @@ async def resolve_ticket(
 ):
     check_ticketing_access(db, current_user.organization_id)
     service = _service(db)
-    ticket = _get_ticket_or_404(db, ticket_id, current_user)
+    # Lock the row so a double-submitted resolve serializes: the second request
+    # blocks until the first commits, then sees RESOLVED_PENDING_CONFIRMATION
+    # and skips re-notifying the customer.
+    ticket = _get_ticket_or_404(db, ticket_id, current_user, for_update=True)
     try:
         await service.resolve(
             ticket,

--- a/backend/app/repositories/ticket.py
+++ b/backend/app/repositories/ticket.py
@@ -87,10 +87,20 @@ class TicketRepository:
         self.db.flush()
         return ticket
 
-    def get_by_id(self, ticket_id: UUID, organization_id: Optional[UUID] = None) -> Optional[Ticket]:
+    def get_by_id(
+        self,
+        ticket_id: UUID,
+        organization_id: Optional[UUID] = None,
+        for_update: bool = False,
+    ) -> Optional[Ticket]:
         query = self.db.query(Ticket).filter(Ticket.id == ticket_id)
         if organization_id is not None:
             query = query.filter(Ticket.organization_id == organization_id)
+        if for_update:
+            # Serialize concurrent mutations of the same ticket (e.g. a
+            # double-submitted resolve) so each request observes the prior
+            # one's committed status. No-op on sqlite (tests).
+            query = query.with_for_update()
         return query.first()
 
     def get_by_number(self, organization_id: UUID, ticket_number: int) -> Optional[Ticket]:

--- a/backend/app/services/ticket.py
+++ b/backend/app/services/ticket.py
@@ -375,6 +375,15 @@ class TicketService:
         """Resolve pending customer confirmation. Notifies the customer with
         the plain-language message; the lifecycle worker closes it after the
         confirmation timeout."""
+        # A repeat resolve (double-clicked button, client retry) must not
+        # re-send the resolution message. transition_status already no-ops when
+        # the status is unchanged, so key the notification off a real
+        # transition: only notify when the ticket wasn't already awaiting
+        # confirmation. Pair with a row lock in the endpoint so concurrent
+        # resolves serialize and the later ones observe the resolved status.
+        already_pending = (
+            TicketStatus(ticket.status) == TicketStatus.RESOLVED_PENDING_CONFIRMATION
+        )
         ticket.resolution_outcome = outcome
         if resolution_summary:
             ticket.resolution_summary = resolution_summary
@@ -387,7 +396,8 @@ class TicketService:
             actor_type=actor_type,
             actor_user_id=actor_user_id,
         )
-        await self.notify_customer_resolved(ticket)
+        if not already_pending:
+            await self.notify_customer_resolved(ticket)
         return ticket
 
     async def close(

--- a/backend/tests/services/test_ticket_service.py
+++ b/backend/tests/services/test_ticket_service.py
@@ -311,6 +311,23 @@ class TestCustomerEmailPath:
         assert TicketActivityType.CUSTOMER_NOTIFIED.value not in types
         assert ticket.first_response_at is None
 
+    @pytest.mark.asyncio
+    async def test_repeat_resolve_notifies_customer_once(
+        self, service, db, test_organization, test_session
+    ):
+        """A double-submitted resolve must send the customer exactly one
+        resolution message — the second call is a no-op transition and must not
+        re-notify."""
+        ticket = make_ticket(
+            service, db, test_organization, session_id=test_session.session_id
+        )
+        with patch.object(
+            service, "notify_customer_resolved"
+        ) as notify:
+            await service.resolve(ticket, outcome="fixed", customer_message="All set")
+            await service.resolve(ticket, outcome="fixed", customer_message="All set")
+        notify.assert_awaited_once()
+
 
 class TestStatusMachine:
     def test_legal_transition(self, service, db, test_organization):

--- a/frontend/src/views/TicketDetailView.vue
+++ b/frontend/src/views/TicketDetailView.vue
@@ -106,13 +106,22 @@ function copyLink() {
     .catch(() => {})
 }
 
+const isResolving = ref(false)
 async function submitResolve() {
-  await resolve({
-    outcome: resolveOutcome.value,
-    customer_message: resolveCustomerMessage.value.trim() || undefined,
-  })
-  showResolvePanel.value = false
-  resolveCustomerMessage.value = ''
+  // Guard against a double-clicked resolve firing multiple /resolve calls,
+  // which would send the customer the resolution message more than once.
+  if (isResolving.value) return
+  isResolving.value = true
+  try {
+    await resolve({
+      outcome: resolveOutcome.value,
+      customer_message: resolveCustomerMessage.value.trim() || undefined,
+    })
+    showResolvePanel.value = false
+    resolveCustomerMessage.value = ''
+  } finally {
+    isResolving.value = false
+  }
 }
 </script>
 
@@ -260,8 +269,8 @@ async function submitResolve() {
           </template>
           <div class="resolve-actions">
             <button class="action-btn" @click="showResolvePanel = false">Cancel</button>
-            <button class="resolve-submit" @click="submitResolve">
-              {{ canNotifyCustomer ? 'Resolve & notify customer' : 'Resolve' }}
+            <button class="resolve-submit" :disabled="isResolving" @click="submitResolve">
+              {{ isResolving ? 'Resolving…' : (canNotifyCustomer ? 'Resolve & notify customer' : 'Resolve') }}
             </button>
           </div>
           <div class="resolve-hint">
@@ -564,6 +573,10 @@ async function submitResolve() {
   font-size: 13px;
   font-weight: var(--font-weight-bold);
   cursor: pointer;
+}
+.resolve-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 .resolve-hint {
   margin-top: 10px;


### PR DESCRIPTION
Resolving a ticket sent the customer the resolution message (email + chat) **once per resolve call**, so a double-clicked "Resolve & notify customer" delivered it two or three times (seen on TKT-2: three identical System messages, one status change).

**Root cause:** `transition_status` correctly no-ops when the status is already the target, but `resolve()` called `notify_customer_resolved` unconditionally — so a repeat resolve re-sent even though nothing transitioned. (That's why the activity feed showed one status change but three sends.)

**Fix (defence in depth):**
- **Service:** notify only on a real transition — skip when the ticket was already `resolved_pending_confirmation`.
- **Endpoint:** `SELECT … FOR UPDATE` the ticket in `/resolve` so two concurrent resolves serialize; the second sees the resolved status and skips the notify.
- **Frontend:** guard the resolve button with an `isResolving` flag + `:disabled`, matching the comment button's existing in-flight pattern.

No migration, no new deps. Added a test asserting a repeat resolve notifies the customer exactly once.