### PR TITLE
feat(help-center): on-demand-TLS ask endpoint for self-host edge

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -292,6 +292,29 @@ async def head_health_check():
         "version": settings.VERSION
     }
 
+
+@app.get("/health/help-center-domain", include_in_schema=False, operation_id="help_center_domain_tls_check")
+async def help_center_domain_tls_check(domain: str = ""):
+    """On-demand-TLS "ask" gate for the edge proxy (e.g. Caddy).
+
+    Returns 200 only when ``domain`` is a help-center host we actually serve —
+    a ``{slug}.HELP_CENTER_BASE_DOMAIN`` subdomain or a DB-verified custom
+    domain — so the edge provisions a certificate for those and refuses every
+    other name pointed at us. Public by design (the edge calls it
+    unauthenticated) but it leaks nothing: the answer is a bare status code and
+    the lookup reuses the same in-memory cache/slug check as host dispatch, so
+    there is no per-request database hit.
+    """
+    from fastapi import Response
+
+    from app.core.help_center_host import is_help_center_host, normalize_host
+
+    host = normalize_host(domain)
+    if host and is_help_center_host(host):
+        return Response(status_code=200)
+    return Response(status_code=404)
+
+
 # Create upload directories if they don't exist
 if not os.path.exists("uploads"):
     os.makedirs("uploads")

--- a/backend/tests/api/test_help_center_tls_ask.py
+++ b/backend/tests/api/test_help_center_tls_ask.py
@@ -1,0 +1,56 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Tests for the on-demand-TLS "ask" gate (GET /health/help-center-domain) that an
+edge proxy (e.g. Caddy) calls before issuing a certificate for a hostname.
+"""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+import app.main  # noqa: F401 — registers routes on the FastAPI app
+from app.core.application import app
+
+client = TestClient(app)
+ASK = "/health/help-center-domain"
+
+
+def test_allows_slug_subdomain():
+    # {slug}.HELP_CENTER_BASE_DOMAIN is a help-center host without any DB lookup.
+    assert client.get(ASK, params={"domain": "acme.chattermate.help"}).status_code == 200
+
+
+def test_allows_verified_custom_domain():
+    with patch("app.core.help_center_host._domain_cache") as cache:
+        cache.contains.return_value = True
+        assert client.get(ASK, params={"domain": "help.customer.com"}).status_code == 200
+
+
+def test_rejects_unknown_domain():
+    with patch("app.core.help_center_host._domain_cache") as cache:
+        cache.contains.return_value = False
+        assert client.get(ASK, params={"domain": "evil.example.com"}).status_code == 404
+
+
+def test_rejects_missing_or_empty_domain():
+    assert client.get(ASK).status_code == 404
+    assert client.get(ASK, params={"domain": ""}).status_code == 404
+
+
+def test_normalizes_host_with_port_and_uppercase():
+    # SNI can arrive with a port / mixed case; normalize_host must canonicalize
+    # it so the slug match still succeeds.
+    assert client.get(ASK, params={"domain": "ACME.chattermate.help:443"}).status_code == 200


### PR DESCRIPTION
Adds `GET /health/help-center-domain?domain=` — returns 200 only for a help-center host we actually serve (a `{slug}.HELP_CENTER_BASE_DOMAIN` subdomain or a DB-verified custom domain), 404 otherwise.

The self-host Caddy edge (`chattermate-deploy`) calls this as its on-demand-TLS `ask` gate, so a self-hosted install auto-provisions a certificate for verified Help Center custom domains and refuses every other name pointed at it. Public by design (the edge calls it unauthenticated) but leaks nothing — bare status code, reusing the same in-memory cache/slug check as host dispatch (no per-request DB hit). Inert on cloud.

Part of the self-host fix for #240. Pairs with the `chattermate-deploy` Caddy edge (separate enterprise PR).