### PR TITLE
feat(notifications): per-user chat notification settings + modal/UX fixes

### DIFF
--- a/backend/alembic/versions/add_notif_prefs_001_user_notification_settings.py
+++ b/backend/alembic/versions/add_notif_prefs_001_user_notification_settings.py
@@ -1,0 +1,57 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""add per-user chat notification preferences
+
+Revision ID: add_notif_prefs_001
+Revises: add_faq_seo_001
+Create Date: 2026-07-22
+
+Rows are created lazily on first read, so nothing is backfilled here — a user
+without a row falls back to the column defaults (transfer/assignment on,
+new-chat off), which keeps today's transfer notifications working unchanged.
+The revision id is kept short — alembic_version.version_num is varchar(32).
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = 'add_notif_prefs_001'
+down_revision = 'add_faq_seo_001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'user_notification_settings',
+        sa.Column('user_id', UUID(as_uuid=True),
+                  sa.ForeignKey('users.id', ondelete='CASCADE'), primary_key=True),
+        sa.Column('notify_new_chat', sa.Boolean(), nullable=False,
+                  server_default=sa.false()),
+        sa.Column('notify_chat_transfer', sa.Boolean(), nullable=False,
+                  server_default=sa.true()),
+        sa.Column('notify_chat_assigned', sa.Boolean(), nullable=False,
+                  server_default=sa.true()),
+        sa.Column('created_at', sa.DateTime(timezone=True),
+                  server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('user_notification_settings')

--- a/backend/app/agents/chat_agent.py
+++ b/backend/app/agents/chat_agent.py
@@ -34,8 +34,7 @@ from app.agents.structured_output import (
     salvage_groq_json_error,
 )
 from app.agents.transfer_agent import get_agent_availability_response
-from app.models.notification import Notification
-from app.services.user import send_fcm_notification
+from app.services.notifications import ChatNotificationEvent, notify_chat_event
 from app.models.user import User, user_groups
 from datetime import datetime
 from app.repositories.jira import JiraRepository
@@ -993,28 +992,22 @@ Keep your responses concise and focused. Provide clear, actionable information i
             }
         )
         
-        # Get all users in the target group and send notifications
+        # Notify the target group's members who haven't muted transfers
         users = db.query(User).join(user_groups).filter(user_groups.c.group_id == group_id).all()
-        
-        for user in users:
-            # Create notification record
-            notification = Notification(
-                user_id=user.id,
-                title="New Chat Transfer",
-                message=notification_message,
-                type="SYSTEM",
-                notification_metadata={
-                    "session_id": session_id,
-                    "transfer_reason": transfer_reason,
-                    "transfer_description": transfer_description
-                }
-            )
-            db.add(notification)
-            db.commit()
-            
-            # Send FCM notification
-            await send_fcm_notification(str(user.id), notification, db)
-        
+
+        await notify_chat_event(
+            db=db,
+            user_ids=[user.id for user in users],
+            event=ChatNotificationEvent.CHAT_TRANSFER,
+            title="New Chat Transfer",
+            message=notification_message,
+            metadata={
+                "session_id": session_id,
+                "transfer_reason": transfer_reason,
+                "transfer_description": transfer_description
+            }
+        )
+
         # Get availability-based response
         availability_response = await get_agent_availability_response(
             agent=self.agent_data,

--- a/backend/app/api/notification.py
+++ b/backend/app/api/notification.py
@@ -21,7 +21,12 @@ from app.database import get_db
 from app.models.user import User
 from app.core.auth import get_current_user
 from app.models.notification import Notification
-from app.models.schemas.notification import NotificationResponse
+from app.models.schemas.notification import (
+    NotificationResponse,
+    NotificationSettingsOut,
+    NotificationSettingsUpdate,
+)
+from app.repositories.notification_settings import UserNotificationSettingsRepository
 from app.core.logger import get_logger
 from app.services.user import send_fcm_notification
 
@@ -106,6 +111,51 @@ async def get_unread_count(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to get unread count"
+        )
+
+
+@router.get("/settings", response_model=NotificationSettingsOut)
+async def get_notification_settings(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """Get the current user's chat notification preferences"""
+    try:
+        return UserNotificationSettingsRepository(db).get_or_create(current_user.id)
+    except Exception as e:
+        logger.error(f"Error fetching notification settings: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to fetch notification settings"
+        )
+
+
+@router.put("/settings", response_model=NotificationSettingsOut)
+async def update_notification_settings(
+    payload: NotificationSettingsUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """Update the current user's chat notification preferences.
+
+    Always scoped to the caller — there is no way to address another user's
+    settings, so no permission check beyond authentication is needed.
+    """
+    try:
+        settings = UserNotificationSettingsRepository(db).get_or_create(current_user.id)
+
+        for key, value in payload.model_dump(exclude_unset=True).items():
+            setattr(settings, key, value)
+
+        db.commit()
+        db.refresh(settings)
+        return settings
+    except Exception as e:
+        logger.error(f"Error updating notification settings: {str(e)}")
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update notification settings"
         )
 
 

--- a/backend/app/api/session_to_agent.py
+++ b/backend/app/api/session_to_agent.py
@@ -225,6 +225,13 @@ async def reassign_chat(
         if session.user_id is None:
             raise HTTPException(status_code=400, detail="Chat must be handled by a user to reassign")
 
+        # Capture the previous assignee BEFORE reassigning. reassign_session
+        # re-fetches this same row, so within one DB session the identity map
+        # hands back the very object `session` points at — it mutates
+        # session.user_id to the new owner in place. Reading it afterward would
+        # target the new assignee's room, not the previous one's.
+        previous_user_id = session.user_id
+
         # Update session owner
         success = session_repo.reassign_session(session_id=session_id, to_user_id=to_user_id)
         if not success:
@@ -253,12 +260,13 @@ async def reassign_chat(
             'assigned_to': to_user_id
         }, room=f"user_{to_user_id}")
 
-        # Also notify previous assignee if exists
-        if session.user_id:
+        # Also notify the PREVIOUS assignee that the chat left their queue —
+        # unless it was reassigned to themselves (a no-op).
+        if previous_user_id and str(previous_user_id) != str(to_user_id):
             await sio.emit('room_event', {
                 'type': 'reassigned_from_you',
                 'session_id': session_id
-            }, room=f"user_{session.user_id}")
+            }, room=f"user_{previous_user_id}")
 
         # Push to the new assignee — a socket event only reaches them if the
         # dashboard is already open.

--- a/backend/app/api/session_to_agent.py
+++ b/backend/app/api/session_to_agent.py
@@ -14,8 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from uuid import UUID
+
 from app.repositories.session_to_agent import SessionToAgentRepository
 from app.repositories.chat import ChatRepository
+from app.repositories.user import UserRepository
 from app.models.schemas.chat import ChatDetailResponse
 from app.core.socketio import sio
 from fastapi import APIRouter, HTTPException, Depends, status
@@ -24,6 +27,7 @@ from app.core.logger import get_logger
 from app.models.user import User
 from app.core.auth import get_current_user, has_any_permission
 from app.database import get_db
+from app.services.chat_notifications import notify_chat_assigned
 from app.services.message_delivery import deliver_to_customer
 
 
@@ -31,13 +35,22 @@ logger = get_logger(__name__)
 
 router = APIRouter()
 
-# Claiming a chat is a "manage" action: either the org-wide grant or the
-# assigned-chats one an agent holds.
-TAKEOVER_PERMISSIONS = ("manage_all_chats", "manage_assigned_chats")
+# Claiming or handing on a chat is a "manage" action: either the org-wide
+# grant or the assigned-chats one an agent holds.
+MANAGE_CHAT_PERMISSIONS = ("manage_all_chats", "manage_assigned_chats")
 
 # Shown to the customer when a human takes over an external-channel chat. The
 # widget surfaces the handover in its own UI, so only channels need a message.
 HANDOVER_NOTICE = "You're now connected with a member of our team."
+
+
+def _is_uuid(value: str) -> bool:
+    """Guard the repository lookup: a malformed id is a 404, not a 500."""
+    try:
+        UUID(str(value))
+        return True
+    except (ValueError, TypeError, AttributeError):
+        return False
 
 
 async def _notify_customer_of_handover(db: Session, session, user: User) -> None:
