### PR TITLE
fix(s3): sign URLs per response instead of storing them

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -46,6 +46,10 @@ S3_BUCKET=chattermate-uploads
 S3_REGION=us-east-1
 AWS_ACCESS_KEY_ID=your_aws_access_key_id
 AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+# Lifetime of generated presigned URLs, in seconds. They are re-signed on every
+# response, so this only needs to outlive a page render. AWS rejects SigV4
+# presigns above 604800 (7 days); larger values are clamped to that.
+S3_PRESIGN_EXPIRY_SECONDS=3600
 
 # Jira OAuth Configuration
 JIRA_CLIENT_ID=your_jira_client_id_here

--- a/backend/app/api/agent.py
+++ b/backend/app/api/agent.py
@@ -32,7 +32,7 @@ import aiofiles
 from uuid import uuid4
 from PIL import Image
 from uuid import UUID
-from app.core.s3 import upload_file_to_s3, get_s3_signed_url
+from app.core.s3 import upload_file_to_s3
 from app.core.config import settings
 from pydantic import BaseModel
 from agno.agent import Agent as AgnoAgent
@@ -280,15 +280,9 @@ async def update_agent(
         # Get knowledge sources for response
         knowledge_items = knowledge_repo.get_by_agent(agent.id)
 
-        # Get signed URL for photo if using S3
+        # photo_url is signed by CustomizationResponse on serialization — do not
+        # assign the signed value onto the ORM object, it gets flushed to the DB.
         customization = agent.customization
-        if settings.S3_FILE_STORAGE and customization and customization.photo_url:
-            try:
-                customization.photo_url = await get_s3_signed_url(customization.photo_url)
-            except Exception as e:
-                logger.error(f"Error getting signed URL for agent photo: {str(e)}")
-                # Don't fail the request if we can't get the signed URL
-                pass
 
         # Prepare response
         response = AgentWithCustomizationResponse(
@@ -349,12 +343,9 @@ async def get_organization_agents(
         for agent in agents:
             knowledge_items = knowledge_repo.get_by_agent(agent.id)
             
-            # Create a copy of the customization to modify the photo_url
+            # photo_url is signed by CustomizationResponse on serialization.
             customization = agent.customization
-            if settings.S3_FILE_STORAGE and customization and customization.photo_url:
-                # Get signed URL for the photo
-                customization.photo_url = await get_s3_signed_url(customization.photo_url)
-            
+
             agent_data = AgentWithCustomizationResponse(
                 id=agent.id,
                 name=agent.name,
@@ -436,10 +427,9 @@ async def create_agent_customization(
         db.commit()
         db.refresh(db_customization)
 
-        # Generate signed URL if using S3 storage
-        if settings.S3_FILE_STORAGE and db_customization.photo_url:
-            db_customization.photo_url = await get_s3_signed_url(db_customization.photo_url)
-
+        # photo_url is signed by CustomizationResponse on serialization. Assigning
+        # it here would leave the refreshed instance dirty and persist the
+        # signature on the next flush.
         return db_customization
 
     except HTTPException as e:
@@ -499,10 +489,9 @@ async def upload_agent_photo(
         db.commit()
         db.refresh(db_customization)
 
-        # Generate signed URL if using S3 storage
-        if settings.S3_FILE_STORAGE and db_customization.photo_url:
-            db_customization.photo_url = await get_s3_signed_url(db_customization.photo_url)
-
+        # photo_url is signed by CustomizationResponse on serialization. Assigning
+        # it here would leave the refreshed instance dirty and persist the
+        # signature on the next flush.
         return db_customization
 
     except HTTPException:
@@ -547,8 +536,6 @@ async def update_agent_groups(
         knowledge_repo = KnowledgeRepository(db)
         knowledge_items = knowledge_repo.get_by_agent(agent.id)
         customization = agent.customization
-        if settings.S3_FILE_STORAGE and customization and customization.photo_url:
-            customization.photo_url = await get_s3_signed_url(customization.photo_url)
         return AgentWithCustomizationResponse(
             id=agent.id,
             name=agent.name,
@@ -607,14 +594,7 @@ async def get_agent_by_id(
     # Check if agent belongs to the authenticated organization
     verify_agent_access(agent, auth_info)
     
-    # Get signed URL for photo if using S3
-    if settings.S3_FILE_STORAGE and agent.customization and agent.customization.photo_url:
-        try:
-            agent.customization.photo_url = await get_s3_signed_url(agent.customization.photo_url)
-        except Exception as e:
-            logger.error(f"Error getting signed URL for agent photo: {str(e)}")
-            # Don't fail the request if we can't get the signed URL
-            pass
+    # photo_url is signed by CustomizationResponse on serialization.
     
     return agent
 

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -181,16 +181,8 @@ async def list_users(
         user_repo = UserRepository(db)
         users = user_repo.get_users_by_organization(current_user.organization_id)
 
-        # Get signed URLs for profile pictures if using S3
-        if settings.S3_FILE_STORAGE:
-            for user in users:
-                if user.profile_pic:
-                    try:
-                        user.profile_pic = await get_s3_signed_url(user.profile_pic)
-                    except Exception as e:
-                        logger.error(f"Error getting signed URL for user profile picture: {str(e)}")
-                        # Don't fail the request if we can't get the signed URL
-                        pass
+        # profile_pic is signed by UserResponse on serialization — assigning the
+        # signed value onto the ORM object would persist it on the next flush.
 
         return users
     except Exception as e:

--- a/backend/app/api/widget.py
+++ b/backend/app/api/widget.py
@@ -237,8 +237,7 @@ async def get_human_agent_session_info(db: Session, customer_id: str) -> dict:
         session_model,user_full_name, user_profile_pic = sessions[0]
         
         if user_full_name:  # If there's a human agent assigned
-            if settings.S3_FILE_STORAGE and user_profile_pic:
-                user_profile_pic = await get_s3_signed_url(user_profile_pic)
+            # HumanAgentResponse signs human_agent_profile_pic on serialization.
 
             # Get human agent info from session
             human_agent_info = {
@@ -355,12 +354,8 @@ async def get_widget_data(
         )
         token_was_generated = True
         
-        # Create a copy of customization to modify photo_url
+        # photo_url is signed by AgentCustomizationResponse on serialization.
         customization = agent.customization
-      
-        if settings.S3_FILE_STORAGE and customization and customization.photo_url:
-            # Get signed URL for the photo
-            customization.photo_url = await get_s3_signed_url(customization.photo_url)
 
         return {
             "id": widget.id,
@@ -396,9 +391,7 @@ async def get_widget_data(
             # Create a copy of customization to modify photo_url
             customization = agent.customization
 
-            if settings.S3_FILE_STORAGE and customization and customization.photo_url:
-                # Get signed URL for the photo
-                customization.photo_url = await get_s3_signed_url(customization.photo_url)
+            # photo_url is signed by AgentCustomizationResponse on serialization.
 
             return {
                 "id": widget.id,
@@ -429,9 +422,7 @@ async def get_widget_data(
     # Create a copy of customization to modify photo_url
     customization = agent.customization
 
-    if settings.S3_FILE_STORAGE and customization and customization.photo_url:
-        # Get signed URL for the photo
-        customization.photo_url = await get_s3_signed_url(customization.photo_url)
+    # photo_url is signed by AgentCustomizationResponse on serialization.
 
     return {
         "id": widget.id,

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -117,6 +117,9 @@ class Settings(BaseSettings):
     S3_REGION: str = os.getenv("S3_REGION", "us-east-1")
     AWS_ACCESS_KEY_ID: str = os.getenv("AWS_ACCESS_KEY_ID", "")
     AWS_SECRET_ACCESS_KEY: str = os.getenv("AWS_SECRET_ACCESS_KEY", "")
+    # Presigned URLs are regenerated on every response, so this only needs to
+    # outlive a single page render. Hard-capped at S3_MAX_PRESIGN_SECONDS.
+    S3_PRESIGN_EXPIRY_SECONDS: int = int(os.getenv("S3_PRESIGN_EXPIRY_SECONDS", "3600"))
 
     # Enhanced Website Knowledge Base Configuration
     KB_MAX_DEPTH: int = int(os.getenv("KB_MAX_DEPTH", "5"))

--- a/backend/app/core/s3.py
+++ b/backend/app/core/s3.py
@@ -17,19 +17,71 @@ limitations under the License.
 """
 S3 Storage Utilities
 """
-import traceback
+import asyncio
+import os
+from functools import lru_cache, partial
 import boto3
 from botocore.exceptions import ClientError
 from app.core.config import settings
 from app.core.logger import get_logger
-from fastapi import HTTPException, UploadFile
+from fastapi import HTTPException
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 logger = get_logger(__name__)
 
+# AWS rejects any SigV4 presigned URL whose X-Amz-Expires exceeds one week with
+# AuthorizationQueryParametersError. Only the legacy SigV2 signer (which
+# botocore still selects for us-east-1 and eu-west-1) has no such limit, so a
+# longer value happens to work in those regions and 403s everywhere else.
+S3_MAX_PRESIGN_SECONDS = 604800
+
+# head_object retries after put_object, to ride out transient read-after-write
+# failures rather than failing the whole upload.
+_UPLOAD_VERIFY_ATTEMPTS = 3
+_UPLOAD_VERIFY_BACKOFF_SECONDS = 0.5
+
+
+def strip_s3_signature(url: Optional[str]) -> Optional[str]:
+    """Reduce a presigned S3 URL back to the bare object URL.
+
+    Signed URLs must never reach the database: they expire, and a stored
+    signature outlives its validity. Clients round-trip response values into
+    update payloads (the agent customization form does exactly this), so
+    stripping on the way in is the only reliable guard.
+    """
+    if not url or 'amazonaws.com' not in url:
+        return url
+    return urlunparse(urlparse(url)._replace(query='', fragment=''))
+
+
+def _url_for_key(s3_key: str) -> str:
+    """The canonical stored URL for an object key. Single source of truth for
+    the URL shape — _key_from_url must be able to round-trip whatever this
+    produces."""
+    return f"https://{settings.S3_BUCKET}.s3.{settings.S3_REGION}.amazonaws.com/{s3_key}"
+
+
+def _key_from_url(s3_url: str) -> str:
+    """Extract the object key from either S3 URL format."""
+    parsed_url = urlparse(s3_url)
+    path_parts = parsed_url.path.strip('/').split('/')
+    if parsed_url.netloc == 's3.amazonaws.com':
+        # Format: https://s3.amazonaws.com/bucket/key
+        return '/'.join(path_parts[1:])
+    # Format: https://bucket.s3.region.amazonaws.com/key
+    return '/'.join(path_parts)
+
+
+@lru_cache(maxsize=1)
 def get_s3_client():
-    """Get boto3 S3 client"""
+    """Get boto3 S3 client.
+
+    Cached: constructing a client resolves session, endpoint and credential
+    config and costs ~1.3ms, which dwarfs the ~0.05ms presign it is usually
+    built for. boto3 clients are thread-safe for method calls. Call
+    get_s3_client.cache_clear() if settings change at runtime (tests).
+    """
     return boto3.client(
         's3',
         aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
@@ -37,14 +89,21 @@ def get_s3_client():
         region_name=settings.S3_REGION
     )
 
-async def get_s3_signed_url(s3_url: str, expiration: int = 2592000) -> str:
+
+def sign_s3_url(s3_url: str, expiration: Optional[int] = None) -> str:
     """
-    Generate a signed URL for an S3 object
+    Generate a signed URL for an S3 object.
+
+    Synchronous on purpose: generate_presigned_url computes an HMAC locally and
+    makes no network call, so this is safe to call from response serialization
+    (see the field_serializers on the response schemas) without an event loop.
+
     Args:
         s3_url: The S3 URL of the object
-        expiration: URL expiration time in seconds (default 30 days)
+        expiration: Lifetime in seconds; defaults to settings.S3_PRESIGN_EXPIRY_SECONDS
+                    and is clamped to S3_MAX_PRESIGN_SECONDS
     Returns:
-        Signed URL for the object
+        Signed URL for the object, or the input unchanged if it is not signable
     """
     try:
         if not settings.S3_FILE_STORAGE or not s3_url:
@@ -55,32 +114,31 @@ async def get_s3_signed_url(s3_url: str, expiration: int = 2592000) -> str:
         if s3_url.startswith('data:') or 'amazonaws.com' not in s3_url:
             return s3_url
 
-        # Parse the URL
-        parsed_url = urlparse(s3_url)
-        path_parts = parsed_url.path.strip('/').split('/')
-        
-        # Handle different S3 URL formats
-        if parsed_url.netloc == 's3.amazonaws.com':
-            # Format: https://s3.amazonaws.com/bucket/key
-            key = '/'.join(path_parts[1:])
-        else:
-            # Format: https://bucket.s3.region.amazonaws.com/key
-            key = '/'.join(path_parts)
-            
+        if expiration is None:
+            expiration = settings.S3_PRESIGN_EXPIRY_SECONDS
+        expiration = min(expiration, S3_MAX_PRESIGN_SECONDS)
+
         s3_client = get_s3_client()
         signed_url = s3_client.generate_presigned_url(
             'get_object',
             Params={
                 'Bucket': settings.S3_BUCKET,
-                'Key': key
+                'Key': _key_from_url(s3_url)
             },
             ExpiresIn=expiration
         )
         return signed_url
     except Exception as e:
-        traceback.print_exc()
-        logger.error(f"Error generating signed URL: {str(e)}")
+        logger.exception(f"Error generating signed URL: {str(e)}")
         return s3_url
+
+
+async def get_s3_signed_url(s3_url: str, expiration: Optional[int] = None) -> str:
+    """Awaitable shim over sign_s3_url for the existing `await` call sites.
+
+    Deprecated: signing never touched the network, so prefer sign_s3_url.
+    """
+    return sign_s3_url(s3_url, expiration)
 
 async def upload_file_to_s3(
     file_content: bytes,
@@ -136,40 +194,43 @@ async def upload_file_to_s3(
             extra_args['ContentType'] = content_type
         
         logger.info(f"Putting object to S3: bucket={settings.S3_BUCKET}, key={s3_key}, size={len(file_content)} bytes")
-        s3_client.put_object(
-            Bucket=settings.S3_BUCKET,
-            Key=s3_key,
-            Body=file_content,
-            **extra_args
+        # boto3 is synchronous — offload so a large body never blocks the loop.
+        await asyncio.to_thread(
+            partial(
+                s3_client.put_object,
+                Bucket=settings.S3_BUCKET,
+                Key=s3_key,
+                Body=file_content,
+                **extra_args
+            )
         )
         # Verify file was written
-        for attempt in range(3):
+        for attempt in range(_UPLOAD_VERIFY_ATTEMPTS):
             try:
-                s3_client.head_object(Bucket=settings.S3_BUCKET, Key=s3_key)
+                await asyncio.to_thread(
+                    partial(s3_client.head_object, Bucket=settings.S3_BUCKET, Key=s3_key)
+                )
                 break
             except Exception as verify_err:
-                if attempt < 2:
-                    import time
-                    time.sleep(0.5)
+                if attempt < _UPLOAD_VERIFY_ATTEMPTS - 1:
+                    await asyncio.sleep(_UPLOAD_VERIFY_BACKOFF_SECONDS)
                 else:
                     logger.error(f"File verification failed after retries: {s3_key} - {str(verify_err)}")
                     raise HTTPException(
                         status_code=500,
                         detail="File upload verification failed"
                     )
-        
-        # Generate AWS S3 URL
-        url = f"https://{settings.S3_BUCKET}.s3.{settings.S3_REGION}.amazonaws.com/{s3_key}"
-        
+
+        url = _url_for_key(s3_key)
+
         logger.info(f"Successfully uploaded file to S3")
         return url
-        
+
     except ClientError as e:
         logger.warning(f"S3 upload failed with ClientError: {str(e)}. Falling back to local storage.")
         return await _save_file_locally(file_content, folder, filename)
     except Exception as e:
-        logger.error(f"S3 upload failed with unexpected error: {str(e)}")
-        traceback.print_exc()
+        logger.exception(f"S3 upload failed with unexpected error: {str(e)}")
         logger.warning(f"Falling back to local storage.")
         return await _save_file_locally(file_content, folder, filename)
 
@@ -183,7 +244,6 @@ async def _save_file_locally(
     Fallback function to save file locally when S3 fails
     """
     try:
-        import os
         upload_dir = os.path.join("uploads", folder)
         os.makedirs(upload_dir, exist_ok=True)
         
@@ -201,21 +261,9 @@ async def _save_file_locally(
         logger.error(f"Failed to save file locally: {str(e)}")
         raise HTTPException(status_code=500, detail="Failed to save file")
 
-def _key_from_url(s3_url: str) -> str:
-    """Extract the object key from either S3 URL format."""
-    parsed_url = urlparse(s3_url)
-    path_parts = parsed_url.path.strip('/').split('/')
-    if parsed_url.netloc == 's3.amazonaws.com':
-        # Format: https://s3.amazonaws.com/bucket/key
-        return '/'.join(path_parts[1:])
-    # Format: https://bucket.s3.region.amazonaws.com/key
-    return '/'.join(path_parts)
-
-
 async def download_file_from_s3(s3_url: str) -> bytes:
     """Download an object's bytes (worker-side readback of stored uploads).
     boto3 is synchronous — offload so the transfer never blocks the event loop."""
-    import asyncio
 
     def _download() -> bytes:
         s3_client = get_s3_client()
@@ -229,21 +277,12 @@ async def delete_file_from_s3(s3_url: str) -> bool:
     """Delete file from S3 bucket"""
     try:
         s3_client = get_s3_client()
-        
-        # Extract key from URL using the same parsing logic as get_s3_signed_url
-        parsed_url = urlparse(s3_url)
-        path_parts = parsed_url.path.strip('/').split('/')
-        
-        if parsed_url.netloc == 's3.amazonaws.com':
-            # Format: https://s3.amazonaws.com/bucket/key
-            key = '/'.join(path_parts[1:])
-        else:
-            # Format: https://bucket.s3.region.amazonaws.com/key
-            key = '/'.join(path_parts)
-        
-        s3_client.delete_object(
-            Bucket=settings.S3_BUCKET,
-            Key=key
+        await asyncio.to_thread(
+            partial(
+                s3_client.delete_object,
+                Bucket=settings.S3_BUCKET,
+                Key=_key_from_url(s3_url)
+            )
         )
         return True
         

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -80,20 +80,6 @@ class AgentCustomization(Base):
     # Relationship
     agent = relationship("Agent", back_populates="customization")
 
-    @property
-    def photo_url_signed(self) -> Optional[str]:
-        """Get signed URL for photo if using S3"""
-        if not self.photo_url:
-            return None
-        
-        from app.core.config import settings
-        if settings.S3_FILE_STORAGE:
-            from app.core.s3 import get_s3_signed_url
-            import asyncio
-            return asyncio.run(get_s3_signed_url(self.photo_url))
-        return self.photo_url
-
-
 
 
 # Association table for agent-usergroup relationship

--- a/backend/app/models/schemas/agent_customization.py
+++ b/backend/app/models/schemas/agent_customization.py
@@ -14,11 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer, field_validator
 from typing import Optional, Dict, List
 from typing_extensions import Annotated
 from uuid import UUID
 import enum
+
+from app.core.s3 import sign_s3_url, strip_s3_signature
 
 # Cap launcher/welcome copy so it can't balloon the widget (the launcher nudge is
 # also clamped to 4 lines client-side). Limits match the frontend input maxlengths
@@ -62,6 +64,17 @@ DEFAULT_QUICK_ACTIONS = [
 
 class CustomizationBase(BaseModel):
     photo_url: Optional[str] = None
+
+    @field_validator('photo_url')
+    @classmethod
+    def _strip_photo_url_signature(cls, v: Optional[str]) -> Optional[str]:
+        """Keep the bare S3 URL as the stored value.
+
+        CustomizationResponse serializes photo_url signed, and the agent
+        customization form POSTs the value it was given straight back, so
+        without this the expiring signature would be written to the column.
+        """
+        return strip_s3_signature(v)
     chat_background_color: Optional[str] = "#F8F9FA"
     chat_bubble_color: Optional[str] = "#E9ECEF"
     chat_text_color: Optional[str] = "#212529"
@@ -98,28 +111,11 @@ class CustomizationResponse(CustomizationBase):
     id: int
     agent_id: UUID
 
-    @property
-    def photo_url_signed(self) -> Optional[str]:
-        """Get signed URL for photo if using S3"""
-        if not self.photo_url:
-            return None
-        
-        from app.core.config import settings
-        if settings.S3_FILE_STORAGE:
-            from app.core.s3 import get_s3_signed_url
-            import asyncio
-            return asyncio.run(get_s3_signed_url(self.photo_url))
-        return self.photo_url
-
-
+    @field_serializer('photo_url')
+    def _sign_photo_url(self, v: Optional[str]) -> Optional[str]:
+        """Sign on the way out, every response. Signing is a local HMAC (~0.05ms),
+        so there is nothing to gain by caching the result in the database."""
+        return sign_s3_url(v) if v else v
 
     class Config:
         from_attributes = True
-        json_schema_extra = {
-            "properties": {
-                "photo_url_signed": {
-                    "type": "string",
-                    "description": "Signed URL for agent photo if using S3"
-                }
-            }
-        }

--- a/backend/app/models/schemas/user.py
+++ b/backend/app/models/schemas/user.py
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, field_serializer
 from typing import Optional, List
 from uuid import UUID
 from datetime import datetime
+
+from app.core.s3 import sign_s3_url
 
 from app.models.schemas.role import RoleResponse
 
@@ -66,30 +68,13 @@ class UserResponse(UserBase):
     groups: Optional[List[UserGroupResponse]] = None    
     role: Optional[RoleResponse] = None
 
-    @property
-    def profile_pic_url(self) -> Optional[str]:
-        """Get signed URL for profile picture if using S3"""
-        if not self.profile_pic:
-            return None
-        
-        from app.core.config import settings
-        if settings.S3_FILE_STORAGE:
-            from app.core.s3 import get_s3_signed_url
-            import asyncio
-            # Run synchronously since this is a property
-            return asyncio.run(get_s3_signed_url(self.profile_pic))
-        return self.profile_pic
+    @field_serializer('profile_pic')
+    def _sign_profile_pic(self, v: Optional[str]) -> Optional[str]:
+        """Sign on the way out, every response — never stored signed."""
+        return sign_s3_url(v) if v else v
 
     class Config:
         from_attributes = True
-        json_schema_extra = {
-            "properties": {
-                "profile_pic_url": {
-                    "type": "string",
-                    "description": "Signed URL for profile picture if using S3"
-                }
-            }
-        }
 
 
 

--- a/backend/app/models/schemas/widget.py
+++ b/backend/app/models/schemas/widget.py
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 from typing import List, Optional
 from uuid import UUID
+
+from app.core.s3 import sign_s3_url
 
 
 class WidgetBase(BaseModel):
@@ -47,29 +49,13 @@ class AgentCustomizationResponse(BaseModel):
     show_citations: Optional[bool] = None
     collect_email: Optional[bool] = None
 
-    @property
-    def photo_url_signed(self) -> Optional[str]:
-        """Get signed URL for photo if using S3"""
-        if not self.photo_url:
-            return None
-        
-        from app.core.config import settings
-        if settings.S3_FILE_STORAGE:
-            from app.core.s3 import get_s3_signed_url
-            import asyncio
-            return asyncio.run(get_s3_signed_url(self.photo_url))
-        return self.photo_url
+    @field_serializer('photo_url')
+    def _sign_photo_url(self, v: Optional[str]) -> Optional[str]:
+        """Sign on the way out, every response — never stored signed."""
+        return sign_s3_url(v) if v else v
 
     class Config:
         from_attributes = True
-        json_schema_extra = {
-            "properties": {
-                "photo_url_signed": {
-                    "type": "string",
-                    "description": "Signed URL for agent photo if using S3"
-                }
-            }
-        }
 
 
 class AgentResponse(BaseModel):
@@ -84,29 +70,13 @@ class HumanAgentResponse(BaseModel):
     human_agent_name: Optional[str] = None
     human_agent_profile_pic: Optional[str] = None
 
-    @property
-    def human_agent_profile_pic_url(self) -> Optional[str]:
-        """Get signed URL for profile picture if using S3"""
-        if not self.human_agent_profile_pic:
-            return None
-        
-        from app.core.config import settings
-        if settings.S3_FILE_STORAGE:
-            from app.core.s3 import get_s3_signed_url
-            import asyncio
-            return asyncio.run(get_s3_signed_url(self.human_agent_profile_pic))
-        return self.human_agent_profile_pic
+    @field_serializer('human_agent_profile_pic')
+    def _sign_profile_pic(self, v: Optional[str]) -> Optional[str]:
+        """Sign on the way out, every response — never stored signed."""
+        return sign_s3_url(v) if v else v
 
     class Config:
         from_attributes = True
-        json_schema_extra = {
-            "properties": {
-                "human_agent_profile_pic_url": {
-                    "type": "string",
-                    "description": "Signed URL for profile picture if using S3"
-                }
-            }
-        }
 
 
 class WidgetResponse(BaseModel):

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -22,6 +22,12 @@ import os
 import aiofiles
 
 from app.core.config import settings
+from app.core.s3 import (
+    delete_file_from_s3,
+    download_file_from_s3,
+    get_s3_signed_url,
+    upload_file_to_s3,
+)
 
 
 async def store_upload(content: bytes, folder: str, file_name: str, content_type: str) -> str:
@@ -29,7 +35,6 @@ async def store_upload(content: bytes, folder: str, file_name: str, content_type
     URL (sign with resolve_public_url before handing to clients); local mode
     returns the path under the /api/v1/uploads static mount."""
     if settings.S3_FILE_STORAGE:
-        from app.core.s3 import upload_file_to_s3
         return await upload_file_to_s3(content, folder, file_name, content_type=content_type)
     upload_dir = os.path.join("uploads", folder)
     os.makedirs(upload_dir, exist_ok=True)
@@ -44,7 +49,6 @@ async def load_upload(stored: str) -> bytes:
     returned. Used by workers running in a different container than the API
     (shared local uploads mount or S3)."""
     if stored.startswith("http"):
-        from app.core.s3 import download_file_from_s3
         return await download_file_from_s3(stored)
     # `{API_V1_STR}/uploads/...` → local `uploads/...`
     marker = f"{settings.API_V1_STR}/uploads/"
@@ -57,7 +61,6 @@ async def delete_upload(stored: str) -> None:
     """Best-effort removal of a stored upload (temp import files)."""
     try:
         if stored.startswith("http"):
-            from app.core.s3 import delete_file_from_s3
             await delete_file_from_s3(stored)
             return
         marker = f"{settings.API_V1_STR}/uploads/"
@@ -71,6 +74,5 @@ async def resolve_public_url(stored_url: str) -> str:
     """Client-facing URL for a stored upload: signed for private S3 objects,
     verbatim otherwise."""
     if stored_url and settings.S3_FILE_STORAGE and stored_url.startswith("http"):
-        from app.core.s3 import get_s3_signed_url
         return await get_s3_signed_url(stored_url)
     return stored_url

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -539,6 +539,72 @@ def test_create_customization_with_existing(
     customization = response.json()
     assert customization["chat_background_color"] == new_customization_data["chat_background_color"]
 
+def test_customization_response_signs_photo_url_without_persisting_it(
+    client,
+    db,
+    test_user,
+    test_agent,
+    test_customization
+):
+    """The response carries a signed photo_url; the column keeps the bare URL.
+
+    Regression: the endpoints used to assign the signed value onto the ORM
+    instance, which SQLAlchemy then flushed, so stored URLs carried a signature
+    that eventually expired.
+    """
+    from unittest.mock import patch, MagicMock
+
+    stored_url = "https://bucket.s3.us-east-1.amazonaws.com/agents/photo.png"
+    signed_url = f"{stored_url}?AWSAccessKeyId=A&Signature=S&Expires=1"
+    test_customization.photo_url = stored_url
+    db.commit()
+
+    signing_client = MagicMock()
+    signing_client.generate_presigned_url.return_value = signed_url
+
+    with patch('app.core.s3.settings.S3_FILE_STORAGE', True), \
+         patch('app.core.s3.get_s3_client', return_value=signing_client):
+
+        response = client.get(f"/api/agents/{test_agent.id}")
+        assert response.status_code == 200
+        assert response.json()["customization"]["photo_url"] == signed_url
+
+    # The request must not leave the instance dirty. Asserting on the committed
+    # row alone would not catch this: a GET never flushes, so the signature only
+    # reaches the column on some later write in the same session.
+    assert test_customization not in db.dirty
+
+    db.refresh(test_customization)
+    assert test_customization.photo_url == stored_url
+
+
+def test_customization_update_rejects_a_signed_photo_url(
+    client,
+    db,
+    test_agent,
+    test_user,
+    test_customization
+):
+    """A client echoing a signed photo_url back into an update must not store it.
+
+    The agent customization form seeds itself from the GET response and POSTs
+    that value straight back, which is how signatures reached the database.
+    """
+    stored_url = "https://bucket.s3.us-east-1.amazonaws.com/agents/photo.png"
+    signed_url = f"{stored_url}?AWSAccessKeyId=A&Signature=S&Expires=1"
+
+    response = client.post(
+        f"/api/agents/{test_agent.id}/customization",
+        json={"photo_url": signed_url}
+    )
+    assert response.status_code == 200
+
+    db.expire_all()
+    saved = db.query(AgentCustomization).filter_by(agent_id=test_agent.id).first()
+    assert saved.photo_url == stored_url
+    assert "Signature=" not in saved.photo_url
+
+
 def test_create_customization_invalid_agent(
     client,
     db,
@@ -1097,23 +1163,26 @@ def test_get_agent_s3_signed_url_error(
     test_customization
 ):
     """Test getting agent when S3 signed URL generation fails"""
-    from unittest.mock import patch
-    
-    # Set photo URL to simulate S3 storage
-    test_customization.photo_url = "s3://bucket/path/photo.png"
+    from unittest.mock import patch, MagicMock
+
+    stored_url = "https://bucket.s3.us-east-1.amazonaws.com/path/photo.png"
+    test_customization.photo_url = stored_url
     db.commit()
-    
-    with patch('app.core.config.settings.S3_FILE_STORAGE', True), \
-         patch('app.api.agent.get_s3_signed_url') as mock_s3_url:
-        
-        mock_s3_url.side_effect = Exception("S3 error")
-        
+
+    # Signing happens during response serialization now, so fail the boto3 call
+    # itself rather than an endpoint-level helper.
+    failing_client = MagicMock()
+    failing_client.generate_presigned_url.side_effect = Exception("S3 error")
+
+    with patch('app.core.s3.settings.S3_FILE_STORAGE', True), \
+         patch('app.core.s3.get_s3_client', return_value=failing_client):
+
         # Should not fail the request, just log the error
         response = client.get(f"/api/agents/{test_agent.id}")
         assert response.status_code == 200
         agent = response.json()
         # Should still have the original S3 URL since signing failed
-        assert agent["customization"]["photo_url"] == "s3://bucket/path/photo.png"
+        assert agent["customization"]["photo_url"] == stored_url
 
 # Edge case and integration tests
 def test_create_agent_with_all_optional_fields(

--- a/backend/tests/core/test_s3.py
+++ b/backend/tests/core/test_s3.py
@@ -18,7 +18,14 @@ import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 from fastapi import UploadFile, HTTPException
 from io import BytesIO
-from app.core.s3 import get_s3_client, get_s3_signed_url, upload_file_to_s3, delete_file_from_s3
+from app.core.s3 import (
+    S3_MAX_PRESIGN_SECONDS,
+    delete_file_from_s3,
+    get_s3_client,
+    get_s3_signed_url,
+    strip_s3_signature,
+    upload_file_to_s3,
+)
 from app.core.config import settings
 from botocore.exceptions import ClientError
 
@@ -28,9 +35,12 @@ def test_get_s3_client():
     with patch('boto3.client') as mock_boto3_client:
         mock_client = MagicMock()
         mock_boto3_client.return_value = mock_client
-        
+
+        # The client is lru_cached; drop any instance an earlier test built so
+        # boto3.client is actually invoked here.
+        get_s3_client.cache_clear()
         client = get_s3_client()
-        
+
         # Verify boto3.client was called with correct parameters
         mock_boto3_client.assert_called_once_with(
             's3',
@@ -64,10 +74,51 @@ async def test_get_s3_signed_url_with_s3_storage_enabled():
                 'Bucket': settings.S3_BUCKET,
                 'Key': 'test/file.jpg'
             },
-            ExpiresIn=2592000  # Default 30 days
+            ExpiresIn=settings.S3_PRESIGN_EXPIRY_SECONDS
         )
-        
+
         assert result == expected_signed_url
+
+
+@pytest.mark.asyncio
+async def test_get_s3_signed_url_clamps_expiry_to_s3_maximum():
+    """A caller asking for longer than S3 allows is clamped, not passed through.
+
+    AWS rejects SigV4 presigns above S3_MAX_PRESIGN_SECONDS with
+    AuthorizationQueryParametersError, which 403s every signed image.
+    """
+    test_s3_url = f"https://{settings.S3_BUCKET}.s3.{settings.S3_REGION}.amazonaws.com/test/file.jpg"
+
+    with patch('app.core.s3.settings.S3_FILE_STORAGE', True), \
+         patch('app.core.s3.get_s3_client') as mock_get_client:
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        # The pre-fix default: 30 days.
+        await get_s3_signed_url(test_s3_url, expiration=2592000)
+
+        assert mock_client.generate_presigned_url.call_args.kwargs['ExpiresIn'] == S3_MAX_PRESIGN_SECONDS
+
+
+@pytest.mark.parametrize("stored,expected", [
+    (
+        "https://b.s3.us-east-1.amazonaws.com/k.png?AWSAccessKeyId=A&Signature=S&Expires=1",
+        "https://b.s3.us-east-1.amazonaws.com/k.png",
+    ),
+    (
+        "https://b.s3.us-east-1.amazonaws.com/k.png",
+        "https://b.s3.us-east-1.amazonaws.com/k.png",
+    ),
+    ("/api/v1/uploads/help_center/k.png", "/api/v1/uploads/help_center/k.png"),
+    ("data:image/png;base64,AAAA", "data:image/png;base64,AAAA"),
+    (None, None),
+    ("", ""),
+])
+def test_strip_s3_signature(stored, expected):
+    """Signed URLs must never reach the database — clients round-trip response
+    values straight back into update payloads."""
+    assert strip_s3_signature(stored) == expected
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/agent/AgentChatPreviewPanel.vue
+++ b/frontend/src/components/agent/AgentChatPreviewPanel.vue
@@ -338,12 +338,8 @@ const photoUrl = computed(() => {
         )
     }
     
-    // Use signed URL if available (for S3)
-    if (props.customization.photo_url_signed) {
-        return props.customization.photo_url_signed
-    }
-    
-    // Absolute S3/CDN URL — use it directly
+    // Absolute S3/CDN URL — use it directly. The API signs photo_url itself, so
+    // there is no separate signed field to prefer.
     if (isAbsoluteUrl(props.customization.photo_url)) {
         return props.customization.photo_url
     }

--- a/frontend/src/components/agent/AgentDetail.vue
+++ b/frontend/src/components/agent/AgentDetail.vue
@@ -95,7 +95,6 @@ const persistAvatarMeta = async (patch: Record<string, unknown>, photoUrl?: stri
   previewCustomization.value = {
     ...previewCustomization.value,
     photo_url: updated.photo_url,
-    photo_url_signed: (updated as AgentCustomization).photo_url_signed,
     customization_metadata: updated.customization_metadata,
   }
 }

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -94,7 +94,6 @@ export interface AgentCustomization {
   id: number
   agent_id: string // UUID
   photo_url?: string
-  photo_url_signed?: string
   chat_background_color?: string
   chat_bubble_color?: string
   chat_text_color?: string

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -47,7 +47,6 @@ export interface User {
   created_at?: string
   updated_at?: string
   profile_pic?: string
-  profile_pic_url?: string
   is_online?: boolean
   last_seen?: string
 } 

--- a/frontend/src/types/widget.ts
+++ b/frontend/src/types/widget.ts
@@ -37,7 +37,6 @@ export interface AgentCustomization {
     id?: number;
     agent_id?: string;
     photo_url?: string;
-    photo_url_signed?: string;
     chat_background_color?: string;
     chat_bubble_color?: string;
     chat_text_color?: string;


### PR DESCRIPTION
Fixes #253.

Presigned URLs used a 30-day expiry. AWS caps SigV4 presigns at 7 days, so every signed image 403s for self-hosters. It never showed up on our side because botocore signs with SigV2 in `us-east-1`, which has no expiry limit.

While tracing it, found we were also storing the signed URLs: 12 of 30 `agent_customizations` rows on production hold a signature, 6 already expired. Two causes — endpoints assigned the signed value onto the ORM instance, and the customization form POSTs back the `photo_url` it was given.

## Changes

- `sign_s3_url` is sync (signing is a local HMAC, no network) and responses sign `photo_url`/`profile_pic` via `field_serializer`, so the DB keeps the bare URL. Wire format unchanged.
- `field_validator` strips signatures on write, so a client echoing one back can't store it.
- Expiry clamped to S3's 604800s max, default now 1h via `S3_PRESIGN_EXPIRY_SECONDS`.
- Cached the boto3 client (1.3ms per call vs 0.05ms for the signing itself), moved blocking boto3 calls off the event loop.
- Removed five copies of a dead `asyncio.run` property that pydantic v2 never serialized — the API advertised `photo_url_signed` but never returned it.

## Testing

Full backend suite passes (2075, +2 new). Both regression tests were checked to fail without their fix.

## Follow-ups (not in this PR)

- Backfill the 12 rows after this deploys: `UPDATE agent_customizations SET photo_url = split_part(photo_url, '?', 1) WHERE photo_url LIKE '%Signature=%';`
- `store_article_image` still bakes unsigned URLs into FAQ markdown.
- `upload_file_to_s3` creates buckets on the request path and silently falls back to local disk.

The production bucket was also world-readable — anyone could strip the query string off a signed URL for permanent access. Locked down separately (bucket policy removed, Block Public Access on); verified presigned access still works.