### PR TITLE
fix(knowledge): honor KB_MAX_LINKS on self-host; restore agent link UI

### DIFF
--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -67,6 +67,15 @@ ALLOWED_PDF_TYPES = ("application/pdf",)
 from app.core.processor import PROCESSOR_STATUS
 
 
+def resolve_plan_max_links(subscription) -> int:
+    """Per-source sub-page crawl cap: the enterprise plan's ``max_sub_pages``
+    when enterprise is active, otherwise the self-host configurable
+    ``KB_MAX_LINKS`` (so self-hosted installs actually control crawl scope)."""
+    if HAS_ENTERPRISE and subscription:
+        return subscription.plan.max_sub_pages
+    return settings.KB_MAX_LINKS
+
+
 class UrlsRequest(BaseModel):
     org_id: UUID
     pdf_urls: List[str] = []
@@ -235,6 +244,8 @@ async def upload_pdf_files(
                 # 404 (not 403) so we don't reveal another org's agent existence.
                 raise HTTPException(status_code=404, detail="Agent not found")
 
+        # Bound for the non-enterprise path (resolve_plan_max_links below).
+        subscription = None
         # Check enterprise subscription limits if enterprise module is available
         if HAS_ENTERPRISE:
             knowledge_repo = KnowledgeRepository(db)
@@ -295,7 +306,7 @@ async def upload_pdf_files(
                 source=file_path,
                 status=QueueStatus.PENDING,
                 queue_metadata={
-                    "max_links": subscription.plan.max_sub_pages if HAS_ENTERPRISE and subscription else 10
+                    "max_links": resolve_plan_max_links(subscription)
                 }
             )
             queued_items.append(queue_repo.create(queue_item))
@@ -346,7 +357,7 @@ async def add_explore_url(
             status=QueueStatus.PENDING,
             priority=10,  # High priority for explore URLs (default is 0)
             queue_metadata={
-                "max_links": 20  # Default to 10 links
+                "max_links": settings.KB_MAX_LINKS
             }
         )
         
@@ -510,6 +521,8 @@ async def add_urls(
                 # 404 (not 403) so we don't reveal another org's agent existence.
                 raise HTTPException(status_code=404, detail="Agent not found")
 
+        # Bound for the non-enterprise path (resolve_plan_max_links below).
+        subscription = None
         # Check enterprise subscription limits if enterprise module is available
         if HAS_ENTERPRISE:
             knowledge_repo = KnowledgeRepository(db)
@@ -539,7 +552,7 @@ async def add_urls(
         # Per-source sub-page cap: the plan limit, optionally narrowed by the
         # request's crawl scope (e.g. "this page only" -> max_links=1), never
         # allowed to exceed the plan limit.
-        plan_sub_pages = subscription.plan.max_sub_pages if (HAS_ENTERPRISE and subscription) else 10
+        plan_sub_pages = resolve_plan_max_links(subscription)
         website_max_links = (
             min(request.max_links, plan_sub_pages) if request.max_links else plan_sub_pages
         )

--- a/backend/app/knowledge/knowledge_base.py
+++ b/backend/app/knowledge/knowledge_base.py
@@ -448,8 +448,8 @@ class KnowledgeManager:
                     )
                     
                     max_links = queue_item.queue_metadata.get(
-                        'max_links', 10) if queue_item.queue_metadata else 10
-                    
+                        'max_links', settings.KB_MAX_LINKS) if queue_item.queue_metadata else settings.KB_MAX_LINKS
+
                     # Use EnhancedWebsiteReader for all website crawling
                     logger.info(f"Using EnhancedWebsiteReader for queue item: {queue_item.source}")
                     reader = EnhancedWebsiteReader(
@@ -502,7 +502,7 @@ class KnowledgeManager:
                     queue_repo.update_progress(queue_item.id, ProcessingStage.CRAWLING)
 
                     max_links = queue_item.queue_metadata.get(
-                        'max_links', 10) if queue_item.queue_metadata else 10
+                        'max_links', settings.KB_MAX_LINKS) if queue_item.queue_metadata else settings.KB_MAX_LINKS
 
                     logger.info(f"Using SitemapReader for queue item: {queue_item.source}")
                     reader = SitemapReader(

--- a/backend/tests/api/test_knowledge.py
+++ b/backend/tests/api/test_knowledge.py
@@ -249,7 +249,24 @@ def test_add_sitemap(client: TestClient, test_organization, db):
     ).first()
     assert item is not None
     assert item.source_type == "sitemap"
-    assert item.queue_metadata.get("max_links") == 10  # non-enterprise default
+    # Non-enterprise honors the configurable KB_MAX_LINKS (not a hardcoded default).
+    assert item.queue_metadata.get("max_links") == settings.KB_MAX_LINKS
+
+
+def test_add_website_honors_kb_max_links(client: TestClient, test_organization, db):
+    """A self-hosted (non-enterprise) website crawl records KB_MAX_LINKS, not a
+    hardcoded 10, so the setting actually controls crawl scope (issue #237)."""
+    with patch("app.core.config.settings.KB_MAX_LINKS", 200):
+        response = client.post("/api/v1/knowledge/add/urls", json={
+            "org_id": str(test_organization.id),
+            "websites": ["https://example.com/docs"],
+        })
+        assert response.status_code == 200
+        item = db.query(KnowledgeQueue).filter(
+            KnowledgeQueue.source == "https://example.com/docs"
+        ).first()
+        assert item is not None
+        assert item.queue_metadata.get("max_links") == 200
 
 
 def test_link_knowledge_to_agent(client: TestClient, test_knowledge, test_agent):

--- a/frontend/src/components/knowledge/KnowledgeExplorer.vue
+++ b/frontend/src/components/knowledge/KnowledgeExplorer.vue
@@ -25,6 +25,7 @@ import KnowledgePageDetail from './KnowledgePageDetail.vue'
 import KnowledgePageEditor from './KnowledgePageEditor.vue'
 import KnowledgePlanMeters from './KnowledgePlanMeters.vue'
 import KnowledgeAddSourceModal from './KnowledgeAddSourceModal.vue'
+import KnowledgeLinkModal from './KnowledgeLinkModal.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -105,6 +106,16 @@ function askDeleteSource(source: ExplorerSource) {
       busyLabel: 'Cancelling…',
       action: () => ex.deleteSource(source),
     }
