### PR TITLE
feat(slack): App Home welcome, Home tab, and Assistant sidebar

### DIFF
--- a/backend/app/api/webhooks/slack.py
+++ b/backend/app/api/webhooks/slack.py
@@ -25,6 +25,11 @@ from app.database import get_db
 from app.models.channels import ChannelType
 from app.repositories.channels import ChannelAccountRepository
 from app.services.channel_chat import process_channel_message
+from app.services.slack_events import (
+    deliver_home_welcome,
+    handle_assistant_thread_started,
+    publish_agent_home,
+)
 
 router = APIRouter()
 logger = get_logger(__name__)
@@ -32,6 +37,15 @@ logger = get_logger(__name__)
 # Workspace-level events that end our access: the app was removed, or its
 # tokens were revoked. Both mean the stored credentials are dead.
 LIFECYCLE_EVENT_TYPES = frozenset({"app_uninstalled", "tokens_revoked"})
+
+# App Home / Assistant surfaces — not messages, so parse_inbound drops them.
+# Handled off the envelope and dispatched to background tasks.
+APP_HOME_OPENED = "app_home_opened"
+ASSISTANT_THREAD_STARTED = "assistant_thread_started"
+ASSISTANT_CONTEXT_CHANGED = "assistant_thread_context_changed"
+APP_SURFACE_EVENT_TYPES = frozenset(
+    {APP_HOME_OPENED, ASSISTANT_THREAD_STARTED, ASSISTANT_CONTEXT_CHANGED}
+)
 
 
 def _revokes_bot_access(event: dict) -> bool:
@@ -75,6 +89,36 @@ def _handle_lifecycle_event(payload: dict, account_repo: ChannelAccountRepositor
         logger.error(f"Failed to remove Slack account for team {team_id}")
 
 
+def _dispatch_app_surface_event(event: dict, team_id: str,
+                                account_repo: ChannelAccountRepository,
+                                background_tasks: BackgroundTasks) -> None:
+    """Fan an App Home / Assistant event out to the right background handler.
+
+    The Home tab publishes agent cards; the Messages tab and the Assistant
+    sidebar both send a welcome — this is what lets the app keep the Messages
+    tab enabled under the Marketplace guidelines.
+    """
+    if not team_id:
+        return
+    account = account_repo.get_by_external_id(ChannelType.SLACK.value, team_id)
+    if account is None or not account.is_active:
+        logger.info(f"Slack app-surface event for inactive/unknown team {team_id}")
+        return
+
+    event_type = event.get("type")
+    if event_type == APP_HOME_OPENED:
+        user = event.get("user", "")
+        if event.get("tab", "messages") == "home":
+            background_tasks.add_task(publish_agent_home, account.id, user)
+        else:  # Messages tab (or unspecified) — welcome on first open.
+            background_tasks.add_task(deliver_home_welcome, account.id, user, event.get("channel", ""))
+    elif event_type == ASSISTANT_THREAD_STARTED:
+        thread = event.get("assistant_thread") or {}
+        background_tasks.add_task(handle_assistant_thread_started, account.id,
+                                  thread.get("channel_id", ""), thread.get("thread_ts", ""))
+    # assistant_thread_context_changed: nothing to do — prompts are set on start.
+
+
 @router.post("")
 async def slack_webhook(
     request: Request,
@@ -100,10 +144,18 @@ async def slack_webhook(
 
     account_repo = ChannelAccountRepository(db)
 
+    event = payload.get("event") or {}
+    event_type = event.get("type")
+
     # Lifecycle events carry no message, so parse_inbound drops them — resolve
     # the workspace off the envelope instead, before the message loop.
-    if (payload.get("event") or {}).get("type") in LIFECYCLE_EVENT_TYPES:
+    if event_type in LIFECYCLE_EVENT_TYPES:
         _handle_lifecycle_event(payload, account_repo)
+        return {"status": "ok"}
+
+    # App Home / Assistant surfaces (welcome, home cards) — also not messages.
+    if event_type in APP_SURFACE_EVENT_TYPES:
+        _dispatch_app_surface_event(event, payload.get("team_id", ""), account_repo, background_tasks)
         return {"status": "ok"}
 
     adapter = get_adapter(ChannelType.SLACK.value)

--- a/backend/app/channels/slack.py
+++ b/backend/app/channels/slack.py
@@ -40,6 +40,26 @@ MAX_SIGNATURE_AGE_SECONDS = 60 * 5
 # Slack recommends keeping messages well under the 40k hard limit
 MAX_MESSAGE_LENGTH = 12000
 
+# App Home / Assistant (Agents & AI Apps) copy — kept in one place so the tone
+# stays consistent across the Messages tab, the Home tab, and the sidebar.
+MAX_SUGGESTED_PROMPTS = 4  # Slack caps setSuggestedPrompts at 4
+ASSISTANT_READY_STATUS = "is getting ready…"
+WELCOME_WITH_AGENT = (
+    "Hi! I'm {agent}. 👋\n\n"
+    "Ask me anything and I'll help right away — I answer from your team's "
+    "knowledge and can bring in a human when you need one."
+)
+WELCOME_NO_AGENT = (
+    "Hi! I'm ChatterMate. 👋\n\n"
+    "No agent is connected to this workspace yet. Set one up in ChatterMate and "
+    "I'll start answering here."
+)
+SUGGESTED_PROMPTS_TITLE = "Try asking:"
+STARTER_PROMPTS = [
+    {"title": "What can you help with?", "message": "What can you help me with?"},
+    {"title": "Talk to a human", "message": "I'd like to talk to a human."},
+]
+
 _MENTION_RE = re.compile(r"<@[A-Z0-9]+>")
 
 _http_client: Optional[httpx.AsyncClient] = None
@@ -62,6 +82,80 @@ async def slack_api(method: str, access_token: str, payload: dict, form: bool = 
         **kwargs,
     )
     return response.json()
+
+
+# --- App Home / Assistant API wrappers (Agents & AI Apps) -------------------
+# All take JSON, so they go through slack_api directly. Status and prompts are
+# cosmetic — failures are logged, never raised, so a hiccup can't break the flow.
+
+async def set_assistant_status(token: str, channel_id: str, thread_ts: str, status: str) -> dict:
+    """Show a transient status line (e.g. 'is thinking…') in an assistant thread."""
+    data = await slack_api("assistant.threads.setStatus", token,
+                           {"channel_id": channel_id, "thread_ts": thread_ts, "status": status})
+    if not data.get("ok"):
+        logger.debug(f"Slack assistant.threads.setStatus: {data.get('error')}")
+    return data
+
+
+async def set_suggested_prompts(token: str, channel_id: str, thread_ts: str,
+                                prompts: List[dict], title: Optional[str] = None) -> dict:
+    """Offer starter prompts in an assistant thread. `prompts` is capped at 4."""
+    payload = {"channel_id": channel_id, "thread_ts": thread_ts,
+               "prompts": prompts[:MAX_SUGGESTED_PROMPTS]}
+    if title:
+        payload["title"] = title
+    data = await slack_api("assistant.threads.setSuggestedPrompts", token, payload)
+    if not data.get("ok"):
+        logger.debug(f"Slack assistant.threads.setSuggestedPrompts: {data.get('error')}")
+    return data
+
+
+async def publish_home_view(token: str, user_id: str, view: dict) -> dict:
+    """Publish the App Home (Home tab) view for one user."""
+    data = await slack_api("views.publish", token, {"user_id": user_id, "view": view})
+    if not data.get("ok"):
+        logger.error(f"Slack views.publish failed: {data.get('error')}")
+    return data
+
+
+# Home-tab presentation. Cards are pre-resolved by the caller (photo URLs signed)
+# so this stays a pure, testable Block Kit builder.
+HOME_INSTRUCTION_MAX = 250
+_STATUS_ONLINE = ":large_green_circle: Online"
+_STATUS_OFFLINE = ":white_circle: Offline"
+
+
+def build_home_view(agent_cards: List[dict]) -> dict:
+    """Assemble the App Home view from resolved agent cards.
+
+    Each card: {"name", "is_active", "instruction", "photo_url" | None}.
+    """
+    blocks: List[dict] = [{"type": "header", "text": {"type": "plain_text", "text": "ChatterMate"}}]
+
+    if not agent_cards:
+        blocks.append({"type": "section", "text": {"type": "mrkdwn",
+                       "text": "No agent is connected yet. Set one up in ChatterMate to start answering here."}})
+        return {"type": "home", "blocks": blocks}
+
+    blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "*Your AI agents*"}})
+    for card in agent_cards:
+        header: List[dict] = []
+        if card.get("photo_url"):
+            header.append({"type": "image", "image_url": card["photo_url"], "alt_text": card["name"]})
+        header.append({"type": "mrkdwn", "text": f"*{card['name']}*"})
+        blocks.append({"type": "context", "elements": header})
+
+        status = _STATUS_ONLINE if card.get("is_active") else _STATUS_OFFLINE
+        blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": status}]})
+
+        instruction = (card.get("instruction") or "").strip()
+        if instruction:
+            if len(instruction) > HOME_INSTRUCTION_MAX:
+                instruction = instruction[:HOME_INSTRUCTION_MAX - 1].rstrip() + "…"
+            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": instruction}})
+        blocks.append({"type": "divider"})
+
+    return {"type": "home", "blocks": blocks}
 
 
 # Placeholder "typing…" message ts per (account, conversation) — set by
