### PR TITLE
feat(help-center): per-article SEO fields, article structured data, og:image

### DIFF
--- a/backend/alembic/versions/add_faq_seo_fields.py
+++ b/backend/alembic/versions/add_faq_seo_fields.py
@@ -1,0 +1,27 @@
+"""Per-article SEO overrides on FAQs
+
+Revision ID: add_faq_seo_001
+Revises: rel_hc_uploads_001
+Create Date: 2026-07-25
+
+Adds nullable meta_title / meta_description to faqs so an org can override the
+public article page's <title> and meta description instead of always deriving
+them from the question and answer excerpt. NULL keeps today's derived behaviour.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "add_faq_seo_001"
+down_revision = "rel_hc_uploads_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("faqs", sa.Column("meta_title", sa.String(length=120), nullable=True))
+    op.add_column("faqs", sa.Column("meta_description", sa.String(length=300), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("faqs", "meta_description")
+    op.drop_column("faqs", "meta_title")

--- a/backend/app/api/help_center/faqs.py
+++ b/backend/app/api/help_center/faqs.py
@@ -43,7 +43,7 @@ from app.services.help_center_images import (
     MAX_FAQ_IMAGE_BYTES,
     store_article_image,
 )
-from app.services.help_center_settings import generate_faq_slug
+from app.services.help_center_settings import generate_faq_slug, resolve_faq_slug
 
 router = APIRouter()
 
@@ -95,13 +95,22 @@ async def create_faq(
     db: Session = Depends(get_db),
 ):
     check_help_center_access(db, current_user.organization_id)
+    org_id = current_user.organization_id
     faq = FAQ(
-        organization_id=current_user.organization_id,
+        organization_id=org_id,
         question=payload.question,
         answer=payload.answer,
         category=payload.category,
         status=payload.status,
-        slug=generate_faq_slug(db, current_user.organization_id, payload.question),
+        # A hand-typed slug is normalized and de-duplicated the same way a
+        # generated one is; omitting it derives the slug from the question.
+        slug=(
+            resolve_faq_slug(db, org_id, payload.slug)
+            if payload.slug
+            else generate_faq_slug(db, org_id, payload.question)
+        ),
+        meta_title=payload.meta_title,
+        meta_description=payload.meta_description,
         source_label="Added manually",
         created_by=current_user.id,
     )
@@ -140,10 +149,18 @@ async def update_faq(
 ):
     check_help_center_access(db, current_user.organization_id)
     faq = _get_owned_faq(faq_id, current_user, db)
-    for field, value in payload.model_dump(exclude_unset=True).items():
+    updates = payload.model_dump(exclude_unset=True)
+    # The slug is never taken verbatim from the client — normalize and dedupe it
+    # (excluding this row, so re-saving an unchanged slug isn't a self-collision).
+    requested_slug = updates.pop("slug", None)
+    for field, value in updates.items():
         setattr(faq, field, value)
+    if requested_slug:
+        faq.slug = resolve_faq_slug(
+            db, current_user.organization_id, requested_slug, exclude_id=faq.id
+        )
     # Backfill a slug for legacy/generated FAQs the first time they're edited;
-    # keep an existing slug stable so published article URLs never change.
+    # otherwise keep it stable so published article URLs never change on their own.
     if not faq.slug:
         faq.slug = generate_faq_slug(db, current_user.organization_id, faq.question)
     return FAQResponse.model_validate(FAQRepository(db).update(faq))

--- a/backend/app/api/help_center_public.py
+++ b/backend/app/api/help_center_public.py
@@ -51,7 +51,17 @@ from app.services.help_center_public import (
     resolve_help_center,
     widget_id_for,
 )
-from app.services.help_center_settings import live_url
+from app.services.help_center_seo import (
+    absolute_asset_url,
+    article_description,
+    article_json_ld,
+    article_title,
+    breadcrumbs,
+    index_description,
+    index_json_ld,
+    index_title,
+    site_url,
+)
 from app.services.public_rate_limit import allow_request
 
 public_app = FastAPI(title="ChatterMate Help Center", docs_url=None, redoc_url=None, openapi_url=None)
@@ -132,33 +142,22 @@ async def _chrome_context(row: HelpCenterSettings, base_path: str = "") -> dict:
     }
 
 
-def _question_entity(faq: FAQ) -> dict:
-    """One schema.org Question + acceptedAnswer, from the plain-text form of the
-    (Markdown) answer."""
-    return {
-        "@type": "Question",
-        "name": faq.question,
-        "acceptedAnswer": {"@type": "Answer", "text": to_plain_text(faq.answer)},
-    }
+def _social_context(row: HelpCenterSettings, site: str) -> dict:
+    """Open Graph / Twitter card values shared by both page types.
 
-
-def _faq_page_json_ld(faqs) -> dict:
-    """schema.org FAQPage structured data (Google FAQ rich results).
-
-    FAQPage - not QAPage - is the correct type for these owner-authored answers.
-    QAPage models community/forum pages where users submit competing answers and
-    requires answerCount/upvoteCount, which don't apply here.
+    og:image must be absolute (scrapers don't resolve relative URLs), so a
+    relative logo is anchored to the serving origin. Deliberately NOT signed
+    like the rendered logo: social scrapers cache the URL and re-fetch it long
+    after a signature would expire, so this uses the stored URL — the same
+    unsigned form article images already bake in, which S3 setups serve via a
+    public-read help_center/ prefix.
     """
+    logo_url = absolute_asset_url(row.logo_url, site)
     return {
-        "@context": "https://schema.org",
-        "@type": "FAQPage",
-        "mainEntity": [_question_entity(faq) for faq in faqs],
+        "og_site_name": index_title(row),
+        "og_image": logo_url,
+        "seo_logo_url": logo_url,
     }
-
-
-def _faq_json_ld(groups) -> dict:
-    """FAQPage structured data for the index page's grouped-by-category FAQs."""
-    return _faq_page_json_ld(faq for _category, faqs in groups for faq in faqs)
 
 
 def _card_view(faq: FAQ) -> dict:
@@ -183,17 +182,21 @@ async def index(request: Request, q: str = "", db: Session = Depends(get_db)):
     groups = published_faq_groups(db, row, search=search)
     colors = category_colors([category for category, _faqs in groups])
     card_groups = [(category, [_card_view(faq) for faq in faqs]) for category, faqs in groups]
+    site = site_url(row)
+    social = _social_context(row, site)
+    published = [faq for _category, faqs in groups for faq in faqs]
     context = {
         **await _chrome_context(row, _base_path(request)),
+        **social,
         "request": request,
         "groups": card_groups,
         "colors": colors,
         "search": search or "",
-        "title": row.title or f"{row.organization.name} Help Center",
-        "description": row.description or f"Answers to common questions about {row.organization.name}.",
-        "canonical_url": f"{live_url(row)}/",
+        "title": index_title(row),
+        "description": index_description(row),
+        "canonical_url": f"{site}/",
         "og_type": "website",
-        "json_ld": _faq_json_ld(groups) if groups else None,
+        "json_ld": index_json_ld(row, published, site, social["seo_logo_url"]),
         "ask_enabled": ask_available(row),
     }
     response = templates.TemplateResponse(request, "help_center/index.html", context)
@@ -230,26 +233,32 @@ async def article(slug: str, request: Request, db: Session = Depends(get_db)):
         }
         for rel in related_articles(db, row, faq)
     ]
+    base_path = _base_path(request)
     article_view = {
         "question": faq.question,
         "category": faq.category,
         "color": default_color,
         "read_time": read_time_label(faq.answer),
-        "body_html": render_article_html(faq.answer, _base_path(request)),
+        "body_html": render_article_html(faq.answer, base_path),
         "related": related,
     }
-    canonical = f"{live_url(row)}/a/{faq.slug}"
-    json_ld = _faq_page_json_ld([faq])
+    site = site_url(row)
+    social = _social_context(row, site)
+    crumbs = breadcrumbs(row, faq, base_path, site)
     context = {
-        **await _chrome_context(row, _base_path(request)),
+        **await _chrome_context(row, base_path),
+        **social,
         "request": request,
         "article": article_view,
+        "breadcrumbs": crumbs,
         "topics": topics,
-        "title": f"{faq.question} · {row.organization.name} Help Center",
-        "description": excerpt(faq.answer, 200) or faq.question,
-        "canonical_url": canonical,
+        "title": article_title(row, faq),
+        "description": article_description(faq),
+        "canonical_url": f"{site}/a/{faq.slug}",
         "og_type": "article",
-        "json_ld": json_ld,
+        "json_ld": article_json_ld(
+            row, faq, site, crumbs, social["seo_logo_url"], social["og_image"]
+        ),
     }
     response = templates.TemplateResponse(request, "help_center/article.html", context)
     response.headers["Cache-Control"] = PAGE_CACHE_CONTROL