+  } else if (props.mode === 'agent') {
+    // In an agent's tab, "Remove" detaches the source from this agent but keeps
+    // it in the organization's knowledge — it does not delete the source.
+    confirmState.value = {
+      title: 'Remove from agent',
+      message: `Remove “${source.name}” from this agent? It stays in your organization’s knowledge.`,
+      actionLabel: 'Remove',
+      busyLabel: 'Removing…',
+      action: () => ex.unlinkSource(source.id),
+    }
   } else {
     confirmState.value = {
       title: 'Delete source',
@@ -156,6 +167,11 @@ onUnmounted(() => {
       </div>
       <div class="explorer__actions">
         <slot name="actions" />
+        <button v-if="mode === 'agent'" class="btn btn--ghost" type="button" @click="ex.openLinkPicker">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2"
+            stroke-linecap="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7 0l2-2a5 5 0 0 0-7-7l-1 1M14 11a5 5 0 0 0-7 0l-2 2a5 5 0 0 0 7 7l1-1" /></svg>
+          Link existing
+        </button>
         <button class="btn btn--primary" type="button" @click="openAdd">
           <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2"
             stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14" /></svg>
@@ -247,6 +263,18 @@ onUnmounted(() => {
       :submitting="isSubmittingSource"
       @close="addOpen = false"
       @submit="onSubmitSource"
+    />
+
+    <KnowledgeLinkModal
+      v-if="ex.linkPickerOpen.value"
+      :sources="ex.orgSources.value"
+      :linked-ids="ex.linkedSourceIds.value"
+      :busy-ids="ex.linkingIds.value"
+      :loading="ex.isLoadingOrgSources.value"
+      :error="ex.orgSourcesError.value"
+      @close="ex.linkPickerOpen.value = false"
+      @link="ex.linkSource"
+      @unlink="ex.unlinkSource"
     />
   </div>
 </template>

--- a/frontend/src/components/knowledge/KnowledgeLinkModal.vue
+++ b/frontend/src/components/knowledge/KnowledgeLinkModal.vue
@@ -1,0 +1,308 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { KnowledgeItem } from '@/types/knowledge'
+
+const props = defineProps<{
+  sources: KnowledgeItem[]
+  linkedIds: Set<number>
+  busyIds: Set<number>
+  loading: boolean
+  error: string | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'link', knowledgeId: number): void
+  (e: 'unlink', knowledgeId: number): void
+}>()
+
+const query = ref('')
+
+const filteredSources = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  if (!q) return props.sources
+  return props.sources.filter(
+    (s) => s.name.toLowerCase().includes(q) || s.type.toLowerCase().includes(q),
+  )
+})
+</script>
+
+<template>
+  <div class="scrim" @click.self="emit('close')">
+    <div class="modal" role="dialog" aria-modal="true" aria-label="Link existing knowledge">
+      <div class="modal__head">
+        <div>
+          <h3 class="modal__title">Link existing knowledge</h3>
+          <p class="modal__sub">Attach knowledge from your organization to this agent so it can use it.</p>
+        </div>
+        <button class="icon-btn" type="button" aria-label="Close" @click="emit('close')">
+          <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18" /></svg>
+        </button>
+      </div>
+
+      <div class="search">
+        <input v-model="query" class="text-input" type="text" placeholder="Search knowledge sources…" />
+      </div>
+
+      <div class="body">
+        <div v-if="loading" class="state">Loading knowledge sources…</div>
+        <div v-else-if="error" class="state state--error">{{ error }}</div>
+        <div v-else-if="!filteredSources.length" class="state">
+          {{ query ? 'No sources match your search.' : 'No organization knowledge to link yet.' }}
+        </div>
+        <ul v-else class="list">
+          <li v-for="item in filteredSources" :key="item.id" class="row">
+            <div class="row__main">
+              <span class="row__name">{{ item.name }}</span>
+              <span class="row__type">{{ item.type }}</span>
+            </div>
+            <button
+              v-if="linkedIds.has(item.id)"
+              class="btn btn--linked"
+              type="button"
+              :disabled="busyIds.has(item.id)"
+              @click="emit('unlink', item.id)"
+            >
+              {{ busyIds.has(item.id) ? 'Removing…' : 'Unlink' }}
+            </button>
+            <button
+              v-else
+              class="btn btn--primary"
+              type="button"
+              :disabled="busyIds.has(item.id)"
+              @click="emit('link', item.id)"
+            >
+              {{ busyIds.has(item.id) ? 'Linking…' : 'Link' }}
+            </button>
+          </li>
+        </ul>
+      </div>
+
+      <div class="foot">
+        <button class="btn btn--ghost" type="button" @click="emit('close')">Done</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: var(--scrim);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 60px 20px;
+  overflow-y: auto;
+}
+
+.modal {
+  width: 560px;
+  max-width: 100%;
+  background: var(--bg2);
+  border: 1px solid var(--o12);
+  border-radius: 20px;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--o08);
+}
+
+.modal__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 19px;
+  color: var(--text);
+  margin: 0 0 4px;
+}
+
+.modal__sub {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0;
+}
+
+.icon-btn {
+  width: 34px;
+  height: 34px;
+  flex-shrink: 0;
+  border-radius: 9px;
+  background: var(--o05);
+  border: 1px solid var(--o10);
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-btn:hover {
+  background: var(--o08);
+  color: var(--text2);
+}
+
+.search {
+  padding: 16px 24px 4px;
+}
+
+.text-input {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--o12);
+  border-radius: 11px;
+  padding: 12px 14px;
+  font-size: 14px;
+  color: var(--text);
+  outline: none;
+  font-family: var(--font-sans);
+}
+
+.text-input:focus {
+  border-color: var(--accent-border, var(--accent-ink));
+}
+
+.body {
+  padding: 12px 24px 4px;
+  min-height: 180px;
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  font-size: 13.5px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.state--error {
+  color: var(--c-coral);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 11px 13px;
+  border-radius: 11px;
+  border: 1px solid var(--o10);
+  background: var(--o04);
+}
+
+.row__main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.row__name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text2);
+  word-break: break-word;
+}
+
+.row__type {
+  font-size: 11.5px;
+  color: var(--muted2);
+  text-transform: capitalize;
+}
+
+.foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 9px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--o08);
+  background: var(--surface);
+}
+
+.btn {
+  padding: 8px 16px;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.btn--primary {
+  background: var(--accent-solid);
+  color: var(--on-accent-solid);
+}
+
+.btn--primary:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.btn--linked {
+  background: var(--o05);
+  border-color: var(--o12);
+  color: var(--muted);
+}
+
+.btn--linked:hover:not(:disabled) {
+  background: var(--coral-bg);
+  border-color: var(--coral-border);
+  color: var(--c-coral);
+}
+
+.btn--ghost {
+  background: transparent;
+  border-color: var(--o12);
+  color: var(--muted);
+}
+
+.btn--ghost:hover:not(:disabled) {
+  background: var(--o05);
+}
+</style>

--- a/frontend/src/composables/useKnowledgeExplorer.ts
+++ b/frontend/src/composables/useKnowledgeExplorer.ts
@@ -437,6 +437,85 @@ export function useKnowledgeExplorer(
     }
   }
 
