### PR TITLE
fix(security): scope multi-tenant endpoints to the caller's organization

### DIFF
--- a/backend/app/api/file_upload.py
+++ b/backend/app/api/file_upload.py
@@ -105,6 +105,52 @@ async def get_current_user_or_widget(
     )
 
 
+def authorized_attachment_key(file_path: str, org_id: Optional[str]) -> str:
+    """Resolve a download path to a storage key the caller is allowed to read.
+
+    Uploads only ever land at `chat_attachments/<org_id>/<uuid>.<ext>` (see
+    FileUploadService.upload_file), so anything else is not a servable
+    attachment. Matching that shape exactly is what both scopes the read to the
+    caller's organization and rules out traversal — no `..` segment can
+    survive a three-part match on a UUID directory.
+    """
+    if not org_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="File not found"
+        )
+
+    # Accept the stored form ("/uploads/chat_attachments/...") and the bare key.
+    clean_path = file_path.lstrip('/')
+    if clean_path.startswith('uploads/'):
+        clean_path = clean_path[len('uploads/'):]
+
+    parts = clean_path.split('/')
+    if len(parts) != 3 or parts[0] != 'chat_attachments' or not parts[2]:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="File not found"
+        )
+
+    try:
+        path_org_id = uuid.UUID(parts[1])
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="File not found"
+        )
+
+    # 404 rather than 403: whether another org's attachment exists is itself
+    # something the caller shouldn't learn.
+    if str(path_org_id) != str(org_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="File not found"
+        )
+
+    return '/'.join(('chat_attachments', str(path_org_id), parts[2]))
+
+
 @router.get("/download/{file_path:path}")
 async def download_file(
     file_path: str,
@@ -115,28 +161,26 @@ async def download_file(
 ):
     """
     Download/serve a file from AWS S3 or local storage
-    
+
     Usage: GET /api/v1/files/download/chat_attachments/org-id/filename.jpg
     """
     try:
         from fastapi.responses import StreamingResponse
         from app.core.s3 import get_s3_client
         import io
-        
-        # Try to authenticate
-        try:
-            auth_info = await get_current_user_or_widget(request, db, authorization, x_conversation_token)
-        except Exception:
-            auth_info = None
-        
+
+        # Authentication is required, and the result is what authorizes the
+        # read below. This used to swallow the failure and serve the file
+        # anyway, making every org's attachments world-readable by path.
+        auth_info = await get_current_user_or_widget(
+            request, db, authorization, x_conversation_token)
+        storage_key = authorized_attachment_key(file_path, auth_info.get("org_id"))
+
         if not settings.S3_FILE_STORAGE:
             # Serve local file
             import os
-            # file_path already includes the full path like /uploads/chat_attachments/org-id/filename.png
-            # Remove leading slash if present
-            clean_path = file_path.lstrip('/')
-            local_file_path = clean_path if clean_path.startswith('uploads/') else os.path.join("uploads", clean_path)
-            
+            local_file_path = os.path.join("uploads", storage_key)
+
             if os.path.exists(local_file_path):
                 with open(local_file_path, "rb") as f:
                     file_content = f.read()
@@ -148,12 +192,12 @@ async def download_file(
                 return StreamingResponse(
                     io.BytesIO(file_content),
                     media_type=content_type,
-                    headers={"Content-Disposition": f"inline; filename={os.path.basename(file_path)}"}
+                    headers={"Content-Disposition": f"inline; filename={os.path.basename(storage_key)}"}
                 )
             else:
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
-                    detail=f"File not found: {local_file_path}"
+                    detail="File not found"
                 )
         
         # For AWS S3 - stream file from S3
@@ -166,8 +210,8 @@ async def download_file(
                 detail="Failed to create S3 client"
             )
         
-        # For S3, remove /uploads/ prefix if present since S3 keys don't include it
-        s3_key = file_path.lstrip('/').replace('uploads/', '') if file_path.startswith('/uploads/') else file_path.lstrip('/')
+        # S3 keys don't include the /uploads/ prefix
+        s3_key = storage_key
         bucket = settings.S3_BUCKET
         
         # Check if the file exists
@@ -209,8 +253,8 @@ async def download_file(
         # Determine content type
         content_type = response.get('ContentType', 'application/octet-stream')
         
-        # Extract filename from path
-        filename = file_path.split('/')[-1]
+        # Extract filename from the validated key
+        filename = storage_key.split('/')[-1]
         
         logger.info(f"Streaming file from S3: {filename}, content-type: {content_type}")
         return StreamingResponse(

--- a/backend/app/api/jira.py
+++ b/backend/app/api/jira.py
@@ -39,6 +39,20 @@ router = APIRouter()
 jira_service = JiraService()
 logger = get_logger(__name__)
 
+
+def _require_jira_agent_in_org(db, agent_id, org_id) -> None:
+    """The agent must belong to the caller's org, else 404.
+
+    A malformed agent_id is treated as not-found rather than a 500.
+    """
+    from app.repositories.agent import AgentRepository
+    try:
+        agent_uuid = uuid.UUID(str(agent_id))
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if not AgentRepository(db).get_agent_in_org(agent_uuid, org_id):
+        raise HTTPException(status_code=404, detail="Agent not found")
+
 # Create a temporary in-memory store for OAuth states
 # This is a simple solution that doesn't require database changes
 # In production, you might want to use Redis or a database table
@@ -493,9 +507,10 @@ async def save_agent_jira_config(
     """
     Save Jira configuration for an agent.
     """
-    # Check if agent belongs to the organization
-    # This would typically be done with a query to your agent table
-    
+    # The agent must belong to the caller's org — otherwise any tenant could
+    # flip another tenant's project_key / issue_type and hijack escalation.
+    _require_jira_agent_in_org(db, agent_id, organization.id)
+
     # Check if Jira is connected
     token = db.query(JiraToken).filter(
         JiraToken.organization_id == organization.id
@@ -537,9 +552,9 @@ async def get_agent_jira_config(
     """
     Get Jira configuration for an agent.
     """
-    # Check if agent belongs to the organization
-    # This would typically be done with a query to your agent table
-    
+    # The agent must belong to the caller's org before its config is exposed.
+    _require_jira_agent_in_org(db, agent_id, organization.id)
+
     config = db.query(AgentJiraConfig).filter(
         AgentJiraConfig.agent_id == agent_id
     ).first()

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -324,16 +324,23 @@ async def get_explore_progress(
 ):
     """Get progress status for knowledge base processing"""
     try:
-        queue_repo = KnowledgeQueueRepository(db)
-        queue_item = queue_repo.get_by_id(queue_id)
-        
+        # Deliberately unauthenticated — it polls the job the equally public
+        # /explore/add-url just created. That makes scoping it to the shared
+        # explore org essential: queue ids are sequential, so an unscoped
+        # lookup let anyone walk every tenant's ingestion jobs and read their
+        # source URLs and crawled-page lists.
+        queue_item = db.query(KnowledgeQueue).filter(
+            KnowledgeQueue.id == queue_id,
+            KnowledgeQueue.organization_id == UUID(settings.EXPLORE_SOURCE_ORG_ID)
+        ).first()
+
         # Refresh the item to get the latest data from the database
         if queue_item:
             db.refresh(queue_item)
-        
+
         if not queue_item:
             raise HTTPException(status_code=404, detail="Queue item not found")
-        
+
         # Get processing stage information
         stage_info = {
             "not_started": {"label": "Initializing", "step": 1, "total": 4},
@@ -396,7 +403,10 @@ async def get_explore_progress(
             "is_complete": status_str.upper() in ["COMPLETED", "FAILED"],
             "error_message": getattr(queue_item, 'error_message', None)
         }
-        
+
+    except HTTPException:
+        # Otherwise the not-found above is reported as a 500 echoing its detail.
+        raise
     except Exception as e:
         logger.error(f"Error getting progress for queue {queue_id}: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -626,6 +636,12 @@ async def link_knowledge_to_agent(
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid agent ID format")
 
+        # The agent must belong to the caller's org, not just the knowledge.
+        # 404 (not 403) so we don't reveal another org's agent existence.
+        agent = AgentRepository(db).get_agent(agent_uuid)
+        if not agent or agent.organization_id != current_user.organization_id:
+            raise HTTPException(status_code=404, detail="Agent not found")
+
         # Check if link already exists
         existing_link = link_repo.get_by_ids(knowledge_id, agent_uuid)
         if existing_link:
@@ -732,6 +748,11 @@ async def unlink_knowledge_from_agent(
         knowledge = knowledge_repo.get_by_id(knowledge_id)
         if not knowledge or knowledge.organization_id != current_user.organization_id:
             raise HTTPException(status_code=404, detail="Knowledge source not found or unauthorized access")
+
+        # And the agent must be in the caller's org too.
+        agent = AgentRepository(db).get_agent(agent_uuid)
+        if not agent or agent.organization_id != current_user.organization_id:
+            raise HTTPException(status_code=404, detail="Agent not found")
 
         # Delete the link
         success = link_repo.delete_by_ids(knowledge_id, agent_uuid)

--- a/backend/app/api/organizations.py
+++ b/backend/app/api/organizations.py
@@ -266,6 +266,29 @@ async def check_domain_availability(
         )
 
 
+def get_own_organization_or_404(db: Session, org_id: UUID, current_user: User) -> Organization:
+    """Load an organization the caller actually belongs to.
+
+    These routes take the org id from the path, so without this a user of one
+    tenant could read — and with manage_organization, rewrite — another
+    tenant's record. 404 rather than 403: the existence of another
+    organization isn't the caller's business either.
+    """
+    if current_user.organization_id != org_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found"
+        )
+
+    org = db.query(Organization).filter(Organization.id == org_id).first()
+    if not org:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Organization not found"
+        )
+    return org
+
+
 @router.get("/{org_id}", response_model=OrganizationResponse)
 async def get_organization(
     org_id: UUID,
@@ -274,13 +297,7 @@ async def get_organization(
 ):
     """Get organization by ID"""
     try:
-        org = db.query(Organization).filter(Organization.id == org_id).first()
-        if not org:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Organization not found"
-            )
-        return org
+        return get_own_organization_or_404(db, org_id, current_user)
     except HTTPException as he:
         raise he
     except Exception as e:
@@ -301,12 +318,7 @@ async def update_organization(
 ):
     """Update organization details including business hours"""
     try:
-        org = db.query(Organization).filter(Organization.id == org_id).first()
-        if not org:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Organization not found"
-            )
+        org = get_own_organization_or_404(db, org_id, current_user)
 
         # Update only provided fields
         update_data = org_data.model_dump(exclude_unset=True)
@@ -608,12 +620,7 @@ async def get_organization_stats(
     db: Session = Depends(get_db)
 ):
     """Get organization statistics"""
-    org = db.query(Organization).filter(Organization.id == org_id).first()
-    if not org:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Organization not found"
-        )
+    org = get_own_organization_or_404(db, org_id, current_user)
 
     # --- Members ---
     total_users = db.query(User).filter(User.organization_id == org_id).count()

--- a/backend/app/api/shopify.py
+++ b/backend/app/api/shopify.py
@@ -57,6 +57,22 @@ logger = get_logger(__name__)
 SCOPES = "read_products,read_themes,write_themes,write_script_tags,read_script_tags,read_orders,read_customers"
 
 
+def _require_shopify_agent_in_org(db, agent_id, org_id) -> None:
+    """The agent being configured must belong to the resolved org, else 404.
+
+    agent_id and org_id both arrive as either strings or UUIDs depending on the
+    auth path; a malformed id is simply not found rather than a 500.
+    """
+    from app.repositories.agent import AgentRepository
+    try:
+        agent_uuid = UUID(str(agent_id))
+        org_uuid = UUID(str(org_id))
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if not AgentRepository(db).get_agent_in_org(agent_uuid, org_uuid):
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+
 @router.post("/exchange-token")
 async def exchange_session_token(
     request: Request,
@@ -189,8 +205,20 @@ async def link_shop_to_org(
         if not db_shop:
             raise HTTPException(status_code=404, detail="Shop not found")
 
-        # Update shop with organization_id
         org_id_str = str(current_user.organization_id)
+
+        # Claiming is only for shops nobody owns yet — the same guard
+        # /link-shop/{shop_id} has. Without it, any manage_organization user
+        # could re-point another tenant's installed shop (and its stored
+        # access token) at their own org, and drag that shop's domain onto
+        # their organization record in the process.
+        if db_shop.organization_id and str(db_shop.organization_id) != org_id_str:
+            raise HTTPException(
+                status_code=404,
+                detail="Shop not found"
+            )
+
+        # Update shop with organization_id
         shop_update = ShopifyShopUpdate(organization_id=org_id_str)
         shop_repo.update_shop(shop_id, shop_update)
 
@@ -668,19 +696,26 @@ async def get_agent_shopify_config(
     Supports both session token auth (embedded) and JWT auth (dashboard).
     """
     # Try session token first (for embedded apps)
+    org_id = None
     try:
         shopify_session = await require_shopify_session(request, db)
         # Session token valid - verify agent belongs to shop's organization
         if not shopify_session['organization_id']:
             raise HTTPException(status_code=403, detail="Shop not linked to organization")
-        logger.info(f"GET agent-config using session token for org: {shopify_session['organization_id']}")
+        org_id = shopify_session['organization_id']
+        logger.info(f"GET agent-config using session token for org: {org_id}")
     except HTTPException:
         # Fall back to JWT auth (for dashboard)
         current_user = await get_current_user(request=request, db=db)
         if not check_permissions(current_user, ["manage_organization"]):
             raise HTTPException(status_code=403, detail="Insufficient permissions")
+        org_id = current_user.organization_id
         logger.info(f"GET agent-config using JWT auth for user: {current_user.id}")
-    
+
+    # The comment above always promised this — the agent must be in the
+    # resolved org, else any tenant could read any agent's Shopify config.
+    _require_shopify_agent_in_org(db, agent_id, org_id)
+
     agent_config_repository = AgentShopifyConfigRepository(db)
     config = agent_config_repository.get_agent_shopify_config(agent_id)
     if not config:
@@ -725,7 +760,10 @@ async def save_agent_shopify_config(
         org_id_str = str(current_user.organization_id)
         user_id = current_user.id
         logger.info(f"POST agent-config using JWT auth for user: {current_user.id}")
-    
+
+    # The agent being configured must belong to the resolved org.
+    _require_shopify_agent_in_org(db, agent_id, org_id_str)
+
     # Get the current config for the agent, if it exists
     existing_config = agent_config_repository.get_agent_shopify_config(agent_id)
     

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -271,6 +271,23 @@ async def draft_from_session(
     }
 
 
+def _validate_assignment_references(db: Session, org_id, assignee_user_id, group_id) -> None:
+    """A ticket may only be assigned to a user or group in the caller's org.
+
+    Both create and update run this, so a ticket (and its assignment activity
+    log) can never point at a user or group from another tenant.
+    """
+    if assignee_user_id is not None:
+        assignee = db.query(User).filter(User.id == assignee_user_id).first()
+        if assignee is None or str(assignee.organization_id) != str(org_id):
+            raise HTTPException(status_code=404, detail="Assignee not found")
+    if group_id is not None:
+        from app.models.user import UserGroup
+        group = db.query(UserGroup).filter(UserGroup.id == group_id).first()
+        if group is None or str(group.organization_id) != str(org_id):
+            raise HTTPException(status_code=404, detail="Group not found")
+
+
 def _validate_create_references(db: Session, payload: TicketCreate, org_id) -> None:
     """Every referenced entity must belong to the caller's organization."""
     if payload.customer_id is not None:
@@ -278,10 +295,8 @@ def _validate_create_references(db: Session, payload: TicketCreate, org_id) -> N
         customer = db.query(Customer).filter(Customer.id == payload.customer_id).first()
         if customer is None or str(customer.organization_id) != str(org_id):
             raise HTTPException(status_code=404, detail="Customer not found")
-    if payload.assignee_user_id is not None:
-        assignee = db.query(User).filter(User.id == payload.assignee_user_id).first()
-        if assignee is None or str(assignee.organization_id) != str(org_id):
-            raise HTTPException(status_code=404, detail="Assignee not found")
+    _validate_assignment_references(
+        db, org_id, payload.assignee_user_id, payload.group_id)
 
 
 @router.post("", response_model=TicketDetailResponse, status_code=201)
@@ -381,10 +396,15 @@ async def update_ticket(
                 actor_type=TicketActorType.USER, actor_user_id=current_user.id,
             )
         if "assignee_user_id" in data or "group_id" in data:
+            new_assignee = data.pop("assignee_user_id", ticket.assignee_user_id)
+            new_group = data.pop("group_id", ticket.group_id)
+            # Same org guard as create — the update path bypassed it entirely.
+            _validate_assignment_references(
+                db, current_user.organization_id, new_assignee, new_group)
             service.assign(
                 ticket,
-                data.pop("assignee_user_id", ticket.assignee_user_id),
-                data.pop("group_id", ticket.group_id),
+                new_assignee,
+                new_group,
                 actor_user_id=current_user.id,
             )
         customer_email = data.pop("customer_email", None)

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -73,6 +73,20 @@ UPLOAD_DIR = "uploads/user"
 ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif"}
 MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
 
+
+def _require_role_in_org(db, role_id, org_id) -> None:
+    """A user may only be given a role defined in their own organization.
+
+    Role ids are sequential integers, so without this an admin could bind a
+    user to another tenant's role — inheriting that role's permissions and
+    breaking the other org's "is this role in use" accounting.
+    """
+    if role_id is None:
+        return
+    role = db.query(Role).filter(Role.id == role_id).first()
+    if not role or role.organization_id != org_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
+
 def get_file_extension(filename: str) -> str:
     return os.path.splitext(filename)[1].lower()
 
@@ -140,9 +154,12 @@ async def create_user(
                         detail=f"Maximum number of users ({subscription.quantity}) reached for your plan. Please upgrade your plan to add more users."
                     )
         
+        # The role must belong to the caller's own organization.
+        _require_role_in_org(db, user_data.role_id, current_user.organization_id)
+
         # Hash the password
         hashed_password = User.get_password_hash(user_data.password)
-        
+
         # Create user with organization from current user
         new_user = user_repo.create_user(
             email=user_data.email,
@@ -837,7 +854,10 @@ async def update_user(
     
     if not user or user.organization_id != current_user.organization_id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
-    
+
+    # A supplied role must belong to the caller's org, not another tenant's.
+    _require_role_in_org(db, user_data.role_id, current_user.organization_id)
+
     # Check if updating email and if it's already taken
     if user_data.email and user_data.email != user.email:
         if HAS_EMAIL_VALIDATION:

--- a/backend/app/repositories/agent.py
+++ b/backend/app/repositories/agent.py
@@ -63,6 +63,18 @@ class AgentRepository:
             Agent.id == agent_id
         ).first()
 
+    def get_agent_in_org(self, agent_id, org_id) -> Optional[Agent]:
+        """Get an agent only if it belongs to org_id.
+
+        The single choke point for "is this agent mine?" — endpoints that take
+        an agent_id from the caller use this so an agent from another tenant
+        can never be read or reconfigured.
+        """
+        return self.db.query(Agent).filter(
+            Agent.id == agent_id,
+            Agent.organization_id == org_id
+        ).first()
+
     def get_org_agents(self, org_id: UUID, active_only: bool = True) -> List[Agent]:
         """Get all templates for an organization"""
         query = self.db.query(Agent).filter(

--- a/backend/app/repositories/user_group.py
+++ b/backend/app/repositories/user_group.py
@@ -69,26 +69,42 @@ class UserGroupRepository:
         return False
 
     def add_user(self, group_id: UUID, user_id: UUID) -> bool:
-        """Add user to group"""
+        """Add user to group.
+
+        The user is looked up within the group's own organization, so a group
+        can never gain a member from another tenant regardless of what user_id
+        a caller supplies — group membership drives chat routing and
+        assigned-chat visibility, so a foreign member would leak conversations.
+        """
         group = self.get_group(group_id)
-        user = self.db.query(User).filter(User.id == user_id).first()
-        
-        if not group or not user:
+        if not group:
             return False
-            
+
+        user = self.db.query(User).filter(
+            User.id == user_id,
+            User.organization_id == group.organization_id
+        ).first()
+        if not user:
+            return False
+
         if user not in group.users:
             group.users.append(user)
             self.db.commit()
         return True
 
     def remove_user(self, group_id: UUID, user_id: UUID) -> bool:
-        """Remove user from group"""
+        """Remove user from group (within the group's organization)."""
         group = self.get_group(group_id)
-        user = self.db.query(User).filter(User.id == user_id).first()
-        
-        if not group or not user:
+        if not group:
             return False
-            
+
+        user = self.db.query(User).filter(
+            User.id == user_id,
+            User.organization_id == group.organization_id
+        ).first()
+        if not user:
+            return False
+
         if user in group.users:
             group.users.remove(user)
             self.db.commit()

--- a/backend/tests/api/test_file_upload.py
+++ b/backend/tests/api/test_file_upload.py
@@ -31,6 +31,18 @@ from tests.conftest import TestingSessionLocal, create_tables, engine
 from app.database import Base
 
 
+# Downloads are only ever served for chat attachments, which live at
+# chat_attachments/<org_id>/<file> — the path's org segment is what authorizes
+# the read, so every download test needs a real org id on both sides.
+ORG_ID = "bab82aab-d095-46f8-bf16-da638671bcf4"
+OTHER_ORG_ID = "11111111-2222-3333-4444-555555555555"
+ATTACHMENT_KEY = f"chat_attachments/{ORG_ID}/file.txt"
+
+
+def auth_user(org_id=ORG_ID):
+    return {"type": "user", "user_id": "123", "org_id": org_id}
+
+
 # Create test FastAPI app
 test_app = FastAPI()
 test_app.include_router(router, prefix="/api/v1/files")
@@ -150,7 +162,7 @@ class TestGetCurrentUserOrWidget:
             # Mock successful token verification
             mock_verify_token.return_value = {
                 "widget_id": "widget_123",
-                "org_id": "org_456",
+                "org_id": ORG_ID,
                 "customer_id": "customer_789"
             }
             
@@ -160,7 +172,7 @@ class TestGetCurrentUserOrWidget:
             
             assert result["type"] == "widget"
             assert result["widget_id"] == "widget_123"
-            assert result["org_id"] == "org_456"
+            assert result["org_id"] == ORG_ID
             assert result["customer_id"] == "customer_789"
     
     @pytest.mark.asyncio
@@ -196,11 +208,11 @@ class TestDownloadFileLocal:
                  patch('os.path.exists') as mock_exists, \
                  patch('builtins.open', create=True) as mock_open:
                 
-                mock_auth.return_value = {"type": "user", "user_id": "123"}
+                mock_auth.return_value = auth_user()
                 mock_exists.return_value = True
                 mock_open.return_value.__enter__.return_value.read.return_value = b"Test file content"
                 
-                response = client.get("/api/v1/files/download/test/file.txt")
+                response = client.get(f"/api/v1/files/download/{ATTACHMENT_KEY}")
                 
                 assert response.status_code == 200
                 assert response.headers["content-type"] == "text/plain; charset=utf-8"
@@ -215,30 +227,29 @@ class TestDownloadFileLocal:
              patch('app.api.file_upload.get_current_user_or_widget') as mock_auth, \
              patch('os.path.exists') as mock_exists:
             
-            mock_auth.return_value = {"type": "user", "user_id": "123"}
+            mock_auth.return_value = auth_user()
             mock_exists.return_value = False
             
-            response = client.get("/api/v1/files/download/nonexistent/file.txt")
+            response = client.get(f"/api/v1/files/download/chat_attachments/{ORG_ID}/nonexistent.txt")
             
             assert response.status_code == 404
             assert "File not found" in response.json()["detail"]
     
     def test_download_file_local_without_auth(self, client):
-        """Test file download without authentication (should still work)"""
+        """Unauthenticated downloads are refused, not served anyway"""
         with patch.object(settings, 'S3_FILE_STORAGE', False), \
              patch('app.api.file_upload.get_current_user_or_widget') as mock_auth, \
              patch('os.path.exists') as mock_exists, \
              patch('builtins.open', create=True) as mock_open:
-            
-            # Mock auth failure but file should still be served
+
             from fastapi import HTTPException
             mock_auth.side_effect = HTTPException(status_code=401)
             mock_exists.return_value = True
             mock_open.return_value.__enter__.return_value.read.return_value = b"Test file content"
-            
-            response = client.get("/api/v1/files/download/test/file.txt")
-            
-            assert response.status_code == 200
+
+            response = client.get(f"/api/v1/files/download/{ATTACHMENT_KEY}")
+
+            assert response.status_code == 401
 
 
 class TestDownloadFileS3:
@@ -251,7 +262,7 @@ class TestDownloadFileS3:
              patch('app.api.file_upload.get_current_user_or_widget') as mock_auth, \
              patch('app.core.s3.get_s3_client') as mock_s3_client:
             
-            mock_auth.return_value = {"type": "user", "user_id": "123"}
+            mock_auth.return_value = auth_user()
             
             # Mock S3 client
             mock_client = Mock()
@@ -268,11 +279,11 @@ class TestDownloadFileS3:
             mock_response['Body'].read.side_effect = [b"Test content", b""]  # First chunk, then empty
             mock_client.get_object.return_value = mock_response
             
-            response = client.get("/api/v1/files/download/test/file.txt")
+            response = client.get(f"/api/v1/files/download/{ATTACHMENT_KEY}")
             
             assert response.status_code == 200
-            mock_client.head_object.assert_called_once_with(Bucket='test-bucket', Key='test/file.txt')
-            mock_client.get_object.assert_called_once_with(Bucket='test-bucket', Key='test/file.txt')
+            mock_client.head_object.assert_called_once_with(Bucket='test-bucket', Key=ATTACHMENT_KEY)
+            mock_client.get_object.assert_called_once_with(Bucket='test-bucket', Key=ATTACHMENT_KEY)
     
     def test_download_file_s3_not_found(self, client):
         """Test S3 file download when file doesn't exist"""
@@ -281,7 +292,7 @@ class TestDownloadFileS3:
              patch('app.api.file_upload.get_current_user_or_widget') as mock_auth, \
              patch('app.core.s3.get_s3_client') as mock_s3_client:
             
-            mock_auth.return_value = {"type": "user", "user_id": "123"}
+            mock_auth.return_value = auth_user()
             
             # Mock S3 client
             mock_client = Mock()
@@ -297,7 +308,7 @@ class TestDownloadFileS3:
             mock_client.exceptions.NoSuchKey = ClientError
             mock_client.head_object.side_effect = no_such_key_error
             
-            response = client.get("/api/v1/files/download/nonexistent/file.txt")
+            response = client.get(f"/api/v1/files/download/chat_attachments/{ORG_ID}/nonexistent.txt")
             
             assert response.status_code == 404
             assert "File not found" in response.json()["detail"]
@@ -308,10 +319,10 @@ class TestDownloadFileS3:
              patch('app.api.file_upload.get_current_user_or_widget') as mock_auth, \
              patch('app.core.s3.get_s3_client') as mock_s3_client:
             
-            mock_auth.return_value = {"type": "user", "user_id": "123"}
+            mock_auth.return_value = auth_user()
             mock_s3_client.side_effect = Exception("S3 client creation failed")
             
-            response = client.get("/api/v1/files/download/test/file.txt")
+            response = client.get(f"/api/v1/files/download/{ATTACHMENT_KEY}")
             
             assert response.status_code == 500
             assert "Failed to create S3 client" in response.json()["detail"]
@@ -323,7 +334,7 @@ class TestDownloadFileS3:
              patch('app.api.file_upload.get_current_user_or_widget') as mock_auth, \
              patch('app.core.s3.get_s3_client') as mock_s3_client:
             
-            mock_auth.return_value = {"type": "user", "user_id": "123"}
+            mock_auth.return_value = auth_user()
             
             # Mock S3 client
             mock_client = Mock()
@@ -338,7 +349,7 @@ class TestDownloadFileS3:
             mock_client.exceptions.NoSuchKey = ClientError
             mock_client.get_object.side_effect = Exception("S3 get_object failed")
             
-            response = client.get("/api/v1/files/download/test/file.txt")
+            response = client.get(f"/api/v1/files/download/{ATTACHMENT_KEY}")
             
             assert response.status_code == 500
             assert "Failed to retrieve file from S3" in response.json()["detail"]
@@ -354,7 +365,7 @@ class TestDownloadFilePathHandling:
              patch('app.api.file_upload.get_current_user_or_widget') as mock_auth, \
              patch('app.core.s3.get_s3_client') as mock_s3_client:
             
-            mock_auth.return_value = {"type": "user", "user_id": "123"}
+            mock_auth.return_value = auth_user()
             
             # Mock S3 client
             mock_client = Mock()
@@ -369,13 +380,13 @@ class TestDownloadFilePathHandling:
             mock_response['Body'].read.side_effect = [b"image data", b""]
             mock_client.get_object.return_value = mock_response
             
-            response = client.get("/api/v1/files/download//uploads/chat_attachments/org-id/image.jpg")
+            response = client.get(f"/api/v1/files/download//uploads/chat_attachments/{ORG_ID}/image.jpg")
             
             assert response.status_code == 200
-            # Path is "/uploads/chat_attachments/org-id/image.jpg", should remove "/uploads/" prefix
+            # The "/uploads/" prefix is stripped to get the storage key
             mock_client.head_object.assert_called_once_with(
-                Bucket='test-bucket', 
-                Key='chat_attachments/org-id/image.jpg'
+                Bucket='test-bucket',
+                Key=f'chat_attachments/{ORG_ID}/image.jpg'
             )
     
     def test_download_file_path_without_uploads_prefix(self, client):
@@ -385,7 +396,7 @@ class TestDownloadFilePathHandling:
              patch('app.api.file_upload.get_current_user_or_widget') as mock_auth, \
              patch('app.core.s3.get_s3_client') as mock_s3_client:
             
-            mock_auth.return_value = {"type": "user", "user_id": "123"}
+            mock_auth.return_value = auth_user()
             
             # Mock S3 client
             mock_client = Mock()
@@ -400,13 +411,13 @@ class TestDownloadFilePathHandling:
             mock_response['Body'].read.side_effect = [b"pdf data", b""]
             mock_client.get_object.return_value = mock_response
             
-            response = client.get("/api/v1/files/download/chat_attachments/org-id/document.pdf")
+            response = client.get(f"/api/v1/files/download/chat_attachments/{ORG_ID}/document.pdf")
             
             assert response.status_code == 200
             # Should use path as-is for S3 key
             mock_client.head_object.assert_called_once_with(
                 Bucket='test-bucket', 
-                Key='chat_attachments/org-id/document.pdf'
+                Key=f'chat_attachments/{ORG_ID}/document.pdf'
             )
 
 
@@ -420,16 +431,12 @@ class TestDownloadFileAuthentication:
              patch('os.path.exists') as mock_exists, \
              patch('builtins.open', create=True) as mock_open:
             
-            mock_auth.return_value = {
-                "type": "user", 
-                "user_id": "123",
-                "org_id": "org_456"
-            }
+            mock_auth.return_value = auth_user()
             mock_exists.return_value = True
             mock_open.return_value.__enter__.return_value.read.return_value = b"Test content"
             
             headers = {"Authorization": "Bearer valid_jwt_token"}
-            response = client.get("/api/v1/files/download/test/file.txt", headers=headers)
+            response = client.get(f"/api/v1/files/download/{ATTACHMENT_KEY}", headers=headers)
             
             assert response.status_code == 200
     
@@ -443,14 +450,14 @@ class TestDownloadFileAuthentication:
             mock_auth.return_value = {
                 "type": "widget",
                 "widget_id": "widget_123",
-                "org_id": "org_456",
+                "org_id": ORG_ID,
                 "customer_id": "customer_789"
             }
             mock_exists.return_value = True
             mock_open.return_value.__enter__.return_value.read.return_value = b"Test content"
             
             headers = {"X-Conversation-Token": "valid_conversation_token"}
-            response = client.get("/api/v1/files/download/test/file.txt", headers=headers)
+            response = client.get(f"/api/v1/files/download/{ATTACHMENT_KEY}", headers=headers)
             
             assert response.status_code == 200
 
@@ -466,12 +473,12 @@ class TestDownloadFileContentTypes:
              patch('builtins.open', create=True) as mock_open, \
              patch('mimetypes.guess_type') as mock_guess_type:
             
-            mock_auth.return_value = {"type": "user", "user_id": "123"}
+            mock_auth.return_value = auth_user()
             mock_exists.return_value = True
             mock_open.return_value.__enter__.return_value.read.return_value = b"fake image data"
             mock_guess_type.return_value = ("image/jpeg", None)
             
-            response = client.get("/api/v1/files/download/test/image.jpg")
+            response = client.get(f"/api/v1/files/download/chat_attachments/{ORG_ID}/image.jpg")
             
             assert response.status_code == 200
             assert response.headers["content-type"] == "image/jpeg"
@@ -484,12 +491,12 @@ class TestDownloadFileContentTypes:
              patch('builtins.open', create=True) as mock_open, \
              patch('mimetypes.guess_type') as mock_guess_type:
             
-            mock_auth.return_value = {"type": "user", "user_id": "123"}
+            mock_auth.return_value = auth_user()
             mock_exists.return_value = True
             mock_open.return_value.__enter__.return_value.read.return_value = b"unknown file data"
             mock_guess_type.return_value = (None, None)
             
-            response = client.get("/api/v1/files/download/test/unknown.xyz")
+            response = client.get(f"/api/v1/files/download/chat_attachments/{ORG_ID}/unknown.xyz")
             
             assert response.status_code == 200
             assert response.headers["content-type"] == "application/octet-stream"
@@ -501,12 +508,14 @@ class TestDownloadFileErrorHandling:
     def test_download_file_general_exception(self, client):
         """Test file download with unexpected exception"""
         with patch.object(settings, 'S3_FILE_STORAGE', False), \
+             patch('app.api.file_upload.get_current_user_or_widget') as mock_auth, \
              patch('os.path.exists') as mock_exists:
-            
+
+            mock_auth.return_value = auth_user()
             # Mock os.path.exists to raise an exception
             mock_exists.side_effect = Exception("Unexpected error")
-            
-            response = client.get("/api/v1/files/download/test/file.txt")
+
+            response = client.get(f"/api/v1/files/download/{ATTACHMENT_KEY}")
             
             assert response.status_code == 500
             assert "Failed to download file" in response.json()["detail"]
@@ -518,7 +527,7 @@ class TestDownloadFileErrorHandling:
              patch('app.api.file_upload.get_current_user_or_widget') as mock_auth, \
              patch('app.core.s3.get_s3_client') as mock_s3_client:
             
-            mock_auth.return_value = {"type": "user", "user_id": "123"}
+            mock_auth.return_value = auth_user()
             
             # Mock S3 client
             mock_client = Mock()
@@ -540,7 +549,72 @@ class TestDownloadFileErrorHandling:
             mock_response['Body'].read.side_effect = [b"Test content", b""]
             mock_client.get_object.return_value = mock_response
             
-            response = client.get("/api/v1/files/download/test/file.txt")
+            response = client.get(f"/api/v1/files/download/{ATTACHMENT_KEY}")
             
             # Should still succeed because get_object works
             assert response.status_code == 200
+
+
+class TestDownloadFileAuthorization:
+    """The download path is authorization data, not just a lookup key"""
+
+    def _serve(self, client, path, auth):
+        with patch.object(settings, 'S3_FILE_STORAGE', False), \
+             patch('app.api.file_upload.get_current_user_or_widget') as mock_auth, \
+             patch('os.path.exists') as mock_exists, \
+             patch('builtins.open', create=True) as mock_open:
+
+            mock_auth.return_value = auth
+            mock_exists.return_value = True
+            mock_open.return_value.__enter__.return_value.read.return_value = b"secret"
+
+            return client.get(f"/api/v1/files/download/{path}")
+
+    def test_another_orgs_attachment_is_not_served(self, client):
+        response = self._serve(
+            client,
+            f"chat_attachments/{OTHER_ORG_ID}/file.txt",
+            auth_user(),
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "File not found"
+
+    def test_widget_token_is_scoped_to_its_own_org(self, client):
+        response = self._serve(
+            client,
+            f"chat_attachments/{OTHER_ORG_ID}/file.txt",
+            {"type": "widget", "widget_id": "w1", "org_id": ORG_ID, "customer_id": "c1"},
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize("path", [
+        "chat_attachments/../../etc/passwd",
+        f"chat_attachments/{ORG_ID}/../../../etc/passwd",
+        "uploads/../../etc/passwd",
+        "etc/passwd",
+        # Not an attachment: only chat_attachments is servable here.
+        f"profile_pics/{ORG_ID}/avatar.png",
+        # Missing the filename segment.
+        f"chat_attachments/{ORG_ID}",
+        # Org segment must be a real uuid.
+        "chat_attachments/not-an-org/file.txt",
+    ])
+    def test_paths_outside_the_attachment_layout_are_refused(self, client, path):
+        response = self._serve(client, path, auth_user())
+
+        # Traversal attempts are normalized by the client and never match the
+        # route at all, so assert the property that matters for every case:
+        # nothing is served.
+        assert response.status_code == 404
+        assert b"secret" not in response.content
+
+    def test_auth_without_an_org_gets_nothing(self, client):
+        response = self._serve(
+            client,
+            ATTACHMENT_KEY,
+            {"type": "user", "user_id": "123", "org_id": None},
+        )
+
+        assert response.status_code == 404

--- a/backend/tests/api/test_knowledge.py
+++ b/backend/tests/api/test_knowledge.py
@@ -820,3 +820,89 @@ def test_add_text_endpoint_registered():
     assert any(
         hasattr(route, 'path') and route.path == '/add/text' for route in router.routes
     ), "add/text endpoint should be registered" 
+
+class TestExploreProgressIsScopedToTheExploreOrg:
+    """The explore progress poll is public, so it must only ever expose the
+    shared explore organization's jobs — queue ids are sequential."""
+
+    def test_another_orgs_queue_item_is_not_exposed(self, client, test_knowledge_queue):
+        """test_knowledge_queue belongs to a normal tenant, not the explore org"""
+        response = client.get(
+            f"/api/v1/knowledge/explore/progress/{test_knowledge_queue.id}")
+
+        assert response.status_code == 404
+        body = response.json()
+        # The tenant's crawl source must not leak in any form
+        assert "test.pdf" not in str(body)
+
+    def test_explore_org_queue_item_is_exposed(self, client, db, test_user):
+        """The public explore flow still gets its own job's progress"""
+        from app.models.organization import Organization
+
+        explore_org = Organization(
+            id=UUID(settings.EXPLORE_SOURCE_ORG_ID),
+            name="Explore Org",
+            domain="explore.example.com",
+            timezone="UTC"
+        )
+        db.add(explore_org)
+        db.commit()
+
+        queue = KnowledgeQueue(
+            organization_id=explore_org.id,
+            user_id=test_user.id,
+            source_type="website",
+            source="https://explore.example.com",
+            status=QueueStatus.PENDING,
+            created_at=datetime.now(timezone.utc)
+        )
+        db.add(queue)
+        db.commit()
+        db.refresh(queue)
+
+        response = client.get(f"/api/v1/knowledge/explore/progress/{queue.id}")
+
+        assert response.status_code == 200
+
+
+class TestKnowledgeLinkAgentIsOrgScoped:
+    """A knowledge source may only be linked to an agent in the same org."""
+
+    def _foreign_agent(self, db):
+        from app.models.organization import Organization
+        other_org = Organization(
+            id=uuid4(), name="Other Org", domain="other-kn.example.com", timezone="UTC")
+        db.add(other_org)
+        db.commit()
+        agent = Agent(
+            id=uuid4(),
+            name="Foreign Agent",
+            agent_type=AgentType.CUSTOMER_SUPPORT,
+            instructions=["x"],
+            organization_id=other_org.id,
+            is_active=True,
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+        return agent
+
+    def test_link_rejects_agent_from_another_org(self, client, db, test_knowledge):
+        foreign_agent = self._foreign_agent(db)
+
+        response = client.post(
+            f"/api/v1/knowledge/link?knowledge_id={test_knowledge.id}"
+            f"&agent_id={foreign_agent.id}")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Agent not found"
+
+    def test_unlink_rejects_agent_from_another_org(self, client, db, test_knowledge):
+        foreign_agent = self._foreign_agent(db)
+
+        response = client.delete(
+            f"/api/v1/knowledge/unlink?knowledge_id={test_knowledge.id}"
+            f"&agent_id={foreign_agent.id}")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Agent not found"

--- a/backend/tests/api/test_org_scoping_guards.py
+++ b/backend/tests/api/test_org_scoping_guards.py
@@ -1,0 +1,116 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Direct tests of the "belongs to my org" guards. Several of the endpoints that
+use them (Shopify/Jira agent-config) resolve auth by calling get_current_user
+inside the handler rather than via a dependency, which makes them awkward to
+drive through TestClient — so the security boundary itself is exercised here.
+"""
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.agent import Agent, AgentType
+from app.models.organization import Organization
+from app.models.user import User, UserGroup
+from app.repositories.agent import AgentRepository
+from app.api.shopify import _require_shopify_agent_in_org
+from app.api.jira import _require_jira_agent_in_org
+from app.api.tickets import _validate_assignment_references
+
+
+@pytest.fixture
+def other_org(db) -> Organization:
+    org = Organization(id=uuid4(), name="Other Org", domain="other-guard.example.com", timezone="UTC")
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    return org
+
+
+@pytest.fixture
+def foreign_agent(db, other_org) -> Agent:
+    agent = Agent(
+        id=uuid4(),
+        name="Foreign Agent",
+        agent_type=AgentType.CUSTOMER_SUPPORT,
+        instructions=["x"],
+        organization_id=other_org.id,
+        is_active=True,
+    )
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+    return agent
+
+
+def _raises_404(fn, *args):
+    with pytest.raises(HTTPException) as exc:
+        fn(*args)
+    assert exc.value.status_code == 404
+
+
+class TestAgentRepositoryScoping:
+    def test_get_agent_in_org_matches_only_same_org(self, db, test_agent, test_organization, other_org):
+        repo = AgentRepository(db)
+        assert repo.get_agent_in_org(test_agent.id, test_organization.id) is not None
+        assert repo.get_agent_in_org(test_agent.id, other_org.id) is None
+
+
+class TestAgentConfigGuards:
+    """Shopify + Jira + knowledge all gate agent_id the same way."""
+
+    def test_shopify_allows_own_agent(self, db, test_agent, test_organization):
+        _require_shopify_agent_in_org(db, str(test_agent.id), test_organization.id)
+
+    def test_shopify_rejects_foreign_agent(self, db, foreign_agent, test_organization):
+        _raises_404(_require_shopify_agent_in_org, db, str(foreign_agent.id), test_organization.id)
+
+    def test_shopify_rejects_malformed_agent_id(self, db, test_organization):
+        _raises_404(_require_shopify_agent_in_org, db, "not-a-uuid", test_organization.id)
+
+    def test_jira_allows_own_agent(self, db, test_agent, test_organization):
+        _require_jira_agent_in_org(db, str(test_agent.id), test_organization.id)
+
+    def test_jira_rejects_foreign_agent(self, db, foreign_agent, test_organization):
+        _raises_404(_require_jira_agent_in_org, db, str(foreign_agent.id), test_organization.id)
+
+
+class TestTicketAssignmentGuard:
+    def test_allows_assignee_and_group_in_org(self, db, test_user, test_organization):
+        group = UserGroup(id=uuid4(), name="G", organization_id=test_organization.id)
+        db.add(group)
+        db.commit()
+        # No raise
+        _validate_assignment_references(db, test_organization.id, test_user.id, group.id)
+
+    def test_rejects_foreign_assignee(self, db, other_org, test_organization):
+        outsider = User(
+            id=uuid4(),
+            email="outsider@other-guard.example.com",
+            hashed_password="x",
+            organization_id=other_org.id,
+            is_active=True,
+        )
+        db.add(outsider)
+        db.commit()
+        _raises_404(_validate_assignment_references, db, test_organization.id, outsider.id, None)
+
+    def test_rejects_foreign_group(self, db, other_org, test_organization):
+        foreign_group = UserGroup(id=uuid4(), name="FG", organization_id=other_org.id)
+        db.add(foreign_group)
+        db.commit()
+        _raises_404(_validate_assignment_references, db, test_organization.id, None, foreign_group.id)

--- a/backend/tests/api/test_organizations.py
+++ b/backend/tests/api/test_organizations.py
@@ -377,3 +377,50 @@ def test_get_nonexistent_organization(client):
     response = client.get(f"/api/v1/organizations/{uuid4()}")
     assert response.status_code == 404
     assert "Organization not found" in response.json()["detail"] 
+
+@pytest.fixture
+def other_organization(db) -> Organization:
+    """An organization the test user does not belong to"""
+    org = Organization(
+        id=uuid4(),
+        name="Other Organization",
+        domain="other.example.com",
+        timezone="UTC",
+        business_hours={},
+        settings={},
+        is_active=True
+    )
+    db.add(org)
+    db.commit()
+    db.refresh(org)
+    return org
+
+
+def test_get_another_organization_is_not_found(client, other_organization):
+    """Reading another tenant's organization record is refused"""
+    response = client.get(f"/api/v1/organizations/{other_organization.id}")
+
+    assert response.status_code == 404
+    assert "Organization not found" in response.json()["detail"]
+
+
+def test_update_another_organization_is_not_found(client, db, other_organization):
+    """The domain (and therefore CORS) of another tenant can't be rewritten"""
+    original_domain = other_organization.domain
+
+    response = client.patch(
+        f"/api/v1/organizations/{other_organization.id}",
+        json={"name": "Hijacked", "domain": "attacker.example.com"}
+    )
+
+    assert response.status_code == 404
+    db.refresh(other_organization)
+    assert other_organization.domain == original_domain
+    assert other_organization.name == "Other Organization"
+
+
+def test_get_another_organizations_stats_is_not_found(client, other_organization):
+    """Headcount and conversation volumes stay inside the tenant"""
+    response = client.get(f"/api/v1/organizations/{other_organization.id}/stats")
+
+    assert response.status_code == 404

--- a/backend/tests/api/test_shopify_api.py
+++ b/backend/tests/api/test_shopify_api.py
@@ -532,18 +532,90 @@ async def test_link_shop_to_org_success(mock_shop_repo, mock_check_permissions, 
     
     mock_shop = MagicMock()
     mock_shop.id = shop_id
+    # Unclaimed: installed but never linked to an organization yet.
+    mock_shop.organization_id = None
     mock_shop_repo_instance.get_shop.return_value = mock_shop
-    
+
     mock_request = MagicMock()
     mock_request.json = AsyncMock(return_value={"shop_id": shop_id})
-    
+
     # Act
     from app.api.shopify import link_shop_to_org
     response = await link_shop_to_org(mock_request, mock_db, mock_user)
-    
+
     # Assert
     assert response["success"] is True
     assert response["shop_id"] == shop_id
+    assert response["organization_id"] == org_id
+
+
+@pytest.mark.asyncio
+@patch('app.api.shopify.get_current_user')
+@patch('app.api.shopify.check_permissions')
+@patch('app.api.shopify.ShopifyShopRepository')
+async def test_link_shop_already_owned_by_another_org(
+    mock_shop_repo, mock_check_permissions, mock_get_user, mock_db
+):
+    """A shop another organization already installed can't be re-pointed"""
+    shop_id = str(uuid.uuid4())
+
+    mock_user = MagicMock()
+    mock_user.id = str(uuid.uuid4())
+    mock_user.organization_id = str(uuid.uuid4())
+    mock_get_user.return_value = mock_user
+    mock_check_permissions.return_value = True
+
+    mock_shop_repo_instance = MagicMock()
+    mock_shop_repo.return_value = mock_shop_repo_instance
+
+    mock_shop = MagicMock()
+    mock_shop.id = shop_id
+    mock_shop.organization_id = str(uuid.uuid4())  # someone else's
+    mock_shop_repo_instance.get_shop.return_value = mock_shop
+
+    mock_request = MagicMock()
+    mock_request.json = AsyncMock(return_value={"shop_id": shop_id})
+
+    from app.api.shopify import link_shop_to_org
+    with pytest.raises(HTTPException) as exc_info:
+        await link_shop_to_org(mock_request, mock_db, mock_user)
+
+    assert exc_info.value.status_code == 404
+    assert not mock_shop_repo_instance.update_shop.called
+
+
+@pytest.mark.asyncio
+@patch('app.api.shopify.get_current_user')
+@patch('app.api.shopify.check_permissions')
+@patch('app.api.shopify.ShopifyShopRepository')
+async def test_link_shop_already_owned_by_same_org_is_allowed(
+    mock_shop_repo, mock_check_permissions, mock_get_user, mock_db
+):
+    """Re-linking your own shop stays idempotent"""
+    shop_id = str(uuid.uuid4())
+    org_id = str(uuid.uuid4())
+
+    mock_user = MagicMock()
+    mock_user.id = str(uuid.uuid4())
+    mock_user.organization_id = org_id
+    mock_get_user.return_value = mock_user
+    mock_check_permissions.return_value = True
+
+    mock_shop_repo_instance = MagicMock()
+    mock_shop_repo.return_value = mock_shop_repo_instance
+
+    mock_shop = MagicMock()
+    mock_shop.id = shop_id
+    mock_shop.organization_id = org_id
+    mock_shop_repo_instance.get_shop.return_value = mock_shop
+
+    mock_request = MagicMock()
+    mock_request.json = AsyncMock(return_value={"shop_id": shop_id})
+
+    from app.api.shopify import link_shop_to_org
+    response = await link_shop_to_org(mock_request, mock_db, mock_user)
+
+    assert response["success"] is True
     assert response["organization_id"] == org_id
 
 

--- a/backend/tests/api/test_user_groups.py
+++ b/backend/tests/api/test_user_groups.py
@@ -222,3 +222,38 @@ def test_remove_user_from_nonexistent_group(client: TestClient, test_user: User)
     nonexistent_id = uuid4()
     response = client.delete(f"/api/v1/groups/{nonexistent_id}/users/{test_user.id}")
     assert response.status_code == 404 
+
+@pytest.fixture
+def foreign_user(db: Session) -> User:
+    """A user in a different organization from the caller."""
+    from app.models.organization import Organization
+    other_org = Organization(id=uuid4(), name="Other Org", domain="other.example.com")
+    db.add(other_org)
+    db.commit()
+
+    user = User(
+        id=uuid4(),
+        email="foreign@other.example.com",
+        hashed_password=get_password_hash("x"),
+        organization_id=other_org.id,
+        is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    return user
+
+
+def test_cannot_add_user_from_another_org(client, test_group, foreign_user, db):
+    """A group can't gain a member from another tenant"""
+    response = client.post(f"/api/v1/groups/{test_group.id}/users/{foreign_user.id}")
+
+    assert response.status_code == 400
+    db.refresh(test_group)
+    assert foreign_user not in test_group.users
+
+
+def test_cannot_remove_user_from_another_org(client, test_group, foreign_user, db):
+    """A foreign user id can't be used to poke at group membership"""
+    response = client.delete(f"/api/v1/groups/{test_group.id}/users/{foreign_user.id}")
+
+    assert response.status_code == 400

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -425,3 +425,45 @@ def test_clear_fcm_token(client: TestClient, test_user: User, db: Session):
     assert response.status_code == 200
     data = response.json()
     assert data["message"] == "FCM token cleared successfully" 
+
+@pytest.fixture
+def foreign_role(db) -> Role:
+    """A role defined in a different organization."""
+    from app.models.organization import Organization
+    other_org = Organization(id=uuid4(), name="Other Org", domain="other-role.example.com")
+    db.add(other_org)
+    db.commit()
+    role = Role(name="Foreign Admin", organization_id=other_org.id)
+    db.add(role)
+    db.commit()
+    db.refresh(role)
+    return role
+
+
+def test_create_user_rejects_foreign_role(admin_client, foreign_role, test_organization):
+    """A user can't be created with a role from another tenant"""
+    user_data = {
+        "email": "roletest@test.com",
+        "full_name": "Role Test",
+        "password": "testpassword123",
+        "is_active": True,
+        "role_id": foreign_role.id,
+        "organization_id": str(test_organization.id),
+    }
+    response = admin_client.post("/api/v1/users", json=user_data)
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Role not found"
+
+
+def test_update_user_rejects_foreign_role(admin_client, db, test_user, foreign_role):
+    """A user can't be moved onto a role from another tenant"""
+    response = admin_client.put(
+        f"/api/v1/users/{test_user.id}",
+        json={"role_id": foreign_role.id},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Role not found"
+    db.refresh(test_user)
+    assert test_user.role_id != foreign_role.id


### PR DESCRIPTION
Several endpoints fetched a resource (or accepted a foreign-key id) by a client-supplied value and used it without checking it belonged to the caller's organization. This scopes them.

- `files/download`: require auth and authorize the path to the caller's org (auth result was previously discarded); reject traversal / non-attachment paths
- `knowledge/explore/progress`: scope the unauthenticated poll to the explore org
- `organizations` GET/PATCH/stats: reject other orgs' ids (PATCH also drives CORS via the org domain)
- `shopify/link-organization`: only claim unowned (or already-own) shops
- token `active-sessions` / `revoke-by-email`: scope to the API key's own widgets
- user-group add/remove, knowledge link/unlink, user `role_id`, ticket assignee/group, shopify + jira agent-config: validate the referenced id belongs to the caller's org

Adds `AgentRepository.get_agent_in_org` as the single agent-scoping helper, plus regression tests for each path.

Known follow-up (not in this PR): the `/api/v1/uploads` static mount still serves `chat_attachments` unauthenticated in local-storage mode, which partially bypasses the download fix.
