### PR TITLE
fix(inbox): let the chat pane fill its column on desktop

### DIFF
--- a/frontend/src/components/conversations/ConversationChat.vue
+++ b/frontend/src/components/conversations/ConversationChat.vue
@@ -503,7 +503,11 @@ watch(() => currentChat.value?.session_id, () => refreshLinkedTicket())
 .chat-layout {
   display: flex;
   flex-direction: column;
-  height: 70vh;
+  /* Fill .chat-view rather than a fixed viewport fraction — the pane is already
+     sized by the grid, and 70vh left a dead strip below the message input. */
+  height: 100%;
+  flex: 1;
+  min-height: 0;
   width: 100%;
   background: var(--bg);
   position: relative;
@@ -1288,12 +1292,6 @@ watch(() => currentChat.value?.session_id, () => refreshLinkedTicket())
 
 /* Mobile: full-screen chat pane */
 @media (max-width: 768px) {
-  .chat-layout {
-    height: 100%;
-    flex: 1;
-    min-height: 0;
-  }
-
   .back-btn,
   .info-btn {
     display: flex;


### PR DESCRIPTION
Follow-up to #251.

`.chat-layout` was pinned to `70vh`. That was invisible before, because the grid row it sat in was sized by content, but now that the row is bounded to the container it leaves a dead strip below the message input on desktop.

It now fills the pane — `height: 100%; flex: 1; min-height: 0`, which is exactly what the mobile override already did, so that override is gone. `ConversationChat` is only used inside `.chat-view`, so nothing else depended on the fixed height.

CSS only.