+  // ---- Link existing org-level knowledge to this agent (agent mode only) ----
+  // Org sources are created with agent_id=NULL, so they never auto-link to an
+  // agent; this picker restores the ability to attach them from the agent tab.
+  const linkPickerOpen = ref(false)
+  const orgSources = ref<KnowledgeItem[]>([])
+  const isLoadingOrgSources = ref(false)
+  const orgSourcesError = ref<string | null>(null)
+  // Knowledge ids with a link/unlink request in flight (per-row busy state).
+  const linkingIds = ref<Set<number>>(new Set())
+
+  // Ids already linked to this agent — drives the Link/Unlink toggle per row.
+  const linkedSourceIds = computed(() => new Set(sources.value.map((s) => s.id)))
+
+  const loadOrgSources = async () => {
+    isLoadingOrgSources.value = true
+    orgSourcesError.value = null
+    try {
+      const response = await knowledgeService.getKnowledgeByOrganization(organizationId, 1, 100)
+      orgSources.value = response.knowledge || []
+    } catch (err) {
+      console.error('Failed to load organization knowledge:', err)
+      orgSourcesError.value = 'Failed to load your organization’s knowledge'
+    } finally {
+      isLoadingOrgSources.value = false
+    }
+  }
+
+  const openLinkPicker = async () => {
+    if (mode !== 'agent' || !agentId) return
+    linkPickerOpen.value = true
+    await loadOrgSources()
+  }
+
+  // Shared link/unlink runner: guards concurrent clicks per row, keeps the
+  // busy-state Set in sync, refetches the agent's linked sources, and toasts.
+  const runLinkOp = async (
+    knowledgeId: number,
+    op: (id: number, agentId: string) => Promise<unknown>,
+    { successMsg, failMsg, onSuccess }: {
+      successMsg: string
+      failMsg: string
+      onSuccess?: () => void
+    },
+  ) => {
+    if (mode !== 'agent' || !agentId || linkingIds.value.has(knowledgeId)) return
+    linkingIds.value.add(knowledgeId)
+    try {
+      await op(knowledgeId, agentId)
+      onSuccess?.()
+      await fetchSources()
+      toast.success(successMsg)
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : failMsg
+      console.error(`${failMsg}:`, err)
+      toast.error(failMsg, { description: msg })
+    } finally {
+      linkingIds.value.delete(knowledgeId)
+    }
+  }
+
+  const linkSource = (knowledgeId: number) =>
+    runLinkOp(knowledgeId, (id, aid) => knowledgeService.linkToAgent(id, aid), {
+      successMsg: 'Knowledge linked to this agent',
+      failMsg: 'Could not link knowledge',
+    })
+
+  const unlinkSource = (knowledgeId: number) =>
+    runLinkOp(knowledgeId, (id, aid) => knowledgeService.unlinkFromAgent(id, aid), {
+      successMsg: 'Knowledge removed from this agent',
+      failMsg: 'Could not remove knowledge',
+      // Clear the detail pane if the removed source was selected.
+      onSuccess: () => {
+        if (selectedSourceId.value === knowledgeId) {
+          selectedSourceId.value = null
+          selectedPageId.value = null
+        }
+      },
+    })
+
   const linkedAgentId = mode === 'agent' ? agentId : undefined
 
   // Handle add/urls responses that report duplicates instead of throwing.
