### PR TITLE
fix(backfill): agent_sessions is in the ai schema

### DIFF
--- a/backend/scripts/encrypt_chat_at_rest.py
+++ b/backend/scripts/encrypt_chat_at_rest.py
@@ -55,8 +55,10 @@ TARGETS = (
     ("session_to_agents", "session_id",
      ("transfer_description", "end_chat_description", "ticket_summary",
       "ticket_description"), TEXT),
-    # The agno agent memory blob.
-    ("agent_sessions", "session_id", ("memory",), JSON),
+    # The agno agent memory blob. agno's PostgresStorage defaults to the "ai"
+    # schema, and app.agents.encrypted_storage does not override it, so the table
+    # is ai.agent_sessions — schema-qualified here or to_regclass won't find it.
+    ("ai.agent_sessions", "session_id", ("memory",), JSON),
 )
 
 


### PR DESCRIPTION
Follow-up to #259.

agno's `PostgresStorage` defaults to the `ai` schema and `encrypted_storage` doesn't override it, so the agent-memory table is `ai.agent_sessions`. The backfill script referenced it unqualified, so `to_regclass` never found it and every agent-memory transcript was silently skipped.

Caught during the prod backfill (785 transcripts were being skipped). Schema-qualified the target; re-ran and all rows encrypted. The runtime app code was always correct — agno handles the schema — only the standalone backfill script had the gap.
