### PR TITLE
fix(slack): make the landing-page install link work

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -338,7 +338,9 @@ router.beforeEach(async (to, from, next) => {
     if (!isSetupComplete && to.path !== '/setup') {
       return next('/setup')
     } else if (requiresAuth) {
-      return next('/login')
+      // Preserve where they were headed (e.g. the Slack install landing link)
+      // so login can send them straight back instead of the default page.
+      return next({ path: '/login', query: { redirect: to.fullPath } })
     }
     // Public route; allow
     return next()

--- a/frontend/src/views/settings/IntegrationsSettings.vue
+++ b/frontend/src/views/settings/IntegrationsSettings.vue
@@ -530,6 +530,17 @@ onMounted(async () => {
     // Remove the query parameters to avoid showing the toast on refresh
     window.history.replaceState({}, document.title, window.location.pathname)
   }
+
+  // Landing-page install: arriving with ?connect=slack starts the OAuth flow
+  // immediately. The router guard has already ensured the user is signed in
+  // (redirecting through login if needed), so this same-domain redirect carries
+  // the session cookie the install endpoint requires.
+  if (route.query.connect === 'slack') {
+    window.history.replaceState({}, document.title, window.location.pathname)
+    if (accountsFor('slack').length === 0) {
+      connectSlack()
+    }
+  }
 })
 </script>
 


### PR DESCRIPTION
The public "Add to Slack" button pointed directly at the auth-guarded API endpoint `/api/v1/channels/slack/install`. Clicked cross-domain from the marketing site with no session, that endpoint can only return `{"detail":"Not authenticated"}` (JSON) — an API route can't redirect a browser to login. It worked from the dashboard only because that's a same-domain call carrying the `access_token` cookie.

Route install through the SPA instead:

- **Auth guard** now preserves the destination when redirecting to login (`?redirect=<to.fullPath>`), so signing in returns the user to where they were headed instead of the default page. Previously `next('/login')` dropped it.
- **Integrations page** treats `?connect=slack` as an install trigger: once the guard has ensured the user is signed in, it starts the OAuth redirect same-domain, where the cookie is present. Skips if Slack is already connected.

**Action:** point the landing-page button at `https://app.chattermate.chat/settings/integrations?connect=slack`.

Type-check passes; LoginView tests pass.