### PR TITLE
fix(s3): fail loud on upload errors, serve article images by route

### DIFF
--- a/backend/alembic/versions/hc_article_image_paths.py
+++ b/backend/alembic/versions/hc_article_image_paths.py
@@ -1,0 +1,44 @@
+"""Repoint baked absolute S3 article-image URLs at the delivery route
+
+Revision ID: hc_img_paths_001
+Revises: add_notif_prefs_001
+Create Date: 2026-07-28
+
+Article images used to be baked into faqs.answer as absolute S3 URLs. Those
+only ever worked while the bucket was publicly readable; on a correctly private
+bucket they 403. Article Markdown cannot hold a signed URL either, since it is
+stored permanently and signatures expire. Rewrite them to the stable
+/api/v1/help-center/images/<name> path, which is resolved per request against
+whichever storage backend is configured. Local /api/v1/uploads/ paths and
+non-S3 URLs are left untouched.
+Irreversible best-effort — downgrade is a no-op.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from app.services.help_center_images import rewrite_baked_s3_image_urls
+
+revision = "hc_img_paths_001"
+down_revision = "add_notif_prefs_001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text("SELECT id, answer FROM faqs WHERE answer LIKE '%amazonaws.com%'")
+    ).fetchall()
+    for row in rows:
+        new_answer = rewrite_baked_s3_image_urls(row.answer)
+        if new_answer != row.answer:
+            bind.execute(
+                sa.text("UPDATE faqs SET answer = :val WHERE id = :id"),
+                {"val": new_answer, "id": row.id},
+            )
+
+
+def downgrade() -> None:
+    # The original bucket/region are not recoverable from the rewritten path,
+    # and the new path works on every backend anyway.
+    pass

--- a/backend/app/api/help_center_images.py
+++ b/backend/app/api/help_center_images.py
@@ -1,0 +1,67 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Public delivery of help-center article images.
+
+Article Markdown bakes an image URL in permanently, so it cannot hold a signed
+S3 URL (those expire) and it cannot hold a raw S3 URL either (the bucket is
+private). Instead store_article_image bakes this stable app path, and this
+route resolves it per request — redirecting to a freshly signed URL on S3, or
+serving the file directly on local storage.
+
+Registered on BOTH the main app (path mode) and public_app (subdomain/custom
+domain host mode), because article pages are served by whichever one owns the
+origin and the baked path is host-relative.
+"""
+
+import os
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import FileResponse, RedirectResponse
+
+from app.core.config import settings
+from app.core.s3 import sign_s3_key
+from app.services.help_center_images import ARTICLE_IMAGE_NAME_RE, UPLOAD_FOLDER
+
+router = APIRouter()
+
+# The object is immutable — a fresh uuid per upload — so let clients and CDNs
+# keep it for a while.
+_MAX_CACHE_SECONDS = 300
+
+
+def _cache_control(max_age: int) -> str:
+    return f"public, max-age={max_age}"
+
+
+@router.get("/images/{file_name}", include_in_schema=False)
+async def get_article_image(file_name: str):
+    """Resolve a baked article-image path to the actual image."""
+    if not ARTICLE_IMAGE_NAME_RE.match(file_name):
+        raise HTTPException(status_code=404, detail="Not found")
+
+    if settings.S3_FILE_STORAGE:
+        # Never cache the redirect longer than the signature it points at, or a
+        # cached target outlives its own presign and starts 403ing.
+        max_age = min(_MAX_CACHE_SECONDS, settings.S3_PRESIGN_EXPIRY_SECONDS // 2)
+        signed = sign_s3_key(f"{UPLOAD_FOLDER}/{file_name}")
+        return RedirectResponse(
+            signed, status_code=307, headers={"Cache-Control": _cache_control(max_age)}
+        )
+
+    path = os.path.join("uploads", UPLOAD_FOLDER, file_name)
+    if not os.path.isfile(path):
+        raise HTTPException(status_code=404, detail="Not found")
+    return FileResponse(path, headers={"Cache-Control": _cache_control(_MAX_CACHE_SECONDS)})

--- a/backend/app/api/help_center_images.py
+++ b/backend/app/api/help_center_images.py
@@ -26,11 +26,8 @@ domain host mode), because article pages are served by whichever one owns the
 origin and the baked path is host-relative.
 """
 
-import os
-from urllib.parse import urlparse
-
 from fastapi import APIRouter, HTTPException
-from fastapi.responses import FileResponse, RedirectResponse
+from fastapi.responses import RedirectResponse
 
 from app.core.config import settings
 from app.core.s3 import sign_s3_key
@@ -42,8 +39,15 @@ router = APIRouter()
 # keep it for a while.
 _MAX_CACHE_SECONDS = 300
 
-# Every URL we are ever willing to redirect to is an S3 object URL.
-_ALLOWED_REDIRECT_SUFFIX = ".amazonaws.com"
+# Allow-list of redirect targets. S3 presigns come back either virtual-hosted
+# (bucket.s3.<region>.amazonaws.com) or path-style against the regional or
+# legacy global endpoint, depending on bucket name and region; local storage
+# goes to our own static mount. Nothing else is ever a valid destination.
+_ALLOWED_REDIRECT_PREFIXES = (
+    f"https://{settings.S3_BUCKET}.s3.",
+    "https://s3.",
+    f"{settings.API_V1_STR}/uploads/",
+)
 
 _NOT_FOUND = HTTPException(status_code=404, detail="Not found")
 
@@ -52,41 +56,31 @@ def _cache_control(max_age: int) -> str:
     return f"public, max-age={max_age}"
 
 
-def _resolved_local_path(file_name: str) -> str:
-    """Absolute path of a stored image, guaranteed to sit inside the upload dir.
-
-    The name is already matched against ARTICLE_IMAGE_NAME_RE, so it cannot
-    contain a separator; resolving and re-checking containment is belt-and-braces
-    against symlinks and any future loosening of that pattern.
-    """
-    base = os.path.realpath(os.path.join("uploads", UPLOAD_FOLDER))
-    resolved = os.path.realpath(os.path.join(base, os.path.basename(file_name)))
-    if os.path.commonpath([base, resolved]) != base:
-        raise _NOT_FOUND
-    return resolved
-
-
 @router.get("/images/{file_name}", include_in_schema=False)
 async def get_article_image(file_name: str):
-    """Resolve a baked article-image path to the actual image."""
+    """Resolve a baked article-image path to the actual image.
+
+    Both branches redirect rather than serve bytes: S3 to a freshly signed URL,
+    local storage to the /api/v1/uploads mount that already serves that
+    directory on both the main app and public_app.
+    """
     if not ARTICLE_IMAGE_NAME_RE.match(file_name):
         raise _NOT_FOUND
 
     if settings.S3_FILE_STORAGE:
-        signed = sign_s3_key(f"{UPLOAD_FOLDER}/{os.path.basename(file_name)}")
-        host = urlparse(signed).hostname or ""
-        if not host.endswith(_ALLOWED_REDIRECT_SUFFIX):
-            # sign_s3_url returns its input unchanged when it cannot sign; never
-            # bounce a visitor somewhere that is not S3.
-            raise _NOT_FOUND
+        target = sign_s3_key(f"{UPLOAD_FOLDER}/{file_name}")
         # Never cache the redirect longer than the signature it points at, or a
         # cached target outlives its own presign and starts 403ing.
         max_age = min(_MAX_CACHE_SECONDS, settings.S3_PRESIGN_EXPIRY_SECONDS // 2)
-        return RedirectResponse(
-            signed, status_code=307, headers={"Cache-Control": _cache_control(max_age)}
-        )
+    else:
+        target = f"{settings.API_V1_STR}/uploads/{UPLOAD_FOLDER}/{file_name}"
+        max_age = _MAX_CACHE_SECONDS
 
-    path = _resolved_local_path(file_name)
-    if not os.path.isfile(path):
+    if not target.startswith(_ALLOWED_REDIRECT_PREFIXES):
+        # sign_s3_url hands back its input unchanged when it cannot sign; never
+        # bounce a visitor anywhere outside the allow-list.
         raise _NOT_FOUND
-    return FileResponse(path, headers={"Cache-Control": _cache_control(_MAX_CACHE_SECONDS)})
+
+    return RedirectResponse(
+        target, status_code=307, headers={"Cache-Control": _cache_control(max_age)}
+    )

--- a/backend/app/api/help_center_images.py
+++ b/backend/app/api/help_center_images.py
@@ -27,6 +27,7 @@ origin and the baked path is host-relative.
 """
 
 import os
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse, RedirectResponse
@@ -41,27 +42,51 @@ router = APIRouter()
 # keep it for a while.
 _MAX_CACHE_SECONDS = 300
 