@@ -547,10 +626,16 @@ export function useKnowledgeExplorer(
     draftUrl,
     isSaving,
     isDeleting,
+    linkPickerOpen,
+    orgSources,
+    isLoadingOrgSources,
+    orgSourcesError,
+    linkingIds,
     // computed
     selectedSource,
     selectedPage,
     filteredSources,
+    linkedSourceIds,
     // helpers for the view
     sourceStatus,
     pageRows,
@@ -567,6 +652,9 @@ export function useKnowledgeExplorer(
     deletePage,
     deleteSource,
     submitSource,
+    openLinkPicker,
+    linkSource,
+    unlinkSource,
     startPolling,
     stopPolling,
   }


### PR DESCRIPTION
Fixes #237 and #238.

**#237 — KB_MAX_LINKS ignored on self-host**
The queue path hardcoded the crawl cap to 10 (and 20 for explore URLs), so `KB_MAX_LINKS` never took effect for non-enterprise installs. Non-enterprise now uses `settings.KB_MAX_LINKS`; enterprise still clamps to the plan's `max_sub_pages`.

**#238 — can't link existing org-level knowledge to an agent**
Org-level knowledge (`agent_id=NULL`) had no way to be attached to an agent after the KnowledgeExplorer rewrite. Adds a "Link existing" picker in the agent's Knowledge tab (reusing the existing link/unlink endpoints), and makes agent-mode "Remove" unlink the source rather than delete it.

Tests: updated the non-enterprise sitemap assertion and added `test_add_website_honors_kb_max_links`.