### PR TITLE
Self-host help center: path-based serving, relative assets, favicon + FAQ import fixes

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -15,6 +15,12 @@ FRONTEND_URL=http://localhost:3000
 # from it, so if it stays localhost the embedded widget can't reach the backend.
 BACKEND_URL=http://localhost:8000
 
+# Public help center URL style:
+#   path      -> {BACKEND_URL}/help/{slug}, served same-origin (no DNS/TLS/proxy). Default, best for self-host.
+#   subdomain -> https://{slug}.<HELP_CENTER_BASE_DOMAIN> (needs wildcard DNS + TLS; used by cloud).
+# A verified custom domain always overrides this.
+HELP_CENTER_PUBLIC_MODE=path
+
 # JWT Configuration
 JWT_SECRET_KEY=your_jwt_secret_key_here
 JWT_ALGORITHM=HS256

--- a/backend/alembic/versions/add_hc_favicon_url.py
+++ b/backend/alembic/versions/add_hc_favicon_url.py
@@ -1,0 +1,24 @@
+"""Help center favicon URL
+
+Revision ID: add_hc_favicon_001
+Revises: merge_tkt_csat_001
+Create Date: 2026-07-25
+
+Adds a nullable favicon_url to help center settings, mirroring logo_url, so orgs
+can set the browser-tab icon for their public help center from Customization.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "add_hc_favicon_001"
+down_revision = "merge_tkt_csat_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("help_center_settings", sa.Column("favicon_url", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("help_center_settings", "favicon_url")

--- a/backend/alembic/versions/relative_hc_upload_urls.py
+++ b/backend/alembic/versions/relative_hc_upload_urls.py
@@ -1,0 +1,48 @@
+"""Make help-center upload URLs relative (strip baked-in absolute host)
+
+Revision ID: rel_hc_uploads_001
+Revises: add_hc_favicon_001
+Create Date: 2026-07-25
+
+Article images (baked into faqs.answer markdown) and, historically, some
+logo/favicon rows carried an absolute host in front of the /api/v1/uploads/
+path (e.g. http://localhost:8000/api/v1/uploads/...). That breaks the moment the
+help center is viewed from any other origin. Convert those to relative paths so
+they resolve against whichever origin serves the page. S3 URLs (no
+/api/v1/uploads/ segment) and already-relative paths are left untouched.
+Irreversible best-effort — downgrade is a no-op.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from app.services.help_center_images import strip_upload_host
+
+revision = "rel_hc_uploads_001"
+down_revision = "add_hc_favicon_001"
+branch_labels = None
+depends_on = None
+
+
+def _rewrite(bind, table: str, column: str) -> None:
+    rows = bind.execute(
+        sa.text(f"SELECT id, {column} AS val FROM {table} WHERE {column} LIKE '%/api/v1/uploads/%'")
+    ).fetchall()
+    for row in rows:
+        new_val = strip_upload_host(row.val)
+        if new_val != row.val:
+            bind.execute(
+                sa.text(f"UPDATE {table} SET {column} = :val WHERE id = :id"),
+                {"val": new_val, "id": row.id},
+            )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    _rewrite(bind, "faqs", "answer")
+    _rewrite(bind, "help_center_settings", "logo_url")
+    _rewrite(bind, "help_center_settings", "favicon_url")
+
+
+def downgrade() -> None:
+    # Can't reliably re-absolutize (original host unknown); relative paths are correct anyway.
+    pass

--- a/backend/app/agents/faq_generator.py
+++ b/backend/app/agents/faq_generator.py
@@ -212,6 +212,9 @@ class FAQGeneratorAgent:
         tools = []
         response_model = FAQExtractionResult
         structured_outputs = True
+        # Keep the original instructions for the plain-JSON fallback — the Groq
+        # branch augments a separate copy with tool-calling guidance.
+        agent_instructions = instructions
         if self._use_groq_json_tool:
             tools.append(
                 build_groq_json_tool(
@@ -220,11 +223,11 @@ class FAQGeneratorAgent:
                     description="Return the final extracted FAQ list. Call exactly once.",
                 )
             )
-            instructions = instructions + _GROQ_FAQ_INSTRUCTION
+            agent_instructions = instructions + _GROQ_FAQ_INSTRUCTION
             response_model = None
             structured_outputs = False
 
-        agent = self._build_agent(instructions, tools, response_model, structured_outputs)
+        agent = self._build_agent(agent_instructions, tools, response_model, structured_outputs)
 
         try:
             self._count_call()
@@ -232,10 +235,13 @@ class FAQGeneratorAgent:
         except Exception as arun_exc:
             if self._use_groq_json_tool:
                 salvaged = salvage_groq_json_error(arun_exc)
-                if not salvaged:
-                    raise
-                logger.warning("Groq FAQ json tool call unparseable (likely truncated); salvaging fields")
-                return self._validate(salvaged)
+                if salvaged:
+                    logger.warning("Groq FAQ json tool call unparseable (likely truncated); salvaging fields")
+                    return self._validate(salvaged)
+                # Tool call errored with nothing to salvage — fall back to the
+                # provider-agnostic plain-JSON path rather than failing the batch.
+                logger.warning(f"Groq FAQ json tool call failed ({arun_exc}); falling back to plain-JSON extraction")
+                return await self._extract_plain_json(instructions, message)
             # Some providers (Ollama/HuggingFace/Mistral via agno) fail on
             # native structured outputs — retry once with a plain-JSON prompt.
             logger.warning(
@@ -245,7 +251,14 @@ class FAQGeneratorAgent:
             return await self._extract_plain_json(instructions, message)
 
         if self._use_groq_json_tool:
-            return self._validate(capture)
+            faqs = self._validate(capture)
+            if faqs:
+                return faqs
+            # Groq answered but never emitted a usable tool call (common with
+            # some Groq models) — `capture` is empty, so the batch would be
+            # silently dropped. Fall back to plain-JSON extraction.
+            logger.warning("Groq FAQ json tool produced no output; falling back to plain-JSON extraction")
+            return await self._extract_plain_json(instructions, message)
         try:
             return self._parse_native(response)
         except _UnparseableOutput:

--- a/backend/app/api/help_center/branding.py
+++ b/backend/app/api/help_center/branding.py
@@ -54,6 +54,13 @@ _LOGO_TYPES = {"image/png", "image/jpeg", "image/webp"}
 MAX_LOGO_DIM = 4000
 LOGO_FIT_DIM = 512
 
+# Favicon: same raster-only policy (SVG/ICO rejected — stored XSS / unsupported by
+# sanitize_image). Stored small and square-ish; the browser scales the PNG.
+MAX_FAVICON_BYTES = 1 * 1024 * 1024
+_FAVICON_TYPES = {"image/png", "image/jpeg", "image/webp"}
+MAX_FAVICON_DIM = 2000
+FAVICON_FIT_DIM = 128
+
 
 def domain_status_response(row: HelpCenterSettings) -> DomainStatusResponse:
     """DNS-records table for the admin UI, shaped from stored state."""
@@ -98,6 +105,9 @@ async def settings_response(
     # /api/v1/uploads/*.png would 404 there. Anchor to the backend origin.
     response.logo_url = (
         absolute_upload_url(await resolve_public_url(row.logo_url)) if row.logo_url else None
+    )
+    response.favicon_url = (
+        absolute_upload_url(await resolve_public_url(row.favicon_url)) if row.favicon_url else None
     )
     response.live_url = live_url(row)
     response.published_count = FAQRepository(db).count_published(organization_id)
@@ -191,5 +201,45 @@ async def remove_logo(
     check_help_center_access(db, current_user.organization_id)
     row = get_or_create_settings(db, current_user.organization)
     row.logo_url = None
+    row = HelpCenterRepository(db).update(row)
+    return await settings_response(db, row, current_user.organization_id)
+
+
+@router.post("/favicon", response_model=HelpCenterSettingsResponse)
+async def upload_favicon(
+    file: UploadFile = File(...),
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    check_help_center_access(db, current_user.organization_id)
+    row = get_or_create_settings(db, current_user.organization)
+
+    content = await file.read()
+    safe_bytes, content_type, ext = sanitize_image(
+        content,
+        allowed_content_types=_FAVICON_TYPES,
+        max_bytes=MAX_FAVICON_BYTES,
+        max_dim=MAX_FAVICON_DIM,
+        fit=FAVICON_FIT_DIM,
+    )
+    file_name = f"{uuid4()}{ext}"
+    row.favicon_url = await store_upload(
+        safe_bytes,
+        f"help_center/{current_user.organization_id}",
+        file_name,
+        content_type=content_type,
+    )
+    row = HelpCenterRepository(db).update(row)
+    return await settings_response(db, row, current_user.organization_id)
+
+
+@router.delete("/favicon", response_model=HelpCenterSettingsResponse)
+async def remove_favicon(
+    current_user: User = Depends(require_permissions("manage_knowledge")),
+    db: Session = Depends(get_db),
+):
+    check_help_center_access(db, current_user.organization_id)
+    row = get_or_create_settings(db, current_user.organization)
+    row.favicon_url = None
     row = HelpCenterRepository(db).update(row)
     return await settings_response(db, row, current_user.organization_id)

--- a/backend/app/api/help_center_public.py
+++ b/backend/app/api/help_center_public.py
@@ -21,6 +21,7 @@ is the rate-limited "Ask AI".
 
 from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse, PlainTextResponse, Response
+from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
@@ -31,7 +32,6 @@ from app.models.faq import FAQ
 from app.models.help_center import HelpCenterSettings
 from app.repositories.faq import FAQRepository
 from app.services.file_storage import resolve_public_url
-from app.services.help_center_images import absolute_upload_url
 from app.services.help_center_content import (
     excerpt,
     read_time_label,
@@ -55,6 +55,17 @@ from app.services.help_center_settings import live_url
 from app.services.public_rate_limit import allow_request
 
 public_app = FastAPI(title="ChatterMate Help Center", docs_url=None, redoc_url=None, openapi_url=None)
+# Serve ONLY help-center images on this app, so relative logo/article-image paths
+# resolve on a subdomain/custom-domain origin (host dispatch). Scoped to the
+# help_center/ subtree — the help center must never expose chat_attachments,
+# knowledge, avatars, etc. (in path mode these paths are served by the main app
+# instead). check_dir=False: the dir may not exist until the first upload; a
+# missing file 404s. Local storage only — S3 URLs never hit this mount.
+public_app.mount(
+    "/api/v1/uploads/help_center",
+    StaticFiles(directory="uploads/help_center", check_dir=False),
+    name="help_center_uploads",
+)
 templates = Jinja2Templates(directory="app/templates")
 
 PAGE_CACHE_CONTROL = "public, max-age=60"
@@ -82,23 +93,36 @@ def _client_ip(request: Request) -> str:
 
 
 def _resolve_or_404(request: Request, db: Session):
-    host = normalize_host(request.headers.get("host"))
-    row = resolve_help_center(db, host)
+    hc = request.scope.get("help_center")
+    if hc:  # path dispatch (/help/{slug}) — org from the path slug, not Host
+        row = resolve_help_center(db, slug=hc["slug"])
+    else:
+        row = resolve_help_center(db, host=normalize_host(request.headers.get("host")))
     if not row:
         raise HTTPException(status_code=404, detail="Help center not found")
     return row
 
 
-async def _chrome_context(row: HelpCenterSettings) -> dict:
-    """Shared header/footer/widget context used by every rendered page."""
+def _base_path(request: Request) -> str:
+    """URL prefix for internal links: "/help/{slug}" under path dispatch, "" otherwise."""
+    return request.scope.get("help_center", {}).get("base_path", "")
+
+
+async def _chrome_context(row: HelpCenterSettings, base_path: str = "") -> dict:
+    """Shared header/footer/widget context used by every rendered page.
+
+    `base_path` is the URL prefix templates prepend to internal links: "" for
+    host dispatch (site at origin root) and "/help/{slug}" for path dispatch."""
     return {
         "row": row,
+        "base_path": base_path,
         "brand_color": row.brand_color,
         "brand_ink": contrast_ink(row.brand_color),
-        # Absolute (api-origin) URL: the public site is host-dispatched to a
-        # limited app that does NOT serve /api/v1/uploads, so a host-relative
-        # path would 404 on the help-center domain. Mirror article images.
-        "logo_url": absolute_upload_url(await resolve_public_url(row.logo_url)) if row.logo_url else None,
+        # Relative (/api/v1/uploads/...) so the logo resolves against whichever
+        # origin serves the page — public_app now mounts uploads for host mode,
+        # and path mode is same-origin as the API. S3 stays absolute (signed).
+        "logo_url": await resolve_public_url(row.logo_url) if row.logo_url else None,
+        "favicon_url": await resolve_public_url(row.favicon_url) if row.favicon_url else None,
         "header_links": row.header_links or [],
         "widget_id": widget_id_for(row),
         # The widget LOADER (chattermate.min.js) is served by the frontend, while
@@ -160,7 +184,7 @@ async def index(request: Request, q: str = "", db: Session = Depends(get_db)):
     colors = category_colors([category for category, _faqs in groups])
     card_groups = [(category, [_card_view(faq) for faq in faqs]) for category, faqs in groups]
     context = {
-        **await _chrome_context(row),
+        **await _chrome_context(row, _base_path(request)),
         "request": request,
         "groups": card_groups,
         "colors": colors,
@@ -211,13 +235,13 @@ async def article(slug: str, request: Request, db: Session = Depends(get_db)):
         "category": faq.category,
         "color": default_color,
         "read_time": read_time_label(faq.answer),
-        "body_html": render_article_html(faq.answer),
+        "body_html": render_article_html(faq.answer, _base_path(request)),
         "related": related,
     }
     canonical = f"{live_url(row)}/a/{faq.slug}"
     json_ld = _faq_page_json_ld([faq])
     context = {
-        **await _chrome_context(row),
+        **await _chrome_context(row, _base_path(request)),
         "request": request,
         "article": article_view,
         "topics": topics,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -135,6 +135,15 @@ class Settings(BaseSettings):
     KNOWLEDGE_SUMMARY_MAX_TOKENS: int = int(os.getenv("KNOWLEDGE_SUMMARY_MAX_TOKENS", "4000"))
 
     # Help center (public FAQ site)
+    # How the public help center URL is advertised (live_url):
+    #   "path"      -> {BACKEND_URL}/help/{slug}, served same-origin as the API.
+    #                  Works on localhost/self-host with no DNS/TLS/proxy. Default.
+    #   "subdomain" -> https://{slug}.<HELP_CENTER_BASE_DOMAIN> (cloud). MUST be set
+    #                  on cloud so subdomain help centers keep their branded URL.
+    # A verified custom domain always takes precedence over both. Host-based dispatch
+    # (subdomains + custom domains) stays active regardless; only path dispatch is gated
+    # to "path" mode.
+    HELP_CENTER_PUBLIC_MODE: str = os.getenv("HELP_CENTER_PUBLIC_MODE", "path")
     # Base domain serving {slug}.<base> help centers.
     HELP_CENTER_BASE_DOMAIN: str = os.getenv("HELP_CENTER_BASE_DOMAIN", "chattermate.help")
     # CNAME target customers point their custom help-center domain at.

--- a/backend/app/core/help_center_host.py
+++ b/backend/app/core/help_center_host.py
@@ -26,6 +26,7 @@ so dispatch and resolution can never disagree.
 """
 
 import asyncio
+import re
 import time
 from typing import Optional
 
@@ -35,6 +36,10 @@ from app.core.logger import get_logger
 logger = get_logger(__name__)
 
 DOMAIN_CACHE_TTL_SECONDS = 60
+
+# Path-based dispatch (self-host): {BACKEND_URL}/help/{slug}/... on the main
+# origin. Group 1 is the help-center slug, group 2 the remainder ("/", "/a/x").
+_HELP_PATH_RE = re.compile(r"^/help/([^/]+)(/.*)?$")
 
 
 def normalize_host(raw_host: Optional[str]) -> str:
@@ -121,7 +126,24 @@ class HelpCenterHostMiddleware:
         self.public_app = public_app
 
     async def __call__(self, scope, receive, send):
-        if scope["type"] == "http" and is_help_center_host(_host_from_scope(scope)):
-            await self.public_app(scope, receive, send)
-            return
+        if scope["type"] == "http":
+            # Path dispatch (self-host default): /help/{slug}/... on the main
+            # origin. Gated to path mode so cloud never serves the /help/ form.
+            if settings.HELP_CENTER_PUBLIC_MODE == "path":
+                match = _HELP_PATH_RE.match(scope.get("path", ""))
+                if match:
+                    slug = match.group(1)
+                    # Drop a trailing slash from the remainder ourselves: letting
+                    # Starlette's redirect_slashes handle it would 307 to a
+                    # Location built from the rewritten (prefix-stripped) path,
+                    # sending the visitor to the origin root without /help/{slug}.
+                    remainder = (match.group(2) or "").rstrip("/") or "/"
+                    scope["help_center"] = {"slug": slug, "base_path": f"/help/{slug}"}
+                    scope["path"] = remainder
+                    scope["raw_path"] = remainder.encode("latin-1")
+                    await self.public_app(scope, receive, send)
+                    return
+            if is_help_center_host(_host_from_scope(scope)):
+                await self.public_app(scope, receive, send)
+                return
         await self.app(scope, receive, send)

--- a/backend/app/models/help_center.py
+++ b/backend/app/models/help_center.py
@@ -63,6 +63,7 @@ class HelpCenterSettings(Base):
     title = Column(String(120), nullable=True)
     description = Column(String(300), nullable=True)
     logo_url = Column(String, nullable=True)
+    favicon_url = Column(String, nullable=True)
     brand_color = Column(String(9), nullable=False, default=DEFAULT_BRAND_COLOR)
     # [{"label": str, "url": str}, ...]
     header_links = Column(JSON, nullable=False, default=lambda: [])

--- a/backend/app/models/schemas/help_center.py
+++ b/backend/app/models/schemas/help_center.py
@@ -110,6 +110,7 @@ class HelpCenterSettingsResponse(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
     logo_url: Optional[str] = None
+    favicon_url: Optional[str] = None
     brand_color: str
     header_links: List[HeaderLink] = []
     cta_text: Optional[str] = None

--- a/backend/app/services/faq_article_import.py
+++ b/backend/app/services/faq_article_import.py
@@ -24,7 +24,7 @@ import asyncio
 import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
-from urllib.parse import urldefrag, urljoin, urlparse, urlunparse
+from urllib.parse import urldefrag, urljoin, urlparse
 
 import httpx
 from bs4 import BeautifulSoup, Tag
@@ -40,9 +40,7 @@ from app.models.faq_generation_job import FAQGenerationJob, FAQJobStage
 from app.models.schemas.faq import MAX_ANSWER_LENGTH, MAX_QUESTION_LENGTH
 from app.repositories.faq import FAQRepository
 from app.repositories.faq_generation_job import FAQGenerationJobRepository
-from app.repositories.help_center import HelpCenterRepository
 from app.services.faq_generation import CategoryMerger, insert_draft_rows, normalize_question
-from app.services.help_center_settings import live_url
 from app.services.faq_import import _FETCH_HEADERS, MIN_STATIC_TEXT_CHARS
 from app.services.help_center_images import (
     FAQ_IMAGE_TYPES,
@@ -91,9 +89,6 @@ _GENERIC_SECTIONS = frozenset({
     "browse", "recent articles", "recently updated", "top articles",
 })
 
-# Breadcrumb "back" links whose leading container should be dropped from bodies.
-_BREADCRUMB_ROOTS = frozenset({"home", "all collections", "all categories", "help center", "help centre"})
-
 # Internal scheme marking images collected during conversion, replaced with the
 # re-hosted URL afterwards (conversion is sync; storage is async). The trailing
 # ".img" delimits the index so "…//1.img" is never a prefix of "…//10.img".
@@ -114,32 +109,20 @@ class _ArticleConverter(MarkdownConverter):
     """HTML→Markdown converter that absolutizes links and swaps images for
     placeholders after downloading them (SSRF-guarded, size/type-capped)."""
 
-    def __init__(self, base_url: str, client: httpx.Client, dest_origin: Optional[str] = None, **options):
+    def __init__(self, base_url: str, client: httpx.Client, **options):
         super().__init__(**options)
         self._base_url = base_url
         self._client = client
-        # Cross-links to the source help center get their origin swapped to the
-        # destination help center (path preserved), so imported articles don't
-        # link back to the site being migrated away from. None = leave links as-is.
-        self._dest_origin = dest_origin.rstrip("/") if dest_origin else None
-        self._source_domain = _registrable_domain(urlparse(base_url).hostname or "")
         self.images: Dict[int, Tuple[bytes, str]] = {}
 
     def convert_a(self, el, text, parent_tags):
+        # Absolutize every link; same-site source links are remapped to the
+        # destination help center in a second pass (run_article_import_job),
+        # once every article's new FAQ slug is known.
         href = el.get("href")
         if href:
-            el["href"] = self._localize_link(urljoin(self._base_url, href))
+            el["href"] = urljoin(self._base_url, href)
         return super().convert_a(el, text, parent_tags)
-
-    def _localize_link(self, url: str) -> str:
-        """Same-site link → destination help-center origin, path unchanged.
-        Off-site links (and everything when no destination is set) pass through."""
-        if not self._dest_origin:
-            return url
-        parsed = urlparse(url)
-        if parsed.scheme in ("http", "https") and _registrable_domain(parsed.hostname or "") == self._source_domain:
-            return self._dest_origin + urlunparse(("", "", parsed.path, parsed.params, parsed.query, parsed.fragment))
-        return url
 
     def convert_img(self, el, text, parent_tags):
         alt = (el.get("alt") or "").strip()
@@ -371,7 +354,8 @@ def _strip_chrome(node: Tag) -> None:
     """Remove in-article chrome that shouldn't become FAQ content: nav bars,
     TOCs, footers, help-center platform branding ('Made with Chatwoot') and
     'Last updated' metadata lines. Best-effort — a detached element mid-loop
-    just skips."""
+    just skips. (Breadcrumb "Home › Category" nav links are dropped later, in
+    _remap_source_links, since they often share a container with the title.)"""
     for chrome in node.find_all("nav") + node.find_all("footer"):
         chrome.decompose()
     for chrome in node.find_all(class_=_TOC_RE) + node.find_all(id=_TOC_RE):
@@ -379,17 +363,6 @@ def _strip_chrome(node: Tag) -> None:
             chrome.decompose()
         except Exception:
             pass
-    # Leading breadcrumb ("Home › …"): strip only when the article's FIRST link
-    # is a back-to-index link in a short container. A "Home" link buried in body
-    # prose is never the first anchor, so real content is never removed.
-    first_anchor = node.find("a")
-    if first_anchor and first_anchor.get_text(strip=True).lower() in _BREADCRUMB_ROOTS:
-        container = first_anchor.find_parent(["nav", "ol", "ul", "div"])
-        if container and len(container.get_text(" ", strip=True)) <= 80:
-            try:
-                container.decompose()
-            except Exception:
-                pass
     # Platform-branding link ("Made with Chatwoot" logo): remove only a SMALL
     # enclosing block (the footer badge), never a large content div that merely
     # links out to the platform.
@@ -413,7 +386,6 @@ def _strip_chrome(node: Tag) -> None:
 
 def fetch_article(
     client: httpx.Client, url: str, category_override: Optional[str] = None,
-    dest_origin: Optional[str] = None,
 ) -> Optional[Article]:
     """One article page → title + Markdown body (+ images pending re-host).
     category_override (from the category listing that linked here) wins over the
@@ -435,7 +407,7 @@ def fetch_article(
         first_h1.extract()
     _strip_chrome(node)
     converter = _ArticleConverter(
-        base_url=final_url, client=client, dest_origin=dest_origin, heading_style="ATX", bullets="-"
+        base_url=final_url, client=client, heading_style="ATX", bullets="-"
     )
     markdown = converter.convert_soup(node).strip()
     if not markdown:
@@ -461,25 +433,68 @@ async def _rehost_images(article: Article) -> str:
     return markdown
 
 
-def _dest_help_center_origin(db, organization_id) -> Optional[str]:
-    """Origin (scheme://host) of the org's ChatterMate help center, used to
-    rewrite imported cross-links off the source site. None when the org has no
-    help center configured — links are then left pointing at the source."""
-    row = HelpCenterRepository(db).get_by_org(organization_id)
-    if not row:
+# Markdown links, excluding image embeds (`![alt](src)`). Group 1 = label,
+# group 2 = the http(s) URL; an optional markdown title (`[x](url "title")`, which
+# markdownify emits for anchors with a title attribute) is tolerated and dropped.
+_MD_LINK_RE = re.compile(r'(?<!!)\[([^\]]*)\]\((https?://[^)\s]+)(?:\s+"[^"]*")?\)')
+
+
+def _article_key(path: str) -> Optional[str]:
+    """Stable identifier for an article from its URL path — the numeric id in
+    `/articles/{id}-{slug}` (falling back to the whole segment). Lets a cross-link
+    resolve to the same article regardless of the slug suffix or a missing slug."""
+    lower = path.lower()
+    idx = lower.find(_ARTICLE_MARKER)
+    if idx == -1:
         return None
-    parsed = urlparse(live_url(row))
-    if not parsed.scheme or not parsed.netloc:
-        return None
-    return f"{parsed.scheme}://{parsed.netloc}"
+    segment = path[idx + len(_ARTICLE_MARKER):].split("/")[0].split("?")[0]
+    numeric = re.match(r"\d+", segment)
+    return numeric.group(0) if numeric else (segment.lower() or None)
+
+
+# Leading breadcrumb residue after "Home › Account" links are dropped: chevron /
+# middot separators (never markdown-structural chars like - > | so hr/blockquote/
+# tables are safe).
+_BREADCRUMB_RESIDUE_RE = re.compile(r"^[\s›»·]+")
+
+
+def _remap_source_links(markdown: str, source_hosts: set, key_to_slug: dict) -> str:
+    """Rewrite links to the SOURCE HELP CENTER as ROOT-RELATIVE help-center paths:
+      - article link → /a/{new-slug} (or /  when the article wasn't imported),
+        kept as a link;
+      - home/category link (non-article) → DROPPED — these are breadcrumb/nav
+        chrome ("Home › Account") that shouldn't appear in article bodies.
+
+    Links are stored WITHOUT an origin or /help/{slug} prefix so they survive a
+    move to a custom domain or subdomain — the serving prefix is added at render
+    time (help_center_content.render_article_html). Matching is by EXACT host
+    against the set of hosts the articles were actually fetched from (handles
+    redirects and main-site→help-subdomain splits), so links to the main product
+    site and every other external link are left untouched."""
+    def repl(match):
+        label, url = match.group(1), match.group(2)
+        parsed = urlparse(url)
+        if (parsed.hostname or "").lower() not in source_hosts:
+            return match.group(0)  # off-site (incl. the main product site) — keep
+        key = _article_key(parsed.path)
+        if key is None:
+            return ""  # home / category breadcrumb link — drop entirely
+        slug = key_to_slug.get(key)
+        return f"[{label}](/a/{slug})" if slug else f"[{label}](/)"
+
+    result = _MD_LINK_RE.sub(repl, markdown)
+    # Tidy up after dropped breadcrumbs: strip leading separator residue and
+    # collapse the blank lines those drops leave behind.
+    result = _BREADCRUMB_RESIDUE_RE.sub("", result)
+    return re.sub(r"\n{3,}", "\n\n", result)
 
 
 async def run_article_import_job(db, job: FAQGenerationJob) -> int:
     """Execute an IMPORT_ARTICLES job. Returns FAQs created. No LLM involved —
-    articles are imported verbatim as Markdown drafts."""
+    articles are imported verbatim as Markdown drafts, then a second pass remaps
+    intra-help-center links to the org's new help center."""
     job_repo = FAQGenerationJobRepository(db)
     job_repo.update_progress(job.id, stage=FAQJobStage.ANALYZING_SOURCES, progress_percentage=5.0)
-    dest_origin = _dest_help_center_origin(db, job.organization_id)
 
     client = httpx.Client(timeout=settings.FAQ_IMPORT_FETCH_TIMEOUT, headers=_FETCH_HEADERS)
     try:
@@ -493,8 +508,9 @@ async def run_article_import_job(db, job: FAQGenerationJob) -> int:
         source_label = f"Imported from {urlparse(job.source_url).netloc}"
 
         rows: List[FAQ] = []
+        row_sources: List[str] = []  # each row's source article URL, for link remapping
         for index, (link, category) in enumerate(links):
-            article = await asyncio.to_thread(fetch_article, client, link, category, dest_origin)
+            article = await asyncio.to_thread(fetch_article, client, link, category)
             job_repo.update_progress(
                 job.id, progress_percentage=10.0 + 78.0 * (index + 1) / len(links)
             )
@@ -518,9 +534,37 @@ async def run_article_import_job(db, job: FAQGenerationJob) -> int:
                     created_by=job.user_id,
                 )
             )
+            row_sources.append(article.url)
     finally:
         client.close()
 
     if not rows:
         return 0
-    return insert_draft_rows(db, job, rows)
+    created = insert_draft_rows(db, job, rows)  # assigns each row a unique slug in place
+    _remap_imported_links(db, rows, row_sources)
+    return created
+
+
+def _remap_imported_links(db, rows, row_sources) -> None:
+    """Second pass: rewrite intra-help-center links in the just-imported answers to
+    root-relative help-center paths (article → /a/{slug}, else → home)."""
+    # Match against the hosts the articles were ACTUALLY fetched from (post-redirect,
+    # possibly a help subdomain) — NOT the typed index URL, which may redirect or be
+    # main-site-hosted. Using the real article hosts fixes redirect/subdomain splits
+    # without risking a match on main-site content links.
+    source_hosts = {(urlparse(src).hostname or "").lower() for src in row_sources}
+    source_hosts.discard("")
+    key_to_slug = {}
+    for src, faq in zip(row_sources, rows):
+        key = _article_key(urlparse(src).path)
+        if key:
+            key_to_slug[key] = faq.slug
+
+    dirty = False
+    for faq in rows:
+        remapped = _remap_source_links(faq.answer, source_hosts, key_to_slug)
+        if remapped != faq.answer:
+            faq.answer = remapped[:MAX_ANSWER_LENGTH]
+            dirty = True
+    if dirty:
+        db.commit()

--- a/backend/app/services/faq_article_import.py
+++ b/backend/app/services/faq_article_import.py
@@ -24,7 +24,7 @@ import asyncio
 import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
-from urllib.parse import urldefrag, urljoin, urlparse
+from urllib.parse import urldefrag, urljoin, urlparse, urlunparse
 
 import httpx
 from bs4 import BeautifulSoup, Tag
@@ -40,7 +40,9 @@ from app.models.faq_generation_job import FAQGenerationJob, FAQJobStage
 from app.models.schemas.faq import MAX_ANSWER_LENGTH, MAX_QUESTION_LENGTH
 from app.repositories.faq import FAQRepository
 from app.repositories.faq_generation_job import FAQGenerationJobRepository
+from app.repositories.help_center import HelpCenterRepository
 from app.services.faq_generation import CategoryMerger, insert_draft_rows, normalize_question
+from app.services.help_center_settings import live_url
 from app.services.faq_import import _FETCH_HEADERS, MIN_STATIC_TEXT_CHARS
 from app.services.help_center_images import (
     FAQ_IMAGE_TYPES,
@@ -112,17 +114,32 @@ class _ArticleConverter(MarkdownConverter):
     """HTML→Markdown converter that absolutizes links and swaps images for
     placeholders after downloading them (SSRF-guarded, size/type-capped)."""
 
-    def __init__(self, base_url: str, client: httpx.Client, **options):
+    def __init__(self, base_url: str, client: httpx.Client, dest_origin: Optional[str] = None, **options):
         super().__init__(**options)
         self._base_url = base_url
         self._client = client
+        # Cross-links to the source help center get their origin swapped to the
+        # destination help center (path preserved), so imported articles don't
+        # link back to the site being migrated away from. None = leave links as-is.
+        self._dest_origin = dest_origin.rstrip("/") if dest_origin else None
+        self._source_domain = _registrable_domain(urlparse(base_url).hostname or "")
         self.images: Dict[int, Tuple[bytes, str]] = {}
 
     def convert_a(self, el, text, parent_tags):
         href = el.get("href")
         if href:
-            el["href"] = urljoin(self._base_url, href)
+            el["href"] = self._localize_link(urljoin(self._base_url, href))
         return super().convert_a(el, text, parent_tags)
+
+    def _localize_link(self, url: str) -> str:
+        """Same-site link → destination help-center origin, path unchanged.
+        Off-site links (and everything when no destination is set) pass through."""
+        if not self._dest_origin:
+            return url
+        parsed = urlparse(url)
+        if parsed.scheme in ("http", "https") and _registrable_domain(parsed.hostname or "") == self._source_domain:
+            return self._dest_origin + urlunparse(("", "", parsed.path, parsed.params, parsed.query, parsed.fragment))
+        return url
 
     def convert_img(self, el, text, parent_tags):
         alt = (el.get("alt") or "").strip()
@@ -395,7 +412,8 @@ def _strip_chrome(node: Tag) -> None:
 
 
 def fetch_article(
-    client: httpx.Client, url: str, category_override: Optional[str] = None
+    client: httpx.Client, url: str, category_override: Optional[str] = None,
+    dest_origin: Optional[str] = None,
 ) -> Optional[Article]:
     """One article page → title + Markdown body (+ images pending re-host).
     category_override (from the category listing that linked here) wins over the
@@ -416,7 +434,9 @@ def fetch_article(
     if first_h1:
         first_h1.extract()
     _strip_chrome(node)
-    converter = _ArticleConverter(base_url=final_url, client=client, heading_style="ATX", bullets="-")
+    converter = _ArticleConverter(
+        base_url=final_url, client=client, dest_origin=dest_origin, heading_style="ATX", bullets="-"
+    )
     markdown = converter.convert_soup(node).strip()
     if not markdown:
         return None
@@ -441,11 +461,25 @@ async def _rehost_images(article: Article) -> str:
     return markdown
 
 
+def _dest_help_center_origin(db, organization_id) -> Optional[str]:
+    """Origin (scheme://host) of the org's ChatterMate help center, used to
+    rewrite imported cross-links off the source site. None when the org has no
+    help center configured — links are then left pointing at the source."""
+    row = HelpCenterRepository(db).get_by_org(organization_id)
+    if not row:
+        return None
+    parsed = urlparse(live_url(row))
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
 async def run_article_import_job(db, job: FAQGenerationJob) -> int:
     """Execute an IMPORT_ARTICLES job. Returns FAQs created. No LLM involved —
     articles are imported verbatim as Markdown drafts."""
     job_repo = FAQGenerationJobRepository(db)
     job_repo.update_progress(job.id, stage=FAQJobStage.ANALYZING_SOURCES, progress_percentage=5.0)
+    dest_origin = _dest_help_center_origin(db, job.organization_id)
 
     client = httpx.Client(timeout=settings.FAQ_IMPORT_FETCH_TIMEOUT, headers=_FETCH_HEADERS)
     try:
@@ -460,7 +494,7 @@ async def run_article_import_job(db, job: FAQGenerationJob) -> int:
 
         rows: List[FAQ] = []
         for index, (link, category) in enumerate(links):
-            article = await asyncio.to_thread(fetch_article, client, link, category)
+            article = await asyncio.to_thread(fetch_article, client, link, category, dest_origin)
             job_repo.update_progress(
                 job.id, progress_percentage=10.0 + 78.0 * (index + 1) / len(links)
             )

--- a/backend/app/services/faq_generation.py
+++ b/backend/app/services/faq_generation.py
@@ -243,6 +243,7 @@ async def draft_batches(
 
     accepted: List[Tuple[BatchT, GeneratedFAQ]] = []
     failures = 0
+    last_error: Optional[Exception] = None
     for index, batch in enumerate(batches):
         faqs = None
         for attempt in range(1 + retries_per_batch):
@@ -250,6 +251,7 @@ async def draft_batches(
                 faqs = await extract(batch, dedup)
                 break
             except Exception as e:
+                last_error = e
                 logger.warning(f"FAQ batch {index + 1}/{len(batches)} attempt {attempt + 1} failed: {e}")
         if faqs is None:
             failures += 1
@@ -259,7 +261,10 @@ async def draft_batches(
             job.id, progress_percentage=30.0 + 60.0 * (index + 1) / len(batches)
         )
     if batches and failures == len(batches):
-        raise RuntimeError("FAQ generation failed for every content batch.")
+        # Surface the underlying provider error (e.g. an unsupported/decommissioned
+        # model) instead of a generic message, so the UI can tell the user what to fix.
+        detail = f" — {last_error}" if last_error else ""
+        raise RuntimeError(f"The AI model could not generate FAQs from this content{detail}")
     return accepted
 
 

--- a/backend/app/services/faq_import.py
+++ b/backend/app/services/faq_import.py
@@ -143,7 +143,14 @@ async def _extract_and_insert(
             )
     else:
         async def extract(batch: str, dedup: DedupState):
-            return await generator.extract_from_faq_page(batch, existing_questions=dedup.for_prompt)
+            faqs = await generator.extract_from_faq_page(batch, existing_questions=dedup.for_prompt)
+            if not faqs:
+                # The page had no verbatim Q&A — an index/category listing or free-form
+                # prose. Rather than import nothing, draft FAQs from the same content.
+                faqs = await generator.generate_from_text(
+                    batch, existing_questions=dedup.for_prompt, existing_categories=categories.names
+                )
+            return faqs
 
     accepted = await draft_batches(db, job, batches, extract, retries_per_batch=0)
 

--- a/backend/app/services/help_center_content.py
+++ b/backend/app/services/help_center_content.py
@@ -53,21 +53,34 @@ _URL_SCHEMES = {"http", "https", "mailto"}
 
 _WHITESPACE_RE = re.compile(r"\s+")
 
+# Intra-help-center links are stored ROOT-RELATIVE (/a/{slug}, or / for the home)
+# so they survive a move between path mode and a subdomain/custom domain. The
+# serving prefix is added here at render time. `/a/` (with the trailing slash)
+# never matches an image path like /api/v1/uploads/...
+_INTERNAL_HREF_RE = re.compile(r'(href=")(/a/[^"]*|/)(")')
 
-def render_article_html(text: str) -> str:
+
+def render_article_html(text: str, base_path: str = "") -> str:
     """Markdown -> sanitized HTML for the public article body. Safe to render
     with Jinja's `| safe` because nh3 strips every tag/attr/scheme off-allowlist
-    and rewrites link rel to neutralise tab-nabbing."""
+    and rewrites link rel to neutralise tab-nabbing.
+
+    `base_path` is the serving prefix ("" at a domain root, "/help/{slug}" in path
+    mode) prepended to root-relative intra-help-center links so cross-article links
+    resolve under whichever mode/domain serves the page."""
     if not text or not text.strip():
         return ""
     raw = _markdown.markdown(text, extensions=_MD_EXTENSIONS, output_format="html")
-    return nh3.clean(
+    html = nh3.clean(
         raw,
         tags=_ALLOWED_TAGS,
         attributes=_ALLOWED_ATTRS,
         url_schemes=_URL_SCHEMES,
         link_rel="noopener noreferrer nofollow",
     )
+    if base_path:
+        html = _INTERNAL_HREF_RE.sub(lambda m: f"{m.group(1)}{base_path}{m.group(2)}{m.group(3)}", html)
+    return html
 
 
 def to_plain_text(text: str) -> str:

--- a/backend/app/services/help_center_images.py
+++ b/backend/app/services/help_center_images.py
@@ -14,16 +14,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 Help-center article images. Images embedded in an article's Markdown must
-resolve to a STABLE, ABSOLUTE URL (they render on the help-center domain, and
-the reference is stored inline in the answer forever — so no signed/expiring
-URLs and no host-relative paths). Shared by the admin upload endpoint and the
-article importer's re-hosting path.
+resolve to a STABLE URL that is baked inline in the answer forever — so no
+signed/expiring URLs. Local storage returns a host-RELATIVE path under the
+/api/v1/uploads mount, which resolves against whichever origin serves the page
+(the main app in path mode, and public_app — which mounts uploads — in host
+mode). S3 returns its own absolute URL. Shared by the admin upload endpoint and
+the article importer's re-hosting path.
 """
 
+import re
 from uuid import uuid4
 
 from app.core.config import settings
 from app.services.file_storage import store_upload
+
+def strip_upload_host(text: str) -> str:
+    """Convert the app's OWN absolute upload URLs to relative /api/v1/uploads/...
+    paths, leaving everything else untouched. Only strips the configured
+    BACKEND_URL origin or a loopback host (localhost/127.0.0.1/0.0.0.0) — a
+    third-party URL that merely contains /api/v1/uploads/ (e.g. a link pasted
+    into an FAQ answer) is NOT rewritten. S3 and already-relative URLs never
+    match. Used by the one-time backfill migration."""
+    if not text:
+        return text
+    backend = settings.BACKEND_URL.rstrip("/")
+    # Match our own backend origin OR any loopback host (with optional port),
+    # only when it sits directly in front of an /api/v1/uploads/ path.
+    pattern = re.compile(
+        r'(?:' + re.escape(backend)
+        + r'|https?://(?:localhost|127\.0\.0\.1|0\.0\.0\.0)(?::\d+)?)'
+        + r'(?=/api/v1/uploads/)'
+    )
+    return pattern.sub("", text)
 
 MAX_FAQ_IMAGE_BYTES = 5 * 1024 * 1024
 # Reject larger-than-this on a side up front (bomb guard); downscale the stored
@@ -49,9 +71,12 @@ def absolute_upload_url(stored: str) -> str:
 
 
 async def store_article_image(content: bytes, content_type: str) -> str:
-    """Persist validated image bytes and return the stable absolute URL.
-    Caller is responsible for size/content-type validation against
-    MAX_FAQ_IMAGE_BYTES / FAQ_IMAGE_TYPES."""
+    """Persist validated image bytes and return the stable URL to bake into the
+    answer markdown: a relative /api/v1/uploads/... path for local storage, or
+    the absolute S3 URL for S3. Caller is responsible for size/content-type
+    validation against MAX_FAQ_IMAGE_BYTES / FAQ_IMAGE_TYPES.
+
+    Note: do NOT wrap in resolve_public_url here — that signs S3 URLs, which
+    expire and must never be baked permanently into stored content."""
     file_name = f"{uuid4()}{FAQ_IMAGE_TYPES[content_type]}"
-    stored = await store_upload(content, folder=_UPLOAD_FOLDER, file_name=file_name, content_type=content_type)
-    return absolute_upload_url(stored)
+    return await store_upload(content, folder=_UPLOAD_FOLDER, file_name=file_name, content_type=content_type)

--- a/backend/app/services/help_center_public.py
+++ b/backend/app/services/help_center_public.py
@@ -58,15 +58,22 @@ couldn't find that in the help center and suggest starting a chat or contacting
 support. Never invent facts, prices, policies, or URLs."""
 
 
-def resolve_help_center(db: Session, host: str) -> Optional[HelpCenterSettings]:
-    """Host header → enabled help center row, or None (renders as 404).
-    Custom domains only match once verified; plan lapses hide the site."""
+def resolve_help_center(
+    db: Session, host: Optional[str] = None, slug: Optional[str] = None
+) -> Optional[HelpCenterSettings]:
+    """Enabled help center row, or None (renders as 404). Resolves by explicit
+    `slug` (path dispatch) when given, else by Host header (subdomain slug or a
+    verified custom domain). Custom domains only match once verified; plan
+    lapses hide the site."""
     repo = HelpCenterRepository(db)
-    slug = slug_for_host(host)
-    if slug:
+    if slug is not None:
         row = repo.get_by_slug(slug)
     else:
-        row = repo.get_by_verified_domain(host)
+        host_slug = slug_for_host(host or "")
+        if host_slug:
+            row = repo.get_by_slug(host_slug)
+        else:
+            row = repo.get_by_verified_domain(host or "")
     if not row or not row.enabled:
         return None
     if not help_center_allowed(db, row.organization_id):

--- a/backend/app/services/help_center_settings.py
+++ b/backend/app/services/help_center_settings.py
@@ -144,7 +144,14 @@ def get_or_create_settings(db: Session, organization) -> HelpCenterSettings:
 
 
 def live_url(row: HelpCenterSettings) -> str:
-    """The public URL the help center is (or will be) served at."""
+    """The public URL the help center is (or will be) served at.
+
+    A verified custom domain always wins. Otherwise the URL shape follows
+    HELP_CENTER_PUBLIC_MODE: "subdomain" advertises {slug}.<base> (cloud); the
+    default "path" mode serves same-origin as the API at {BACKEND_URL}/help/{slug}
+    (self-host — no DNS/TLS/proxy needed, and correct scheme+port via BACKEND_URL)."""
     if row.domain_verified:
         return f"https://{row.custom_domain}"
-    return f"https://{row.slug}.{settings.HELP_CENTER_BASE_DOMAIN}"
+    if settings.HELP_CENTER_PUBLIC_MODE == "subdomain":
+        return f"https://{row.slug}.{settings.HELP_CENTER_BASE_DOMAIN}"
+    return f"{settings.BACKEND_URL.rstrip('/')}/help/{row.slug}"

--- a/backend/app/templates/help_center/article.html
+++ b/backend/app/templates/help_center/article.html
@@ -28,7 +28,7 @@ every other value stays autoescaped.
       <div class="hc-aside-label">BROWSE TOPICS</div>
       <div class="hc-topics">
         {% for topic in topics %}
-        <a class="hc-topic{% if topic.active %} active{% endif %}" href="/?topic={{ topic.category | urlencode }}" style="--ic: {{ topic.color }};">
+        <a class="hc-topic{% if topic.active %} active{% endif %}" href="{{ base_path }}/?topic={{ topic.category | urlencode }}" style="--ic: {{ topic.color }};">
           <span class="hc-topic-icon">
             <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path></svg>
           </span>
@@ -53,7 +53,7 @@ every other value stays autoescaped.
     <!-- ---- ARTICLE ---- -->
     <main class="hc-main">
       <article class="hc-article" style="--ic: {{ article.color }};">
-        <a class="hc-back" href="/?topic={{ article.category | urlencode }}">
+        <a class="hc-back" href="{{ base_path }}/?topic={{ article.category | urlencode }}">
           <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"></path></svg>
           All {{ article.category }} articles
         </a>
@@ -83,7 +83,7 @@ every other value stays autoescaped.
           <div class="hc-related-label">RELATED ARTICLES</div>
           <div class="hc-related-grid">
             {% for r in article.related %}
-            <a class="hc-related-card" href="/a/{{ r.slug }}" style="--ic: {{ r.color }};">
+            <a class="hc-related-card" href="{{ base_path }}/a/{{ r.slug }}" style="--ic: {{ r.color }};">
               <span class="hc-related-top">
                 <span class="hc-related-icon">
                   <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6a2 2 0 0 1 2-2h4l2 2h6a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"></path></svg>

--- a/backend/app/templates/help_center/base.html
+++ b/backend/app/templates/help_center/base.html
@@ -30,6 +30,7 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
   <title>{{ title }}</title>
   <meta name="description" content="{{ description }}">
   <link rel="canonical" href="{{ canonical_url }}">
+  {% if favicon_url %}<link rel="icon" href="{{ favicon_url }}">{% endif %}
   <meta property="og:title" content="{{ title }}">
   <meta property="og:description" content="{{ description }}">
   <meta property="og:type" content="{{ og_type | default('website') }}">
@@ -293,7 +294,7 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
   <!-- ============ HEADER ============ -->
   <header class="hc-header">
     <div class="hc-header-in">
-      <a class="hc-brand" href="/">
+      <a class="hc-brand" href="{{ base_path }}/">
         {% if logo_url %}
           <img class="hc-logo" src="{{ logo_url }}" alt="{{ row.organization.name }} logo">
         {% else %}

--- a/backend/app/templates/help_center/index.html
+++ b/backend/app/templates/help_center/index.html
@@ -25,7 +25,7 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
     <div class="hc-hero-in">
       <h1>How can we help?</h1>
       <p class="lead">Search our knowledge base, or pick a topic to browse.</p>
-      <form class="hc-searchbar" method="get" action="/" role="search" onsubmit="return false;">
+      <form class="hc-searchbar" method="get" action="{{ base_path }}/" role="search" onsubmit="return false;">
         <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="#9aa0ad" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
         <input id="hc-search" type="search" name="q" value="{{ search }}" placeholder="Search for answers…" maxlength="200" autocomplete="off">
         <button class="hc-clear" id="hc-clear" type="button" aria-label="Clear search">✕</button>
@@ -144,7 +144,7 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
           </div>
           <div class="hc-list">
             {% for faq in faqs %}
-            <a class="hc-card" href="/a/{{ faq.slug }}" data-category="{{ category }}"
+            <a class="hc-card" href="{{ base_path }}/a/{{ faq.slug }}" data-category="{{ category }}"
                data-title="{{ faq.search_title }}" data-search="{{ faq.search_text }}"
                style="--ic: {{ colors[category] }};">
               <span class="hc-card-main">
@@ -400,7 +400,7 @@ Ask-AI fetch). Card previews/read-times are computed server-side.
       askBtn.hidden = true;
       card.hidden = true;
       loading.hidden = false;
-      fetch('/ask', {
+      fetch('{{ base_path }}/ask', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ question: question })

--- a/backend/app/workers/faq_processor.py
+++ b/backend/app/workers/faq_processor.py
@@ -66,9 +66,15 @@ async def process_faq_job(job_id: int):
             if created:
                 body = f"{created} draft FAQ{'s' if created != 1 else ''} added — review and publish them in Help center."
             elif is_import:
-                body = "Nothing new was imported — the pages were unreadable or duplicated existing FAQs."
+                body = (
+                    "Nothing new was imported — no Q&A was found on the page, or it duplicates "
+                    "existing FAQs. Tip: use Import → Articles to bring in whole articles verbatim (no AI needed)."
+                )
             else:
-                body = "No new FAQs were found — your existing FAQs already cover this content."
+                body = (
+                    "No new FAQs were generated — the model returned nothing for this content. "
+                    "Try a larger/different model, or Import → Articles to import pages directly."
+                )
             await notify_user(
                 db,
                 job.user_id,

--- a/backend/tests/agents/test_faq_generator.py
+++ b/backend/tests/agents/test_faq_generator.py
@@ -203,6 +203,38 @@ async def test_plain_json_fallback_on_structured_output_failure():
 
 
 @pytest.mark.asyncio
+async def test_groq_empty_capture_falls_back_to_plain_json():
+    """Groq answered but never invoked the json tool (capture stays empty) — the
+    batch would otherwise be silently dropped (0 FAQs). Fall back to plain-JSON."""
+    fallback_response = MagicMock()
+    fallback_response.content = (
+        '{"faqs": [{"question": "How do I add employees?", '
+        '"answer": "Open Settings and invite them.", "category": "Account"}]}'
+    )
+    attempts = []
+
+    def fake_agent(**kwargs):
+        agent = MagicMock()
+        if not attempts:
+            attempts.append("groq-tool")
+            # Model replies but never calls the registered json tool → capture empty.
+            agent.arun = AsyncMock(return_value=MagicMock(content="Sorry, I cannot."))
+        else:
+            attempts.append("fallback")
+            assert "ONLY a JSON object" in kwargs["instructions"]
+            assert kwargs["response_model"] is None
+            assert kwargs["tools"] == []
+            agent.arun = AsyncMock(return_value=fallback_response)
+        return agent
+
+    with patch("app.agents.faq_generator.create_model", return_value=MagicMock()), \
+         patch("agno.agent.Agent", side_effect=fake_agent):
+        faqs = await _agent("GROQ").generate_from_text("HR docs...")
+    assert attempts == ["groq-tool", "fallback"]
+    assert [f.question for f in faqs] == ["How do I add employees?"]
+
+
+@pytest.mark.asyncio
 async def test_metering_hook_counts_fallback_call_too():
     """on_llm_call fires once per ACTUAL provider call — the fallback's second
     call must be billed, not hidden inside one 'attempt'."""

--- a/backend/tests/api/test_help_center_api.py
+++ b/backend/tests/api/test_help_center_api.py
@@ -88,7 +88,8 @@ def test_settings_get_or_create_assigns_slug_and_defaults(client, test_agent):
     assert r.status_code == 200
     body = r.json()
     assert body["slug"] == "test-organization"
-    assert body["live_url"].startswith("https://test-organization.")
+    # Default (path) mode advertises {BACKEND_URL}/help/{slug}.
+    assert body["live_url"].endswith("/help/test-organization")
     assert body["plan_allowed"] is True  # OSS mode: never locked
     assert body["auto_generate"] is True
     assert body["ai_search_enabled"] is True

--- a/backend/tests/api/test_help_center_public.py
+++ b/backend/tests/api/test_help_center_public.py
@@ -26,7 +26,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.api.help_center_public import public_app
-from app.core.help_center_host import is_help_center_host
+from app.core.config import settings
+from app.core.help_center_host import HelpCenterHostMiddleware, is_help_center_host
 from app.database import get_db
 from app.models.faq import FAQ, FAQStatus
 from app.models.help_center import HelpCenterSettings
@@ -76,6 +77,33 @@ def _publish_faq(db, org_id, question="How do I sign up?", answer="Use your <b>e
     ))
 
 
+@pytest.fixture
+def subdomain_mode(monkeypatch):
+    """Advertise {slug}.{base} URLs (cloud config) for tests that assert them."""
+    monkeypatch.setattr(settings, "HELP_CENTER_PUBLIC_MODE", "subdomain")
+
+
+async def _not_found_app(scope, receive, send):
+    """Main-app stand-in: anything not dispatched to public_app 404s as 'main app'."""
+    await send({"type": "http.response.start", "status": 404,
+                "headers": [(b"content-type", b"text/plain")]})
+    await send({"type": "http.response.body", "body": b"main app"})
+
+
+@pytest.fixture
+def path_client(db, monkeypatch):
+    """Client through the real dispatch middleware in PATH mode, so /help/{slug}
+    requests exercise path dispatch (public_app is bypassed by the plain client)."""
+    monkeypatch.setattr(settings, "HELP_CENTER_PUBLIC_MODE", "path")
+
+    def override_db():
+        yield db
+
+    public_app.dependency_overrides[get_db] = override_db
+    yield TestClient(HelpCenterHostMiddleware(_not_found_app, public_app))
+    public_app.dependency_overrides.clear()
+
+
 # ---------- helpers ----------
 
 def test_slug_for_host():
@@ -93,7 +121,7 @@ def test_contrast_ink():
 
 # ---------- rendering ----------
 
-def test_page_renders_published_only_and_escapes(client, db, test_organization, help_center):
+def test_page_renders_published_only_and_escapes(client, db, test_organization, help_center, subdomain_mode):
     _publish_faq(db, test_organization.id)
     FAQRepository(db).create(FAQ(
         organization_id=test_organization.id, question="Secret draft?",
@@ -175,11 +203,75 @@ def test_lapsed_plan_hides_site(client, db, test_organization, help_center):
         assert client.get("/", headers={"host": HOST}).status_code == 404
 
 
-def test_sitemap_and_robots(client, db, test_organization, help_center):
+def test_sitemap_and_robots(client, db, test_organization, help_center, subdomain_mode):
     sitemap = client.get("/sitemap.xml", headers={"host": HOST})
     assert sitemap.status_code == 200 and f"https://{HOST}/" in sitemap.text
     robots = client.get("/robots.txt", headers={"host": HOST})
     assert "Sitemap:" in robots.text
+
+
+# ---------- path dispatch (self-host default) ----------
+
+def test_path_dispatch_serves_index(path_client, db, test_organization, help_center):
+    _publish_faq(db, test_organization.id)
+    r = path_client.get("/help/test-org")
+    assert r.status_code == 200
+    assert "How do I sign up?" in r.text
+    # Internal links carry the /help/{slug} base_path prefix.
+    assert 'href="/help/test-org/a/' in r.text
+    # Canonical follows path mode (BACKEND_URL/help/{slug}).
+    assert '<link rel="canonical" href="http' in r.text and "/help/test-org/" in r.text
+
+
+def test_path_dispatch_nested_article(path_client, db, test_organization, help_center):
+    faq = _publish_faq(db, test_organization.id, answer="Click **Settings**.")
+    faq.slug = "how-do-i-sign-up"
+    db.commit()
+    r = path_client.get("/help/test-org/a/how-do-i-sign-up")
+    assert r.status_code == 200
+    assert "<strong>Settings</strong>" in r.text
+
+
+def test_path_dispatch_unknown_slug_404(path_client, db):
+    assert path_client.get("/help/nope").status_code == 404
+
+
+def test_public_app_only_serves_help_center_uploads():
+    """The help-center app must expose ONLY help_center images — never the whole
+    uploads/ tree (chat_attachments, knowledge, avatars, …) or /assets."""
+    from starlette.routing import Mount
+    mount_paths = {r.path for r in public_app.routes if isinstance(r, Mount)}
+    assert "/api/v1/uploads/help_center" in mount_paths
+    assert "/api/v1/uploads" not in mount_paths   # not the whole tree
+    assert "/assets" not in mount_paths
+
+
+def test_path_dispatch_trailing_slash_served_not_redirected(path_client, db, test_organization, help_center):
+    """A trailing slash must serve the article, not 307 to the origin root without
+    the /help/{slug} prefix (which would 404)."""
+    faq = _publish_faq(db, test_organization.id)
+    faq.slug = "how-do-i-sign-up"
+    db.commit()
+    r = path_client.get("/help/test-org/a/how-do-i-sign-up/")
+    assert r.status_code == 200
+    assert "How do I sign up?" in r.text
+
+
+def test_path_dispatch_feedback_post(path_client, db, test_organization, help_center):
+    faq = _publish_faq(db, test_organization.id)
+    faq.slug = "how-do-i-sign-up"
+    db.commit()
+    r = path_client.post("/help/test-org/a/how-do-i-sign-up/feedback", json={"helpful": True})
+    assert r.status_code == 200
+
+
+def test_path_dispatch_inert_in_subdomain_mode(db, monkeypatch):
+    """In subdomain mode, /help/{slug} is NOT claimed — it falls through to the
+    main app (cloud safety: no path serving, no duplicate content)."""
+    monkeypatch.setattr(settings, "HELP_CENTER_PUBLIC_MODE", "subdomain")
+    client = TestClient(HelpCenterHostMiddleware(_not_found_app, public_app))
+    r = client.get("/help/test-org")
+    assert r.status_code == 404 and r.text == "main app"
 
 
 # ---------- ask ----------

--- a/backend/tests/services/test_faq_article_import.py
+++ b/backend/tests/services/test_faq_article_import.py
@@ -187,6 +187,34 @@ def test_converter_skips_oversized_and_wrong_type_images():
         assert "pic" in markdown and "![" not in markdown
 
 
+def test_converter_swaps_same_site_link_origin_to_destination():
+    """dest_origin rewrites the origin of same-site cross-links (relative and
+    absolute) to the destination help center, leaving the path and off-site
+    links untouched."""
+    conv = _ArticleConverter(
+        base_url="https://help.paywithatoa.co.uk/hc/x/articles/1-base",
+        client=MagicMock(), dest_origin="https://support.mycompany.com",
+    )
+    md = conv.convert(
+        '<a href="/hc/x/articles/2-add-employees">rel</a> '
+        '<a href="https://help.paywithatoa.co.uk/hc/x/articles/3-refunds">abs</a> '
+        '<a href="https://stripe.com/docs">ext</a>'
+    )
+    assert "https://support.mycompany.com/hc/x/articles/2-add-employees" in md
+    assert "https://support.mycompany.com/hc/x/articles/3-refunds" in md
+    assert "https://stripe.com/docs" in md            # off-site untouched
+    assert "paywithatoa.co.uk" not in md              # no source origin left
+
+
+def test_converter_without_dest_origin_keeps_source_links():
+    """No destination configured → same-site links stay absolutized to source."""
+    conv = _ArticleConverter(
+        base_url="https://help.paywithatoa.co.uk/hc/x/articles/1-base", client=MagicMock(),
+    )
+    md = conv.convert('<a href="/hc/x/articles/2-add">rel</a>')
+    assert "https://help.paywithatoa.co.uk/hc/x/articles/2-add" in md
+
+
 @pytest.mark.asyncio
 async def test_article_import_job_inserts_drafts(db, test_organization):
     job = FAQGenerationJob(
@@ -217,7 +245,7 @@ async def test_article_import_job_inserts_drafts(db, test_organization):
     # discover now yields (url, category) pairs; the category flows to fetch_article.
     discovered = [(url, "Billing") for url in articles]
     with patch.object(faq_article_import, "discover_article_links", return_value=discovered), \
-         patch.object(faq_article_import, "fetch_article", side_effect=lambda c, url, category: articles[url]):
+         patch.object(faq_article_import, "fetch_article", side_effect=lambda c, url, category, dest_origin: articles[url]):
         created = await run_article_import_job(db, job)
 
     assert created == 1

--- a/backend/tests/services/test_faq_article_import.py
+++ b/backend/tests/services/test_faq_article_import.py
@@ -29,6 +29,8 @@ from app.repositories.faq import FAQRepository
 from app.services import faq_article_import
 from app.services.faq_article_import import (
     _ArticleConverter,
+    _article_key,
+    _remap_source_links,
     discover_article_links,
     fetch_article,
     run_article_import_job,
@@ -160,7 +162,7 @@ def test_fetch_article_converts_markdown_strips_chrome_and_collects_images():
     # h1 removed (would duplicate the question), list preserved as Markdown.
     assert "# How to install" not in article.markdown
     assert "1. Download the app." in article.markdown
-    # Link absolutized.
+    # Link absolutized (same-site remapping happens later, in the import job).
     assert "[pricing](https://help.example.com/pricing)" in article.markdown
     # Real image collected as placeholder; data: image reduced to alt text.
     assert "cm-pending-image://0.img" in article.markdown
@@ -187,32 +189,61 @@ def test_converter_skips_oversized_and_wrong_type_images():
         assert "pic" in markdown and "![" not in markdown
 
 
-def test_converter_swaps_same_site_link_origin_to_destination():
-    """dest_origin rewrites the origin of same-site cross-links (relative and
-    absolute) to the destination help center, leaving the path and off-site
-    links untouched."""
-    conv = _ArticleConverter(
-        base_url="https://help.paywithatoa.co.uk/hc/x/articles/1-base",
-        client=MagicMock(), dest_origin="https://support.mycompany.com",
-    )
-    md = conv.convert(
-        '<a href="/hc/x/articles/2-add-employees">rel</a> '
-        '<a href="https://help.paywithatoa.co.uk/hc/x/articles/3-refunds">abs</a> '
-        '<a href="https://stripe.com/docs">ext</a>'
-    )
-    assert "https://support.mycompany.com/hc/x/articles/2-add-employees" in md
-    assert "https://support.mycompany.com/hc/x/articles/3-refunds" in md
-    assert "https://stripe.com/docs" in md            # off-site untouched
-    assert "paywithatoa.co.uk" not in md              # no source origin left
-
-
-def test_converter_without_dest_origin_keeps_source_links():
-    """No destination configured → same-site links stay absolutized to source."""
+def test_converter_absolutizes_links():
+    """The converter absolutizes every link (relative → absolute); same-site
+    remapping happens later in the import job, not here."""
     conv = _ArticleConverter(
         base_url="https://help.paywithatoa.co.uk/hc/x/articles/1-base", client=MagicMock(),
     )
-    md = conv.convert('<a href="/hc/x/articles/2-add">rel</a>')
+    md = conv.convert(
+        '<a href="/hc/x/articles/2-add">rel</a> and <a href="https://stripe.com/d">ext</a>'
+    )
     assert "https://help.paywithatoa.co.uk/hc/x/articles/2-add" in md
+    assert "https://stripe.com/d" in md
+
+
+def test_article_key_extracts_numeric_id():
+    assert _article_key("/hc/atoa/articles/1711032863-how-do-i-add-employees") == "1711032863"
+    assert _article_key("/hc/atoa/articles/1711032863") == "1711032863"
+    assert _article_key("/hc/atoa/categories/account-") is None  # not an article
+
+
+def test_remap_source_links_articles_categories_and_offsite():
+    """Article links → ROOT-RELATIVE /a/{slug} (no origin, so a custom-domain move
+    keeps them working); home/category breadcrumb links dropped. Main-site links
+    (same registrable domain, different host) and all external links untouched."""
+    key_to_slug = {"1711032863": "how-do-i-add-employees"}
+    md = (
+        "[Add staff](https://help.paywithatoa.co.uk/hc/atoa/articles/1711032863-how-do-i-add-employees) "
+        "[Home](https://help.paywithatoa.co.uk/hc/atoa/en) "
+        "[Account](https://help.paywithatoa.co.uk/hc/atoa/en/categories/account-) "
+        "[QR in-store](https://paywithatoa.co.uk/in-store-qr/) "  # main site, NOT the help center
+        "[Stripe](https://stripe.com/docs) "
+        "![img](/api/v1/uploads/help_center/x.png)"
+    )
+    out = _remap_source_links(md, {"help.paywithatoa.co.uk"}, key_to_slug)
+    assert "[Add staff](/a/how-do-i-add-employees)" in out         # root-relative, no origin
+    assert "[Home]" not in out                                     # breadcrumb dropped
+    assert "[Account]" not in out                                  # category breadcrumb dropped
+    assert "[QR in-store](https://paywithatoa.co.uk/in-store-qr/)" in out  # main site kept
+    assert "[Stripe](https://stripe.com/docs)" in out              # off-site untouched
+    assert "help.paywithatoa.co.uk" not in out
+    assert "![img](/api/v1/uploads/help_center/x.png)" in out      # image embed untouched
+
+
+def test_remap_source_links_handles_markdown_titles():
+    """markdownify emits `[x](url "title")` for anchors with a title attribute —
+    a titled help-center link must still be remapped, and a titled off-site link
+    kept intact."""
+    key_to_slug = {"1711032863": "how-do-i-add-employees"}
+    md = (
+        '[Add staff](https://help.paywithatoa.co.uk/hc/atoa/articles/1711032863-x "Tip") '
+        '[Docs](https://stripe.com/docs "Stripe docs")'
+    )
+    out = _remap_source_links(md, {"help.paywithatoa.co.uk"}, key_to_slug)
+    assert "[Add staff](/a/how-do-i-add-employees)" in out          # remapped despite title
+    assert '[Docs](https://stripe.com/docs "Stripe docs")' in out   # off-site title preserved
+    assert "help.paywithatoa.co.uk" not in out
 
 
 @pytest.mark.asyncio
@@ -245,7 +276,7 @@ async def test_article_import_job_inserts_drafts(db, test_organization):
     # discover now yields (url, category) pairs; the category flows to fetch_article.
     discovered = [(url, "Billing") for url in articles]
     with patch.object(faq_article_import, "discover_article_links", return_value=discovered), \
-         patch.object(faq_article_import, "fetch_article", side_effect=lambda c, url, category, dest_origin: articles[url]):
+         patch.object(faq_article_import, "fetch_article", side_effect=lambda c, url, category: articles[url]):
         created = await run_article_import_job(db, job)
 
     assert created == 1
@@ -254,3 +285,62 @@ async def test_article_import_job_inserts_drafts(db, test_organization):
     assert row.answer == "**Billing** steps."
     assert row.source_label == "Imported from help.example.com"
     assert row.knowledge_id is None
+
+
+@pytest.mark.asyncio
+async def test_article_import_job_remaps_cross_links(db, test_organization):
+    """Cross-links remap even when the typed index host differs from the ACTUAL
+    article host (redirect / main-site index → help subdomain): article link →
+    /a/{new-slug}, home breadcrumb dropped, main-site link KEPT."""
+    from app.models.help_center import HelpCenterSettings
+
+    db.add(HelpCenterSettings(
+        organization_id=test_organization.id, slug="acme", enabled=True, brand_color="#4338CA",
+    ))
+    job = FAQGenerationJob(
+        organization_id=test_organization.id,
+        job_type=FAQJobType.IMPORT_ARTICLES.value,
+        source_url="https://example.com/help",  # main-site index, NOT the article host
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    articles = {
+        "https://help.example.com/hc/articles/1711-install": faq_article_import.Article(
+            url="https://help.example.com/hc/articles/1711-install",  # real host = help subdomain
+            title="How to install", markdown="Install steps.", category_hint="Guides",
+        ),
+        "https://help.example.com/hc/articles/2822-billing": faq_article_import.Article(
+            url="https://help.example.com/hc/articles/2822-billing",
+            title="How billing works",
+            markdown=(
+                "See [install](https://help.example.com/hc/articles/1711-install), "
+                "[home](https://help.example.com/hc/en), "
+                "and [pricing](https://example.com/pricing)."
+            ),
+            category_hint="Billing",
+        ),
+    }
+    discovered = [(url, None) for url in articles]
+    with patch.object(faq_article_import, "discover_article_links", return_value=discovered), \
+         patch.object(faq_article_import, "fetch_article", side_effect=lambda c, url, category: articles[url]):
+        created = await run_article_import_job(db, job)
+
+    assert created == 2
+    install = db.query(FAQ).filter(FAQ.question == "How to install").one()
+    billing = db.query(FAQ).filter(FAQ.question == "How billing works").one()
+    # Article link → root-relative /a/{slug} (prefix added at render); home dropped.
+    assert f"(/a/{install.slug})" in billing.answer
+    assert "http://localhost:8000" not in billing.answer     # no origin baked in
+    assert "[home]" not in billing.answer                    # breadcrumb dropped
+    assert "help.example.com" not in billing.answer          # source-host links remapped/dropped
+    assert "[pricing](https://example.com/pricing)" in billing.answer  # main-site link KEPT
+
+
+def test_remap_cleans_breadcrumb_separator_residue():
+    """Dropping "Home › Account" links must not leave a stray "› ›" line."""
+    md = "[Home](https://help.x.co/en) › [Account](https://help.x.co/categories/2-a)\n\nReal content."
+    out = _remap_source_links(md, {"help.x.co"}, {})
+    assert "›" not in out
+    assert out.lstrip().startswith("Real content.")

--- a/backend/tests/services/test_faq_generation.py
+++ b/backend/tests/services/test_faq_generation.py
@@ -220,7 +220,9 @@ async def test_run_generation_job_fails_when_all_batches_fail(db, test_organizat
     mock_generator = SimpleNamespace(generate_from_text=AsyncMock(side_effect=RuntimeError("boom")), batch_chars=15000)
     with patch.object(faq_generation, "build_generator", return_value=mock_generator), \
          patch.object(faq_generation, "load_source_pages", return_value=["text"]):
-        with pytest.raises(RuntimeError, match="every content batch"):
+        # The underlying provider error is now surfaced (e.g. an unsupported model),
+        # instead of a generic "every content batch" message.
+        with pytest.raises(RuntimeError, match="boom"):
             await run_generation_job(db, job)
     # One retry per batch.
     assert mock_generator.generate_from_text.await_count == 2

--- a/backend/tests/services/test_faq_import.py
+++ b/backend/tests/services/test_faq_import.py
@@ -81,6 +81,36 @@ async def test_import_job_inserts_drafts_with_source_label(db, test_organization
 
 
 @pytest.mark.asyncio
+async def test_import_job_falls_back_to_generate_when_no_verbatim_qa(db, test_organization, test_ai_config):
+    """An index/prose page has no verbatim Q&A, so extract_from_faq_page returns
+    nothing. Rather than import 0, the batch is drafted with generate_from_text."""
+    job = FAQGenerationJob(
+        organization_id=test_organization.id,
+        job_type=FAQJobType.IMPORT_URL.value,
+        source_url="https://help.example.com/",
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+
+    drafted = [GeneratedFAQ(question="Can I use it in my shop?", answer="Yes.", category="General")]
+    mock_generator = SimpleNamespace(
+        extract_from_faq_page=AsyncMock(return_value=[]),          # no verbatim Q&A on the page
+        generate_from_text=AsyncMock(return_value=drafted),        # fallback drafts from content
+        batch_chars=15000,
+    )
+    with patch.object(faq_import, "build_generator", return_value=mock_generator), \
+         patch.object(faq_import, "fetch_page_text", return_value="Industry specific\nUsing it in shops\nView all"):
+        created = await run_import_job(db, job)
+
+    assert created == 1
+    mock_generator.extract_from_faq_page.assert_awaited()   # verbatim tried first
+    mock_generator.generate_from_text.assert_awaited()      # then fell back
+    row = db.query(FAQ).filter(FAQ.organization_id == test_organization.id).one()
+    assert row.question == "Can I use it in my shop?"
+
+
+@pytest.mark.asyncio
 async def test_import_job_propagates_ssrf_block(db, test_organization, test_ai_config):
     job = FAQGenerationJob(
         organization_id=test_organization.id,

--- a/backend/tests/services/test_help_center_content.py
+++ b/backend/tests/services/test_help_center_content.py
@@ -58,9 +58,20 @@ def test_render_rewrites_link_rel():
     assert 'rel="noopener noreferrer nofollow"' in html
 
 
-def test_empty_answer_renders_empty():
-    assert render_article_html("") == ""
-    assert render_article_html("   ") == ""
+def test_base_path_prefixes_internal_links_only():
+    """Root-relative intra-help-center links (/a/{slug}, /) get the serving prefix;
+    images and external links do not — so links work under path mode AND a custom
+    domain from the SAME stored content."""
+    md = "[other](/a/x) [home](/) ![i](/api/v1/uploads/y.png) [ext](https://e.com)"
+    # Path mode: prefix added.
+    html = render_article_html(md, base_path="/help/acme")
+    assert 'href="/help/acme/a/x"' in html
+    assert 'href="/help/acme/"' in html
+    assert 'src="/api/v1/uploads/y.png"' in html          # image NOT prefixed
+    assert 'href="https://e.com"' in html                 # external NOT prefixed
+    # Host/custom-domain mode (base_path=""): stored links serve as-is at root.
+    root = render_article_html(md)
+    assert 'href="/a/x"' in root and 'href="/help/' not in root
 
 
 def test_to_plain_text_strips_markdown_and_html():

--- a/backend/tests/services/test_help_center_settings.py
+++ b/backend/tests/services/test_help_center_settings.py
@@ -1,0 +1,100 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+live_url mode selection and help-center upload URL relativization.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.core.config import settings
+from app.services.help_center_images import store_article_image, strip_upload_host
+from app.services.help_center_settings import live_url
+
+
+def _row(**kw):
+    base = {"domain_verified": False, "custom_domain": None, "slug": "acme"}
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+# ---------- live_url per mode ----------
+
+def test_live_url_custom_domain_wins(monkeypatch):
+    """A verified custom domain takes precedence in every mode."""
+    monkeypatch.setattr(settings, "HELP_CENTER_PUBLIC_MODE", "path")
+    row = _row(domain_verified=True, custom_domain="help.acme.com")
+    assert live_url(row) == "https://help.acme.com"
+
+
+def test_live_url_subdomain_mode(monkeypatch):
+    monkeypatch.setattr(settings, "HELP_CENTER_PUBLIC_MODE", "subdomain")
+    monkeypatch.setattr(settings, "HELP_CENTER_BASE_DOMAIN", "chattermate.help")
+    assert live_url(_row()) == "https://acme.chattermate.help"
+
+
+def test_live_url_path_mode_uses_backend_url(monkeypatch):
+    monkeypatch.setattr(settings, "HELP_CENTER_PUBLIC_MODE", "path")
+    monkeypatch.setattr(settings, "BACKEND_URL", "http://localhost:8000")
+    assert live_url(_row()) == "http://localhost:8000/help/acme"
+
+
+# ---------- upload URL relativization ----------
+
+def test_strip_upload_host_local_absolute():
+    md = "![](http://localhost:8000/api/v1/uploads/help_center/x.png)"
+    assert strip_upload_host(md) == "![](/api/v1/uploads/help_center/x.png)"
+
+
+def test_strip_upload_host_leaves_s3_and_relative_untouched():
+    s3 = "![](https://bucket.s3.amazonaws.com/help_center/x.png)"
+    rel = "![](/api/v1/uploads/help_center/x.png)"
+    assert strip_upload_host(s3) == s3
+    assert strip_upload_host(rel) == rel
+
+
+def test_strip_upload_host_leaves_third_party_urls_untouched(monkeypatch):
+    """A third-party URL that merely contains /api/v1/uploads/ (e.g. pasted into
+    an answer) must NOT be rewritten — only our own backend/loopback origin is."""
+    monkeypatch.setattr(settings, "BACKEND_URL", "http://localhost:8000")
+    foreign = "See https://legacy.vendor.com/api/v1/uploads/guide.pdf for details."
+    assert strip_upload_host(foreign) == foreign
+
+
+def test_strip_upload_host_strips_configured_backend_origin(monkeypatch):
+    monkeypatch.setattr(settings, "BACKEND_URL", "https://self.example.com")
+    md = "![](https://self.example.com/api/v1/uploads/help_center/x.png)"
+    assert strip_upload_host(md) == "![](/api/v1/uploads/help_center/x.png)"
+
+
+@pytest.mark.asyncio
+async def test_store_article_image_returns_relative_for_local(monkeypatch):
+    async def fake_store_upload(content, folder=None, file_name=None, content_type=None):
+        return f"/api/v1/uploads/{folder}/{file_name}"
+
+    monkeypatch.setattr("app.services.help_center_images.store_upload", fake_store_upload)
+    url = await store_article_image(b"x", "image/png")
+    assert url.startswith("/api/v1/uploads/help_center/")
+    assert not url.startswith("http")  # relative — no baked host
+
+
+@pytest.mark.asyncio
+async def test_store_article_image_keeps_absolute_s3(monkeypatch):
+    async def fake_store_upload(content, folder=None, file_name=None, content_type=None):
+        return "https://bucket.s3.amazonaws.com/help_center/x.png"
+
+    monkeypatch.setattr("app.services.help_center_images.store_upload", fake_store_upload)
+    url = await store_article_image(b"x", "image/png")
+    assert url == "https://bucket.s3.amazonaws.com/help_center/x.png"

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -89,6 +89,8 @@ const {
   saveNow,
   uploadLogo,
   removeLogo,
+  uploadFavicon,
+  removeFavicon,
   domainBusy,
   setDomain,
   verifyDomain,
@@ -410,6 +412,8 @@ onUnmounted(stopPolling)
             @save-now="saveNow"
             @upload-logo="uploadLogo"
             @remove-logo="removeLogo"
+            @upload-favicon="uploadFavicon"
+            @remove-favicon="removeFavicon"
           />
           <HelpCenterPublic
             class="settings-section"

--- a/frontend/src/components/faq/HelpCenterAppearance.vue
+++ b/frontend/src/components/faq/HelpCenterAppearance.vue
@@ -32,6 +32,8 @@ const emit = defineEmits<{
   'save-now': [payload: HelpCenterSettingsUpdate]
   'upload-logo': [file: File]
   'remove-logo': []
+  'upload-favicon': [file: File]
+  'remove-favicon': []
 }>()
 
 const BRAND_SWATCHES = ['#4338CA', '#0E8C8C', '#CF5B38', '#6D5BD0', '#1F8A5B', '#2A6FDB']
@@ -117,9 +119,23 @@ function removeLink(index: number) {
         <div>
           <label class="mono-label">LOGO</label>
           <HelpCenterLogoField
-            :logo-url="settings.logo_url"
+            :image-url="settings.logo_url"
+            kind="logo"
             @upload="$emit('upload-logo', $event)"
             @remove="$emit('remove-logo')"
+          />
+        </div>
+
+        <div>
+          <label class="mono-label">FAVICON</label>
+          <HelpCenterLogoField
+            :image-url="settings.favicon_url"
+            kind="favicon"
+            :max-bytes="1048576"
+            :output-max="128"
+            square
+            @upload="$emit('upload-favicon', $event)"
+            @remove="$emit('remove-favicon')"
           />
         </div>
 

--- a/frontend/src/components/faq/HelpCenterLogoField.vue
+++ b/frontend/src/components/faq/HelpCenterLogoField.vue
@@ -19,7 +19,18 @@ import { computed, ref } from 'vue'
 import { Cropper } from 'vue-advanced-cropper'
 import 'vue-advanced-cropper/dist/style.css'
 
-const props = defineProps<{ logoUrl: string | null }>()
+// Generic image field (logo or favicon): file pick → square-optional crop →
+// PNG export. Configurable size caps and crop aspect so one component serves both.
+const props = withDefaults(
+  defineProps<{
+    imageUrl: string | null
+    kind?: 'logo' | 'favicon'
+    maxBytes?: number
+    outputMax?: number
+    square?: boolean
+  }>(),
+  { kind: 'logo', maxBytes: 2 * 1024 * 1024, outputMax: 512, square: false },
+)
 
 const emit = defineEmits<{
   upload: [file: File]
@@ -28,9 +39,9 @@ const emit = defineEmits<{
 
 // Raster only — SVG is rejected (it would be active markup on the public site).
 const ACCEPT = 'image/png,image/jpeg,image/webp'
-const MAX_BYTES = 2 * 1024 * 1024
-// Bound the exported canvas so the stored logo is small (header renders it ~30px).
-const OUTPUT_MAX = 512
+
+const maxMbLabel = computed(() => `${Math.round(props.maxBytes / (1024 * 1024))} MB`)
+const stencilProps = computed(() => (props.square ? { aspectRatio: 1 } : {}))
 
 const fileInput = ref<HTMLInputElement | null>(null)
 const error = ref('')
@@ -40,9 +51,9 @@ const cropperImage = ref('')
 const cropper = ref<any>(null)
 const saving = ref(false)
 
-const logoName = computed(() => {
-  if (!props.logoUrl) return ''
-  return props.logoUrl.split('/').pop()?.split('?')[0] || 'logo'
+const imageName = computed(() => {
+  if (!props.imageUrl) return ''
+  return props.imageUrl.split('/').pop()?.split('?')[0] || props.kind
 })
 
 function pick() {
@@ -59,8 +70,8 @@ function onFileChange(event: Event) {
     error.value = 'Use a PNG, JPG or WebP image.'
     return
   }
-  if (file.size > MAX_BYTES) {
-    error.value = 'Image must be 2 MB or smaller.'
+  if (file.size > props.maxBytes) {
+    error.value = `Image must be ${maxMbLabel.value} or smaller.`
     return
   }
   error.value = ''
@@ -77,7 +88,7 @@ async function confirmCrop() {
     const blob: Blob = await new Promise((resolve, reject) => {
       canvas.toBlob((b: Blob | null) => (b ? resolve(b) : reject(new Error('blob'))), 'image/png')
     })
-    emit('upload', new File([blob], 'logo.png', { type: 'image/png' }))
+    emit('upload', new File([blob], `${props.kind}.png`, { type: 'image/png' }))
     closeCropper()
   } catch {
     error.value = 'Could not process that image. Try another one.'
@@ -96,13 +107,13 @@ function closeCropper() {
 <template>
   <div>
     <input ref="fileInput" class="file-input" type="file" :accept="ACCEPT" @change="onFileChange" />
-    <div v-if="logoUrl" class="logo-row">
+    <div v-if="imageUrl" class="logo-row">
       <div class="logo-chip">
-        <img class="logo-chip__img" :src="logoUrl" alt="Logo" />
-        <div class="logo-chip__name">{{ logoName }}</div>
+        <img class="logo-chip__img" :src="imageUrl" :alt="kind" />
+        <div class="logo-chip__name">{{ imageName }}</div>
       </div>
       <button class="btn-sm" type="button" @click="pick">Replace</button>
-      <button class="icon-btn" type="button" title="Remove logo" @click="$emit('remove')">
+      <button class="icon-btn" type="button" :title="`Remove ${kind}`" @click="$emit('remove')">
         <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h16" /><path d="M9 7V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" /><path d="M6 7l1 13a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1l1-13" /></svg>
       </button>
     </div>
@@ -111,8 +122,8 @@ function closeCropper() {
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 16V4" /><path d="M8 8l4-4 4 4" /><path d="M4 20h16" /></svg>
       </span>
       <span>
-        <span class="upload-btn__title">Upload your logo</span>
-        <span class="upload-btn__sub">PNG, JPG or WebP, up to 2 MB · crop it to fit</span>
+        <span class="upload-btn__title">Upload your {{ kind }}</span>
+        <span class="upload-btn__sub">PNG, JPG or WebP, up to {{ maxMbLabel }} · crop it to fit</span>
       </span>
     </button>
 
@@ -122,12 +133,13 @@ function closeCropper() {
          from the original file (metadata, oversized pixels) reaches the server. -->
     <div v-if="showCropper" class="crop-modal" @click.self="closeCropper">
       <div class="crop-panel">
-        <div class="crop-head">Crop your logo</div>
+        <div class="crop-head">Crop your {{ kind }}</div>
         <div class="crop-stage">
           <Cropper
             ref="cropper"
             :src="cropperImage"
-            :canvas="{ maxWidth: OUTPUT_MAX, maxHeight: OUTPUT_MAX }"
+            :canvas="{ maxWidth: outputMax, maxHeight: outputMax }"
+            :stencil-props="stencilProps"
             image-restriction="fit-area"
             background="var(--o05)"
           />
@@ -135,7 +147,7 @@ function closeCropper() {
         <div class="crop-actions">
           <button class="btn-cancel" type="button" @click="closeCropper">Cancel</button>
           <button class="btn-save" type="button" :disabled="saving" @click="confirmCrop">
-            {{ saving ? 'Saving…' : 'Save logo' }}
+            {{ saving ? 'Saving…' : `Save ${kind}` }}
           </button>
         </div>
       </div>

--- a/frontend/src/components/faq/HelpCenterPreview.vue
+++ b/frontend/src/components/faq/HelpCenterPreview.vue
@@ -27,7 +27,10 @@ const ink = computed(() => contrastInk(brand.value))
 const address = computed(() => {
   const domain = props.settings.domain
   if (domain?.domain_status === 'verified' && domain.custom_domain) return domain.custom_domain
-  return `${props.settings.slug || 'your-company'}.chattermate.help`
+  // live_url is mode-aware (path {origin}/help/{slug} or {slug}.{base}); show it
+  // without the scheme so the preview matches wherever the site is actually served.
+  if (props.settings.live_url) return props.settings.live_url.replace(/^https?:\/\//, '')
+  return props.settings.slug || 'your-company'
 })
 
 const rootStyle = computed(() => ({ '--hc-brand': brand.value, '--hc-ink': ink.value }))

--- a/frontend/src/composables/useHelpCenterSettings.ts
+++ b/frontend/src/composables/useHelpCenterSettings.ts
@@ -24,6 +24,7 @@ export type SaveState = 'idle' | 'saving' | 'saved' | 'error'
 
 const AUTOSAVE_DEBOUNCE_MS = 800
 const MAX_LOGO_BYTES = 2 * 1024 * 1024
+const MAX_FAVICON_BYTES = 1 * 1024 * 1024
 
 /** Appearance/settings editing with debounced autosave — the design has no
  * Save button ("changes apply instantly to your published help center"). */
@@ -117,6 +118,32 @@ export function useHelpCenterSettings(settings: Ref<HelpCenterSettings | null>) 
     }
   }
 
+  async function uploadFavicon(file: File): Promise<void> {
+    if (file.size > MAX_FAVICON_BYTES) {
+      toast.error('Favicon must be 1 MB or smaller')
+      return
+    }
+    saveState.value = 'saving'
+    try {
+      applyResponse(await faqService.uploadFavicon(file))
+      saveState.value = 'saved'
+    } catch (error: any) {
+      saveState.value = 'error'
+      toast.error(error.message)
+    }
+  }
+
+  async function removeFavicon(): Promise<void> {
+    saveState.value = 'saving'
+    try {
+      applyResponse(await faqService.removeFavicon())
+      saveState.value = 'saved'
+    } catch (error: any) {
+      saveState.value = 'error'
+      toast.error(error.message)
+    }
+  }
+
   // Domain lifecycle (explicit Verify button — never autosaved).
   const domainBusy = ref(false)
 
@@ -168,6 +195,8 @@ export function useHelpCenterSettings(settings: Ref<HelpCenterSettings | null>) 
     saveNow,
     uploadLogo,
     removeLogo,
+    uploadFavicon,
+    removeFavicon,
     domainBusy,
     setDomain,
     verifyDomain,

--- a/frontend/src/services/faq.ts
+++ b/frontend/src/services/faq.ts
@@ -210,6 +210,28 @@ export const faqService = {
     }
   },
 
+  async uploadFavicon(file: File): Promise<HelpCenterSettings> {
+    try {
+      const formData = new FormData()
+      formData.append('file', file)
+      const response = await api.post('/help-center/favicon', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      })
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to upload favicon')
+    }
+  },
+
+  async removeFavicon(): Promise<HelpCenterSettings> {
+    try {
+      const response = await api.delete('/help-center/favicon')
+      return response.data
+    } catch (error: any) {
+      throw errorMessage(error, 'Failed to remove favicon')
+    }
+  },
+
   async setDomain(domain: string): Promise<HelpCenterDomain> {
     try {
       const response = await api.post('/help-center/domain', { domain })

--- a/frontend/src/types/faq.ts
+++ b/frontend/src/types/faq.ts
@@ -120,6 +120,7 @@ export interface HelpCenterSettings {
   title: string | null
   description: string | null
   logo_url: string | null
+  favicon_url: string | null
   brand_color: string
   header_links: HelpCenterHeaderLink[]
   cta_text: string | null


### PR DESCRIPTION
Makes the public help center usable on self-host/localhost and fixes FAQ import (incl. Groq).

## Help center
- Serve by path (`{BACKEND_URL}/help/{slug}`) by default — works on localhost with no DNS/TLS/reverse proxy. `HELP_CENTER_PUBLIC_MODE=subdomain` keeps the cloud `{slug}.{base}` form; verified custom domains are unchanged. Both dispatch modes coexist; path dispatch is gated off in subdomain mode.
- Store image/logo/favicon URLs relative (no baked-in host) so they resolve on whatever origin serves the page; `public_app` now serves uploads too. Migration strips existing hardcoded hosts from stored answers.
- Add favicon upload in Customization.
- Imported article cross-links are remapped to the new help center — stored root-relative and prefixed per mode at render, so they survive a later move to a custom domain. Breadcrumb nav is dropped; main-site and external links are kept.

## FAQ import
- Import URL falls back to generating FAQs when a page has no verbatim Q&A.
- Surface the real provider error instead of a generic "couldn't generate" message.
- Groq: recover FAQs when the model returns JSON as text instead of a tool call.

Cloud stays on subdomain mode: it uses S3 (relative-URL change is inert) and the backfill is a no-op there. Requires `HELP_CENTER_PUBLIC_MODE=subdomain` in the cloud env before deploy.

The `/help/*` Caddy route and the CLI's mode default live in the enterprise deploy CLI (separate).