@@ -293,7 +302,7 @@ async def article_feedback(
 @public_app.get("/sitemap.xml")
 async def sitemap(request: Request, db: Session = Depends(get_db)):
     row = _resolve_or_404(request, db)
-    base = live_url(row)
+    base = site_url(row)
     groups = published_faq_groups(db, row)
     urls = [f"  <url><loc>{base}/</loc></url>"]
     for _category, faqs in groups:
@@ -312,7 +321,7 @@ async def sitemap(request: Request, db: Session = Depends(get_db)):
 @public_app.get("/robots.txt", response_class=PlainTextResponse)
 async def robots(request: Request, db: Session = Depends(get_db)):
     row = _resolve_or_404(request, db)
-    return PlainTextResponse(f"User-agent: *\nAllow: /\nSitemap: {live_url(row)}/sitemap.xml\n")
+    return PlainTextResponse(f"User-agent: *\nAllow: /\nSitemap: {site_url(row)}/sitemap.xml\n")
 
 
 @public_app.get("/healthz")

--- a/backend/app/api/help_center_public.py
+++ b/backend/app/api/help_center_public.py
@@ -139,6 +139,11 @@ async def _chrome_context(row: HelpCenterSettings, base_path: str = "") -> dict:
         # the widget APP it pulls in (/assets/widget.js) is served from
         # VITE_WIDGET_URL by the backend. In prod both resolve to the app domain.
         "widget_script_url": f"{settings.FRONTEND_URL}/webclient/chattermate.min.js",
+        # This install's API root, handed to the loader as window.chattermateBaseUrl
+        # (same contract as the dashboard's embed snippet). Without it the loader
+        # uses its build-time default — the vendor cloud — which no self-hosted
+        # deployment can talk to.
+        "widget_api_url": f"{settings.BACKEND_URL.rstrip('/')}{settings.API_V1_STR}",
     }
 
 

--- a/backend/app/models/faq.py
+++ b/backend/app/models/faq.py
@@ -25,6 +25,11 @@ from sqlalchemy.sql import func
 from app.database import Base
 
 DEFAULT_FAQ_CATEGORY = "General"
+# Column widths, kept here so the API schemas bound input to exactly what the
+# columns accept instead of restating the numbers (see models.schemas.faq).
+FAQ_SLUG_MAX_LENGTH = 80
+FAQ_META_TITLE_MAX_LENGTH = 120
+FAQ_META_DESCRIPTION_MAX_LENGTH = 300
 
 
 class FAQStatus(str, enum.Enum):
@@ -52,10 +57,17 @@ class FAQ(Base):
     # Answer is authored/stored as Markdown; rendered to sanitized HTML on the
     # public article page (app.services.help_center_content).
     answer = Column(Text, nullable=False)
-    # URL slug for the public article page (/a/{slug}). Assigned once from the
-    # question and kept stable so published article URLs don't churn on edits.
+    # URL slug for the public article page (/a/{slug}). Assigned from the
+    # question at creation and kept stable so published article URLs don't churn
+    # on edits — but editable by hand for SEO (app.api.help_center.faqs).
     # Unique per org (see ix_faqs_org_slug); NULL until assigned.
-    slug = Column(String(80), nullable=True)
+    slug = Column(String(FAQ_SLUG_MAX_LENGTH), nullable=True)
+    # Per-article SEO overrides for the public page's <title> and meta
+    # description. NULL means "derive from the content": the question and an
+    # excerpt of the answer (see app.api.help_center_public). Lengths mirror
+    # help_center_settings.title/description.
+    meta_title = Column(String(FAQ_META_TITLE_MAX_LENGTH), nullable=True)
+    meta_description = Column(String(FAQ_META_DESCRIPTION_MAX_LENGTH), nullable=True)
     # Free-form category assigned by the LLM grouping step (or the user).
     category = Column(String(100), nullable=False, default=DEFAULT_FAQ_CATEGORY)
     # Plain string (values from FAQStatus), like knowledge_queue.status — new

--- a/backend/app/models/schemas/faq.py
+++ b/backend/app/models/schemas/faq.py
@@ -21,7 +21,13 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # Reuse the ORM enums so the API contract can never drift from the DB.
-from app.models.faq import DEFAULT_FAQ_CATEGORY, FAQStatus
+from app.models.faq import (
+    DEFAULT_FAQ_CATEGORY,
+    FAQ_META_DESCRIPTION_MAX_LENGTH,
+    FAQ_META_TITLE_MAX_LENGTH,
+    FAQ_SLUG_MAX_LENGTH,
+    FAQStatus,
+)
 from app.models.schemas.pagination import Pagination
 from app.utils.urls import normalize_url
 
@@ -31,6 +37,29 @@ MAX_QUESTION_LENGTH = 300
 # cap only guards against runaway payloads.
 MAX_ANSWER_LENGTH = 20000
 MAX_BULK_IDS = 200
