### PR TITLE
fix(inbox): restore list scrolling on mobile

### DIFF
--- a/frontend/src/components/conversations/ConversationsList.vue
+++ b/frontend/src/components/conversations/ConversationsList.vue
@@ -358,6 +358,9 @@ onBeforeUnmount(() => {
 .conversations-container {
   display: grid;
   grid-template-columns: 320px 1fr;
+  /* Same as the parent grid: without a bounded row the sidebar's height: 100%
+     resolves against content, so .conversations-list can never scroll. */
+  grid-template-rows: minmax(0, 1fr);
   gap: 0;
   height: 100%;
   width: 100%;

--- a/frontend/src/layouts/DashboardLayout.vue
+++ b/frontend/src/layouts/DashboardLayout.vue
@@ -1178,8 +1178,11 @@ const openNotificationsFromSheet = () => {
         display: none;
     }
 
-    /* Full-height pages (Inbox): shrink the content area instead of padding it */
+    /* Full-height pages (Inbox): shrink the content area instead of padding it.
+       flex: 0 0 auto is required — the default flex: 1 zeroes the flex basis and
+       grows back to the full 100dvh, putting the page bottom under the nav. */
     .dashboard-layout.has-bottom-nav.header-hidden .content {
+        flex: 0 0 auto;
         height: calc(100dvh - var(--bottom-nav-height) - var(--safe-bottom));
         padding-bottom: 0;
     }

--- a/frontend/src/views/ConversationsView.vue
+++ b/frontend/src/views/ConversationsView.vue
@@ -448,6 +448,9 @@ const handleChatClosed = (_sessionId?: string) => {
 .main-content {
   display: grid;
   grid-template-columns: 1fr 350px;
+  /* Bound the implicit row: an auto row is content-sized, so the list/chat
+     panes inherit no height limit and their inner overflow never scrolls. */
+  grid-template-rows: minmax(0, 1fr);
   flex: 1;
   min-height: 0;
   width: 100%;


### PR DESCRIPTION
The conversations list didn't scroll on mobile, on both the Open and Closed tabs, and the bottom of the page sat under the bottom nav.

Two causes:

- Neither conversations grid declares `grid-template-rows`, so the implicit row was sized by its content. Every `height: 100%` below it resolved against that, so `.conversations-list` never got a bounded height and its `overflow-y: auto` never engaged — the list was just clipped. Both grids now use `grid-template-rows: minmax(0, 1fr)`.
- `.content` carries `flex: 1`, which zeroes the flex basis and grows back to a full `100dvh`, defeating the mobile `height: calc(100dvh - nav)`. Pinned with `flex: 0 0 auto`.

CSS only. Desktop is unaffected apart from the same row now being bounded.