### PR TITLE
fix(docker): unblock amd64/x86_64 self-host (multi-arch + yanked transformers)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,12 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
+# Install Python dependencies. Bump pip's per-request timeout and retry count so
+# the large torch/opencv/onnxruntime wheel downloads survive slow links and the
+# heavier amd64/x86_64 wheels don't abort with ReadTimeoutError.
+ENV PIP_DEFAULT_TIMEOUT=120
 COPY backend/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --retries 10 -r requirements.txt
 
 # Copy application code
 COPY backend/app ./app

--- a/Dockerfile.backend.prod
+++ b/Dockerfile.backend.prod
@@ -10,9 +10,12 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
+# Install Python dependencies. Bump pip's per-request timeout and retry count so
+# the large torch/opencv/onnxruntime wheel downloads survive slow links and the
+# heavier amd64/x86_64 wheels don't abort with ReadTimeoutError.
+ENV PIP_DEFAULT_TIMEOUT=120
 COPY backend/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir --retries 10 -r requirements.txt
 RUN crawl4ai-setup
 
 # Copy application code

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -92,7 +92,7 @@ groq
 
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.8.0+cpu
-transformers==4.57.0
+transformers==4.57.1
 sentence-transformers==5.1.1
 
 fastembed==0.7.3


### PR DESCRIPTION
Fixes #239.

Self-host Docker deploy fails on amd64/x86_64 but works on arm64/Graviton. Three causes:

1. **Published images are arm64-only.** Verified via the Docker Hub registry API — both `chattermate/backend:latest` and `chattermate/frontend:latest` are single-arch `linux/arm64` manifests, so x86_64 hosts get `no matching manifest for linux/amd64` / `exec format error`. The multi-arch `publish-images.yml` workflow (already on main) builds `linux/amd64,linux/arm64`; it just needs to be run to replace the Hub images.

2. **Source build pip failures on amd64.** The heavier x86 torch/opencv/onnxruntime wheels can abort with `ReadTimeoutError` on slow links. Added `PIP_DEFAULT_TIMEOUT=120` + `pip --retries 10` to both `Dockerfile` and `Dockerfile.backend.prod`.

3. **`transformers==4.57.0` is yanked** on PyPI ("Error in the setup causing installation issues"). Bumped to `4.57.1`. Transitive constraints unchanged (patch release).

Merge this before dispatching `publish-images.yml` so the rebuilt images carry the transformers fix.