+
+
+class SeoFields(BaseModel):
+    """Optional per-article SEO overrides, shared by create and update.
+
+    Blank strings are coerced to None so clearing a field in the admin UI
+    restores the derived default instead of publishing an empty tag. `slug` is
+    normalized and de-duplicated server-side (see resolve_faq_slug) — validation
+    here only bounds the input, to exactly what the columns accept (values that
+    are too long are rejected rather than silently truncated).
+    """
+    slug: Optional[str] = Field(default=None, max_length=FAQ_SLUG_MAX_LENGTH)
+    meta_title: Optional[str] = Field(default=None, max_length=FAQ_META_TITLE_MAX_LENGTH)
+    meta_description: Optional[str] = Field(
+        default=None, max_length=FAQ_META_DESCRIPTION_MAX_LENGTH
+    )
+
+    @field_validator("slug", "meta_title", "meta_description")
+    @classmethod
+    def _blank_to_none(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        return v.strip() or None
 
 
 class FAQBase(BaseModel):
@@ -47,11 +76,11 @@ class FAQBase(BaseModel):
         return v
 
 
-class FAQCreate(FAQBase):
+class FAQCreate(FAQBase, SeoFields):
     status: FAQStatus = FAQStatus.DRAFT
 
 
-class FAQUpdate(BaseModel):
+class FAQUpdate(SeoFields):
     """Partial update — omitted fields keep their current values (apply with
     model_dump(exclude_unset=True)), so e.g. a status-only PATCH can't silently
     reset the category to its default."""
@@ -79,6 +108,8 @@ class FAQResponse(BaseModel):
     answer: str
     category: str
     slug: Optional[str] = None
+    meta_title: Optional[str] = None
+    meta_description: Optional[str] = None
     status: FAQStatus
     knowledge_id: Optional[int] = None
     source_label: Optional[str] = None

--- a/backend/app/repositories/faq.py
+++ b/backend/app/repositories/faq.py
@@ -85,10 +85,15 @@ class FAQRepository:
             query = self._apply_search(query, search)
         return query.order_by(FAQ.category.asc(), FAQ.sort_order.asc(), FAQ.created_at.asc()).all()
 
-    def slug_exists(self, organization_id: UUID, slug: str) -> bool:
-        return self.db.query(
-            self._org_query(organization_id).filter(FAQ.slug == slug).exists()
-        ).scalar()
+    def slug_exists(
+        self, organization_id: UUID, slug: str, exclude_id: Optional[UUID] = None
+    ) -> bool:
+        """Whether another FAQ in the org already owns this slug. `exclude_id`
+        skips one row so re-saving an article doesn't collide with itself."""
+        query = self._org_query(organization_id).filter(FAQ.slug == slug)
+        if exclude_id is not None:
+            query = query.filter(FAQ.id != exclude_id)
+        return self.db.query(query.exists()).scalar()
 
     def get_published_by_slug(self, organization_id: UUID, slug: str) -> Optional[FAQ]:
         """A single published article by its slug (the public /a/{slug} lookup)."""

--- a/backend/app/services/help_center_seo.py
+++ b/backend/app/services/help_center_seo.py
@@ -1,0 +1,246 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SEO surface of the public help center: the <head> values (title, description,
+canonical, Open Graph) and the schema.org JSON-LD graph. Kept out of the route
+module so every page derives its metadata by the same rules.
+
+Two URL spaces are in play and must not be mixed up:
+  - ABSOLUTE (live_url-based) for canonical, og:*, sitemap and every JSON-LD
+    @id/url — crawlers and social scrapers need a fetchable address.
+  - RELATIVE (base_path-prefixed) for links the page actually renders, so the
+    same markup works on a subdomain, a custom domain and /help/{slug}.
+Breadcrumbs carry both, which is how the BreadcrumbList markup is guaranteed to
+match the visible trail (a Google requirement).
+"""
+
+from datetime import datetime
+from typing import List, Optional, Sequence
+from urllib.parse import quote, urlsplit
+
+from app.models.faq import FAQ
+from app.models.help_center import HelpCenterSettings
+from app.services.help_center_content import excerpt, to_plain_text
+from app.services.help_center_settings import live_url
+
+HOME_CRUMB = "Home"
+# Meta descriptions get truncated by search engines around here; the excerpt
+# helper adds an ellipsis rather than cutting mid-word.
+META_DESCRIPTION_CHARS = 200
+
+
+def site_url(row: HelpCenterSettings) -> str:
+    """The help center's public base URL, never trailing-slashed."""
+    return live_url(row).rstrip("/")
+
+
+def asset_origin(site: str) -> str:
+    """Scheme + host the site's uploads are served from. Same origin as the
+    site in every mode — but NOT the same prefix in path mode, where the site
+    is {backend}/help/{slug} while uploads stay at {backend}/api/v1/uploads/…"""
+    parts = urlsplit(site)
+    return f"{parts.scheme}://{parts.netloc}"
+
+
+def absolute_asset_url(stored_url: Optional[str], site: str) -> Optional[str]:
+    """A stored logo/image URL made absolute for og:image and JSON-LD. S3 URLs
+    are already absolute and pass through; local uploads are relative and get
+    anchored to the serving origin."""
+    if not stored_url:
+        return None
+    if stored_url.startswith("http://") or stored_url.startswith("https://"):
+        return stored_url
+    return f"{asset_origin(site)}{stored_url}"
+
+
+def _isoformat(value: Optional[datetime]) -> Optional[str]:
+    return value.isoformat() if value else None
+
+
+def article_title(row: HelpCenterSettings, faq: FAQ) -> str:
+    """The article's <title>: the org's override, else question + site name."""
+    return faq.meta_title or f"{faq.question} · {row.organization.name} Help Center"
+
+
+def article_description(faq: FAQ) -> str:
+    """The article's meta description: the org's override, else an excerpt of
+    the answer (falling back to the question for answers with no prose)."""
+    return faq.meta_description or excerpt(faq.answer, META_DESCRIPTION_CHARS) or faq.question
+
+
+def index_title(row: HelpCenterSettings) -> str:
+    return row.title or f"{row.organization.name} Help Center"
+
+
+def index_description(row: HelpCenterSettings) -> str:
+    return row.description or f"Answers to common questions about {row.organization.name}."
+
+
+def category_url(site: str, category: str) -> str:
+    """Absolute URL of the index filtered to one category — the middle
+    breadcrumb. Mirrors the ?topic= link the templates render."""
+    return f"{site}/?topic={quote(category)}"
+
+
+def breadcrumbs(
+    row: HelpCenterSettings, faq: FAQ, base_path: str, site: str
+) -> List[dict]:
+    """Home › Category › Article. Each crumb carries `href` (what the page
+    links to) and `url` (what BreadcrumbList advertises); the last crumb is the
+    current page and is rendered as text, so it has no href."""
+    return [
+        {"label": HOME_CRUMB, "href": f"{base_path}/", "url": f"{site}/"},
+        {
+            "label": faq.category,
+            "href": f"{base_path}/?topic={quote(faq.category)}",
+            "url": category_url(site, faq.category),
+        },
+        {"label": faq.question, "href": None, "url": f"{site}/a/{faq.slug}"},
+    ]
+
+
+def _organization_node(row: HelpCenterSettings, site: str, logo_url: Optional[str]) -> dict:
+    node = {
+        "@type": "Organization",
+        "@id": f"{site}/#organization",
+        "name": row.organization.name,
+        "url": f"{site}/",
+    }
+    if logo_url:
+        node["logo"] = {"@type": "ImageObject", "url": logo_url}
+    return node
+
+
+def _website_node(row: HelpCenterSettings, site: str) -> dict:
+    return {
+        "@type": "WebSite",
+        "@id": f"{site}/#website",
+        "url": f"{site}/",
+        "name": index_title(row),
+        "publisher": {"@id": f"{site}/#organization"},
+    }
+
+
+def _question_entity(faq: FAQ) -> dict:
+    """One schema.org Question + acceptedAnswer, from the plain-text form of the
+    (Markdown) answer."""
+    return {
+        "@type": "Question",
+        "name": faq.question,
+        "acceptedAnswer": {"@type": "Answer", "text": to_plain_text(faq.answer)},
+    }
+
+
+def _breadcrumb_node(crumbs: Sequence[dict], page_url: str) -> dict:
+    return {
+        "@type": "BreadcrumbList",
+        "@id": f"{page_url}#breadcrumb",
+        "itemListElement": [
+            {"@type": "ListItem", "position": i, "name": crumb["label"], "item": crumb["url"]}
+            for i, crumb in enumerate(crumbs, start=1)
+        ],
+    }
+
+
+def index_json_ld(
+    row: HelpCenterSettings, faqs: Sequence[FAQ], site: str, logo_url: Optional[str]
+) -> dict:
+    """The landing page graph: Organization + WebSite + a CollectionPage that is
+    also the FAQPage carrying every published Q&A.
+
+    FAQPage - not QAPage - is the correct type for these owner-authored answers.
+    QAPage models community/forum pages where users submit competing answers and
+    requires answerCount/upvoteCount, which don't apply here. Google retired FAQ
+    rich results, but the markup still describes the page for other consumers.
+    """
+    page_url = f"{site}/"
+    page: dict = {
+        "@type": ["CollectionPage", "FAQPage"],
+        "@id": f"{page_url}#webpage",
+        "url": page_url,
+        "name": index_title(row),
+        "description": index_description(row),
+        "isPartOf": {"@id": f"{site}/#website"},
+        "about": {"@id": f"{site}/#organization"},
+    }
+    if faqs:
+        page["mainEntity"] = [_question_entity(faq) for faq in faqs]
+    return {
+        "@context": "https://schema.org",
+        "@graph": [
+            _organization_node(row, site, logo_url),
+            _website_node(row, site),
+            page,
+        ],
+    }
+
+
+def article_json_ld(
+    row: HelpCenterSettings,
+    faq: FAQ,
+    site: str,
+    crumbs: Sequence[dict],
+    logo_url: Optional[str],
+    image_url: Optional[str],
+) -> dict:
+    """The article page graph: Organization + WebSite + WebPage + BreadcrumbList
+    + TechArticle, wired together by @id.
+
+    TechArticle (not FAQPage) is what a single how-to/help article is: Google
+    dropped FAQ rich results, while BreadcrumbList still renders in search.
+    """
+    page_url = f"{site}/a/{faq.slug}"
+    description = article_description(faq)
+    article: dict = {
+        "@type": "TechArticle",
+        "@id": f"{page_url}#article",
+        "headline": faq.question,
+        "description": description,
+        "articleSection": faq.category,
+        "inLanguage": "en",
+        "mainEntityOfPage": {"@id": f"{page_url}#webpage"},
+        "isPartOf": {"@id": f"{page_url}#webpage"},
+        "author": {"@id": f"{site}/#organization"},
+        "publisher": {"@id": f"{site}/#organization"},
+    }
+    published_at = _isoformat(faq.created_at)
+    # updated_at stays NULL until the first edit, so fall back to the creation
+    # date rather than claiming a modification date older than publication.
+    modified_at = _isoformat(faq.updated_at) or published_at
+    if published_at:
+        article["datePublished"] = published_at
+    if modified_at:
+        article["dateModified"] = modified_at
+    if image_url:
+        article["image"] = image_url
+    web_page = {
+        "@type": "WebPage",
+        "@id": f"{page_url}#webpage",
+        "url": page_url,
+        "name": article_title(row, faq),
+        "description": description,
+        "isPartOf": {"@id": f"{site}/#website"},
+        "breadcrumb": {"@id": f"{page_url}#breadcrumb"},
+    }
+    return {
+        "@context": "https://schema.org",
+        "@graph": [
+            _organization_node(row, site, logo_url),
+            _website_node(row, site),
+            web_page,
+            _breadcrumb_node(crumbs, page_url),
+            article,
+        ],
+    }

--- a/backend/app/services/help_center_settings.py
+++ b/backend/app/services/help_center_settings.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.core.logger import get_logger
 from app.models.agent import Agent
+from app.models.faq import FAQ_SLUG_MAX_LENGTH
 from app.models.help_center import HelpCenterSettings
 from app.models.knowledge_to_agent import KnowledgeToAgent
 from app.repositories.help_center import HelpCenterRepository
@@ -35,9 +36,6 @@ logger = get_logger(__name__)
 
 SLUG_MAX_LENGTH = 63
 _SLUG_CLEAN_RE = re.compile(r"[^a-z0-9]+")
-
-
-FAQ_SLUG_MAX_LENGTH = 80
 
 
 def slugify_org_name(name: str) -> str:
@@ -68,6 +66,22 @@ def generate_faq_slug(db: Session, organization_id: UUID, question: str) -> str:
 
     repo = FAQRepository(db)
     return _dedupe_slug(_faq_base_slug(question), lambda c: repo.slug_exists(organization_id, c))
+
+
+def resolve_faq_slug(
+    db: Session, organization_id: UUID, requested: str, exclude_id: Optional[UUID] = None
+) -> str:
+    """A hand-typed slug, reduced to the same shape generation produces
+    (lowercase, a-z0-9 and single hyphens, length-capped) and made unique within
+    the org. `exclude_id` is the FAQ being edited, so keeping its own slug is a
+    no-op rather than a collision that appends -2."""
+    from app.repositories.faq import FAQRepository
+
+    repo = FAQRepository(db)
+    return _dedupe_slug(
+        _faq_base_slug(requested),
+        lambda c: repo.slug_exists(organization_id, c, exclude_id=exclude_id),
+    )
 
 
 def assign_faq_slugs(db: Session, faqs) -> None:

--- a/backend/app/templates/help_center/article.html
+++ b/backend/app/templates/help_center/article.html
@@ -13,7 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-A single help-center article: breadcrumb, rich Markdown body, "Was this helpful?"
+A single help-center article: breadcrumb trail (which must stay in step with the
+BreadcrumbList JSON-LD), rich Markdown body, "Was this helpful?"
 feedback, and related articles. `article.body_html` is the ONLY value rendered
 `| safe` — it is pre-sanitized to an HTML allowlist by help_center_content;
 every other value stays autoescaped.
@@ -53,10 +54,16 @@ every other value stays autoescaped.
     <!-- ---- ARTICLE ---- -->
     <main class="hc-main">
       <article class="hc-article" style="--ic: {{ article.color }};">
-        <a class="hc-back" href="{{ base_path }}/?topic={{ article.category | urlencode }}">
-          <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 18l-6-6 6-6"></path></svg>
-          All {{ article.category }} articles
-        </a>
+        <nav class="hc-crumbs" aria-label="Breadcrumb">
+          {%- for crumb in breadcrumbs %}
+          {%- if not loop.first %}<span class="hc-crumb-sep" aria-hidden="true">›</span>{% endif %}
+          {%- if crumb.href %}
+          <a href="{{ crumb.href }}">{{ crumb.label }}</a>
+          {%- else %}
+          <span class="hc-crumb-current" aria-current="page" title="{{ crumb.label }}">{{ crumb.label }}</span>
+          {%- endif %}
+          {%- endfor %}
+        </nav>
         <div class="hc-article-meta">
           <span class="hc-article-tag">{{ article.category }}</span>
           <span class="hc-article-time">{{ article.read_time }}</span>

--- a/backend/app/templates/help_center/base.html
+++ b/backend/app/templates/help_center/base.html
@@ -35,6 +35,19 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
   <meta property="og:description" content="{{ description }}">
   <meta property="og:type" content="{{ og_type | default('website') }}">
   <meta property="og:url" content="{{ canonical_url }}">
+  {% if og_site_name %}<meta property="og:site_name" content="{{ og_site_name }}">{% endif %}
+  {# og:image must be absolute (scrapers don't resolve relative URLs) — the
+     route absolutizes it. Without an image the card degrades to a text
+     summary rather than showing a broken thumbnail. #}
+  {% if og_image %}
+  <meta property="og:image" content="{{ og_image }}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="{{ og_image }}">
+  {% else %}
+  <meta name="twitter:card" content="summary">
+  {% endif %}
+  <meta name="twitter:title" content="{{ title }}">
+  <meta name="twitter:description" content="{{ description }}">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&family=Instrument+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -160,8 +173,15 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
     .hc-empty p { font-size: 15px; color: #8a90a0; margin: 0 0 20px; }
 
     /* ---------- article page ---------- */
-    .hc-back { display: inline-flex; align-items: center; gap: 7px; margin-bottom: 20px; text-decoration: none; font-family: var(--sans); font-size: 13.5px; color: #8a90a0; }
-    .hc-back:hover { color: #4a5163; }
+    /* Breadcrumb trail. The markup mirrors the BreadcrumbList JSON-LD exactly —
+       change one and change the other, or the structured data stops matching
+       the visible content. The current page is text, not a link. */
+    .hc-crumbs { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; margin-bottom: 20px; font-family: var(--sans); font-size: 13.5px; color: #8a90a0; }
+    .hc-crumbs a { color: #8a90a0; text-decoration: none; }
+    .hc-crumbs a:hover { color: #4a5163; text-decoration: underline; }
+    .hc-crumb-sep { color: #c4c8d2; }
+    /* The article title can be long; keep the trail to one tidy line. */
+    .hc-crumb-current { color: #4a5163; max-width: min(100%, 340px); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .hc-article-meta { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; flex-wrap: wrap; }
     .hc-article-tag { font-family: var(--mono); font-size: 11px; padding: 4px 10px; border-radius: 7px; background: color-mix(in srgb, var(--ic) 12%, #fff); color: var(--ic); }
     .hc-article-time { font-size: 13px; color: #9aa0ad; }

--- a/backend/app/templates/help_center/base.html
+++ b/backend/app/templates/help_center/base.html
@@ -403,6 +403,11 @@ org content safe. Colors: only `--brand`/`--brand-ink` come from the server
   {% if widget_id %}
   <script>
     window.chattermateId = {{ widget_id | tojson }};
+    // Must be set, exactly like the dashboard's install snippet does: the loader
+    // otherwise falls back to the API URL baked in at build time (the vendor
+    // cloud), so a self-hosted help center would ask the wrong backend for its
+    // widget and the visitor would just see "Chat Unavailable".
+    window.chattermateBaseUrl = {{ widget_api_url | tojson }};
     (function () {
       var s = document.createElement('script');
       s.src = {{ widget_script_url | tojson }};

--- a/backend/tests/api/test_help_center_api.py
+++ b/backend/tests/api/test_help_center_api.py
@@ -147,6 +147,65 @@ def test_faq_crud_flow(client, db, test_organization):
     assert client.get(f"{BASE}/faqs").json()["pagination"]["total"] == 0
 
 
+def test_faq_seo_fields_round_trip(client):
+    """Slug and meta overrides are settable at create and edit time."""
+    created = client.post(f"{BASE}/faqs", json={
+        "question": "What does it cost?", "answer": "From $19.",
+        "slug": "Pricing & Plans!", "meta_title": "Pricing",
+        "meta_description": "What ChatterMate costs.",
+    })
+    assert created.status_code == 201
+    # A hand-typed slug is normalized the same way a generated one is.
+    assert created.json()["slug"] == "pricing-plans"
+    assert created.json()["meta_title"] == "Pricing"
+
+    faq_id = created.json()["id"]
+    updated = client.put(f"{BASE}/faqs/{faq_id}", json={"slug": "our-pricing"})
+    assert updated.json()["slug"] == "our-pricing"
+    # Untouched overrides survive a partial update.
+    assert updated.json()["meta_description"] == "What ChatterMate costs."
+
+
+def test_faq_slug_is_deduped_but_stable_for_its_own_row(client):
+    """A taken slug gets a numeric suffix; re-saving a row's own slug is a
+    no-op rather than a self-collision that renames the article."""
+    first = client.post(f"{BASE}/faqs", json={
+        "question": "A", "answer": "a", "slug": "pricing",
+    }).json()
+    second = client.post(f"{BASE}/faqs", json={
+        "question": "B", "answer": "b", "slug": "pricing",
+    }).json()
+    assert first["slug"] == "pricing"
+    assert second["slug"] == "pricing-2"
+
+    resaved = client.put(f"{BASE}/faqs/{first['id']}", json={"slug": "pricing"})
+    assert resaved.json()["slug"] == "pricing"
+
+
+def test_blank_seo_values_clear_overrides_but_keep_the_slug(client):
+    """Emptying a field in the UI restores the derived default. The slug has no
+    derived-at-render fallback, so a blank one keeps the assigned value instead
+    of leaving the article unreachable."""
+    faq = client.post(f"{BASE}/faqs", json={
+        "question": "What does it cost?", "answer": "From $19.", "meta_title": "Pricing",
+    }).json()
+    cleared = client.put(f"{BASE}/faqs/{faq['id']}", json={"meta_title": "", "slug": ""})
+    assert cleared.json()["meta_title"] is None
+    assert cleared.json()["slug"] == faq["slug"]
+
+
+def test_faq_seo_fields_reject_oversized_values(client):
+    """Lengths are bounded at the API so a value can never exceed its column."""
+    over_title = client.post(f"{BASE}/faqs", json={
+        "question": "Q", "answer": "a", "meta_title": "x" * 121,
+    })
+    over_description = client.post(f"{BASE}/faqs", json={
+        "question": "Q", "answer": "a", "meta_description": "x" * 301,
+    })
+    assert over_title.status_code == 422
+    assert over_description.status_code == 422
+
+
 def test_faq_cross_org_is_404(client, db):
     from app.models.organization import Organization
     other_org = Organization(name="Other", domain="other.com", timezone="UTC")

--- a/backend/tests/api/test_help_center_public.py
+++ b/backend/tests/api/test_help_center_public.py
@@ -157,30 +157,155 @@ def test_article_page_renders_sanitized_markdown(client, db, test_organization, 
     assert "alert(1)" not in r.text
 
 
-def test_article_page_emits_faqpage_json_ld(client, db, test_organization, help_center):
-    """Owner-authored articles must be FAQPage, not QAPage. QAPage is for
-    community Q&A and requires answerCount, which Search Console flags as an
-    error on these pages."""
+def _json_ld(response) -> dict:
+    blocks = re.findall(
+        r'<script type="application/ld\+json">(.*?)</script>', response.text, re.DOTALL
+    )
+    assert blocks, "page emitted no JSON-LD"
+    return json.loads(blocks[0])
+
+
+def _nodes_by_type(graph: dict) -> dict:
+    """Graph nodes keyed by @type (multi-typed nodes land under each type)."""
+    nodes: dict = {}
+    for node in graph["@graph"]:
+        types = node["@type"]
+        for node_type in [types] if isinstance(types, str) else types:
+            nodes[node_type] = node
+    return nodes
+
+
+def test_index_json_ld_graph_keeps_faqpage(client, db, test_organization, help_center, subdomain_mode):
+    """The landing page stays a FAQPage (it really is a list of Q&A), wired into
+    an @graph with the Organization and WebSite nodes."""
+    _publish_faq(db, test_organization.id, answer="Click **Settings**.")
+    r = client.get("/", headers={"host": HOST})
+    assert r.status_code == 200
+
+    nodes = _nodes_by_type(_json_ld(r))
+    assert set(nodes) >= {"Organization", "WebSite", "CollectionPage", "FAQPage"}
+    page = nodes["FAQPage"]
+    # Same node carries both types, and it is wired to the WebSite by @id.
+    assert page["@id"] == nodes["CollectionPage"]["@id"]
+    assert page["isPartOf"]["@id"] == nodes["WebSite"]["@id"]
+    assert nodes["WebSite"]["publisher"]["@id"] == nodes["Organization"]["@id"]
+    question = page["mainEntity"][0]
+    assert question["@type"] == "Question"
+    assert question["name"] == "How do I sign up?"
+    # Answer text is plain text, with the Markdown stripped.
+    assert question["acceptedAnswer"]["text"] == "Click Settings ."
+    assert "QAPage" not in r.text
+
+
+def test_article_json_ld_is_techarticle_with_breadcrumbs(
+    client, db, test_organization, help_center, subdomain_mode
+):
+    """A single help article is a TechArticle, not a FAQPage: Google retired FAQ
+    rich results, while BreadcrumbList still renders in search."""
     faq = _publish_faq(db, test_organization.id, answer="Click **Settings**.")
     faq.slug = "how-do-i-sign-up"
     db.commit()
     r = client.get(f"/a/{faq.slug}", headers={"host": HOST})
     assert r.status_code == 200
 
-    blocks = re.findall(
-        r'<script type="application/ld\+json">(.*?)</script>', r.text, re.DOTALL
+    nodes = _nodes_by_type(_json_ld(r))
+    assert set(nodes) >= {"Organization", "WebSite", "WebPage", "BreadcrumbList", "TechArticle"}
+    assert "FAQPage" not in nodes and "QAPage" not in r.text
+
+    article, page, crumbs = nodes["TechArticle"], nodes["WebPage"], nodes["BreadcrumbList"]
+    assert article["headline"] == "How do I sign up?"
+    assert article["articleSection"] == "Getting started"
+    # Every node is wired by @id, not repeated inline.
+    assert article["mainEntityOfPage"]["@id"] == page["@id"]
+    assert article["publisher"]["@id"] == nodes["Organization"]["@id"]
+    assert page["breadcrumb"]["@id"] == crumbs["@id"]
+    # datePublished comes from the row; dateModified falls back to it when the
+    # article has never been edited (so it can't predate publication).
+    assert article["dateModified"] == article["datePublished"]
+
+    items = crumbs["itemListElement"]
+    assert [c["position"] for c in items] == [1, 2, 3]
+    assert [c["name"] for c in items] == ["Home", "Getting started", "How do I sign up?"]
+    assert items[-1]["item"] == f"https://{HOST}/a/how-do-i-sign-up"
+
+
+def test_article_renders_visible_breadcrumb_matching_markup(
+    client, db, test_organization, help_center
+):
+    """Google requires the BreadcrumbList to match what the page shows, so the
+    trail must actually be rendered — the current page as text, not a link."""
+    faq = _publish_faq(db, test_organization.id)
+    faq.slug = "how-do-i-sign-up"
+    db.commit()
+    r = client.get(f"/a/{faq.slug}", headers={"host": HOST})
+
+    assert '<nav class="hc-crumbs" aria-label="Breadcrumb">' in r.text
+    assert '<a href="/">Home</a>' in r.text
+    assert '<a href="/?topic=Getting%20started">Getting started</a>' in r.text
+    assert 'aria-current="page"' in r.text
+
+
+def test_meta_overrides_win_over_derived_values(client, db, test_organization, help_center):
+    """meta_title/meta_description replace the derived title and excerpt; the
+    canonical URL is unaffected."""
+    faq = _publish_faq(db, test_organization.id, answer="Click **Settings**.")
+    faq.slug = "how-do-i-sign-up"
+    faq.meta_title = "Signing up, step by step"
+    faq.meta_description = "A short custom description."
+    db.commit()
+    r = client.get(f"/a/{faq.slug}", headers={"host": HOST})
+
+    assert "<title>Signing up, step by step</title>" in r.text
+    assert '<meta name="description" content="A short custom description.">' in r.text
+    assert '<meta property="og:title" content="Signing up, step by step">' in r.text
+    # The visible <h1> still shows the real question — meta is search-only.
+    assert "How do I sign up?" in r.text
+
+
+def test_og_image_is_absolute(client, db, test_organization, help_center, subdomain_mode):
+    """Scrapers don't resolve relative og:image URLs, so a stored relative logo
+    path has to be anchored to the serving origin."""
+    help_center.logo_url = "/api/v1/uploads/help_center/logo.png"
+    db.commit()
+    r = client.get("/", headers={"host": HOST})
+
+    expected = f"https://{HOST}/api/v1/uploads/help_center/logo.png"
+    assert f'<meta property="og:image" content="{expected}">' in r.text
+    assert '<meta name="twitter:card" content="summary_large_image">' in r.text
+
+
+def test_custom_domain_page_is_self_contained(
+    client, db, test_organization, help_center, test_widget, monkeypatch
+):
+    """On a verified custom domain the page must advertise ITS OWN origin for
+    canonical/og/assets — public_app serves the uploads mount there — even
+    though the install is otherwise in path mode."""
+    monkeypatch.setattr(settings, "HELP_CENTER_PUBLIC_MODE", "path")
+    monkeypatch.setattr(settings, "BACKEND_URL", "https://api.selfhosted.example")
+    help_center.custom_domain = "help.customer.com"
+    help_center.txt_record_verified = True
+    help_center.cname_record_verified = True
+    help_center.logo_url = "/api/v1/uploads/help_center/logo.png"
+    help_center.agent_id = test_widget.agent_id
+    db.commit()
+
+    r = client.get("/", headers={"host": "help.customer.com"})
+    assert r.status_code == 200
+    # The custom domain wins over path mode — no /help/{slug} anywhere.
+    assert '<link rel="canonical" href="https://help.customer.com/">' in r.text
+    assert "/help/test-org" not in r.text
+    assert (
+        '<meta property="og:image" content="https://help.customer.com/api/v1/uploads/help_center/logo.png">'
+        in r.text
     )
-    assert blocks, "article page emitted no JSON-LD"
-    data = json.loads(blocks[0])
-    assert data["@type"] == "FAQPage"
-    # mainEntity must be a list — FAQPage models one-or-more Questions.
-    assert isinstance(data["mainEntity"], list)
-    question = data["mainEntity"][0]
-    assert question["@type"] == "Question"
-    assert question["name"] == "How do I sign up?"
-    # Answer text is plain text, with the Markdown stripped.
-    assert question["acceptedAnswer"]["text"] == "Click Settings ."
-    assert "QAPage" not in r.text
+
+
+def test_og_card_degrades_without_a_logo(client, db, test_organization, help_center):
+    """No logo means no og:image at all — a broken thumbnail is worse than a
+    text-only card."""
+    r = client.get("/", headers={"host": HOST})
+    assert "og:image" not in r.text
+    assert '<meta name="twitter:card" content="summary">' in r.text
 
 
 def test_search_filters_results(client, db, test_organization, help_center):

--- a/backend/tests/api/test_help_center_public.py
+++ b/backend/tests/api/test_help_center_public.py
@@ -274,12 +274,29 @@ def test_og_image_is_absolute(client, db, test_organization, help_center, subdom
     assert '<meta name="twitter:card" content="summary_large_image">' in r.text
 
 
+def test_widget_embed_points_at_this_install(
+    client, db, test_organization, help_center, test_widget, monkeypatch
+):
+    """The loader falls back to the API URL baked in at build time (the vendor
+    cloud) unless the page sets window.chattermateBaseUrl. Without it, a
+    self-hosted help center asks the wrong backend for its widget and the
+    visitor gets "Chat Unavailable"."""
+    monkeypatch.setattr(settings, "BACKEND_URL", "https://api.selfhosted.example")
+    help_center.agent_id = test_widget.agent_id
+    db.commit()
+
+    r = client.get("/", headers={"host": HOST})
+    assert f'window.chattermateId = "{test_widget.id}"' in r.text
+    assert 'window.chattermateBaseUrl = "https://api.selfhosted.example/api/v1"' in r.text
+
+
 def test_custom_domain_page_is_self_contained(
     client, db, test_organization, help_center, test_widget, monkeypatch
 ):
     """On a verified custom domain the page must advertise ITS OWN origin for
-    canonical/og/assets — public_app serves the uploads mount there — even
-    though the install is otherwise in path mode."""
+    canonical/og/assets (public_app serves the uploads mount there), while the
+    widget still calls back to the install's API origin cross-origin — which is
+    exactly what domain verification adds to CORS."""
     monkeypatch.setattr(settings, "HELP_CENTER_PUBLIC_MODE", "path")
     monkeypatch.setattr(settings, "BACKEND_URL", "https://api.selfhosted.example")
     help_center.custom_domain = "help.customer.com"
@@ -298,6 +315,7 @@ def test_custom_domain_page_is_self_contained(
         '<meta property="og:image" content="https://help.customer.com/api/v1/uploads/help_center/logo.png">'
         in r.text
     )
+    assert 'window.chattermateBaseUrl = "https://api.selfhosted.example/api/v1"' in r.text
 
 
 def test_og_card_degrades_without_a_logo(client, db, test_organization, help_center):

--- a/backend/tests/services/test_help_center_seo.py
+++ b/backend/tests/services/test_help_center_seo.py
@@ -1,0 +1,187 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Help-center SEO helpers: absolute-vs-relative URL handling across the three
+serving modes, meta derivation/overrides, and the JSON-LD graph wiring.
+"""
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from app.core.config import settings
+from app.services.help_center_seo import (
+    absolute_asset_url,
+    article_description,
+    article_json_ld,
+    article_title,
+    asset_origin,
+    breadcrumbs,
+    index_json_ld,
+    site_url,
+)
+
+
+def _row(**kw):
+    base = {
+        "domain_verified": False,
+        "custom_domain": None,
+        "slug": "acme",
+        "title": None,
+        "description": None,
+        "organization": SimpleNamespace(name="Acme"),
+    }
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _faq(**kw):
+    base = {
+        "question": "How do I sign up?",
+        "answer": "Click **Settings**.",
+        "category": "Getting started",
+        "slug": "how-do-i-sign-up",
+        "meta_title": None,
+        "meta_description": None,
+        "created_at": datetime(2026, 1, 2, tzinfo=timezone.utc),
+        "updated_at": None,
+    }
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _graph(doc):
+    """Graph nodes keyed by @type (multi-typed nodes land under each type)."""
+    nodes = {}
+    for node in doc["@graph"]:
+        types = node["@type"]
+        for node_type in [types] if isinstance(types, str) else types:
+            nodes[node_type] = node
+    return nodes
+
+
+# ---------- URL space ----------
+
+def test_asset_origin_drops_the_path_in_path_mode(monkeypatch):
+    """In path mode the site lives under /help/{slug} but uploads stay at the
+    origin root, so assets must anchor to the origin, not the site prefix."""
+    monkeypatch.setattr(settings, "HELP_CENTER_PUBLIC_MODE", "path")
+    monkeypatch.setattr(settings, "BACKEND_URL", "http://localhost:8000")
+    site = site_url(_row())
+    assert site == "http://localhost:8000/help/acme"
+    assert asset_origin(site) == "http://localhost:8000"
+    assert (
+        absolute_asset_url("/api/v1/uploads/help_center/l.png", site)
+        == "http://localhost:8000/api/v1/uploads/help_center/l.png"
+    )
+
+
+def test_absolute_asset_url_passes_s3_urls_through():
+    """S3 URLs are already absolute — anchoring them would corrupt them."""
+    stored = "https://bucket.s3.amazonaws.com/help_center/l.png"
+    assert absolute_asset_url(stored, "https://help.acme.com") == stored
+    assert absolute_asset_url(None, "https://help.acme.com") is None
+
+
+def test_site_url_has_no_trailing_slash(monkeypatch):
+    """Every absolute URL is built by concatenation, so a trailing slash here
+    would produce '//a/slug' everywhere."""
+    monkeypatch.setattr(settings, "HELP_CENTER_PUBLIC_MODE", "path")
+    monkeypatch.setattr(settings, "BACKEND_URL", "http://localhost:8000/")
+    assert site_url(_row()) == "http://localhost:8000/help/acme"
+
+
+# ---------- meta ----------
+
+def test_meta_derives_from_content_then_yields_to_overrides():
+    row, faq = _row(), _faq()
+    assert article_title(row, faq) == "How do I sign up? · Acme Help Center"
+    assert article_description(faq) == "Click Settings ."
+
+    overridden = _faq(meta_title="Signing up", meta_description="Custom.")
+    assert article_title(row, overridden) == "Signing up"
+    assert article_description(overridden) == "Custom."
+
+
+def test_description_falls_back_to_the_question_for_prose_free_answers():
+    assert article_description(_faq(answer="![](/img.png)")) == "How do I sign up?"
+
+
+# ---------- breadcrumbs ----------
+
+def test_breadcrumbs_carry_relative_hrefs_and_absolute_urls():
+    """The page links relatively (so the markup works on any origin) while
+    BreadcrumbList advertises absolute URLs."""
+    site = "https://help.acme.com"
+    crumbs = breadcrumbs(_row(), _faq(), "/help/acme", site)
+    assert [c["label"] for c in crumbs] == ["Home", "Getting started", "How do I sign up?"]
+    assert crumbs[0]["href"] == "/help/acme/"
+    assert crumbs[1]["href"] == "/help/acme/?topic=Getting%20started"
+    assert crumbs[1]["url"] == f"{site}/?topic=Getting%20started"
+    # The current page is rendered as text, so it has no link.
+    assert crumbs[-1]["href"] is None
+    assert crumbs[-1]["url"] == f"{site}/a/how-do-i-sign-up"
+
+
+# ---------- JSON-LD ----------
+
+def test_article_graph_is_wired_by_id():
+    site = "https://help.acme.com"
+    faq = _faq()
+    crumbs = breadcrumbs(_row(), faq, "", site)
+    nodes = _graph(article_json_ld(_row(), faq, site, crumbs, None, None))
+
+    page_id = f"{site}/a/how-do-i-sign-up#webpage"
+    assert nodes["WebPage"]["@id"] == page_id
+    assert nodes["TechArticle"]["mainEntityOfPage"]["@id"] == page_id
+    assert nodes["WebPage"]["breadcrumb"]["@id"] == nodes["BreadcrumbList"]["@id"]
+    assert nodes["TechArticle"]["author"]["@id"] == nodes["Organization"]["@id"]
+    assert "FAQPage" not in nodes
+
+
+def test_article_graph_omits_empty_optional_nodes():
+    """No logo and no image must not leave null-valued keys in the graph."""
+    site = "https://help.acme.com"
+    faq = _faq()
+    nodes = _graph(
+        article_json_ld(_row(), faq, site, breadcrumbs(_row(), faq, "", site), None, None)
+    )
+    assert "logo" not in nodes["Organization"]
+    assert "image" not in nodes["TechArticle"]
+
+
+def test_date_modified_never_predates_publication():
+    """updated_at is NULL until the first edit, so it falls back to created_at
+    rather than being omitted or set earlier than datePublished."""
+    site = "https://help.acme.com"
+    faq = _faq()
+    article = _graph(
+        article_json_ld(_row(), faq, site, breadcrumbs(_row(), faq, "", site), None, None)
+    )["TechArticle"]
+    assert article["dateModified"] == article["datePublished"]
+
+    edited = _faq(updated_at=datetime(2026, 3, 4, tzinfo=timezone.utc))
+    article = _graph(
+        article_json_ld(_row(), edited, site, breadcrumbs(_row(), edited, "", site), None, None)
+    )["TechArticle"]
+    assert article["dateModified"] > article["datePublished"]
+
+
+def test_index_graph_keeps_faqpage_and_drops_mainentity_when_empty():
+    site = "https://help.acme.com"
+    nodes = _graph(index_json_ld(_row(), [_faq()], site, None))
+    assert nodes["FAQPage"]["mainEntity"][0]["name"] == "How do I sign up?"
+
+    empty = _graph(index_json_ld(_row(), [], site, None))
+    # An empty mainEntity is invalid FAQPage markup — omit the key entirely.
+    assert "mainEntity" not in empty["FAQPage"]

--- a/frontend/src/__tests__/components/faq/FaqSeoFields.spec.ts
+++ b/frontend/src/__tests__/components/faq/FaqSeoFields.spec.ts
@@ -1,0 +1,76 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import FaqSeoFields from '../../../components/faq/FaqSeoFields.vue'
+
+const createWrapper = (props = {}) => mount(FaqSeoFields, { props })
+
+describe('FaqSeoFields', () => {
+  it('stays collapsed until opened when nothing is customised', async () => {
+    const wrapper = createWrapper()
+    expect(wrapper.find('.seo__fields').exists()).toBe(false)
+
+    await wrapper.find('.seo__toggle').trigger('click')
+    expect(wrapper.find('.seo__fields').exists()).toBe(true)
+  })
+
+  it('opens itself when the article already has overrides', () => {
+    // A customised value must never be hidden behind a collapsed panel.
+    const wrapper = createWrapper({ metaTitle: 'Custom title' })
+    expect(wrapper.find('.seo__fields').exists()).toBe(true)
+    expect(wrapper.find('.seo__badge').exists()).toBe(true)
+  })
+
+  it('can still be collapsed after opening itself', async () => {
+    const wrapper = createWrapper({ metaTitle: 'Custom title' })
+    await wrapper.find('.seo__toggle').trigger('click')
+    expect(wrapper.find('.seo__fields').exists()).toBe(false)
+  })
+
+  it('does not treat a slug alone as customised', () => {
+    // Every article gets a generated slug, so its presence says nothing about
+    // whether the org edited anything.
+    const wrapper = createWrapper({ slug: 'auto-generated-slug' })
+    expect(wrapper.find('.seo__badge').exists()).toBe(false)
+  })
+
+  it('emits updates for each field', async () => {
+    const wrapper = createWrapper({ metaTitle: 'x' })
+    const [slug, title] = wrapper.findAll('input')
+
+    await slug.setValue('custom-slug')
+    await title.setValue('New title')
+    await wrapper.find('textarea').setValue('New description')
+
+    expect(wrapper.emitted('update:slug')?.[0]).toEqual(['custom-slug'])
+    expect(wrapper.emitted('update:metaTitle')?.at(-1)).toEqual(['New title'])
+    expect(wrapper.emitted('update:metaDescription')?.[0]).toEqual(['New description'])
+  })
+
+  it('flags a title past the length search engines truncate at', () => {
+    const wrapper = createWrapper({ metaTitle: 'a'.repeat(61) })
+    expect(wrapper.find('.seo__count--over').exists()).toBe(true)
+  })
+
+  it('shows the question as the title placeholder so the default is visible', () => {
+    const wrapper = createWrapper({ metaTitle: 'x', question: 'How do I sign up?' })
+    const title = wrapper.findAll('input')[1]
+    expect(title.attributes('placeholder')).toBe('How do I sign up?')
+  })
+})

--- a/frontend/src/components/faq/FaqCard.vue
+++ b/frontend/src/components/faq/FaqCard.vue
@@ -16,6 +16,7 @@ limitations under the License.
 
 <script setup lang="ts">
 import type { FaqItem } from '@/types/faq'
+import FaqSeoFields from './FaqSeoFields.vue'
 import MarkdownEditor from './MarkdownEditor.vue'
 
 const props = defineProps<{
@@ -25,6 +26,11 @@ const props = defineProps<{
   saving?: boolean
   draftQuestion: string
   draftAnswer: string
+  /** Per-article SEO drafts. Optional so callers that don't expose the SEO
+   *  section (and tests) can leave them out — they default to empty. */
+  draftSlug?: string
+  draftMetaTitle?: string
+  draftMetaDescription?: string
   locked?: boolean
   /** Selection mode is on somewhere in the list (keeps checkboxes visible). */
   selectable?: boolean
@@ -40,6 +46,9 @@ const emit = defineEmits<{
   'toggle-select': []
   'update:draftQuestion': [value: string]
   'update:draftAnswer': [value: string]
+  'update:draftSlug': [value: string]
+  'update:draftMetaTitle': [value: string]
+  'update:draftMetaDescription': [value: string]
 }>()
 
 function onQuestionInput(event: Event) {
@@ -81,6 +90,15 @@ function answerPreview(md: string): string {
         @update:model-value="$emit('update:draftAnswer', $event)"
       />
       <p class="edit-hint">Markdown supported — headings, <strong>bold</strong>, lists, links and images.</p>
+      <FaqSeoFields
+        :slug="draftSlug"
+        :meta-title="draftMetaTitle"
+        :meta-description="draftMetaDescription"
+        :question="draftQuestion"
+        @update:slug="$emit('update:draftSlug', $event)"
+        @update:meta-title="$emit('update:draftMetaTitle', $event)"
+        @update:meta-description="$emit('update:draftMetaDescription', $event)"
+      />
       <div class="edit-actions">
         <button class="btn-save" type="button" :disabled="saving" @click="$emit('save')">
           {{ saving ? 'Saving…' : 'Save' }}

--- a/frontend/src/components/faq/FaqSeoFields.vue
+++ b/frontend/src/components/faq/FaqSeoFields.vue
@@ -1,0 +1,275 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Per-article SEO overrides inside the FAQ editor: URL slug, meta title and meta
+description. Collapsed by default — every field is optional, and leaving one
+empty keeps the value the public page derives from the question and answer.
+-->
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    slug?: string
+    metaTitle?: string
+    metaDescription?: string
+    /** Shown as the placeholder for the title, so the derived default is visible. */
+    question?: string
+  }>(),
+  { slug: '', metaTitle: '', metaDescription: '', question: '' },
+)
+
+const emit = defineEmits<{
+  'update:slug': [value: string]
+  'update:metaTitle': [value: string]
+  'update:metaDescription': [value: string]
+}>()
+
+// Hard caps mirror the backend column widths in app/models/faq.py, which is the
+// source of truth — the API rejects anything longer with a 422, so these only
+// stop the user typing past the limit. The "recommended" numbers are softer:
+// where search engines start truncating the tag in results.
+const MAX_SLUG = 80
+const MAX_TITLE = 120
+const MAX_DESCRIPTION = 300
+const RECOMMENDED_TITLE = 60
+const RECOMMENDED_DESCRIPTION = 160
+
+// A customised article opens the section on mount, so an override is never
+// hidden behind a collapsed panel — but it stays a plain toggle afterwards, so
+// the user can still fold it away. The editor mounts fresh per article, which
+// is what makes the initial value correct.
+const hasValues = computed(
+  () => Boolean(props.metaTitle.trim() || props.metaDescription.trim()),
+)
+const expanded = ref(hasValues.value)
+
+const titleCount = computed(() => props.metaTitle.trim().length)
+const descriptionCount = computed(() => props.metaDescription.trim().length)
+
+function onInput(event: Event): string {
+  return (event.target as HTMLInputElement | HTMLTextAreaElement).value
+}
+</script>
+
+<template>
+  <div class="seo">
+    <button class="seo__toggle" type="button" :aria-expanded="expanded" @click="expanded = !expanded">
+      <svg
+        class="seo__chevron"
+        :class="{ 'seo__chevron--open': expanded }"
+        viewBox="0 0 24 24"
+        width="13"
+        height="13"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M9 6l6 6-6 6" />
+      </svg>
+      SEO &amp; URL
+      <span v-if="hasValues" class="seo__badge">customised</span>
+    </button>
+
+    <div v-if="expanded" class="seo__fields">
+      <label class="seo__field">
+        <span class="seo__label">URL slug</span>
+        <span class="seo__slug">
+          <span class="seo__prefix">/a/</span>
+          <input
+            type="text"
+            class="seo__input seo__input--slug"
+            :maxlength="MAX_SLUG"
+            placeholder="auto-generated from the question"
+            :value="slug"
+            @input="emit('update:slug', onInput($event))"
+          />
+        </span>
+        <span class="seo__hint">
+          Changing this breaks existing links to the article. Spaces and symbols become hyphens.
+        </span>
+      </label>
+
+      <label class="seo__field">
+        <span class="seo__label">
+          Meta title
+          <span class="seo__count" :class="{ 'seo__count--over': titleCount > RECOMMENDED_TITLE }">
+            {{ titleCount }}/{{ RECOMMENDED_TITLE }}
+          </span>
+        </span>
+        <input
+          type="text"
+          class="seo__input"
+          :maxlength="MAX_TITLE"
+          :placeholder="question || 'Defaults to the question'"
+          :value="metaTitle"
+          @input="emit('update:metaTitle', onInput($event))"
+        />
+      </label>
+
+      <label class="seo__field">
+        <span class="seo__label">
+          Meta description
+          <span
+            class="seo__count"
+            :class="{ 'seo__count--over': descriptionCount > RECOMMENDED_DESCRIPTION }"
+          >
+            {{ descriptionCount }}/{{ RECOMMENDED_DESCRIPTION }}
+          </span>
+        </span>
+        <textarea
+          class="seo__input seo__textarea"
+          rows="2"
+          :maxlength="MAX_DESCRIPTION"
+          placeholder="Defaults to the start of the answer"
+          :value="metaDescription"
+          @input="emit('update:metaDescription', onInput($event))"
+        ></textarea>
+      </label>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.seo {
+  margin-top: 10px;
+  border-top: 1px solid var(--o08);
+  padding-top: 10px;
+}
+
+.seo__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.seo__toggle:hover {
+  color: var(--text);
+}
+
+.seo__chevron {
+  transition: transform 0.15s ease;
+}
+
+.seo__chevron--open {
+  transform: rotate(90deg);
+}
+
+.seo__badge {
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--o08);
+  font-size: 9.5px;
+  letter-spacing: 0.06em;
+  color: var(--muted2);
+}
+
+.seo__fields {
+  display: grid;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.seo__field {
+  display: block;
+}
+
+.seo__label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.seo__count {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 400;
+  color: var(--muted2);
+}
+
+.seo__count--over {
+  color: var(--c-coral);
+}
+
+.seo__slug {
+  display: flex;
+  align-items: center;
+  background: var(--bg);
+  border: 1px solid var(--o12);
+  border-radius: 9px;
+  overflow: hidden;
+}
+
+.seo__prefix {
+  padding: 0 2px 0 11px;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--muted2);
+}
+
+.seo__input {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--bg);
+  border: 1px solid var(--o12);
+  border-radius: 9px;
+  padding: 9px 11px;
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  outline: none;
+}
+
+.seo__input:focus {
+  border-color: var(--o20);
+}
+
+/* The slug input sits inside the prefixed shell, which draws the border. */
+.seo__input--slug {
+  border: none;
+  border-radius: 0;
+  padding-left: 0;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+}
+
+.seo__textarea {
+  resize: vertical;
+  line-height: 1.5;
+}
+
+.seo__hint {
+  display: block;
+  margin-top: 5px;
+  font-size: 11px;
+  color: var(--muted2);
+}
+</style>

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -61,6 +61,9 @@ const {
   isNewFaq,
   draftQuestion,
   draftAnswer,
+  draftSlug,
+  draftMetaTitle,
+  draftMetaDescription,
   isSaving,
   selectedIds,
   selectionActive,
@@ -330,6 +333,9 @@ onUnmounted(stopPolling)
               :saving="isSaving"
               v-model:draft-question="draftQuestion"
               v-model:draft-answer="draftAnswer"
+              v-model:draft-slug="draftSlug"
+              v-model:draft-meta-title="draftMetaTitle"
+              v-model:draft-meta-description="draftMetaDescription"
               @save="saveEdit"
               @cancel="cancelEdit"
             />
@@ -388,8 +394,14 @@ onUnmounted(stopPolling)
                 :selected="selectedIds.has(faq.id)"
                 :draft-question="draftQuestion"
                 :draft-answer="draftAnswer"
+                :draft-slug="draftSlug"
+                :draft-meta-title="draftMetaTitle"
+                :draft-meta-description="draftMetaDescription"
                 @update:draft-question="draftQuestion = $event"
                 @update:draft-answer="draftAnswer = $event"
+                @update:draft-slug="draftSlug = $event"
+                @update:draft-meta-title="draftMetaTitle = $event"
+                @update:draft-meta-description="draftMetaDescription = $event"
                 @toggle-select="toggleSelect(faq.id)"
                 @toggle-status="togglePublish(faq)"
                 @edit="startEdit(faq)"

--- a/frontend/src/composables/useFaqWorkspace.ts
+++ b/frontend/src/composables/useFaqWorkspace.ts
@@ -100,6 +100,11 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
   const isNewFaq = ref(false)
   const draftQuestion = ref('')
   const draftAnswer = ref('')
+  // Per-article SEO overrides. Empty means "derive it" — the server normalizes
+  // a hand-typed slug and treats blanks as cleared, so no client-side slugify.
+  const draftSlug = ref('')
+  const draftMetaTitle = ref('')
+  const draftMetaDescription = ref('')
   const isSaving = ref(false)
 
   let pollTimer: ReturnType<typeof setInterval> | null = null
@@ -341,11 +346,18 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     }
   }
 
+  function setSeoDraft(faq: FaqItem | null): void {
+    draftSlug.value = faq?.slug || ''
+    draftMetaTitle.value = faq?.meta_title || ''
+    draftMetaDescription.value = faq?.meta_description || ''
+  }
+
   function startEdit(faq: FaqItem): void {
     editingId.value = faq.id
     isNewFaq.value = false
     draftQuestion.value = faq.question
     draftAnswer.value = faq.answer
+    setSeoDraft(faq)
   }
 
   function startAdd(): void {
@@ -353,6 +365,7 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     isNewFaq.value = true
     draftQuestion.value = ''
     draftAnswer.value = ''
+    setSeoDraft(null)
   }
 
   function cancelEdit(): void {
@@ -360,6 +373,7 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     isNewFaq.value = false
     draftQuestion.value = ''
     draftAnswer.value = ''
+    setSeoDraft(null)
   }
 
   async function saveEdit(): Promise<void> {
@@ -369,13 +383,21 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
       toast.error('Both a question and an answer are required')
       return
     }
+    // Blank SEO fields are sent through so clearing one in the UI clears it
+    // server-side, restoring the derived title/description (and, for the slug,
+    // keeping whatever is already assigned).
+    const seo = {
+      slug: draftSlug.value.trim(),
+      meta_title: draftMetaTitle.value.trim(),
+      meta_description: draftMetaDescription.value.trim(),
+    }
     isSaving.value = true
     try {
       if (isNewFaq.value) {
-        const created = await faqService.createFaq({ question, answer })
+        const created = await faqService.createFaq({ question, answer, ...seo })
         faqs.value = [...faqs.value, created]
       } else if (editingId.value) {
-        const updated = await faqService.updateFaq(editingId.value, { question, answer })
+        const updated = await faqService.updateFaq(editingId.value, { question, answer, ...seo })
         faqs.value = faqs.value.map((f) => (f.id === updated.id ? updated : f))
       }
       cancelEdit()
@@ -432,6 +454,9 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     isNewFaq,
     draftQuestion,
     draftAnswer,
+    draftSlug,
+    draftMetaTitle,
+    draftMetaDescription,
     isSaving,
     refresh,
     fetchSettings,

--- a/frontend/src/services/faq.ts
+++ b/frontend/src/services/faq.ts
@@ -20,6 +20,7 @@ import type {
   FaqItem,
   FaqImportMode,
   FaqListResponse,
+  FaqSeoFields,
   FaqStatus,
   GenerateEstimate,
   HelpCenterDomain,
@@ -64,7 +65,14 @@ export const faqService = {
     }
   },
 
-  async createFaq(payload: { question: string; answer: string; category?: string; status?: FaqStatus }): Promise<FaqItem> {
+  async createFaq(
+    payload: {
+      question: string
+      answer: string
+      category?: string
+      status?: FaqStatus
+    } & Partial<FaqSeoFields>,
+  ): Promise<FaqItem> {
     try {
       const response = await api.post('/help-center/faqs', payload)
       return response.data
@@ -73,7 +81,12 @@ export const faqService = {
     }
   },
 
-  async updateFaq(id: string, payload: Partial<Pick<FaqItem, 'question' | 'answer' | 'category' | 'status'>>): Promise<FaqItem> {
+  async updateFaq(
+    id: string,
+    payload: Partial<
+      Pick<FaqItem, 'question' | 'answer' | 'category' | 'status'> & FaqSeoFields
+    >,
+  ): Promise<FaqItem> {
     try {
       const response = await api.put(`/help-center/faqs/${id}`, payload)
       return response.data

--- a/frontend/src/types/faq.ts
+++ b/frontend/src/types/faq.ts
@@ -22,6 +22,10 @@ export interface FaqItem {
   answer: string
   category: string
   slug?: string | null
+  /** Per-article SEO overrides. Null means the public page derives them from
+   *  the question and answer. */
+  meta_title?: string | null
+  meta_description?: string | null
   status: FaqStatus
   knowledge_id: number | null
   source_label: string | null
@@ -30,6 +34,10 @@ export interface FaqItem {
   created_at?: string | null
   updated_at?: string | null
 }
+
+/** Editable per-article SEO fields. Blank strings are sent as-is and cleared
+ *  server-side, restoring the derived defaults. */
+export type FaqSeoFields = Pick<FaqItem, 'slug' | 'meta_title' | 'meta_description'>
 
 export interface FaqPagination {
   total: number


### PR DESCRIPTION
Closes the remaining SEO gaps on the public help center (#205), plus a widget bug found while testing.

## Per-article SEO

- Editable meta title, meta description and URL slug, in a collapsible "SEO & URL" section in the FAQ editor. All optional — leave one empty and the page derives it from the question and answer as before.
- Hand-typed slugs are normalized and de-duped per org; re-saving an article never renames it.

## Structured data

- Article pages emit one `@graph` — Organization, WebSite, WebPage, BreadcrumbList, TechArticle — wired by `@id`.
- This replaces `FAQPage` on article pages. Google retired FAQ rich results, so that markup earned nothing on a single article, while BreadcrumbList still shows in search. The landing page keeps `FAQPage` — it genuinely is a list of Q&A.
- Article pages now show a `Home › Category › Article` trail instead of just a back link, which is also what makes the BreadcrumbList legitimate (the markup has to match what's visible).

## og:image

Not in the issue, but shared help-center links came through as bare text. Defaults to the help center logo, absolutized for scrapers, with `twitter:card` degrading to `summary` when there's no logo.

## Widget fix

The help center set `window.chattermateId` but not `window.chattermateBaseUrl`, so the loader fell back to the API URL baked in at build time — the vendor cloud. Self-hosted help centers asked the wrong backend for their widget and showed "Chat Unavailable" with a misleading hint about organization domains. Cloud was unaffected since its `BACKEND_URL` matches the baked default. Separate commit so it can be cherry-picked.

## Notes

- Migration `add_faq_seo_001` adds two nullable columns; no backfill.
- Verified in all three modes (path, subdomain, verified custom domain) — a custom domain still advertises its own origin for canonical/og/assets while the widget calls back to the API origin cross-origin, which domain verification already adds to CORS.
- Not doing: custom `<head>` injection (self-XSS on the customer's own origin), hreflang (needs a translation feature that doesn't exist yet), IndexNow. Rationale is in #205.