@@ -78,7 +91,7 @@ async def takeover_chat(
         # manage_all_chats, not "manage_chats" — the latter is not a real
         # permission and never matched. has_any_permission also honours the
         # super_admin bypass the previous hand-rolled set check ignored.
-        if not has_any_permission(current_user, TAKEOVER_PERMISSIONS):
+        if not has_any_permission(current_user, MANAGE_CHAT_PERMISSIONS):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Not enough permissions"
@@ -176,9 +189,11 @@ async def reassign_chat(
 ):
     """Reassign a chat session to a different user"""
     try:
-        # Permission: need manage_chats
-        user_permissions = {p.name for p in current_user.role.permissions}
-        if not ("manage_chats" in user_permissions or "manage_assigned_chats" in user_permissions):
+        # Same grants as claiming a chat — and has_any_permission honours the
+        # super_admin bypass the previous hand-rolled set check ignored. It
+        # also checked "manage_chats", which is not a real permission and so
+        # never matched.
+        if not has_any_permission(current_user, MANAGE_CHAT_PERMISSIONS):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Not enough permissions"
@@ -188,6 +203,21 @@ async def reassign_chat(
         session = session_repo.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Chat session not found")
+
+        # A session id is guessable and was never scoped here: without this a
+        # user could hand off a conversation belonging to another organization.
+        if session.organization_id != current_user.organization_id:
+            raise HTTPException(status_code=404, detail="Chat session not found")
+
+        # The new owner must be a real, active member of the same org —
+        # otherwise a chat (and its assignment notification) could be pushed
+        # onto someone outside it. A 404 here doesn't confirm whether an id
+        # exists elsewhere.
+        target_user = UserRepository(db).get_user(to_user_id) if _is_uuid(to_user_id) else None
+        if (target_user is None
+                or not target_user.is_active
+                or target_user.organization_id != current_user.organization_id):
+            raise HTTPException(status_code=404, detail="User not found")
 
         # Only allow reassignment for open sessions handled by a user (not AI)
         if str(session.status.name).lower() != 'open':
@@ -229,6 +259,10 @@ async def reassign_chat(
                 'type': 'reassigned_from_you',
                 'session_id': session_id
             }, room=f"user_{session.user_id}")
+
+        # Push to the new assignee — a socket event only reaches them if the
+        # dashboard is already open.
+        await notify_chat_assigned(db, session, to_user_id, assigned_by=current_user.id)
 
         return ChatDetailResponse(**chat)
     except HTTPException:

--- a/backend/app/api/widget_chat.py
+++ b/backend/app/api/widget_chat.py
@@ -44,6 +44,7 @@ from app.core.s3 import get_s3_signed_url
 from app.models.session_to_agent import SessionStatus
 from app.agents.transfer_agent import get_agent_availability_response
 from app.repositories.agent import AgentRepository
+from app.services.chat_notifications import notify_new_chat
 from app.services.lead_capture import record_lead_from_response
 from app.services.message_delivery import deliver_to_customer
 from app.repositories.rating import RatingRepository
@@ -455,7 +456,13 @@ async def handle_widget_chat(sid, data):
         
         if str(active_session.session_id) != session_id:
             raise ValueError("Session mismatch")
-        
+
+        # The session opens when the widget connects, so the chat only really
+        # starts on the customer's first message — notify there, not on connect,
+        # or merely opening the chat window would ping the team.
+        if not ChatRepository(db).has_customer_messages(session_id):
+            await notify_new_chat(db, active_session)
+
         # Check if agent uses workflow and no human agent has taken over
         if active_session.workflow_id and active_session.user_id is None:
             # Handle workflow chat using the dedicated service

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -60,6 +60,7 @@ from app.models.investigation import (
     InvestigationHypothesis, InvestigationEvent, RCADocument, TicketProposal,
 )
 from app.models.ticket_db_connector import TicketDBConnector, DBConnectorAuditLog
+from app.models.notification_settings import UserNotificationSettings
 
 
 
@@ -119,6 +120,7 @@ __all__ = [
     "TicketActivityType",
     "TicketActorType",
     "OrganizationTicketSettings",
+    "UserNotificationSettings",
     "InvestigationRun",
     "InvestigationRunType",
     "InvestigationRunStatus",

--- a/backend/app/models/notification_settings.py
+++ b/backend/app/models/notification_settings.py
@@ -1,0 +1,58 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import expression, func
+
+from app.database import Base
+
+# Preference column per chat event, and the value assumed for a user who has
+# no row yet. Transfer/assignment default on so existing users keep the
+# notifications they already get; new-chat is opt-in because it fires on every
+# conversation, including the ones the AI handles alone.
+NOTIFY_NEW_CHAT = "notify_new_chat"
+NOTIFY_CHAT_TRANSFER = "notify_chat_transfer"
+NOTIFY_CHAT_ASSIGNED = "notify_chat_assigned"
+
+NOTIFICATION_PREFERENCE_DEFAULTS = {
+    NOTIFY_NEW_CHAT: False,
+    NOTIFY_CHAT_TRANSFER: True,
+    NOTIFY_CHAT_ASSIGNED: True,
+}
+
+
+class UserNotificationSettings(Base):
+    """Per-user chat push preferences. One row per user, created lazily with
+    defaults on first read — absence of a row means the defaults above apply.
+    """
+    __tablename__ = "user_notification_settings"
+
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+
+    notify_new_chat = Column(Boolean, nullable=False, default=False, server_default=expression.false())
+    notify_chat_transfer = Column(Boolean, nullable=False, default=True, server_default=expression.true())
+    notify_chat_assigned = Column(Boolean, nullable=False, default=True, server_default=expression.true())
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    user = relationship("User")

--- a/backend/app/models/schemas/notification.py
+++ b/backend/app/models/schemas/notification.py
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from datetime import datetime
 from typing import Optional, Dict
 from app.models.notification import NotificationType
@@ -33,3 +33,19 @@ class NotificationResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class NotificationSettingsOut(BaseModel):
+    """A user's chat push preferences."""
+    notify_new_chat: bool
+    notify_chat_transfer: bool
+    notify_chat_assigned: bool
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class NotificationSettingsUpdate(BaseModel):
+    """Partial update — only the toggles the caller sent are applied."""
+    notify_new_chat: Optional[bool] = None
+    notify_chat_transfer: Optional[bool] = None
+    notify_chat_assigned: Optional[bool] = None

--- a/backend/app/repositories/chat.py
+++ b/backend/app/repositories/chat.py
@@ -41,6 +41,20 @@ class ChatRepository:
     def __init__(self, db: Session):
         self.db = db
 
+    def has_customer_messages(self, session_id: UUID | str) -> bool:
+        """Whether the customer has said anything in this session yet.
+
+        The widget opens its session on socket connect, before the visitor
+        types, so this is what distinguishes a real new chat from someone
+        merely opening the chat window.
+        """
+        if isinstance(session_id, str):
+            session_id = UUID(session_id)
+        return self.db.query(ChatHistory.id).filter(
+            ChatHistory.session_id == session_id,
+            ChatHistory.message_type == 'user'
+        ).first() is not None
+
     def get_message_count_for_period(
         self,
         org_id: UUID | str,

--- a/backend/app/repositories/notification_settings.py
+++ b/backend/app/repositories/notification_settings.py
@@ -1,0 +1,89 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Iterable, List, Optional, Set
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.notification_settings import (
+    NOTIFICATION_PREFERENCE_DEFAULTS,
+    UserNotificationSettings,
+)
+
+
+def _to_uuid(value: UUID | str) -> UUID:
+    return UUID(value) if isinstance(value, str) else value
+
+
+class UserNotificationSettingsRepository:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def get(self, user_id: UUID | str) -> Optional[UserNotificationSettings]:
+        return (
+            self.db.query(UserNotificationSettings)
+            .filter(UserNotificationSettings.user_id == _to_uuid(user_id))
+            .first()
+        )
+
+    def get_or_create(self, user_id: UUID | str) -> UserNotificationSettings:
+        settings = self.get(user_id)
+        if settings is None:
+            settings = UserNotificationSettings(user_id=_to_uuid(user_id))
+            self.db.add(settings)
+            try:
+                self.db.commit()
+                self.db.refresh(settings)
+            except IntegrityError:
+                # Two concurrent first-reads (e.g. two tabs) race on the
+                # user_id PK; the loser re-reads the row the winner inserted
+                # rather than surfacing a 500.
+                self.db.rollback()
+                settings = self.get(user_id)
+        return settings
+
+    def filter_enabled(self, user_ids: Iterable[UUID | str], field: str) -> Set[UUID]:
+        """Of `user_ids`, return those who want notifications for `field`.
+
+        One query regardless of recipient count — transfer fans out to a whole
+        group and new chats fan out across the org. Users with no row yet fall
+        back to the column default rather than being dropped, so nothing has to
+        be backfilled.
+        """
+        if field not in NOTIFICATION_PREFERENCE_DEFAULTS:
+            raise ValueError(f"Unknown notification preference: {field}")
+
+        candidates = {_to_uuid(user_id) for user_id in user_ids if user_id}
+        if not candidates:
+            return set()
+
+        rows = (
+            self.db.query(
+                UserNotificationSettings.user_id,
+                getattr(UserNotificationSettings, field),
+            )
+            .filter(UserNotificationSettings.user_id.in_(candidates))
+            .all()
+        )
+
+        stored = {user_id: enabled for user_id, enabled in rows}
+        default = NOTIFICATION_PREFERENCE_DEFAULTS[field]
+        return {
+            user_id for user_id in candidates
+            if stored.get(user_id, default)
+        }

--- a/backend/app/repositories/user.py
+++ b/backend/app/repositories/user.py
@@ -16,8 +16,10 @@ limitations under the License.
 
 from sqlalchemy.orm import Session
 from app.models.user import User
+from app.models.role import Role
+from app.models.permission import Permission, role_permissions
 from uuid import UUID
-from typing import List, Optional
+from typing import Iterable, List, Optional
 from app.core.logger import get_logger
 
 logger = get_logger(__name__)
@@ -32,6 +34,31 @@ class UserRepository:
         return self.db.query(User)\
             .filter(User.organization_id == organization_id)\
             .order_by(User.created_at.desc())\
+            .all()
+
+    def get_users_with_any_permission(
+        self, organization_id: str | UUID, permission_names: Iterable[str]
+    ) -> List[User]:
+        """Active users in an org whose role grants any of `permission_names`.
+
+        Used to pick notification recipients for chats nobody owns yet, so the
+        push only reaches people who can actually open the conversation.
+        """
+        if isinstance(organization_id, str):
+            organization_id = UUID(organization_id)
+
+        names = list(permission_names)
+        if not names:
+            return []
+
+        return self.db.query(User)\
+            .join(Role, User.role_id == Role.id)\
+            .join(role_permissions, role_permissions.c.role_id == Role.id)\
+            .join(Permission, Permission.id == role_permissions.c.permission_id)\
+            .filter(User.organization_id == organization_id)\
+            .filter(User.is_active == True)\
+            .filter(Permission.name.in_(names))\
+            .distinct()\
             .all()
 
     def get_active_users_count(self, organization_id: str | UUID) -> int:

--- a/backend/app/services/channel_chat.py
+++ b/backend/app/services/channel_chat.py
@@ -39,6 +39,7 @@ from app.repositories.channels import (
     AgentChannelConfigRepository,
 )
 from app.repositories.session_to_agent import SessionToAgentRepository
+from app.services.chat_notifications import notify_new_chat
 from app.services.lead_capture import record_lead_from_response
 from app.services.message_delivery import DeliveryResult, deliver_to_customer
 
@@ -81,10 +82,12 @@ async def process_channel_message(account_id, inbound: InboundMessage) -> None:
         # real one via the platform API — only then, not on every message.
         if adapter is not None:
             await _enrich_customer_name(db, adapter, account, inbound, customer_id)
-        session_record, conversation = _get_or_create_session(
+        session_record, conversation, is_new_session = _get_or_create_session(
             db, account, inbound, agent_id, customer_id, org_id
         )
         session_id = str(session_record.session_id)
+        if is_new_session:
+            await notify_new_chat(db, session_record)
 
         # Merge channel-specific per-conversation state (e.g. email threading
         # headers) so outbound replies can use it.
@@ -332,7 +335,11 @@ def _agent_changed(session_record, agent_id) -> bool:
 
 def _get_or_create_session(db: Session, account: ChannelAccount, inbound: InboundMessage,
                            agent_id, customer_id: str, org_id: str):
-    """Find the open session for this platform conversation or start a new one."""
+    """Find the open session for this platform conversation or start a new one.
+
+    Returns (session, conversation, is_new) — callers use is_new to notify the
+    team only when a conversation actually starts.
+    """
     conv_repo = ChannelConversationRepository(db)
     session_repo = SessionToAgentRepository(db)
 
@@ -341,7 +348,7 @@ def _get_or_create_session(db: Session, account: ChannelAccount, inbound: Inboun
         session_record = session_repo.get_session(conversation.session_id)
         if not _agent_changed(session_record, agent_id):
             conv_repo.touch_inbound(conversation)
-            return session_record, conversation
+            return session_record, conversation, False
         # Retire the thread so the newly configured agent starts clean. Closing
         # the session is what makes get_active skip it, so the create below
         # opens a fresh conversation for the same platform thread.
@@ -368,7 +375,7 @@ def _get_or_create_session(db: Session, account: ChannelAccount, inbound: Inboun
         agent_id=agent_id,
         customer_id=uuid.UUID(customer_id),
     )
-    return session_record, conversation
+    return session_record, conversation, True
 
 
 def _store_customer_message(db: Session, inbound: InboundMessage, session_record,

--- a/backend/app/services/chat_notifications.py
+++ b/backend/app/services/chat_notifications.py
@@ -1,0 +1,93 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.logger import get_logger
+from app.repositories.user import UserRepository
+from app.services.notifications import ChatNotificationEvent, notify_chat_event
+
+logger = get_logger(__name__)
+
+# A brand-new chat belongs to nobody, so recipients are whoever could actually
+# open it from the inbox. Anything narrower (e.g. the agent's groups) misses
+# new chats, which usually have no group at all.
+UNASSIGNED_CHAT_VIEWERS = (
+    "view_all_chats",
+    "manage_all_chats",
+    "view_unassigned_chats",
+    "super_admin",
+)
+
+CHANNEL_LABELS = {
+    "web": "the web widget",
+    "whatsapp": "WhatsApp",
+    "telegram": "Telegram",
+    "messenger": "Messenger",
+    "instagram": "Instagram",
+    "email": "email",
+}
+
+
+async def notify_new_chat(db: Session, session) -> None:
+    """Tell the team a customer started a new conversation.
+
+    Never raises — chat creation must not fail because a push did.
+    """
+    try:
+        if session is None or not session.organization_id:
+            return
+
+        users = UserRepository(db).get_users_with_any_permission(
+            session.organization_id, UNASSIGNED_CHAT_VIEWERS
+        )
+        if not users:
+            return
+
+        channel = CHANNEL_LABELS.get(session.channel, session.channel or "chat")
+        await notify_chat_event(
+            db=db,
+            user_ids=[user.id for user in users],
+            event=ChatNotificationEvent.NEW_CHAT,
+            title="New chat",
+            message=f"A new conversation started on {channel}.",
+            metadata={"session_id": str(session.session_id)},
+        )
+    except Exception as e:
+        logger.error(f"Error notifying new chat: {e}")
+
+
+async def notify_chat_assigned(db: Session, session, user_id, assigned_by: Optional[str] = None) -> None:
+    """Tell a user a colleague handed them a conversation.
+
+    Never raises, and no-ops when someone claims a chat for themselves.
+    """
+    try:
+        if not user_id or (assigned_by and str(assigned_by) == str(user_id)):
+            return
+
+        await notify_chat_event(
+            db=db,
+            user_ids=[user_id],
+            event=ChatNotificationEvent.CHAT_ASSIGNED,
+            title="Chat assigned to you",
+            message="A conversation has been assigned to you.",
+            metadata={"session_id": str(session.session_id)},
+        )
+    except Exception as e:
+        logger.error(f"Error notifying chat assignment: {e}")

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -14,15 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Optional
+import enum
+from typing import Iterable, Optional
 
 from sqlalchemy.orm import Session
 
 from app.core.logger import get_logger
 from app.models.notification import Notification, NotificationType
+from app.models.notification_settings import (
+    NOTIFY_CHAT_ASSIGNED,
+    NOTIFY_CHAT_TRANSFER,
+    NOTIFY_NEW_CHAT,
+)
+from app.repositories.notification_settings import UserNotificationSettingsRepository
 from app.services.user import send_fcm_notification
 
 logger = get_logger(__name__)
+
+
+class ChatNotificationEvent(str, enum.Enum):
+    """Chat events a user can mute. The value is both the preference column
+    and the `event` discriminator carried in the push metadata.
+    """
+    NEW_CHAT = NOTIFY_NEW_CHAT
+    CHAT_TRANSFER = NOTIFY_CHAT_TRANSFER
+    CHAT_ASSIGNED = NOTIFY_CHAT_ASSIGNED
 
 
 async def notify_user(
@@ -37,6 +53,10 @@ async def notify_user(
 
     Never raises and no-ops without a user (background jobs may have none) —
     a notification failure must not fail the work it reports on.
+
+    NOTE: this commits (and, on error, rolls back) the caller's `db` session,
+    so call it only once any work you want persisted is already committed.
+    Every current caller either commits first or has nothing pending.
     """
     if not user_id:
         return
@@ -57,3 +77,38 @@ async def notify_user(
             db.rollback()
         except Exception:
             pass
+
+
+async def notify_chat_event(
+    db: Session,
+    user_ids: Iterable,
+    event: ChatNotificationEvent,
+    title: str,
+    message: str,
+    metadata: Optional[dict] = None,
+) -> None:
+    """Notify every user in `user_ids` who hasn't muted `event`.
+
+    Recipients are resolved in a single query, so fanning out to a whole group
+    or org costs one lookup rather than one per user. Like notify_user, this
+    never raises — a notification must not fail the chat it reports on.
+    """
+    try:
+        recipients = UserNotificationSettingsRepository(db).filter_enabled(
+            user_ids, event.value
+        )
+        if not recipients:
+            return
+
+        payload = {**(metadata or {}), "event": event.value}
+        for user_id in recipients:
+            await notify_user(
+                db=db,
+                user_id=user_id,
+                type_=NotificationType.CHAT,
+                title=title,
+                message=message,
+                metadata=payload,
+            )
+    except Exception as e:
+        logger.error(f"Error sending '{event.value}' notification: {e}")

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -52,6 +52,15 @@ async def send_fcm_notification(user_id: str, notification: Notification, db):
                 'metadata': json.dumps(metadata, default=str)
             },
             token=user.fcm_token_web,
+            # These are web-push tokens, so the priority knob is the WebPush
+            # `Urgency` header — NOT AndroidConfig/APNSConfig, which only apply
+            # to native FCM SDK tokens and are ignored for web push. High
+            # urgency asks the push service to deliver promptly even while the
+            # device is idle / in battery-saver instead of batching it; TTL
+            # keeps it deliverable for a day if the device is offline.
+            webpush=messaging.WebpushConfig(
+                headers={'Urgency': 'high', 'TTL': '86400'},
+            ),
         )
 
         # Send message

--- a/backend/app/services/whatsapp_outbound.py
+++ b/backend/app/services/whatsapp_outbound.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Session
 from app.channels import get_adapter
 from app.channels.constants import DEFAULT_TEMPLATE_LANGUAGE
 from app.services.channel_chat import placeholder_name
+from app.services.chat_notifications import notify_new_chat
 from app.channels.meta_base import fetch_message_templates
 from app.core.logger import get_logger
 from app.models.channels import ChannelAccount
@@ -220,13 +221,14 @@ async def start_outbound_conversation(
     else:
         customer = _resolve_customer(db, account, phone, customer_id, customer_name)
         session_id = uuid.uuid4()
-        SessionToAgentRepository(db).create_session(
+        new_session = SessionToAgentRepository(db).create_session(
             session_id=session_id,
             agent_id=str(agent_id),
             customer_id=str(customer.id),
             organization_id=str(account.organization_id),
             channel=account.channel_type,
         )
+        await notify_new_chat(db, new_session)
         conversation = conv_repo.create(
             channel_account_id=account.id,
             channel_type=account.channel_type,

--- a/backend/tests/api/test_notification.py
+++ b/backend/tests/api/test_notification.py
@@ -20,6 +20,7 @@ from app.database import get_db
 from fastapi import FastAPI
 from app.models.user import User
 from app.models.notification import Notification, NotificationType
+from app.models.notification_settings import UserNotificationSettings
 from app.models.role import Role
 from app.models.organization import Organization
 from datetime import datetime, timezone
@@ -219,6 +220,111 @@ def test_get_unread_count(
     response = client.get("/api/notifications/unread-count")
     assert response.status_code == 200
     assert response.json()["count"] == 2  # Two unread notifications from fixture
+
+def test_get_or_create_survives_insert_race(db, test_user):
+    """A concurrent first-insert (IntegrityError) re-reads instead of 500ing"""
+    from unittest.mock import patch
+    from sqlalchemy.exc import IntegrityError
+    from app.repositories.notification_settings import UserNotificationSettingsRepository
+
+    repo = UserNotificationSettingsRepository(db)
+
+    # The row the winning racer inserted; our repo's first get() is forced to
+    # miss it (as if the winner hadn't committed yet when we looked).
+    winner_row = UserNotificationSettings(user_id=test_user.id)
+    db.add(winner_row)
+    db.commit()
+
+    real_get = repo.get
+    calls = {"n": 0}
+
+    def get_missing_first(user_id):
+        calls["n"] += 1
+        return None if calls["n"] == 1 else real_get(user_id)
+
+    with patch.object(repo, "get", side_effect=get_missing_first), \
+         patch.object(db, "commit", side_effect=IntegrityError("dup", {}, Exception())):
+        result = repo.get_or_create(test_user.id)
+
+    assert result is not None
+    assert result.user_id == test_user.id
+
+
+def test_get_settings_creates_defaults(
+    client,
+    db,
+    test_user
+):
+    """First read lazily creates the row with the shipped defaults"""
+    response = client.get("/api/notifications/settings")
+    assert response.status_code == 200
+    assert response.json() == {
+        "notify_new_chat": False,
+        "notify_chat_transfer": True,
+        "notify_chat_assigned": True,
+    }
+
+    settings = db.query(UserNotificationSettings)\
+        .filter_by(user_id=test_user.id).first()
+    assert settings is not None
+
+
+def test_update_settings_is_partial(
+    client,
+    db,
+    test_user
+):
+    """Only the toggles sent are changed; the rest keep their values"""
+    response = client.put(
+        "/api/notifications/settings",
+        json={"notify_new_chat": True}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["notify_new_chat"] is True
+    assert body["notify_chat_transfer"] is True
+    assert body["notify_chat_assigned"] is True
+
+    response = client.put(
+        "/api/notifications/settings",
+        json={"notify_chat_transfer": False}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["notify_new_chat"] is True
+    assert body["notify_chat_transfer"] is False
+
+
+def test_settings_are_per_user(
+    client,
+    db,
+    test_user
+):
+    """Updating the caller's settings never touches another user's row"""
+    other_user = User(
+        id=uuid4(),
+        email="other-settings@example.com",
+        full_name="Other User",
+        hashed_password="hashed_password",
+        organization_id=test_user.organization_id
+    )
+    db.add(other_user)
+    db.commit()
+
+    other_settings = UserNotificationSettings(user_id=other_user.id)
+    db.add(other_settings)
+    db.commit()
+
+    response = client.put(
+        "/api/notifications/settings",
+        json={"notify_new_chat": True, "notify_chat_assigned": False}
+    )
+    assert response.status_code == 200
+
+    db.refresh(other_settings)
+    assert other_settings.notify_new_chat is False
+    assert other_settings.notify_chat_assigned is True
+
 
 def test_send_test_notification(
     client,

--- a/backend/tests/api/test_session_to_agent.py
+++ b/backend/tests/api/test_session_to_agent.py
@@ -594,6 +594,63 @@ def test_reassign_chat_success(client_with_error_mock, db, user_with_manage_chat
     assert mock_notify.called
 
 
+def test_reassign_notifies_previous_assignee_not_new_one(
+    client_with_error_mock, db, user_with_manage_chats_permission,
+    user_with_manage_assigned_chats, create_chat_session
+):
+    """The 'reassigned_from_you' event must target the PREVIOUS owner's room.
+
+    reassign_session mutates the loaded session in place, so reading
+    session.user_id after it would wrongly point at the new assignee.
+    """
+    from unittest.mock import AsyncMock
+    previous = user_with_manage_chats_permission
+    new = user_with_manage_assigned_chats
+    session = _assigned_session(db, create_chat_session, previous)
+
+    with patch('app.api.session_to_agent.notify_chat_assigned', new=AsyncMock()), \
+         patch('app.api.session_to_agent.sio.emit', new=AsyncMock()) as mock_emit:
+        response = client_with_error_mock.post(
+            f"/api/v1/session-to-agent/{session.session_id}/reassign",
+            params={"to_user_id": str(new.id)}
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    from_you = [
+        c for c in mock_emit.call_args_list
+        if c.args and isinstance(c.args[1], dict)
+        and c.args[1].get('type') == 'reassigned_from_you'
+    ]
+    assert len(from_you) == 1, "expected exactly one reassigned_from_you emit"
+    assert from_you[0].kwargs.get('room') == f"user_{previous.id}"
+    assert from_you[0].kwargs.get('room') != f"user_{new.id}"
+
+
+def test_reassign_to_same_user_skips_from_you_event(
+    client_with_error_mock, db, user_with_manage_chats_permission, create_chat_session
+):
+    """Reassigning a chat to its current owner is a no-op — no contradictory ping."""
+    from unittest.mock import AsyncMock
+    owner = user_with_manage_chats_permission
+    session = _assigned_session(db, create_chat_session, owner)
+
+    with patch('app.api.session_to_agent.notify_chat_assigned', new=AsyncMock()), \
+         patch('app.api.session_to_agent.sio.emit', new=AsyncMock()) as mock_emit:
+        response = client_with_error_mock.post(
+            f"/api/v1/session-to-agent/{session.session_id}/reassign",
+            params={"to_user_id": str(owner.id)}
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    from_you = [
+        c for c in mock_emit.call_args_list
+        if c.args and isinstance(c.args[1], dict)
+        and c.args[1].get('type') == 'reassigned_from_you'
+    ]
+    assert from_you == []
+
+
 def test_reassign_chat_other_org_session(client_with_error_mock, db, other_org_user,
                                          user_with_manage_assigned_chats,
                                          user_with_manage_chats_permission, create_chat_session):

--- a/backend/tests/api/test_session_to_agent.py
+++ b/backend/tests/api/test_session_to_agent.py
@@ -538,3 +538,127 @@ def test_takeover_chat_closed_session(client_with_error_mock, db, user_with_mana
     
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert "Failed to take over chat" in response.json()["detail"] 
+
+@pytest.fixture
+def other_org_user(db, test_role_with_manage_chats) -> User:
+    """A user (and their org) entirely separate from the caller's."""
+    other_org = Organization(
+        id=uuid4(),
+        name="Other Organization",
+        domain="other.example.com",
+        business_hours={},
+        settings={}
+    )
+    db.add(other_org)
+    db.commit()
+
+    user = User(
+        id=uuid4(),
+        email="outsider@example.com",
+        hashed_password="hashed_password",
+        is_active=True,
+        organization_id=other_org.id,
+        full_name="Outsider",
+        role_id=test_role_with_manage_chats.id
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _assigned_session(db, create_chat_session, user):
+    """An open session already handled by a human — reassignable."""
+    session = create_chat_session()
+    session.user_id = user.id
+    db.commit()
+    db.refresh(session)
+    return session
+
+
+def test_reassign_chat_success(client_with_error_mock, db, user_with_manage_chats_permission,
+                               user_with_manage_assigned_chats, create_chat_session):
+    """Reassigning to a colleague in the same org pushes them a notification"""
+    session = _assigned_session(db, create_chat_session, user_with_manage_chats_permission)
+
+    with patch('app.api.session_to_agent.notify_chat_assigned') as mock_notify:
+        mock_notify.return_value = None
+        response = client_with_error_mock.post(
+            f"/api/v1/session-to-agent/{session.session_id}/reassign",
+            params={"to_user_id": str(user_with_manage_assigned_chats.id)}
+        )
+
+    assert response.status_code == status.HTTP_200_OK
+    db.refresh(session)
+    assert session.user_id == user_with_manage_assigned_chats.id
+    assert mock_notify.called
+
+
+def test_reassign_chat_other_org_session(client_with_error_mock, db, other_org_user,
+                                         user_with_manage_assigned_chats,
+                                         user_with_manage_chats_permission, create_chat_session):
+    """A session belonging to another org is invisible, not reassignable"""
+    session = _assigned_session(db, create_chat_session, user_with_manage_chats_permission)
+    session.organization_id = other_org_user.organization_id
+    db.commit()
+
+    response = client_with_error_mock.post(
+        f"/api/v1/session-to-agent/{session.session_id}/reassign",
+        params={"to_user_id": str(user_with_manage_assigned_chats.id)}
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "Chat session not found"
+    db.refresh(session)
+    assert session.user_id == user_with_manage_chats_permission.id
+
+
+def test_reassign_chat_target_in_another_org(client_with_error_mock, db, other_org_user,
+                                             user_with_manage_chats_permission, create_chat_session):
+    """A chat can't be handed to someone outside the caller's org"""
+    session = _assigned_session(db, create_chat_session, user_with_manage_chats_permission)
+
+    response = client_with_error_mock.post(
+        f"/api/v1/session-to-agent/{session.session_id}/reassign",
+        params={"to_user_id": str(other_org_user.id)}
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json()["detail"] == "User not found"
+    db.refresh(session)
+    assert session.user_id == user_with_manage_chats_permission.id
+
+
+def test_reassign_chat_unknown_target(client_with_error_mock, db,
+                                      user_with_manage_chats_permission, create_chat_session):
+    """An unknown user id is a 404, and a malformed one isn't a 500"""
+    session = _assigned_session(db, create_chat_session, user_with_manage_chats_permission)
+
+    for target in (str(uuid4()), "not-a-uuid"):
+        response = client_with_error_mock.post(
+            f"/api/v1/session-to-agent/{session.session_id}/reassign",
+            params={"to_user_id": target}
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND, target
+        assert response.json()["detail"] == "User not found"
+
+
+def test_reassign_chat_no_permission(client_with_error_mock, db, regular_user,
+                                     user_with_manage_chats_permission,
+                                     user_with_manage_assigned_chats, create_chat_session):
+    """Without a manage grant, reassignment is forbidden"""
+    session = _assigned_session(db, create_chat_session, user_with_manage_chats_permission)
+
+    async def override_get_current_user():
+        return regular_user
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    try:
+        response = client_with_error_mock.post(
+            f"/api/v1/session-to-agent/{session.session_id}/reassign",
+            params={"to_user_id": str(user_with_manage_assigned_chats.id)}
+        )
+    finally:
+        app.dependency_overrides[get_current_user] = lambda: user_with_manage_chats_permission
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/backend/tests/services/test_chat_notifications.py
+++ b/backend/tests/services/test_chat_notifications.py
@@ -1,0 +1,253 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Chat notification preference gating: who gets a push for which event, and
+what happens for users who have never opened the settings page.
+"""
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.models.notification import Notification, NotificationType
+from app.models.notification_settings import UserNotificationSettings
+from app.models.permission import Permission
+from app.models.role import Role
+from app.models.user import User
+from app.repositories.chat import ChatRepository
+from app.repositories.session_to_agent import SessionToAgentRepository
+from app.services.chat_notifications import notify_chat_assigned, notify_new_chat
+from app.services.notifications import ChatNotificationEvent, notify_chat_event
+
+
+@pytest.fixture
+def second_user(db, test_organization, test_role) -> User:
+    user = User(
+        id=uuid4(),
+        email="second@example.com",
+        full_name="Second User",
+        hashed_password="hashed_password",
+        is_active=True,
+        organization_id=test_organization.id,
+        role_id=test_role.id,
+    )
+    db.add(user)
+    db.commit()
+    return user
+
+
+async def _notify(db, user_ids, event):
+    with patch("app.services.notifications.send_fcm_notification", new=AsyncMock()):
+        await notify_chat_event(
+            db=db,
+            user_ids=user_ids,
+            event=event,
+            title="New Chat Transfer",
+            message="A chat has been transferred to your group.",
+            metadata={"session_id": "abc-123"},
+        )
+
+
+def _notifications_for(db, user_id):
+    return db.query(Notification).filter(Notification.user_id == user_id).all()
+
+
+@pytest.mark.asyncio
+async def test_users_without_settings_get_default_enabled_events(db, test_user):
+    """No settings row means the defaults apply — transfers still notify."""
+    await _notify(db, [test_user.id], ChatNotificationEvent.CHAT_TRANSFER)
+
+    notifications = _notifications_for(db, test_user.id)
+    assert len(notifications) == 1
+    assert notifications[0].type == NotificationType.CHAT
+    assert notifications[0].notification_metadata["event"] == "notify_chat_transfer"
+    # session_id must survive — the push uses it to deep-link the conversation.
+    assert notifications[0].notification_metadata["session_id"] == "abc-123"
+
+
+@pytest.mark.asyncio
+async def test_users_without_settings_do_not_get_default_disabled_events(db, test_user):
+    """New-chat is opt-in, so an untouched user gets nothing."""
+    await _notify(db, [test_user.id], ChatNotificationEvent.NEW_CHAT)
+
+    assert _notifications_for(db, test_user.id) == []
+
+
+@pytest.mark.asyncio
+async def test_muted_user_is_skipped_others_are_not(db, test_user, second_user):
+    db.add(UserNotificationSettings(user_id=test_user.id, notify_chat_transfer=False))
+    db.commit()
+
+    await _notify(db, [test_user.id, second_user.id], ChatNotificationEvent.CHAT_TRANSFER)
+
+    assert _notifications_for(db, test_user.id) == []
+    assert len(_notifications_for(db, second_user.id)) == 1
+
+
+@pytest.mark.asyncio
+async def test_opted_in_user_gets_new_chat(db, test_user):
+    db.add(UserNotificationSettings(user_id=test_user.id, notify_new_chat=True))
+    db.commit()
+
+    await _notify(db, [test_user.id], ChatNotificationEvent.NEW_CHAT)
+
+    assert len(_notifications_for(db, test_user.id)) == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_recipients_notified_once(db, test_user):
+    await _notify(
+        db,
+        [test_user.id, test_user.id, str(test_user.id)],
+        ChatNotificationEvent.CHAT_TRANSFER,
+    )
+
+    assert len(_notifications_for(db, test_user.id)) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_recipients_is_a_no_op(db):
+    await _notify(db, [], ChatNotificationEvent.CHAT_TRANSFER)
+
+    assert db.query(Notification).count() == 0
+
+
+@pytest.fixture
+def inbox_user(db, test_organization) -> User:
+    """A user whose role can see unclaimed chats, opted in to new-chat pushes."""
+    permission = Permission(name="view_unassigned_chats")
+    db.add(permission)
+    db.commit()
+
+    role = Role(name="Inbox Agent", organization_id=test_organization.id)
+    role.permissions = [permission]
+    db.add(role)
+    db.commit()
+
+    user = User(
+        id=uuid4(),
+        email="inbox@example.com",
+        full_name="Inbox Agent",
+        hashed_password="hashed_password",
+        is_active=True,
+        organization_id=test_organization.id,
+        role_id=role.id,
+    )
+    db.add(user)
+    db.add(UserNotificationSettings(user_id=user.id, notify_new_chat=True))
+    db.commit()
+    return user
+
+
+def _new_session(db, test_organization, test_agent, test_customer):
+    return SessionToAgentRepository(db).create_session(
+        session_id=uuid4(),
+        agent_id=test_agent.id,
+        customer_id=test_customer.id,
+        organization_id=test_organization.id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_new_chat_notifies_only_users_who_can_open_it(
+    db, test_organization, test_agent, test_customer, test_user, inbox_user
+):
+    """test_user's role has no chat permissions, so it isn't a recipient."""
+    session = _new_session(db, test_organization, test_agent, test_customer)
+
+    with patch("app.services.notifications.send_fcm_notification", new=AsyncMock()):
+        await notify_new_chat(db, session)
+
+    assert len(_notifications_for(db, inbox_user.id)) == 1
+    assert _notifications_for(db, test_user.id) == []
+
+    notification = _notifications_for(db, inbox_user.id)[0]
+    assert notification.notification_metadata["session_id"] == str(session.session_id)
+    assert "web widget" in notification.message
+
+
+@pytest.mark.asyncio
+async def test_new_chat_respects_the_opt_in(
+    db, test_organization, test_agent, test_customer, inbox_user
+):
+    db.query(UserNotificationSettings)\
+        .filter(UserNotificationSettings.user_id == inbox_user.id)\
+        .update({"notify_new_chat": False})
+    db.commit()
+
+    session = _new_session(db, test_organization, test_agent, test_customer)
+    with patch("app.services.notifications.send_fcm_notification", new=AsyncMock()):
+        await notify_new_chat(db, session)
+
+    assert _notifications_for(db, inbox_user.id) == []
+
+
+@pytest.mark.asyncio
+async def test_opening_the_widget_alone_is_not_a_new_chat(
+    db, test_organization, test_agent, test_customer
+):
+    """The widget opens its session on connect — no customer message, no chat."""
+    session = _new_session(db, test_organization, test_agent, test_customer)
+    chat_repo = ChatRepository(db)
+
+    assert chat_repo.has_customer_messages(session.session_id) is False
+
+    chat_repo.create_message({
+        "message": "Hello?",
+        "message_type": "user",
+        "session_id": str(session.session_id),
+        "organization_id": str(test_organization.id),
+        "agent_id": str(test_agent.id),
+        "customer_id": str(test_customer.id),
+    })
+
+    assert chat_repo.has_customer_messages(session.session_id) is True
+    # A bot-only session still counts as unstarted.
+    other = _new_session(db, test_organization, test_agent, test_customer)
+    chat_repo.create_message({
+        "message": "Hi there!",
+        "message_type": "bot",
+        "session_id": str(other.session_id),
+        "organization_id": str(test_organization.id),
+        "agent_id": str(test_agent.id),
+        "customer_id": str(test_customer.id),
+    })
+    assert chat_repo.has_customer_messages(other.session_id) is False
+
+
+@pytest.mark.asyncio
+async def test_assignment_notifies_the_target(
+    db, test_organization, test_agent, test_customer, test_user, second_user
+):
+    session = _new_session(db, test_organization, test_agent, test_customer)
+
+    with patch("app.services.notifications.send_fcm_notification", new=AsyncMock()):
+        await notify_chat_assigned(db, session, second_user.id, assigned_by=test_user.id)
+
+    assert len(_notifications_for(db, second_user.id)) == 1
+    assert _notifications_for(db, test_user.id) == []
+
+
+@pytest.mark.asyncio
+async def test_self_assignment_notifies_nobody(
+    db, test_organization, test_agent, test_customer, test_user
+):
+    """Claiming a chat yourself shouldn't push a notification back at you."""
+    session = _new_session(db, test_organization, test_agent, test_customer)
+
+    with patch("app.services.notifications.send_fcm_notification", new=AsyncMock()):
+        await notify_chat_assigned(db, session, test_user.id, assigned_by=test_user.id)
+
+    assert _notifications_for(db, test_user.id) == []

--- a/backend/tests/services/test_user.py
+++ b/backend/tests/services/test_user.py
@@ -185,7 +185,10 @@ async def test_send_fcm_notification_message_structure(mock_db, sample_user, sam
         # Verify message was created with correct parameters: data-only payload
         # (title/body in data so the web SDK doesn't auto-display a duplicate),
         # metadata as JSON (not a Python repr), session_id flattened for SW
-        # deep links
+        # deep links, and high-urgency webpush delivery.
+        mock_messaging.WebpushConfig.assert_called_once_with(
+            headers={'Urgency': 'high', 'TTL': '86400'}
+        )
         mock_messaging.Message.assert_called_once_with(
             data={
                 'title': sample_notification.title,
@@ -196,6 +199,7 @@ async def test_send_fcm_notification_message_structure(mock_db, sample_user, sam
                 'metadata': json.dumps(sample_notification.notification_metadata)
             },
             token=sample_user.fcm_token_web,
+            webpush=mock_messaging.WebpushConfig.return_value,
         )
 
 

--- a/frontend/src/__tests__/composables/useNotificationSettings.spec.ts
+++ b/frontend/src/__tests__/composables/useNotificationSettings.spec.ts
@@ -1,0 +1,73 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useNotificationSettings } from '@/composables/useNotificationSettings'
+import { notificationService } from '@/services/notification'
+
+vi.mock('@/services/notification', () => ({
+  notificationService: {
+    getSettings: vi.fn(),
+    updateSettings: vi.fn(),
+  },
+}))
+
+vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+const defaults = {
+  notify_new_chat: false,
+  notify_chat_transfer: true,
+  notify_chat_assigned: true,
+}
+
+describe('useNotificationSettings', () => {
+  beforeEach(() => {
+    vi.mocked(notificationService.getSettings).mockResolvedValue({ ...defaults })
+    vi.mocked(notificationService.updateSettings).mockReset()
+  })
+
+  it('loads the current preferences', async () => {
+    const { settings, isLoading, load } = useNotificationSettings()
+    await load()
+
+    expect(isLoading.value).toBe(false)
+    expect(settings.value).toEqual(defaults)
+  })
+
+  it('applies a toggle optimistically and keeps the server response', async () => {
+    vi.mocked(notificationService.updateSettings).mockResolvedValue({
+      ...defaults,
+      notify_new_chat: true,
+    })
+
+    const { settings, load, save } = useNotificationSettings()
+    await load()
+    await save({ notify_new_chat: true })
+
+    expect(notificationService.updateSettings).toHaveBeenCalledWith({ notify_new_chat: true })
+    expect(settings.value?.notify_new_chat).toBe(true)
+  })
+
+  it('rolls the toggle back when the save fails', async () => {
+    vi.mocked(notificationService.updateSettings).mockRejectedValue(new Error('nope'))
+
+    const { settings, load, save } = useNotificationSettings()
+    await load()
+    await save({ notify_chat_transfer: false })
+
+    expect(settings.value).toEqual(defaults)
+  })
+})

--- a/frontend/src/components/common/Modal.vue
+++ b/frontend/src/components/common/Modal.vue
@@ -15,17 +15,24 @@ limitations under the License.
 -->
 
 <script setup lang="ts">
-defineProps<{
+const props = withDefaults(defineProps<{
   title?: string
-}>()
+  // When true, clicking the backdrop does NOT close the modal — for forms
+  // where an accidental outside-click would discard the user's input.
+  persistent?: boolean
+}>(), { persistent: false })
 
-defineEmits<{
+const emit = defineEmits<{
   close: []
 }>()
+
+const onOverlayClick = () => {
+  if (!props.persistent) emit('close')
+}
 </script>
 
 <template>
-  <div class="modal-overlay" @click="$emit('close')">
+  <div class="modal-overlay" @click="onOverlayClick">
     <div class="modal-content" @click.stop>
       <div class="modal-header">
         <h3 class="modal-title">

--- a/frontend/src/components/human-agent/UserForm.vue
+++ b/frontend/src/components/human-agent/UserForm.vue
@@ -249,33 +249,42 @@ const handleSubmit = () => {
 .user-form {
   display: flex;
   flex-direction: column;
-  gap: var(--space-lg);
-
+  gap: 18px;
 }
 
+/* The global .form-group already adds margin-bottom: var(--space-lg); combined
+   with the flex gap above that doubled the spacing between every field. Zero
+   it and let the single flex gap own the vertical rhythm. */
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: var(--space-xs);
+  gap: 8px;
+  margin-bottom: 0;
 }
 
-.form-input {
-  padding: var(--space-sm);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius-sm);
+.form-group label {
+  font-size: 13.5px;
+  font-weight: var(--font-weight-medium);
+  color: var(--text3);
 }
+
+/* Inputs deliberately inherit the app-wide .form-input styling from
+   components.css (padding, radius, hover + focus ring) so they match every
+   other form — only the <select> chevron is added below. */
 
 .checkbox-label {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
+  font-size: var(--text-sm);
+  color: var(--text);
 }
 
 .form-actions {
   display: flex;
   justify-content: flex-end;
-  gap: var(--space-md);
-  margin-top: var(--space-md);
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
 }
 
 .password-strength {

--- a/frontend/src/components/human-agent/UserList.vue
+++ b/frontend/src/components/human-agent/UserList.vue
@@ -458,7 +458,7 @@ onMounted(async () => {
     </template>
 
     <!-- Edit User Modal -->
-    <Modal v-if="showEditModal" @close="showEditModal = false">
+    <Modal v-if="showEditModal" persistent @close="showEditModal = false">
       <template #title>Edit User</template>
       <template #content>
         <UserForm 
@@ -492,7 +492,7 @@ onMounted(async () => {
     </Modal>
 
     <!-- Create User Modal -->
-    <Modal v-if="showCreateModal" @close="showCreateModal = false">
+    <Modal v-if="showCreateModal" persistent @close="showCreateModal = false">
       <template #title>Create New User</template>
       <template #content>
         <UserForm

--- a/frontend/src/components/integrations/ChannelConnectModal.vue
+++ b/frontend/src/components/integrations/ChannelConnectModal.vue
@@ -179,7 +179,9 @@ const saveAgent = async () => {
 </script>
 
 <template>
-  <div class="cc-modal" @click.self="emit('close')">
+  <!-- Intentionally no backdrop-click dismiss: these forms hold credentials
+       the user is mid-entry on, so only the × / Cancel buttons close it. -->
+  <div class="cc-modal">
     <div class="cc-modal-content">
       <div class="cc-modal-header">
         <h3>{{ isManage ? form.title.replace('Connect', 'Manage') : form.title }}</h3>

--- a/frontend/src/components/notifications/NotificationList.vue
+++ b/frontend/src/components/notifications/NotificationList.vue
@@ -16,8 +16,12 @@ limitations under the License.
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { notificationService, type Notification } from '@/services/notification'
 import { getNotificationIcon } from './notificationIcons'
+import { conversationSessionUrl } from '@/pwa/pushContract'
+
+const router = useRouter()
 
 const props = defineProps<{
     isOpen: boolean
@@ -54,6 +58,25 @@ const markAsRead = async (id: number) => {
         }
     } catch (err) {
         console.error('Error marking notification as read:', err)
+    }
+}
+
+// Chat notifications (new chat, transfer, assignment) carry the session id in
+// their metadata; clicking one marks it read and deep-links to that
+// conversation, closing the drawer.
+const sessionIdOf = (notification: Notification): string | undefined => {
+    const id = notification.notification_metadata?.session_id
+    return id ? String(id) : undefined
+}
+
+const handleNotificationClick = async (notification: Notification) => {
+    if (!notification.is_read) {
+        await markAsRead(notification.id)
+    }
+    const sessionId = sessionIdOf(notification)
+    if (sessionId) {
+        emit('close')
+        router.push(conversationSessionUrl(sessionId))
     }
 }
 
@@ -153,7 +176,8 @@ onMounted(fetchNotifications)
 
             <div v-else class="notifications">
                 <div v-for="notification in filteredNotifications" :key="notification.id" class="notification-item"
-                    :class="{ unread: !notification.is_read }" @click="markAsRead(notification.id)">
+                    :class="{ unread: !notification.is_read, linkable: sessionIdOf(notification) }"
+                    @click="handleNotificationClick(notification)">
                     <span class="notification-icon-wrap">
                         <img v-if="getNotificationIcon(notification.type.toLowerCase())"
                             :src="getNotificationIcon(notification.type.toLowerCase())" class="notification-type-icon"
@@ -350,6 +374,27 @@ onMounted(fetchNotifications)
 
 .notification-item:hover {
     background: var(--o03);
+}
+
+/* Chat notifications deep-link to their conversation — hint it on hover. */
+.notification-item.linkable {
+    position: relative;
+}
+
+.notification-item.linkable::after {
+    content: 'Open ›';
+    position: absolute;
+    right: 18px;
+    bottom: 10px;
+    font-size: 11px;
+    font-weight: var(--font-weight-medium);
+    color: var(--accent-ink);
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.notification-item.linkable:hover::after {
+    opacity: 1;
 }
 
 .notification-item.unread {

--- a/frontend/src/components/user/UserSettings.vue
+++ b/frontend/src/components/user/UserSettings.vue
@@ -22,8 +22,38 @@ import { validatePassword, type PasswordStrength } from '@/utils/validators'
 import userAvatar from '@/assets/user.svg'
 import type { User } from '@/types/user'
 import { isAbsoluteUrl } from '@/utils/avatars'
+import { useNotificationSettings } from '@/composables/useNotificationSettings'
+import { useNotifications } from '@/composables/useNotifications'
+import type { NotificationSettings } from '@/services/notification'
 
 const { user } = useAuth()
+
+const {
+  settings: notificationSettings,
+  isLoading: notificationsLoading,
+  isSaving: notificationsSaving,
+  save: saveNotificationSetting
+} = useNotificationSettings()
+const { hasPermission: hasPushPermission, enableNotifications } = useNotifications()
+
+// One row per toggle so the markup stays a single loop.
+const NOTIFICATION_TOGGLES: { key: keyof NotificationSettings; title: string; desc: string }[] = [
+  {
+    key: 'notify_new_chat',
+    title: 'New chats',
+    desc: 'When a new conversation starts, including ones the AI is handling.'
+  },
+  {
+    key: 'notify_chat_transfer',
+    title: 'Chats transferred to my group',
+    desc: 'When an AI agent hands a conversation to a group you belong to.'
+  },
+  {
+    key: 'notify_chat_assigned',
+    title: 'Chats assigned to me',
+    desc: 'When a teammate reassigns a conversation to you.'
+  }
+]
 
 const profilePicFile = ref<File | null>(null)
 const profilePicPreview = ref<string>('')
@@ -410,6 +440,41 @@ const handleProfilePicClick = () => {
         <span class="saved-text">{{ message }}</span>
       </div>
     </form>
+
+    <!-- Notifications: saved on toggle, so deliberately outside the profile form -->
+    <div class="settings-card notifications-card">
+      <h3 class="card-title">Notifications</h3>
+      <p class="card-subtitle">Choose which chat events send you a push notification.</p>
+
+      <div v-if="!hasPushPermission" class="permission-notice">
+        <font-awesome-icon icon="fa-solid fa-bell-slash" class="permission-icon" />
+        <span class="permission-text">
+          Your browser isn't allowed to show notifications yet, so nothing below will reach you.
+        </span>
+        <button type="button" class="upload-button" @click="enableNotifications">Enable</button>
+      </div>
+
+      <div v-if="notificationsLoading" class="notification-hint">Loading your preferences…</div>
+
+      <template v-else-if="notificationSettings">
+        <div v-for="toggle in NOTIFICATION_TOGGLES" :key="toggle.key" class="notification-row">
+          <div class="notification-meta">
+            <div class="notification-title">{{ toggle.title }}</div>
+            <div class="notification-desc">{{ toggle.desc }}</div>
+          </div>
+          <label class="switch">
+            <input
+              type="checkbox"
+              :checked="notificationSettings[toggle.key]"
+              :disabled="notificationsSaving"
+              @change="saveNotificationSetting({ [toggle.key]: !notificationSettings[toggle.key] })"
+            >
+            <span class="slider" :class="{ enabled: notificationSettings[toggle.key] }"></span>
+          </label>
+        </div>
+        <div class="notification-hint">Saved automatically.</div>
+      </template>
+    </div>
   </div>
 </template>
 
@@ -465,6 +530,111 @@ const handleProfilePicClick = () => {
   font-size: 13.5px;
   color: var(--muted);
   margin: -16px 0 20px;
+}
+
+/* Notifications card */
+.notifications-card {
+  margin-top: 18px;
+}
+
+.permission-notice {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  margin-bottom: 20px;
+  border: 1px solid var(--o08);
+  border-radius: var(--radius-btn);
+  background: var(--bg2);
+}
+
+.permission-icon {
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.permission-text {
+  flex: 1;
+  font-size: 13.5px;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.notification-row {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 16px 0;
+  border-top: 1px solid var(--o07);
+}
+
+.notification-meta {
+  flex: 1;
+  min-width: 0;
+}
+
+.notification-title {
+  font-size: 14.5px;
+  font-weight: var(--font-weight-medium);
+  color: var(--text);
+}
+
+.notification-desc {
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.45;
+  margin-top: 3px;
+}
+
+.notification-hint {
+  font-size: 12.5px;
+  color: var(--muted);
+  padding-top: 14px;
+  border-top: 1px solid var(--o07);
+}
+
+/* Toggle switch (46x26) — matches the agent settings toggles */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 46px;
+  height: 26px;
+  flex-shrink: 0;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: var(--toggle-track-off);
+  transition: background 0.15s;
+  border-radius: var(--radius-pill);
+}
+
+.slider.enabled {
+  background: var(--toggle-on-teal);
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 20px;
+  width: 20px;
+  left: 3px;
+  top: 3px;
+  background: var(--toggle-knob);
+  transition: transform 0.15s;
+  border-radius: 50%;
+}
+
+input:checked + .slider:before {
+  transform: translateX(20px);
 }
 
 /* Avatar row */

--- a/frontend/src/composables/useNotificationSettings.ts
+++ b/frontend/src/composables/useNotificationSettings.ts
@@ -1,0 +1,59 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { onMounted, ref } from 'vue'
+import { toast } from 'vue-sonner'
+import { notificationService, type NotificationSettings } from '@/services/notification'
+
+export function useNotificationSettings() {
+  const settings = ref<NotificationSettings | null>(null)
+  const isLoading = ref(true)
+  const isSaving = ref(false)
+  const error = ref<string | null>(null)
+
+  async function load() {
+    isLoading.value = true
+    try {
+      settings.value = await notificationService.getSettings()
+      error.value = null
+    } catch (e: any) {
+      error.value = e?.message || 'Failed to load notification settings'
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  // Optimistic: the toggle flips immediately and reverts if the save fails,
+  // so a slow round-trip never makes the switch feel unresponsive.
+  async function save(patch: Partial<NotificationSettings>) {
+    if (!settings.value || isSaving.value) return
+    isSaving.value = true
+    const previous = { ...settings.value }
+    Object.assign(settings.value, patch)
+    try {
+      settings.value = await notificationService.updateSettings(patch)
+    } catch (e: any) {
+      settings.value = previous
+      toast.error(e?.message || 'Failed to save notification settings')
+    } finally {
+      isSaving.value = false
+    }
+  }
+
+  onMounted(load)
+
+  return { settings, isLoading, isSaving, error, load, save }
+}

--- a/frontend/src/services/notification.ts
+++ b/frontend/src/services/notification.ts
@@ -26,6 +26,12 @@ export interface Notification {
   created_at: string
 }
 
+export interface NotificationSettings {
+  notify_new_chat: boolean
+  notify_chat_transfer: boolean
+  notify_chat_assigned: boolean
+}
+
 export const notificationService = {
   async getNotifications(skip = 0, limit = 50): Promise<Notification[]> {
     const response = await api.get(`/notifications?skip=${skip}&limit=${limit}`)
@@ -39,5 +45,15 @@ export const notificationService = {
   async getUnreadCount(): Promise<number> {
     const response = await api.get('/notifications/unread-count')
     return response.data.count
+  },
+
+  async getSettings(): Promise<NotificationSettings> {
+    const response = await api.get('/notifications/settings')
+    return response.data
+  },
+
+  async updateSettings(patch: Partial<NotificationSettings>): Promise<NotificationSettings> {
+    const response = await api.put('/notifications/settings', patch)
+    return response.data
   },
 }


### PR DESCRIPTION
Per-user chat notification settings plus related UI fixes.

- Notifications card on `/settings/user` with three toggles: new chat, transferred to my group, assigned to me (transfer/assignment default on, new-chat opt-in). Browser-permission banner when notifications are blocked.
- Backend gate + triggers: a per-user preference gate (single bulk query), wired into new chat (fires on the customer's first message, not on widget connect), transfer-to-group, and reassignment. Web push now sent at high urgency.
- Click a notification in the drawer to deep-link to its conversation.
- Fix: the `reassigned_from_you` socket event targeted the new assignee instead of the previous one (the ORM instance was mutated in place before the emit).
- UI: credential (SMS/Email) and create/edit-user modals no longer dismiss on outside-click; tidy the user form spacing.

Stacked on #254 (shares the reassign_chat changes) — review/merge that first, then this retargets to main.
