### PR TITLE
fix(slack): make the App Home tab useful

### DIFF
--- a/backend/app/channels/slack.py
+++ b/backend/app/channels/slack.py
@@ -118,42 +118,67 @@ async def publish_home_view(token: str, user_id: str, view: dict) -> dict:
     return data
 
 
-# Home-tab presentation. Cards are pre-resolved by the caller (photo URLs signed)
-# so this stays a pure, testable Block Kit builder.
+# Home-tab presentation. The card is pre-resolved by the caller (photo URL
+# signed) so this stays a pure, testable Block Kit builder. Per Slack's App Home
+# guidance: lead with what the app does, surface the most relevant thing (the
+# connected agent), keep call-to-actions minimal, link out to settings.
 HOME_INSTRUCTION_MAX = 250
 _STATUS_ONLINE = ":large_green_circle: Online"
 _STATUS_OFFLINE = ":white_circle: Offline"
+HOME_INTRO = (
+    "AI customer support, right inside Slack. @mention me in a channel and I'll "
+    "answer in the thread, or send me a direct message. My answers come from your "
+    "team's own knowledge, and I hand off to a human when a conversation needs one."
+)
+HOME_HOW_TO = (
+    "*How to use me*\n"
+    "• @mention *ChatterMate* in any channel — I reply in the thread\n"
+    "• Send me a *direct message* for a private conversation\n"
+    "• Open me from the *assistant* in the top bar for a side-by-side chat"
+)
+HOME_NO_AGENT = (
+    "*No agent connected yet*\nConnect an agent to this workspace from the "
+    "ChatterMate dashboard and I'll start answering here."
+)
+DASHBOARD_LINK_LABEL = "Open the ChatterMate dashboard →"
 
 
-def build_home_view(agent_cards: List[dict]) -> dict:
-    """Assemble the App Home view from resolved agent cards.
+def build_home_view(agent_card: Optional[dict], dashboard_url: str) -> dict:
+    """Assemble the App Home view: what the app does, the connected agent, how to
+    use it, and a link to the dashboard.
 