@@ -137,6 +231,11 @@ class SlackAdapter(ChannelAdapter):
         if is_mention:
             thread_ts = event.get("thread_ts") or ts
             conversation_id = f"{channel}:{thread_ts}"
+        elif event.get("thread_ts"):
+            # Assistant-sidebar messages are DMs that carry the assistant thread's
+            # ts; key by thread so the reply posts back into that thread. Plain
+            # DMs have no thread_ts and stay one continuous conversation.
+            conversation_id = f"{channel}:{event['thread_ts']}"
         else:
             conversation_id = channel
 

--- a/backend/app/services/slack_events.py
+++ b/backend/app/services/slack_events.py
@@ -1,0 +1,164 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Slack App Home / Assistant lifecycle handlers.
+
+These run as FastAPI background tasks (the webhook acks within 3s and hands off
+here), so each opens its own DB session. They cover the non-message surfaces:
+the Messages-tab welcome, the Home tab view, and the Assistant sidebar — all of
+which the Slack Marketplace requires an app with the Messages tab enabled to use.
+"""
+
+from uuid import UUID
+
+from app.channels.slack import (
+    SUGGESTED_PROMPTS_TITLE,
+    STARTER_PROMPTS,
+    WELCOME_NO_AGENT,
+    WELCOME_WITH_AGENT,
+    ASSISTANT_READY_STATUS,
+    SlackAdapter,
+    build_home_view,
+    publish_home_view,
+    set_assistant_status,
+    set_suggested_prompts,
+    slack_api,
+)
+from app.core.config import settings
+from app.core.logger import get_logger
+from app.core.redis import get_redis
+from app.core.s3 import get_s3_signed_url
+from app.database import SessionLocal
+from app.repositories.agent import AgentRepository
+from app.repositories.channels import ChannelAccountRepository
+from app.repositories.channels.agent_config import AgentChannelConfigRepository
+
+logger = get_logger(__name__)
+
+# One welcome per user, forever — this flag is never meant to expire (a re-welcome
+# on a Redis flush is harmless). SETNX; TTL only as a backstop against orphans.
+_WELCOME_FLAG_TTL_SECONDS = 60 * 60 * 24 * 365
+
+
+def _assigned_agent(db, account):
+    """The single agent answering this Slack workspace, or None if unassigned."""
+    agent_id = AgentChannelConfigRepository(db).get_active_agent_id(account.id)
+    if not agent_id:
+        return None
+    return AgentRepository(db).get_agent(agent_id)
+
+
+def _welcome_text(agent) -> str:
+    if agent is None:
+        return WELCOME_NO_AGENT
+    return WELCOME_WITH_AGENT.format(agent=agent.display_name or agent.name)
+
+
+def _already_welcomed(account_id, user_id: str) -> bool:
+    """Claim the first-welcome slot for (account, user). True if already welcomed.
+
+    Without Redis we can't dedupe, so we welcome (once per process start is the
+    worst case) rather than stay silent — the review requires a welcome to be sent.
+    """
+    redis_client = get_redis()
+    if redis_client is None:
+        return False
+    try:
+        key = f"slack_home_welcomed:{account_id}:{user_id}"
+        claimed = redis_client.set(key, "1", nx=True, ex=_WELCOME_FLAG_TTL_SECONDS)
+        return not claimed
+    except Exception as e:
+        logger.error(f"Slack welcome dedupe failed (welcoming anyway): {e}")
+        return False
+
+
+async def deliver_home_welcome(account_id: UUID, user_id: str, channel: str) -> None:
+    """Send the one-time welcome DM when a user first opens the Messages tab."""
+    if not user_id or not channel:
+        return
+    if _already_welcomed(account_id, user_id):
+        return
+    db = SessionLocal()
+    try:
+        account = ChannelAccountRepository(db).get_by_id(account_id)
+        if account is None or not account.is_active:
+            return
+        text = _welcome_text(_assigned_agent(db, account))
+        await slack_api("chat.postMessage", SlackAdapter._access_token(account),
+                        {"channel": channel, "text": text})
+    except Exception as e:
+        logger.error(f"Slack Messages-tab welcome failed: {e}")
+    finally:
+        db.close()
+
+
+async def handle_assistant_thread_started(account_id: UUID, channel_id: str, thread_ts: str) -> None:
+    """On assistant-sidebar open: show a status, offer starter prompts, welcome."""
+    if not channel_id or not thread_ts:
+        return
+    db = SessionLocal()
+    try:
+        account = ChannelAccountRepository(db).get_by_id(account_id)
+        if account is None or not account.is_active:
+            return
+        token = SlackAdapter._access_token(account)
+        await set_assistant_status(token, channel_id, thread_ts, ASSISTANT_READY_STATUS)
+        await set_suggested_prompts(token, channel_id, thread_ts, STARTER_PROMPTS, SUGGESTED_PROMPTS_TITLE)
+        text = _welcome_text(_assigned_agent(db, account))
+        await slack_api("chat.postMessage", token,
+                        {"channel": channel_id, "text": text, "thread_ts": thread_ts})
+    except Exception as e:
+        logger.error(f"Slack assistant welcome failed: {e}")
+    finally:
+        db.close()
+
+
+async def _agent_card(agent) -> dict:
+    """Flatten an Agent into the resolved shape build_home_view expects."""
+    photo_url = None
+    customization = getattr(agent, "customization", None)
+    if customization and customization.photo_url:
+        photo_url = customization.photo_url
+        if settings.S3_FILE_STORAGE:
+            try:
+                photo_url = await get_s3_signed_url(customization.photo_url)
+            except Exception as e:
+                logger.debug(f"Could not sign agent photo URL: {e}")
+    instructions = agent.instructions or []
+    return {
+        "name": agent.display_name or agent.name,
+        "is_active": agent.is_active,
+        "instruction": instructions[0] if instructions else "",
+        "photo_url": photo_url,
+    }
+
+
+async def publish_agent_home(account_id: UUID, user_id: str) -> None:
+    """Publish the Home tab for a user: a card per org agent."""
+    if not user_id:
+        return
+    db = SessionLocal()
+    try:
+        account = ChannelAccountRepository(db).get_by_id(account_id)
+        if account is None or not account.is_active:
+            return
+        agents = AgentRepository(db).get_org_agents(account.organization_id, active_only=False)
+        cards = [await _agent_card(agent) for agent in agents]
+        await publish_home_view(SlackAdapter._access_token(account), user_id, build_home_view(cards))
+    except Exception as e:
+        logger.error(f"Slack Home tab publish failed: {e}")
+    finally:
+        db.close()

--- a/backend/tests/channels/test_slack_adapter.py
+++ b/backend/tests/channels/test_slack_adapter.py
@@ -17,13 +17,15 @@ limitations under the License.
 import hashlib
 import hmac
 import time
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import app.api.webhooks.slack as slack_webhook
+import app.services.slack_events as slack_events
 from app.api.webhooks.slack import _handle_lifecycle_event
 from app.channels import get_adapter
-from app.channels.slack import SlackAdapter, verify_slack_signature
+from app.channels.slack import SlackAdapter, build_home_view, verify_slack_signature
 from app.core.config import settings
 
 
@@ -263,3 +265,141 @@ class TestSlackProfileAndTyping:
         assert ("a", "c1") not in slk._typing_placeholders  # stale, pruned
         assert ("a", "c2") in slk._typing_placeholders       # fresh, kept
         slk._typing_placeholders.clear()
+
+
+def test_parse_dm_with_thread_keys_by_thread(adapter):
+    """Assistant-sidebar messages are DMs carrying the assistant thread ts — they
+    key by thread so the reply posts back into that thread."""
+    ev = make_event({"type": "message", "channel_type": "im", "user": "U42",
+                     "text": "hi", "channel": "D7", "ts": "1720000002.0003",
+                     "thread_ts": "1719999999.0001"})
+    m = adapter.parse_inbound(ev)[0]
+    assert m.external_conversation_id == "D7:1719999999.0001"
+
+
+class TestHomeView:
+    def test_empty_prompts_setup(self):
+        v = build_home_view([])
+        assert v["type"] == "home"
+        assert any("No agent" in b.get("text", {}).get("text", "") for b in v["blocks"])
+
+    def test_card_and_truncation(self):
+        import json
+        v = build_home_view([{"name": "Support", "is_active": True,
+                              "instruction": "x" * 300, "photo_url": None}])
+        assert "Support" in json.dumps(v)  # name renders somewhere in the card
+        section_texts = [b["text"]["text"] for b in v["blocks"] if b.get("type") == "section"]
+        long_text = next(t for t in section_texts if t.startswith("x"))
+        assert long_text.endswith("…") and len(long_text) <= 250
+
+
+class TestAppSurfaceDispatch:
+    """Webhook fan-out: the right event schedules the right background handler."""
+
+    def _repo(self, active=True):
+        account = MagicMock(); account.id = "acc1"; account.is_active = active
+        repo = MagicMock(); repo.get_by_external_id.return_value = account
+        return repo
+
+    def test_messages_tab_open_schedules_welcome(self):
+        bg = MagicMock()
+        slack_webhook._dispatch_app_surface_event(
+            {"type": "app_home_opened", "user": "U1", "channel": "D1", "tab": "messages"},
+            "T1", self._repo(), bg)
+        args = bg.add_task.call_args[0]
+        assert args[0] is slack_webhook.deliver_home_welcome
+        assert args[1:] == ("acc1", "U1", "D1")
+
+    def test_missing_tab_defaults_to_welcome(self):
+        bg = MagicMock()
+        slack_webhook._dispatch_app_surface_event(
+            {"type": "app_home_opened", "user": "U1", "channel": "D1"}, "T1", self._repo(), bg)
+        assert bg.add_task.call_args[0][0] is slack_webhook.deliver_home_welcome
+
+    def test_home_tab_open_schedules_home_publish(self):
+        bg = MagicMock()
+        slack_webhook._dispatch_app_surface_event(
+            {"type": "app_home_opened", "user": "U1", "tab": "home"}, "T1", self._repo(), bg)
+        args = bg.add_task.call_args[0]
+        assert args[0] is slack_webhook.publish_agent_home and args[1:] == ("acc1", "U1")
+
+    def test_assistant_started_schedules_handler(self):
+        bg = MagicMock()
+        slack_webhook._dispatch_app_surface_event(
+            {"type": "assistant_thread_started",
+             "assistant_thread": {"channel_id": "D2", "thread_ts": "111.222"}},
+            "T1", self._repo(), bg)
+        args = bg.add_task.call_args[0]
+        assert args[0] is slack_webhook.handle_assistant_thread_started
+        assert args[1:] == ("acc1", "D2", "111.222")
+
+    def test_context_changed_is_noop(self):
+        bg = MagicMock()
+        slack_webhook._dispatch_app_surface_event(
+            {"type": "assistant_thread_context_changed"}, "T1", self._repo(), bg)
+        bg.add_task.assert_not_called()
+
+    def test_inactive_team_is_noop(self):
+        bg = MagicMock()
+        slack_webhook._dispatch_app_surface_event(
+            {"type": "app_home_opened", "user": "U1", "tab": "messages"},
+            "T1", self._repo(active=False), bg)
+        bg.add_task.assert_not_called()
+
+    def test_missing_team_id_is_noop(self):
+        bg = MagicMock()
+        slack_webhook._dispatch_app_surface_event(
+            {"type": "app_home_opened", "user": "U1"}, "", self._repo(), bg)
+        bg.add_task.assert_not_called()
+
+
+class TestHomeWelcomeDelivery:
+    def _patch_common(self, monkeypatch):
+        db = MagicMock()
+        monkeypatch.setattr(slack_events, "SessionLocal", lambda: db)
+        account = MagicMock(); account.is_active = True
+        repo = MagicMock(); repo.get_by_id.return_value = account
+        monkeypatch.setattr(slack_events, "ChannelAccountRepository", lambda d: repo)
+        monkeypatch.setattr(slack_events, "_assigned_agent", lambda d, a: None)
+        monkeypatch.setattr(slack_events.SlackAdapter, "_access_token", staticmethod(lambda a: "tok"))
+        api = AsyncMock()
+        monkeypatch.setattr(slack_events, "slack_api", api)
+        return api
+
+    @pytest.mark.asyncio
+    async def test_welcome_sent_once(self, monkeypatch):
+        api = self._patch_common(monkeypatch)
+        redis = MagicMock()
+        redis.set.side_effect = [True, None]  # first claims the slot, second is taken
+        monkeypatch.setattr(slack_events, "get_redis", lambda: redis)
+
+        await slack_events.deliver_home_welcome("acc1", "U1", "D1")
+        await slack_events.deliver_home_welcome("acc1", "U1", "D1")
+
+        assert api.await_count == 1
+        assert api.await_args[0][0] == "chat.postMessage"
+        assert api.await_args[0][2]["channel"] == "D1"
+
+    @pytest.mark.asyncio
+    async def test_no_channel_no_send(self, monkeypatch):
+        api = self._patch_common(monkeypatch)
+        monkeypatch.setattr(slack_events, "get_redis", lambda: None)
+        await slack_events.deliver_home_welcome("acc1", "U1", "")
+        api.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_assistant_started_sets_status_prompts_and_welcome(self, monkeypatch):
+        self._patch_common(monkeypatch)
+        status = AsyncMock(); prompts = AsyncMock()
+        monkeypatch.setattr(slack_events, "set_assistant_status", status)
+        monkeypatch.setattr(slack_events, "set_suggested_prompts", prompts)
+        api = AsyncMock()
+        monkeypatch.setattr(slack_events, "slack_api", api)
+
+        await slack_events.handle_assistant_thread_started("acc1", "D2", "111.222")
+
+        status.assert_awaited_once()
+        prompts.assert_awaited_once()
+        api.assert_awaited_once()
+        assert api.await_args[0][0] == "chat.postMessage"
+        assert api.await_args[0][2].get("thread_ts") == "111.222"


### PR DESCRIPTION
Clears the Slack Marketplace check that flags the Messages tab being enabled without the app sending messages to users. Restores the richer App Home / Assistant experience the unified-channel rewrite dropped, ported onto the new adapter stack (reusing `slack_api` + `ChannelAccount`).

**What it adds**
- **Messages tab** — one-time welcome DM on first open (Redis-gated per user). This is the piece that clears the review warning.
- **Assistant sidebar** — on `assistant_thread_started`: status → starter prompts → welcome in-thread. Sidebar replies arrive as `message.im` with the assistant `thread_ts`; `parse_inbound` now keys those by thread so replies thread back (plain DMs unchanged).
- **Home tab** — a card per org agent (name, status, instruction, photo) via `views.publish`.

**Structure** — API wrappers in `channels/slack.py` reuse `slack_api`; handlers in new `services/slack_events.py` run as background tasks so the webhook acks < 3s; events dispatched off the envelope before `parse_inbound`, like the lifecycle events.

**Requires dashboard config** (separate): re-add `assistant:write` scope + `app_home_opened` / `assistant_thread_started` / `assistant_thread_context_changed` events, enable the Agents feature, turn the Home tab back on, reinstall.

**Tests** — 13 new; 36 pass in the Slack file, 152 across channels/channel-API/channel-chat. Adapter reused; no regressions.

One item needs live confirmation: the assistant-sidebar message event shape is inferred from Slack docs — verify replies thread correctly in a test workspace.