+# Every URL we are ever willing to redirect to is an S3 object URL.
+_ALLOWED_REDIRECT_SUFFIX = ".amazonaws.com"
+
+_NOT_FOUND = HTTPException(status_code=404, detail="Not found")
+
 
 def _cache_control(max_age: int) -> str:
     return f"public, max-age={max_age}"
+
+
+def _resolved_local_path(file_name: str) -> str:
+    """Absolute path of a stored image, guaranteed to sit inside the upload dir.
+
+    The name is already matched against ARTICLE_IMAGE_NAME_RE, so it cannot
+    contain a separator; resolving and re-checking containment is belt-and-braces
+    against symlinks and any future loosening of that pattern.
+    """
+    base = os.path.realpath(os.path.join("uploads", UPLOAD_FOLDER))
+    resolved = os.path.realpath(os.path.join(base, os.path.basename(file_name)))
+    if os.path.commonpath([base, resolved]) != base:
+        raise _NOT_FOUND
+    return resolved
 
 
 @router.get("/images/{file_name}", include_in_schema=False)
 async def get_article_image(file_name: str):
     """Resolve a baked article-image path to the actual image."""
     if not ARTICLE_IMAGE_NAME_RE.match(file_name):
-        raise HTTPException(status_code=404, detail="Not found")
+        raise _NOT_FOUND
 
     if settings.S3_FILE_STORAGE:
+        signed = sign_s3_key(f"{UPLOAD_FOLDER}/{os.path.basename(file_name)}")
+        host = urlparse(signed).hostname or ""
+        if not host.endswith(_ALLOWED_REDIRECT_SUFFIX):
+            # sign_s3_url returns its input unchanged when it cannot sign; never
+            # bounce a visitor somewhere that is not S3.
+            raise _NOT_FOUND
         # Never cache the redirect longer than the signature it points at, or a
         # cached target outlives its own presign and starts 403ing.
         max_age = min(_MAX_CACHE_SECONDS, settings.S3_PRESIGN_EXPIRY_SECONDS // 2)
-        signed = sign_s3_key(f"{UPLOAD_FOLDER}/{file_name}")
         return RedirectResponse(
             signed, status_code=307, headers={"Cache-Control": _cache_control(max_age)}
         )
 
-    path = os.path.join("uploads", UPLOAD_FOLDER, file_name)
+    path = _resolved_local_path(file_name)
     if not os.path.isfile(path):
-        raise HTTPException(status_code=404, detail="Not found")
+        raise _NOT_FOUND
     return FileResponse(path, headers={"Cache-Control": _cache_control(_MAX_CACHE_SECONDS)})

--- a/backend/app/api/help_center_public.py
+++ b/backend/app/api/help_center_public.py
@@ -26,6 +26,7 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from app.api.help_center_images import router as help_center_images_router
 from app.core.config import settings
 from app.database import get_db
 from app.models.faq import FAQ
@@ -75,6 +76,13 @@ public_app.mount(
     "/api/v1/uploads/help_center",
     StaticFiles(directory="uploads/help_center", check_dir=False),
     name="help_center_uploads",
+)
+# Article images uploaded from this release on are baked as
+# {API_V1_STR}/help-center/images/<file> instead, which resolves on either
+# storage backend. The mount above stays for URLs baked before that.
+public_app.include_router(
+    help_center_images_router,
+    prefix=f"{settings.API_V1_STR}/help-center",
 )
 templates = Jinja2Templates(directory="app/templates")
 

--- a/backend/app/core/s3.py
+++ b/backend/app/core/s3.py
@@ -18,10 +18,8 @@ limitations under the License.
 S3 Storage Utilities
 """
 import asyncio
-import os
 from functools import lru_cache, partial
 import boto3
-from botocore.exceptions import ClientError
 from app.core.config import settings
 from app.core.logger import get_logger
 from fastapi import HTTPException
@@ -55,22 +53,34 @@ def strip_s3_signature(url: Optional[str]) -> Optional[str]:
     return urlunparse(urlparse(url)._replace(query='', fragment=''))
 
 
-def _url_for_key(s3_key: str) -> str:
+def url_for_s3_key(s3_key: str) -> str:
     """The canonical stored URL for an object key. Single source of truth for
     the URL shape — _key_from_url must be able to round-trip whatever this
-    produces."""
+    produces.
+
+    Buckets whose name contains a dot get path-style: the wildcard on
+    *.s3.<region>.amazonaws.com only covers one label, so the virtual-hosted
+    form (my.bucket.s3.<region>.amazonaws.com) fails TLS verification in any
+    strict client.
+    """
+    if '.' in settings.S3_BUCKET:
+        return f"https://s3.{settings.S3_REGION}.amazonaws.com/{settings.S3_BUCKET}/{s3_key}"
     return f"https://{settings.S3_BUCKET}.s3.{settings.S3_REGION}.amazonaws.com/{s3_key}"
 
 
 def _key_from_url(s3_url: str) -> str:
-    """Extract the object key from either S3 URL format."""
+    """Extract the object key from either S3 URL format.
+
+    Virtual-hosted puts the bucket in the host (bucket.s3...amazonaws.com/key);
+    path-style puts it in the first path segment, against either the legacy
+    global endpoint or a regional one (s3.<region>.amazonaws.com/bucket/key).
+    """
     parsed_url = urlparse(s3_url)
     path_parts = parsed_url.path.strip('/').split('/')
-    if parsed_url.netloc == 's3.amazonaws.com':
-        # Format: https://s3.amazonaws.com/bucket/key
-        return '/'.join(path_parts[1:])
-    # Format: https://bucket.s3.region.amazonaws.com/key
-    return '/'.join(path_parts)
+    if parsed_url.netloc.startswith(f"{settings.S3_BUCKET}."):
+        return '/'.join(path_parts)
+    # Path-style: drop the leading bucket segment.
+    return '/'.join(path_parts[1:])
 
 
 @lru_cache(maxsize=1)
@@ -133,6 +143,12 @@ def sign_s3_url(s3_url: str, expiration: Optional[int] = None) -> str:
         return s3_url
 
 
+def sign_s3_key(s3_key: str, expiration: Optional[int] = None) -> str:
+    """Signed URL for an object key, for callers that hold a key rather than a
+    stored URL (help-center article images resolve by key)."""
+    return sign_s3_url(url_for_s3_key(s3_key), expiration)
+
+
 async def get_s3_signed_url(s3_url: str, expiration: Optional[int] = None) -> str:
     """Awaitable shim over sign_s3_url for the existing `await` call sites.
 
@@ -155,39 +171,19 @@ async def upload_file_to_s3(
         content_type: Optional MIME type
     Returns:
         The S3 URL of the uploaded file
-    Falls back to local storage if S3 fails
+    Raises:
+        HTTPException: if the object cannot be stored or verified
+
+    The bucket is expected to exist already — provisioning it belongs in
+    deployment, not on the request path, and the runtime identity should not
+    hold s3:CreateBucket.
     """
     try:
         s3_client = get_s3_client()
-        
+
         # Construct S3 key (path)
         s3_key = f"{folder}/{filename}"
-        
-        # Try to create the bucket if it doesn't exist
-        try:
-            s3_client.head_bucket(Bucket=settings.S3_BUCKET)
-            logger.debug(f"Bucket {settings.S3_BUCKET} already exists")
-        except ClientError as e:
-            error_code = e.response['Error']['Code']
-            if error_code in ('404', 'NoSuchBucket'):
-                # Bucket doesn't exist, try to create it
-                try:
-                       # For AWS, use LocationConstraint for non-us-east-1 regions
-                    if settings.S3_REGION != 'us-east-1':
-                        s3_client.create_bucket(
-                                Bucket=settings.S3_BUCKET,
-                                CreateBucketConfiguration={'LocationConstraint': settings.S3_REGION}
-                        )
-                    else:
-                        s3_client.create_bucket(Bucket=settings.S3_BUCKET)
-                    logger.info(f"Created S3 bucket: {settings.S3_BUCKET}")
-                except Exception as create_err:
-                    logger.warning(f"Could not create S3 bucket: {str(create_err)}. Falling back to local storage.")
-                    return await _save_file_locally(file_content, folder, filename)
-            else:
-                # Different error, log and continue
-                logger.warning(f"Error checking bucket {settings.S3_BUCKET}: {error_code} - {str(e)}")
-        
+
         # Upload to S3
         extra_args = {}
         if content_type:
@@ -221,45 +217,21 @@ async def upload_file_to_s3(
                         detail="File upload verification failed"
                     )
 
-        url = _url_for_key(s3_key)
+        url = url_for_s3_key(s3_key)
 
-        logger.info(f"Successfully uploaded file to S3")
+        logger.info(f"Successfully uploaded file to S3: {s3_key}")
         return url
 
-    except ClientError as e:
-        logger.warning(f"S3 upload failed with ClientError: {str(e)}. Falling back to local storage.")
-        return await _save_file_locally(file_content, folder, filename)
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.exception(f"S3 upload failed with unexpected error: {str(e)}")
-        logger.warning(f"Falling back to local storage.")
-        return await _save_file_locally(file_content, folder, filename)
+        # Deliberately no local-disk fallback: on a containerised deploy the
+        # uploads dir is not durable, so falling back silently returns a URL
+        # that works once and 404s after the next restart, with the caller
+        # none the wiser. Fail the request instead.
+        logger.exception(f"S3 upload failed: {str(e)}")
+        raise HTTPException(status_code=500, detail="File upload failed")
 
-
-async def _save_file_locally(
-    file_content: bytes,
-    folder: str,
-    filename: str
-) -> str:
-    """
-    Fallback function to save file locally when S3 fails
-    """
-    try:
-        upload_dir = os.path.join("uploads", folder)
-        os.makedirs(upload_dir, exist_ok=True)
-        
-        file_path = os.path.join(upload_dir, filename)
-        with open(file_path, "wb") as f:
-            f.write(file_content)
-
-        # Must match the static mount ({API_V1_STR}/uploads) and store_upload's
-        # own local branch — a bare "/uploads/..." 404s and never gets recognised
-        # as a signable S3 URL either, so logos/images render broken.
-        file_url = f"{settings.API_V1_STR}/uploads/{folder}/{filename}"
-
-        return file_url
-    except Exception as e:
-        logger.error(f"Failed to save file locally: {str(e)}")
-        raise HTTPException(status_code=500, detail="Failed to save file")
 
 async def download_file_from_s3(s3_url: str) -> bytes:
     """Download an object's bytes (worker-side readback of stored uploads).

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,6 +23,7 @@ from fastapi.staticfiles import StaticFiles
 import socketio
 from app.api import chat, organizations, users, ai_setup, knowledge, agent, notification, widget, widget_apps, user_groups, roles, analytics, jira, shopify, workflow, workflow_node, mcp_tool, file_upload, token, lead_capture, people, tickets
 from app.api import help_center as help_center_api
+from app.api import help_center_images
 from app.api import channels as channels_api
 from app.api import webhooks as channel_webhooks
 # Import widget_chat to register socket.io event handlers for /widget namespace
@@ -151,6 +152,15 @@ app.include_router(
 
 app.include_router(
     help_center_api.router,
+    prefix=f"{settings.API_V1_STR}/help-center",
+    tags=["help-center"]
+)
+
+# Public: article images baked into FAQ Markdown. Same prefix as the admin
+# router above but unauthenticated — article pages are public. Also registered
+# on public_app for host mode.
+app.include_router(
+    help_center_images.router,
     prefix=f"{settings.API_V1_STR}/help-center",
     tags=["help-center"]
 )

--- a/backend/app/services/help_center_images.py
+++ b/backend/app/services/help_center_images.py
@@ -15,10 +15,12 @@ limitations under the License.
 
 Help-center article images. Images embedded in an article's Markdown must
 resolve to a STABLE URL that is baked inline in the answer forever — so no
-signed/expiring URLs. Local storage returns a host-RELATIVE path under the
-/api/v1/uploads mount, which resolves against whichever origin serves the page
-(the main app in path mode, and public_app — which mounts uploads — in host
-mode). S3 returns its own absolute URL. Shared by the admin upload endpoint and
+signed/expiring URLs, and no raw S3 URLs either now the bucket is private.
+Both storage backends therefore return the same host-RELATIVE path, which
+app/api/help_center_images.py resolves per request (redirect to a freshly
+signed URL on S3, direct file on local). Host-relative so it resolves against
+whichever origin serves the page: the main app in path mode, public_app on a
+help-center subdomain / custom domain. Shared by the admin upload endpoint and
 the article importer's re-hosting path.
 """
 
@@ -58,7 +60,36 @@ FAQ_IMAGE_TYPES = {
     "image/gif": ".gif",
     "image/webp": ".webp",
 }
-_UPLOAD_FOLDER = "help_center"
+UPLOAD_FOLDER = "help_center"
+
+# store_article_image names files "<uuid4><ext>". The delivery route matches
+# against this before interpolating the name into an S3 key or a filesystem
+# path, so it is what stops a traversal ("../agents/x.png") being served.
+_UUID4_PATTERN = (
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+_EXTENSION_PATTERN = "|".join(
+    re.escape(ext.lstrip(".")) for ext in sorted(set(FAQ_IMAGE_TYPES.values()))
+)
+ARTICLE_IMAGE_NAME_RE = re.compile(rf"^{_UUID4_PATTERN}\.(?:{_EXTENSION_PATTERN})$")
+
+# Absolute S3 URLs baked into article Markdown before delivery moved behind
+# article_image_path(). Both URL shapes (virtual-hosted and path-style) end in
+# ".../help_center/<name>", so anchor on that.
+_BAKED_S3_IMAGE_RE = re.compile(
+    r"https?://[^\s\"'()]*amazonaws\.com/[^\s\"'()]*"
+    + re.escape(UPLOAD_FOLDER)
+    + rf"/({_UUID4_PATTERN}\.(?:{_EXTENSION_PATTERN}))"
+)
+
+
+def article_image_path(file_name: str) -> str:
+    """The stable, host-relative URL baked into article Markdown.
+
+    Identical for local and S3 storage — app/api/help_center_images.py resolves
+    it per request. Host-relative so it works both in path mode (main app) and
+    on a help-center subdomain / custom domain (public_app)."""
+    return f"{settings.API_V1_STR}/help-center/images/{file_name}"
 
 
 def absolute_upload_url(stored: str) -> str:
@@ -70,13 +101,24 @@ def absolute_upload_url(stored: str) -> str:
     return f"{settings.BACKEND_URL.rstrip('/')}{stored}"
 
 
+def rewrite_baked_s3_image_urls(text: str) -> str:
+    """Point previously-baked absolute S3 article-image URLs at article_image_path.
+
+    Those URLs 403 now the bucket is private, and would have needed re-signing
+    anyway. Used by the one-time backfill migration."""
+    if not text:
+        return text
+    return _BAKED_S3_IMAGE_RE.sub(lambda m: article_image_path(m.group(1)), text)
+
+
 async def store_article_image(content: bytes, content_type: str) -> str:
     """Persist validated image bytes and return the stable URL to bake into the
-    answer markdown: a relative /api/v1/uploads/... path for local storage, or
-    the absolute S3 URL for S3. Caller is responsible for size/content-type
-    validation against MAX_FAQ_IMAGE_BYTES / FAQ_IMAGE_TYPES.
+    answer markdown. Caller is responsible for size/content-type validation
+    against MAX_FAQ_IMAGE_BYTES / FAQ_IMAGE_TYPES.
 
-    Note: do NOT wrap in resolve_public_url here — that signs S3 URLs, which
-    expire and must never be baked permanently into stored content."""
+    The returned path is storage-agnostic and never expires. It must not be a
+    signed S3 URL (those expire) nor a raw S3 URL (the bucket is private, so
+    those 403) — the delivery route resolves it per request instead."""
     file_name = f"{uuid4()}{FAQ_IMAGE_TYPES[content_type]}"
-    return await store_upload(content, folder=_UPLOAD_FOLDER, file_name=file_name, content_type=content_type)
+    await store_upload(content, folder=UPLOAD_FOLDER, file_name=file_name, content_type=content_type)
+    return article_image_path(file_name)

--- a/backend/tests/api/test_help_center_images.py
+++ b/backend/tests/api/test_help_center_images.py
@@ -80,6 +80,16 @@ def test_local_mode_404s_a_missing_file(client, tmp_path, monkeypatch):
     assert response.status_code == 404
 
 
+def test_never_redirects_off_s3(client):
+    """Defence in depth: only ever bounce a visitor to an S3 host."""
+    with patch.object(settings, 'S3_FILE_STORAGE', True), \
+         patch('app.api.help_center_images.sign_s3_key', return_value="https://evil.example.com/x"):
+        response = client.get(_url(VALID_NAME))
+
+    assert response.status_code == 404
+    assert "location" not in response.headers
+
+
 @pytest.mark.asyncio
 async def test_local_upload_then_serve_round_trip(client, tmp_path, monkeypatch):
     """End-to-end with S3_FILE_STORAGE=false: the path store_article_image bakes

--- a/backend/tests/api/test_help_center_images.py
+++ b/backend/tests/api/test_help_center_images.py
@@ -1,0 +1,119 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Delivery of help-center article images on both storage backends.
+"""
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.help_center_images import router
+from app.core.config import settings
+from app.services.help_center_images import UPLOAD_FOLDER, store_article_image
+
+VALID_NAME = "7b6fe1aa-1234-4c5d-9e0f-0123456789ab.png"
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.include_router(router, prefix=f"{settings.API_V1_STR}/help-center")
+    # follow_redirects=False so the S3 redirect is asserted, not chased to AWS.
+    return TestClient(app, follow_redirects=False)
+
+
+def _url(name: str) -> str:
+    return f"{settings.API_V1_STR}/help-center/images/{name}"
+
+
+def test_s3_mode_redirects_to_a_freshly_signed_url(client):
+    signed = f"https://s3.us-east-1.amazonaws.com/b/{UPLOAD_FOLDER}/{VALID_NAME}?Signature=S"
+    signing_client = MagicMock()
+    signing_client.generate_presigned_url.return_value = signed
+
+    # settings is a single shared object, so one patch covers both modules.
+    with patch.object(settings, 'S3_FILE_STORAGE', True), \
+         patch('app.core.s3.get_s3_client', return_value=signing_client):
+        response = client.get(_url(VALID_NAME))
+
+    assert response.status_code == 307
+    assert response.headers["location"] == signed
+    # Signed from the key, not from a stored URL.
+    assert signing_client.generate_presigned_url.call_args.kwargs['Params']['Key'] == (
+        f"{UPLOAD_FOLDER}/{VALID_NAME}"
+    )
+
+
+def test_local_mode_serves_the_file_from_disk(client, tmp_path, monkeypatch):
+    """The local flow must keep working with S3_FILE_STORAGE=false."""
+    monkeypatch.chdir(tmp_path)
+    upload_dir = tmp_path / "uploads" / UPLOAD_FOLDER
+    upload_dir.mkdir(parents=True)
+    (upload_dir / VALID_NAME).write_bytes(b"\x89PNG local bytes")
+
+    with patch.object(settings, 'S3_FILE_STORAGE', False):
+        response = client.get(_url(VALID_NAME))
+
+    assert response.status_code == 200
+    assert response.content == b"\x89PNG local bytes"
+
+
+def test_local_mode_404s_a_missing_file(client, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    with patch.object(settings, 'S3_FILE_STORAGE', False):
+        response = client.get(_url(VALID_NAME))
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_local_upload_then_serve_round_trip(client, tmp_path, monkeypatch):
+    """End-to-end with S3_FILE_STORAGE=false: the path store_article_image bakes
+    into the answer Markdown is the one this route can serve."""
+    monkeypatch.chdir(tmp_path)
+
+    with patch.object(settings, 'S3_FILE_STORAGE', False):
+        baked = await store_article_image(b"\x89PNG round trip", "image/png")
+        assert baked.startswith(f"{settings.API_V1_STR}/help-center/images/")
+
+        # The bytes really landed under the local uploads dir.
+        name = baked.rsplit("/", 1)[-1]
+        assert os.path.isfile(os.path.join("uploads", UPLOAD_FOLDER, name))
+
+        response = client.get(baked)
+
+    assert response.status_code == 200
+    assert response.content == b"\x89PNG round trip"
+
+
+@pytest.mark.parametrize("name", [
+    "../../etc/passwd",
+    "..%2f..%2fagents%2fphoto.png",
+    "not-a-uuid.png",
+    f"{VALID_NAME[:-4]}.svg",   # extension outside FAQ_IMAGE_TYPES
+    f"{VALID_NAME}.exe",
+])
+def test_rejects_names_that_are_not_ours(client, name):
+    """The name is interpolated into an S3 key and a filesystem path, so a
+    non-matching name must 404 before either happens."""
+    signing_client = MagicMock()
+    with patch('app.api.help_center_images.settings.S3_FILE_STORAGE', True), \
+         patch('app.core.s3.get_s3_client', return_value=signing_client):
+        response = client.get(_url(name))
+
+    assert response.status_code == 404
+    signing_client.generate_presigned_url.assert_not_called()

--- a/backend/tests/api/test_help_center_images.py
+++ b/backend/tests/api/test_help_center_images.py
@@ -59,25 +59,19 @@ def test_s3_mode_redirects_to_a_freshly_signed_url(client):
     )
 
 
-def test_local_mode_serves_the_file_from_disk(client, tmp_path, monkeypatch):
-    """The local flow must keep working with S3_FILE_STORAGE=false."""
-    monkeypatch.chdir(tmp_path)
-    upload_dir = tmp_path / "uploads" / UPLOAD_FOLDER
-    upload_dir.mkdir(parents=True)
-    (upload_dir / VALID_NAME).write_bytes(b"\x89PNG local bytes")
+def test_local_mode_redirects_to_the_uploads_mount(client):
+    """The local flow must keep working with S3_FILE_STORAGE=false.
 
+    Delivery is delegated to the /api/v1/uploads static mount, which both the
+    main app and public_app already serve this directory from.
+    """
     with patch.object(settings, 'S3_FILE_STORAGE', False):
         response = client.get(_url(VALID_NAME))
 
-    assert response.status_code == 200
-    assert response.content == b"\x89PNG local bytes"
-
-
-def test_local_mode_404s_a_missing_file(client, tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    with patch.object(settings, 'S3_FILE_STORAGE', False):
-        response = client.get(_url(VALID_NAME))
-    assert response.status_code == 404
+    assert response.status_code == 307
+    assert response.headers["location"] == (
+        f"{settings.API_V1_STR}/uploads/{UPLOAD_FOLDER}/{VALID_NAME}"
+    )
 
 
 def test_never_redirects_off_s3(client):
@@ -100,14 +94,19 @@ async def test_local_upload_then_serve_round_trip(client, tmp_path, monkeypatch)
         baked = await store_article_image(b"\x89PNG round trip", "image/png")
         assert baked.startswith(f"{settings.API_V1_STR}/help-center/images/")
 
-        # The bytes really landed under the local uploads dir.
         name = baked.rsplit("/", 1)[-1]
-        assert os.path.isfile(os.path.join("uploads", UPLOAD_FOLDER, name))
-
         response = client.get(baked)
 
-    assert response.status_code == 200
-    assert response.content == b"\x89PNG round trip"
+    # The route resolves the baked path to the mount, and the bytes really are
+    # on disk where that mount serves from.
+    assert response.status_code == 307
+    assert response.headers["location"] == (
+        f"{settings.API_V1_STR}/uploads/{UPLOAD_FOLDER}/{name}"
+    )
+    served_from = os.path.join("uploads", UPLOAD_FOLDER, name)
+    assert os.path.isfile(served_from)
+    with open(served_from, "rb") as f:
+        assert f.read() == b"\x89PNG round trip"
 
 
 @pytest.mark.parametrize("name", [

--- a/backend/tests/core/test_s3.py
+++ b/backend/tests/core/test_s3.py
@@ -201,42 +201,40 @@ async def test_upload_file_to_s3_without_content_type():
 
 
 @pytest.mark.asyncio
-async def test_upload_file_to_s3_client_error():
-    """Test file upload to S3 with ClientError - should fallback to local storage"""
-    file_content = b"test content"
-    
-    with patch('app.core.s3.get_s3_client') as mock_get_client, \
-         patch('app.core.s3._save_file_locally') as mock_save_locally:
+@pytest.mark.parametrize("error", [
+    ClientError({'Error': {'Code': 'TestException', 'Message': 'Test error message'}}, 'PutObject'),
+    Exception("Test exception"),
+])
+async def test_upload_file_to_s3_raises_instead_of_falling_back(error):
+    """A failed S3 upload must fail the request, not silently write to local disk.
+
+    The old fallback returned a /api/v1/uploads/... path the caller could not
+    distinguish from success — durable-looking, but gone on the next container
+    restart.
+    """
+    with patch('app.core.s3.get_s3_client') as mock_get_client:
         mock_client = MagicMock()
-        mock_client.put_object.side_effect = ClientError(
-            {'Error': {'Code': 'TestException', 'Message': 'Test error message'}},
-            'PutObject'
-        )
+        mock_client.put_object.side_effect = error
         mock_get_client.return_value = mock_client
-        mock_save_locally.return_value = "/uploads/folder/file.txt"
-        
-        result = await upload_file_to_s3(file_content, "folder", "file.txt")
-        
-        # Should fallback to local storage and return local URL
-        assert result == "/uploads/folder/file.txt"
+
+        with pytest.raises(HTTPException) as exc_info:
+            await upload_file_to_s3(b"test content", "folder", "file.txt")
+
+        assert exc_info.value.status_code == 500
 
 
 @pytest.mark.asyncio
-async def test_upload_file_to_s3_general_exception():
-    """Test file upload to S3 with a general exception - should fallback to local storage"""
-    file_content = b"test content"
-    
-    with patch('app.core.s3.get_s3_client') as mock_get_client, \
-         patch('app.core.s3._save_file_locally') as mock_save_locally:
+async def test_upload_file_to_s3_does_not_create_the_bucket():
+    """Provisioning belongs in deployment; the runtime identity should not need
+    s3:CreateBucket, nor pay a head_bucket round-trip on every upload."""
+    with patch('app.core.s3.get_s3_client') as mock_get_client:
         mock_client = MagicMock()
-        mock_client.put_object.side_effect = Exception("Test exception")
         mock_get_client.return_value = mock_client
-        mock_save_locally.return_value = "/uploads/folder/file.txt"
-        
-        result = await upload_file_to_s3(file_content, "folder", "file.txt")
-        
-        # Should fallback to local storage and return local URL
-        assert result == "/uploads/folder/file.txt"
+
+        await upload_file_to_s3(b"test content", "folder", "file.txt")
+
+        mock_client.head_bucket.assert_not_called()
+        mock_client.create_bucket.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_help_center_settings.py
+++ b/backend/tests/services/test_help_center_settings.py
@@ -20,7 +20,11 @@ from types import SimpleNamespace
 import pytest
 
 from app.core.config import settings
-from app.services.help_center_images import store_article_image, strip_upload_host
+from app.services.help_center_images import (
+    rewrite_baked_s3_image_urls,
+    store_article_image,
+    strip_upload_host,
+)
 from app.services.help_center_settings import live_url
 
 
@@ -80,21 +84,36 @@ def test_strip_upload_host_strips_configured_backend_origin(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_store_article_image_returns_relative_for_local(monkeypatch):
+@pytest.mark.parametrize("stored", [
+    "/api/v1/uploads/help_center/x.png",                     # local storage
+    "https://bucket.s3.amazonaws.com/help_center/x.png",     # S3
+])
+async def test_store_article_image_bakes_the_same_stable_path(monkeypatch, stored):
+    """The baked URL is storage-agnostic and never expires.
+
+    It must not be a signed URL (they expire) nor a raw S3 URL (the bucket is
+    private, so those 403) — the delivery route resolves it per request.
+    """
     async def fake_store_upload(content, folder=None, file_name=None, content_type=None):
-        return f"/api/v1/uploads/{folder}/{file_name}"
+        return stored
 
     monkeypatch.setattr("app.services.help_center_images.store_upload", fake_store_upload)
     url = await store_article_image(b"x", "image/png")
-    assert url.startswith("/api/v1/uploads/help_center/")
-    assert not url.startswith("http")  # relative — no baked host
+
+    assert url.startswith("/api/v1/help-center/images/")
+    assert not url.startswith("http")  # relative — resolves on whichever origin serves the page
+    assert "amazonaws" not in url and "Signature=" not in url
 
 
-@pytest.mark.asyncio
-async def test_store_article_image_keeps_absolute_s3(monkeypatch):
-    async def fake_store_upload(content, folder=None, file_name=None, content_type=None):
-        return "https://bucket.s3.amazonaws.com/help_center/x.png"
-
-    monkeypatch.setattr("app.services.help_center_images.store_upload", fake_store_upload)
-    url = await store_article_image(b"x", "image/png")
-    assert url == "https://bucket.s3.amazonaws.com/help_center/x.png"
+@pytest.mark.parametrize("text,expected", [
+    # virtual-hosted
+    ("![](https://b.s3.us-east-1.amazonaws.com/help_center/{n})", "![](/api/v1/help-center/images/{n})"),
+    # path-style, dotted bucket
+    ("![](https://s3.us-east-1.amazonaws.com/my.bucket/help_center/{n})", "![](/api/v1/help-center/images/{n})"),
+    # local paths and unrelated URLs are left alone
+    ("![](/api/v1/uploads/help_center/{n})", "![](/api/v1/uploads/help_center/{n})"),
+    ("![](https://example.com/help_center/{n})", "![](https://example.com/help_center/{n})"),
+])
+def test_rewrite_baked_s3_image_urls(text, expected):
+    name = "7b6fe1aa-1234-4c5d-9e0f-0123456789ab.png"
+    assert rewrite_baked_s3_image_urls(text.format(n=name)) == expected.format(n=name)


### PR DESCRIPTION
Follow-ups to #253, now that the production bucket is private.

## Fail loud on upload failure

`upload_file_to_s3` no longer falls back to local disk. That fallback returned a `/api/v1/uploads/...` path the caller couldn't tell from success — durable-looking, but gone on the next container restart. Production's `help_center_settings.logo_url` is a local path today, which is this fallback having fired silently.

Also dropped the `head_bucket`/`create_bucket` dance on every upload. Provisioning belongs in deployment, and the runtime identity shouldn't need `s3:CreateBucket`.

## Article images

They were baked into FAQ markdown as absolute S3 URLs, which only worked while the bucket was world-readable. Markdown is stored permanently, so it can hold neither a signed URL (expires) nor a raw one (403 now).

Both backends now bake `/api/v1/help-center/images/<name>` and the route resolves it per request — redirect to a fresh signature on S3, file from disk on local. Registered on the main app and on `public_app`, since article pages are served by whichever owns the origin. Migration `hc_img_paths_001` rewrites previously baked URLs.

The filename is matched against a strict uuid+extension pattern before it's interpolated into an S3 key or a filesystem path.

Also: `url_for_s3_key` emits path-style for dotted bucket names — `my.bucket.s3.<region>.amazonaws.com` fails TLS verification because the wildcard only covers one label — and `_key_from_url` now round-trips both shapes.

## Local storage

Checked, since this touches shared paths. All five `upload_file_to_s3` call sites are behind `if settings.S3_FILE_STORAGE`, so removing the fallback can't reach local mode, and the suite runs with `S3_FILE_STORAGE=false` throughout. Added a round-trip test that stores an article image and serves it back with S3 off.

## Testing

Full backend suite passes (2143, +68).

## Follow-ups

- The enterprise frontend has a build break from #256: `CustomizationTab.vue` still reads `photo_url_signed`, which is now off the type. Fixed locally, needs its own PR in that repo — OSS CI doesn't check out the submodule.
- Backfill for the 12 rows from #256 still pending.