-    Each card: {"name", "is_active", "instruction", "photo_url" | None}.
+    `agent_card` (or None if no agent is assigned): {"name", "is_active",
+    "instruction", "photo_url" | None}.
     """
-    blocks: List[dict] = [{"type": "header", "text": {"type": "plain_text", "text": "ChatterMate"}}]
+    blocks: List[dict] = [
+        {"type": "header", "text": {"type": "plain_text", "text": "ChatterMate", "emoji": True}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": HOME_INTRO}},
+        {"type": "divider"},
+    ]
 
-    if not agent_cards:
-        blocks.append({"type": "section", "text": {"type": "mrkdwn",
-                       "text": "No agent is connected yet. Set one up in ChatterMate to start answering here."}})
-        return {"type": "home", "blocks": blocks}
-
-    blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "*Your AI agents*"}})
-    for card in agent_cards:
+    if agent_card:
+        status = _STATUS_ONLINE if agent_card.get("is_active") else _STATUS_OFFLINE
         header: List[dict] = []
-        if card.get("photo_url"):
-            header.append({"type": "image", "image_url": card["photo_url"], "alt_text": card["name"]})
-        header.append({"type": "mrkdwn", "text": f"*{card['name']}*"})
+        if agent_card.get("photo_url"):
+            header.append({"type": "image", "image_url": agent_card["photo_url"],
+                           "alt_text": agent_card["name"]})
+        header.append({"type": "mrkdwn", "text": f"*{agent_card['name']}*  ·  {status}"})
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": "*Connected agent*"}})
         blocks.append({"type": "context", "elements": header})
 
-        status = _STATUS_ONLINE if card.get("is_active") else _STATUS_OFFLINE
-        blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": status}]})
-
-        instruction = (card.get("instruction") or "").strip()
+        instruction = (agent_card.get("instruction") or "").strip()
         if instruction:
             if len(instruction) > HOME_INSTRUCTION_MAX:
                 instruction = instruction[:HOME_INSTRUCTION_MAX - 1].rstrip() + "…"
             blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": instruction}})
-        blocks.append({"type": "divider"})
+    else:
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": HOME_NO_AGENT}})
+
+    blocks.append({"type": "divider"})
+    blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": HOME_HOW_TO}})
+    # A markdown link, not a Block Kit button — link buttons still require
+    # Interactivity to be enabled, which this app intentionally leaves off.
+    blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": f"<{dashboard_url}|{DASHBOARD_LINK_LABEL}>"}})
 
     return {"type": "home", "blocks": blocks}
 

--- a/backend/app/services/slack_events.py
+++ b/backend/app/services/slack_events.py
@@ -146,8 +146,13 @@ async def _agent_card(agent) -> dict:
     }
 
 
+def _dashboard_url() -> str:
+    return settings.FRONTEND_URL.rstrip("/")
+
+
 async def publish_agent_home(account_id: UUID, user_id: str) -> None:
-    """Publish the Home tab for a user: a card per org agent."""
+    """Publish the Home tab: what ChatterMate does, the agent connected to this
+    workspace, how to use it, and a link to the dashboard."""
     if not user_id:
         return
     db = SessionLocal()
@@ -155,9 +160,10 @@ async def publish_agent_home(account_id: UUID, user_id: str) -> None:
         account = ChannelAccountRepository(db).get_by_id(account_id)
         if account is None or not account.is_active:
             return
-        agents = AgentRepository(db).get_org_agents(account.organization_id, active_only=False)
-        cards = [await _agent_card(agent) for agent in agents]
-        await publish_home_view(SlackAdapter._access_token(account), user_id, build_home_view(cards))
+        agent = _assigned_agent(db, account)
+        card = await _agent_card(agent) if agent is not None else None
+        view = build_home_view(card, _dashboard_url())
+        await publish_home_view(SlackAdapter._access_token(account), user_id, view)
     except Exception as e:
         logger.error(f"Slack Home tab publish failed: {e}")
     finally:

--- a/backend/tests/channels/test_slack_adapter.py
+++ b/backend/tests/channels/test_slack_adapter.py
@@ -277,17 +277,29 @@ def test_parse_dm_with_thread_keys_by_thread(adapter):
     assert m.external_conversation_id == "D7:1719999999.0001"
 
 
-class TestHomeView:
-    def test_empty_prompts_setup(self):
-        v = build_home_view([])
-        assert v["type"] == "home"
-        assert any("No agent" in b.get("text", {}).get("text", "") for b in v["blocks"])
+DASH = "https://app.chattermate.chat"
 
-    def test_card_and_truncation(self):
+
+class TestHomeView:
+    def test_intro_and_dashboard_link_always_present(self):
         import json
-        v = build_home_view([{"name": "Support", "is_active": True,
-                              "instruction": "x" * 300, "photo_url": None}])
-        assert "Support" in json.dumps(v)  # name renders somewhere in the card
+        blob = json.dumps(build_home_view(None, DASH))
+        assert "AI customer support" in blob   # what it does, up top
+        assert DASH in blob                     # dashboard link
+        assert "How to use me" in blob
+
+    def test_no_agent_shows_connect_prompt(self):
+        import json
+        v = build_home_view(None, DASH)
+        assert v["type"] == "home"
+        assert "No agent connected" in json.dumps(v)
+
+    def test_connected_agent_card_and_truncation(self):
+        import json
+        v = build_home_view({"name": "Support", "is_active": True,
+                             "instruction": "x" * 300, "photo_url": None}, DASH)
+        blob = json.dumps(v)
+        assert "Connected agent" in blob and "Support" in blob
         section_texts = [b["text"]["text"] for b in v["blocks"] if b.get("type") == "section"]
         long_text = next(t for t in section_texts if t.startswith("x"))
         assert long_text.endswith("…") and len(long_text) <= 250


### PR DESCRIPTION
The Home tab dumped every org agent with generic instructions — no context on what ChatterMate is or how to use it (see the screenshot that prompted this). Rebuilt per Slack's [App Home guidance](https://docs.slack.dev/surfaces/app-home): most-relevant content first, clear hierarchy, minimal CTAs.

Now shows:
- **What ChatterMate does** (up top)
- **The connected agent** — the one assigned to this workspace, with name/status/description, instead of every org agent
- **How to use it** — @mention, DM, assistant
- **A link to the dashboard**

Markdown link, not a Block Kit button: link buttons still require Interactivity enabled, which this app intentionally leaves off.

Tests updated; 37 pass in the Slack file.