### PR TITLE
Stop shipping a working ENCRYPTION_KEY, fail startup on public secrets

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,9 +22,11 @@ BACKEND_URL=http://localhost:8000
 HELP_CENTER_PUBLIC_MODE=path
 
 # JWT Configuration
-# Generate each with: openssl rand -hex 32
 # These sign your auth and conversation tokens - anyone who knows them can forge
-# tokens for any user, so never ship the placeholder values below to a real deployment.
+# tokens for any user, so the placeholders below must be replaced. Outside
+# ENVIRONMENT=development the app refuses to start while they are still in place.
+# Generate each (64 hex characters) with:
+#   openssl rand -hex 32
 JWT_SECRET_KEY=your_jwt_secret_key_here
 JWT_ALGORITHM=HS256
 CONVERSATION_SECRET_KEY=your_conversation_secret_key_here
@@ -32,9 +34,25 @@ CONVERSATION_SECRET_KEY=your_conversation_secret_key_here
 # Encryption and Redis
 # REQUIRED outside development: encrypts API keys, provider/OAuth credentials, chat
 # messages, session summaries and agent memory at rest. Losing or changing it makes
-# existing data unreadable, so back it up separately from the database. Generate with:
+# existing data unreadable, so back it up separately from the database.
+#
+# The value is a Fernet key that has been base64-encoded a second time: a
+# 60-character string ending in '='. Generate one with either of:
 #   python -c "import base64;from cryptography.fernet import Fernet;print(base64.b64encode(Fernet.generate_key()).decode())"
+#   openssl rand -base64 32 | tr '+/' '-_' | tr -d '\n' | base64
+#
+# Leaving the placeholder below in place means: outside development the app
+# refuses to start; in development it generates a throwaway key on every boot,
+# so anything encrypted before a restart becomes unreadable after it.
 ENCRYPTION_KEY=your_fernet_encryption_key_here
+
+# Escape hatch for deployments created before ENCRYPTION_KEY had to be set, whose
+# data is encrypted under the old public default. It downgrades the startup error
+# to a warning so those instances still boot. Anyone with a copy of the database
+# can read their conversations and stored credentials, so treat it as temporary.
+# Moving off the old key means re-encrypting what it wrote, not just swapping the
+# value - see the key-id rotation note at the top of app/core/encryption.py.
+# ALLOW_INSECURE_ENCRYPTION_KEY=false
 REDIS_ENABLED=true
 REDIS_URL=redis://localhost:6379/0
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,7 +34,7 @@ CONVERSATION_SECRET_KEY=your_conversation_secret_key_here
 # messages, session summaries and agent memory at rest. Losing or changing it makes
 # existing data unreadable, so back it up separately from the database. Generate with:
 #   python -c "import base64;from cryptography.fernet import Fernet;print(base64.b64encode(Fernet.generate_key()).decode())"
-ENCRYPTION_KEY=RFQ4SzhyRTVYdGtsLUxsc25SaDB0QlZpbTdQRmlVRlpsZUlCaFRlU2Vxbz0=
+ENCRYPTION_KEY=your_fernet_encryption_key_here
 REDIS_ENABLED=true
 REDIS_URL=redis://localhost:6379/0
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -67,6 +67,11 @@ class Settings(BaseSettings):
     # check_secret_configuration can audit it, hence no default: unset is itself
     # one of the states that audit flags.
     ENCRYPTION_KEY: str = os.getenv("ENCRYPTION_KEY", "")
+    # Downgrades the public-default ENCRYPTION_KEY startup error to a warning, for
+    # deployments whose existing data is encrypted under that key. See
+    # verify_secret_configuration.
+    ALLOW_INSECURE_ENCRYPTION_KEY: bool = os.getenv(
+        "ALLOW_INSECURE_ENCRYPTION_KEY", "false").lower() == "true"
 
     # SMTP Settings
     SMTP_SERVER: str = os.getenv("SMTP_SERVER", "smtp.gmail.com")
@@ -276,33 +281,83 @@ _PLACEHOLDER_VALUES = {
     "your_fernet_encryption_key_here",
 }
 
+# Canonical hint for producing an ENCRYPTION_KEY. Lives here rather than in
+# app.core.encryption because that module imports this one, and the two error
+# paths (missing key at load, public key at startup) must not drift apart.
+ENCRYPTION_KEY_HINT = (
+    'python -c "import base64;from cryptography.fernet import Fernet;'
+    'print(base64.b64encode(Fernet.generate_key()).decode())"'
+)
+
+# Shell one-liner producing a real value for each secret, quoted in the startup
+# error so the fix does not require going and finding the docs.
+_GENERATION_HINTS = {
+    "SECRET_KEY": "openssl rand -hex 32",
+    "CONVERSATION_SECRET_KEY": "openssl rand -hex 32",
+    "ENCRYPTION_KEY": ENCRYPTION_KEY_HINT,
+}
+
+# The env var name behind each setting, since they differ for the JWT secrets and
+# the error is only actionable if it names what the operator actually sets.
+_ENV_VAR_NAMES = {
+    "SECRET_KEY": "JWT_SECRET_KEY",
+    "CONVERSATION_SECRET_KEY": "CONVERSATION_SECRET_KEY",
+    "ENCRYPTION_KEY": "ENCRYPTION_KEY",
+}
+
 
 def check_secret_configuration(config: Settings = settings) -> list[str]:
-    """Warn when auth/encryption secrets are missing or still at their public
-    defaults outside development. Returns the names of the offending settings.
+    """Names of the auth/encryption secrets that are missing or still at a public
+    default/placeholder. Empty in development, which runs on the defaults on purpose.
 
-    This warns rather than refusing to boot: existing self-hosted deployments may
-    still be running on the default ENCRYPTION_KEY, and their stored credentials
-    are encrypted under it, so failing hard would lock them out of their own data.
+    Pure audit: verify_secret_configuration decides what to do about the result.
     """
     if config.ENVIRONMENT == "development":
         return []
 
-    insecure = [
+    return [
         name for name, default in _INSECURE_DEFAULTS.items()
         if not getattr(config, name, None)
         or getattr(config, name) == default
         or getattr(config, name) in _PLACEHOLDER_VALUES
     ]
 
-    if insecure:
-        logger.warning(
-            "INSECURE CONFIGURATION: %s still set to the public default/placeholder "
-            "value. Anyone can forge tokens or decrypt stored credentials. Generate "
-            "real values (openssl rand -hex 32 for the secret keys, "
-            "Fernet.generate_key() for ENCRYPTION_KEY) and restart. Note that changing "
-            "ENCRYPTION_KEY makes already-encrypted credentials unreadable.",
-            ", ".join(insecure),
-        )
 
-    return insecure
+def verify_secret_configuration(config: Settings = settings) -> None:
+    """Refuse to start on secrets anyone can look up in this repo.
+
+    Every value in _INSECURE_DEFAULTS and _PLACEHOLDER_VALUES is public, so a
+    deployment using one has no auth boundary at all — tokens can be forged and
+    stored credentials decrypted by anyone. A warning was not enough: it scrolls
+    past in the boot log and the deployment stays exposed indefinitely.
+
+    ENCRYPTION_KEY alone gets an escape hatch. An instance predating the required
+    key has real data encrypted under the public one, and refusing to boot would
+    lock it out of that data — worse than the exposure it already lives with.
+    Rotating a JWT secret only ends sessions, so those get no exemption.
+    """
+    insecure = check_secret_configuration(config)
+
+    if "ENCRYPTION_KEY" in insecure and config.ALLOW_INSECURE_ENCRYPTION_KEY:
+        logger.warning(
+            "ENCRYPTION_KEY is the public default and ALLOW_INSECURE_ENCRYPTION_KEY "
+            "is set, so startup continues. Conversations and stored credentials in "
+            "this database can be decrypted by anyone who has a copy of it. Generate "
+            "a real key (%s), re-encrypt what the old key wrote, then unset this.",
+            ENCRYPTION_KEY_HINT,
+        )
+        insecure = [name for name in insecure if name != "ENCRYPTION_KEY"]
+
+    if not insecure:
+        return
+
+    fixes = "\n".join(
+        f"  {_ENV_VAR_NAMES[name]}=$({_GENERATION_HINTS[name]})" for name in insecure
+    )
+    raise RuntimeError(
+        f"Refusing to start: {', '.join(insecure)} " +
+        ("is" if len(insecure) == 1 else "are") +
+        " unset or still set to a value published in this repository, so anyone "
+        "can forge tokens or decrypt stored data. Set real values and restart:\n"
+        f"{fixes}"
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -17,7 +17,7 @@ limitations under the License.
 import os
 import json
 from pydantic_settings import BaseSettings
-from typing import List, Optional
+from typing import List, NamedTuple, Optional
 from dotenv import load_dotenv
 from pathlib import Path
 from pydantic import field_validator
@@ -264,14 +264,47 @@ settings = Settings()
 logger = get_logger(__name__)
 
 
-# Values that were once shipped in the repo (config defaults / .env.example) and so
-# are public: a deployment still using them can have its tokens forged and its
-# stored credentials decrypted by anyone. They no longer appear as defaults above,
-# but they stay listed here to catch deployments that copied them before that.
-_INSECURE_DEFAULTS = {
-    "SECRET_KEY": "your-secret-key",
-    "CONVERSATION_SECRET_KEY": "your-conversation-secret-key",
-    "ENCRYPTION_KEY": "RFQ4SzhyRTVYdGtsLUxsc25SaDB0QlZpbTdQRmlVRlpsZUlCaFRlU2Vxbz0=",
+# Environments where the public defaults are acceptable, because nothing durable or
+# reachable is protected by them. Anything else is treated as a real deployment.
+_THROWAWAY_ENVIRONMENTS = frozenset({"development", "test", "testing"})
+
+# Shell one-liners producing a real value for each kind of secret, quoted back in
+# the startup error so the fix does not require going and finding the docs.
+# ENCRYPTION_KEY_HINT is public because app.core.encryption reports the same fix
+# when the key is missing at load time, and the two must not drift apart.
+ENCRYPTION_KEY_HINT = (
+    'python -c "import base64;from cryptography.fernet import Fernet;'
+    'print(base64.b64encode(Fernet.generate_key()).decode())"'
+)
+_HEX_SECRET_HINT = "openssl rand -hex 32"
+
+
+class _ManagedSecret(NamedTuple):
+    """A secret the app refuses to serve traffic without.
+
+    One record per secret rather than parallel dicts keyed by setting name: adding
+    a secret should be one line, and a half-filled entry should not surface as a
+    KeyError while building the very error meant to explain the problem.
+    """
+
+    # What the operator sets, which is not always the setting name.
+    env_var: str
+    # Value once shipped in this repo (config default / .env.example). Public, so
+    # it stays listed after being removed as a default — deployments copied it.
+    public_default: str
+    # Shell one-liner producing a real replacement.
+    generate: str
+
+
+_MANAGED_SECRETS = {
+    "SECRET_KEY": _ManagedSecret(
+        "JWT_SECRET_KEY", "your-secret-key", _HEX_SECRET_HINT),
+    "CONVERSATION_SECRET_KEY": _ManagedSecret(
+        "CONVERSATION_SECRET_KEY", "your-conversation-secret-key", _HEX_SECRET_HINT),
+    "ENCRYPTION_KEY": _ManagedSecret(
+        "ENCRYPTION_KEY",
+        "RFQ4SzhyRTVYdGtsLUxsc25SaDB0QlZpbTdQRmlVRlpsZUlCaFRlU2Vxbz0=",
+        ENCRYPTION_KEY_HINT),
 }
 
 # .env.example placeholders - not secret either, and they mean "never configured"
@@ -281,29 +314,13 @@ _PLACEHOLDER_VALUES = {
     "your_fernet_encryption_key_here",
 }
 
-# Canonical hint for producing an ENCRYPTION_KEY. Lives here rather than in
-# app.core.encryption because that module imports this one, and the two error
-# paths (missing key at load, public key at startup) must not drift apart.
-ENCRYPTION_KEY_HINT = (
-    'python -c "import base64;from cryptography.fernet import Fernet;'
-    'print(base64.b64encode(Fernet.generate_key()).decode())"'
-)
 
-# Shell one-liner producing a real value for each secret, quoted in the startup
-# error so the fix does not require going and finding the docs.
-_GENERATION_HINTS = {
-    "SECRET_KEY": "openssl rand -hex 32",
-    "CONVERSATION_SECRET_KEY": "openssl rand -hex 32",
-    "ENCRYPTION_KEY": ENCRYPTION_KEY_HINT,
-}
-
-# The env var name behind each setting, since they differ for the JWT secrets and
-# the error is only actionable if it names what the operator actually sets.
-_ENV_VAR_NAMES = {
-    "SECRET_KEY": "JWT_SECRET_KEY",
-    "CONVERSATION_SECRET_KEY": "CONVERSATION_SECRET_KEY",
-    "ENCRYPTION_KEY": "ENCRYPTION_KEY",
-}
+def is_throwaway_environment(config: Settings = settings) -> bool:
+    """True for local development and test runs, where the public defaults are
+    harmless. Defined here so every check of "is this a real deployment" agrees;
+    app.core.encryption asks the same question before generating a throwaway key.
+    """
+    return config.ENVIRONMENT.lower() in _THROWAWAY_ENVIRONMENTS
 
 
 def check_secret_configuration(config: Settings = settings) -> list[str]:
@@ -312,13 +329,13 @@ def check_secret_configuration(config: Settings = settings) -> list[str]:
 
     Pure audit: verify_secret_configuration decides what to do about the result.
     """
-    if config.ENVIRONMENT == "development":
+    if is_throwaway_environment(config):
         return []
 
     return [
-        name for name, default in _INSECURE_DEFAULTS.items()
+        name for name, secret in _MANAGED_SECRETS.items()
         if not getattr(config, name, None)
-        or getattr(config, name) == default
+        or getattr(config, name) == secret.public_default
         or getattr(config, name) in _PLACEHOLDER_VALUES
     ]
 
@@ -326,7 +343,7 @@ def check_secret_configuration(config: Settings = settings) -> list[str]:
 def verify_secret_configuration(config: Settings = settings) -> None:
     """Refuse to start on secrets anyone can look up in this repo.
 
-    Every value in _INSECURE_DEFAULTS and _PLACEHOLDER_VALUES is public, so a
+    Every value in _MANAGED_SECRETS and _PLACEHOLDER_VALUES is public, so a
     deployment using one has no auth boundary at all — tokens can be forged and
     stored credentials decrypted by anyone. A warning was not enough: it scrolls
     past in the boot log and the deployment stays exposed indefinitely.
@@ -351,13 +368,14 @@ def verify_secret_configuration(config: Settings = settings) -> None:
     if not insecure:
         return
 
+    names = ", ".join(insecure)
+    verb = "is" if len(insecure) == 1 else "are"
     fixes = "\n".join(
-        f"  {_ENV_VAR_NAMES[name]}=$({_GENERATION_HINTS[name]})" for name in insecure
+        f"  {_MANAGED_SECRETS[name].env_var}=$({_MANAGED_SECRETS[name].generate})"
+        for name in insecure
     )
     raise RuntimeError(
-        f"Refusing to start: {', '.join(insecure)} " +
-        ("is" if len(insecure) == 1 else "are") +
-        " unset or still set to a value published in this repository, so anyone "
-        "can forge tokens or decrypt stored data. Set real values and restart:\n"
-        f"{fixes}"
+        f"Refusing to start: {names} {verb} unset or still set to a value published "
+        "in this repository, so anyone can forge tokens or decrypt stored data. "
+        f"Set real values and restart:\n{fixes}"
     )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -64,9 +64,9 @@ class Settings(BaseSettings):
 
     # app.core.encryption owns the actual key loading (reads the env var directly and
     # refuses to start without it outside development). This mirror exists only so
-    # check_secret_configuration can audit it; the demo default is what that audit
-    # flags in production.
-    ENCRYPTION_KEY: str = os.getenv("ENCRYPTION_KEY", "RFQ4SzhyRTVYdGtsLUxsc25SaDB0QlZpbTdQRmlVRlpsZUlCaFRlU2Vxbz0=")
+    # check_secret_configuration can audit it, hence no default: unset is itself
+    # one of the states that audit flags.
+    ENCRYPTION_KEY: str = os.getenv("ENCRYPTION_KEY", "")
 
     # SMTP Settings
     SMTP_SERVER: str = os.getenv("SMTP_SERVER", "smtp.gmail.com")
@@ -259,9 +259,10 @@ settings = Settings()
 logger = get_logger(__name__)
 
 
-# Values that ship in the repo (config defaults / .env.example). They are public,
-# so a deployment still using them can have its tokens forged and its stored
-# credentials decrypted by anyone.
+# Values that were once shipped in the repo (config defaults / .env.example) and so
+# are public: a deployment still using them can have its tokens forged and its
+# stored credentials decrypted by anyone. They no longer appear as defaults above,
+# but they stay listed here to catch deployments that copied them before that.
 _INSECURE_DEFAULTS = {
     "SECRET_KEY": "your-secret-key",
     "CONVERSATION_SECRET_KEY": "your-conversation-secret-key",

--- a/backend/app/core/encryption.py
+++ b/backend/app/core/encryption.py
@@ -25,7 +25,7 @@ CURRENT_KEY_ID moves to it, and ``v1`` stays in the registry so old rows keep
 reading while a backfill re-encrypts them.
 
 This module deliberately depends on nothing but the standard library, cryptography,
-SQLAlchemy and app.core.logger (stdlib-only itself), so the backfill script can load
+SQLAlchemy and app.core.{logger,config} (both light), so the backfill script can load
 it by file path on the host without importing the `app` package — whose __init__
 pulls in the FastAPI app and the whole ML stack.
 """
@@ -40,7 +40,7 @@ from cryptography.fernet import Fernet
 from sqlalchemy import Text
 from sqlalchemy.types import TypeDecorator
 
-from app.core.config import ENCRYPTION_KEY_HINT, settings
+from app.core.config import ENCRYPTION_KEY_HINT, is_throwaway_environment
 from app.core.logger import get_logger
 
 logger = get_logger(__name__)
@@ -59,12 +59,6 @@ ENCRYPTION_KEY_ENV = "ENCRYPTION_KEY"
 # Indented for the multi-line error messages below; the command itself is defined
 # once in app.core.config so this and the startup audit cannot drift apart.
 GENERATE_KEY_HINT = f"  {ENCRYPTION_KEY_HINT}"
-
-
-def _is_throwaway_environment() -> bool:
-    """True only for local development and test runs, where a generated key is
-    harmless. Anywhere else a fresh key would orphan every encrypted row."""
-    return settings.ENVIRONMENT.lower() in {"development", "test", "testing"}
 
 
 def load_key() -> bytes:
@@ -91,14 +85,14 @@ def load_key() -> bytes:
             return key
         except Exception as e:
             logger.error(f"Invalid encryption key format: {str(e)}")
-            if not _is_throwaway_environment():
+            if not is_throwaway_environment():
                 raise RuntimeError(
                     f"{ENCRYPTION_KEY_ENV} is set but is not a usable Fernet key. "
                     "Encrypted data cannot be read; refusing to start with a "
                     f"different key. Generate one with:\n{GENERATE_KEY_HINT}"
                 ) from e
 
-    if not _is_throwaway_environment():
+    if not is_throwaway_environment():
         raise RuntimeError(
             f"{ENCRYPTION_KEY_ENV} is not set. It encrypts chat messages, session "
             "summaries and agent memory at rest, so starting without it would make "

--- a/backend/app/core/encryption.py
+++ b/backend/app/core/encryption.py
@@ -77,17 +77,26 @@ def load_key() -> bytes:
 
     Outside development and tests a missing or malformed key is fatal: chat
     messages, session summaries and agent memory are all encrypted with it.
+
+    Usability of the key is checked here rather than left to ``Fernet()`` in
+    get_keys(), so that the .env.example placeholder and the common near-miss of
+    pasting a raw ``Fernet.generate_key()`` (base64-encoded once, not twice) both
+    surface the message below instead of a bare "must be 32 url-safe base64-encoded
+    bytes" from deep inside the library.
     """
     env_key = os.getenv(ENCRYPTION_KEY_ENV)
     if env_key:
         try:
-            return base64.b64decode(env_key)
+            key = base64.b64decode(env_key)
+            Fernet(key)
+            return key
         except Exception as e:
             logger.error(f"Invalid encryption key format: {str(e)}")
             if not _is_throwaway_environment():
                 raise RuntimeError(
-                    f"{ENCRYPTION_KEY_ENV} is set but is not valid base64. Encrypted "
-                    "data cannot be read; refusing to start with a different key."
+                    f"{ENCRYPTION_KEY_ENV} is set but is not a usable Fernet key. "
+                    "Encrypted data cannot be read; refusing to start with a "
+                    f"different key. Generate one with:\n{GENERATE_KEY_HINT}"
                 ) from e
 
     if not _is_throwaway_environment():

--- a/backend/app/core/encryption.py
+++ b/backend/app/core/encryption.py
@@ -40,7 +40,7 @@ from cryptography.fernet import Fernet
 from sqlalchemy import Text
 from sqlalchemy.types import TypeDecorator
 
-from app.core.config import settings
+from app.core.config import ENCRYPTION_KEY_HINT, settings
 from app.core.logger import get_logger
 
 logger = get_logger(__name__)
@@ -56,10 +56,9 @@ JSON_MARKER = "__enc__"
 ENCRYPTION_KEY_ENV = "ENCRYPTION_KEY"
 
 
-GENERATE_KEY_HINT = (
-    '  python -c "import base64;from cryptography.fernet import Fernet;'
-    'print(base64.b64encode(Fernet.generate_key()).decode())"'
-)
+# Indented for the multi-line error messages below; the command itself is defined
+# once in app.core.config so this and the startup audit cannot drift apart.
+GENERATE_KEY_HINT = f"  {ENCRYPTION_KEY_HINT}"
 
 
 def _is_throwaway_environment() -> bool:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ from app.api import webhooks as channel_webhooks
 from app.api import widget_chat  # noqa: F401 - imported for side effects (socket.io handlers registration)
 from fastapi import FastAPI, BackgroundTasks
 from fastapi.middleware.cors import CORSMiddleware
-from app.core.config import settings, check_secret_configuration
+from app.core.config import settings, verify_secret_configuration
 from app.core.encryption import verify_encryption_key
 from app.services.firebase import initialize_firebase
 from app.database import engine, Base
@@ -58,7 +58,7 @@ async def lifespan(app: FastAPI):
     # First: a bad ENCRYPTION_KEY must stop the boot, not surface as an unreadable
     # conversation once the app is already serving traffic.
     verify_encryption_key()
-    check_secret_configuration()
+    verify_secret_configuration()
     initialize_firebase()
     await startup_event()
     yield

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,10 +17,11 @@ limitations under the License.
 import os
 
 # Set before any app import: app.core.encryption reads these when it first loads a
-# key, and a fixed key keeps encrypted fixtures reproducible across runs.
+# key, and a fixed key keeps encrypted fixtures reproducible across runs. This key
+# is for tests only — deployments generate their own (see backend/.env.example).
 os.environ.setdefault("ENVIRONMENT", "test")
 os.environ.setdefault(
-    "ENCRYPTION_KEY", "RFQ4SzhyRTVYdGtsLUxsc25SaDB0QlZpbTdQRmlVRlpsZUlCaFRlU2Vxbz0=")
+    "ENCRYPTION_KEY", "QmFTbXc5RWQ4czRfQWpqSnhqZjhraGtYSGFYaXZ4SkRNS2kxZFB1Y2NrMD0=")
 
 import pytest
 import uuid

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -1,0 +1,65 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from app.core.config import Settings, check_secret_configuration
+
+# The key that used to ship as the ENCRYPTION_KEY default and in .env.example. It
+# is public, so a deployment still using it must be flagged.
+LEGACY_PUBLIC_KEY = "RFQ4SzhyRTVYdGtsLUxsc25SaDB0QlZpbTdQRmlVRlpsZUlCaFRlU2Vxbz0="
+GOOD = {
+    "SECRET_KEY": "a-real-secret",
+    "CONVERSATION_SECRET_KEY": "another-real-secret",
+    "ENCRYPTION_KEY": "a-real-key",
+}
+
+
+def _config(**overrides) -> Settings:
+    return Settings(ENVIRONMENT="production", **{**GOOD, **overrides})
+
+
+def test_configured_secrets_are_not_flagged():
+    assert check_secret_configuration(_config()) == []
+
+
+def test_unset_encryption_key_is_flagged():
+    """ENCRYPTION_KEY no longer carries a default, so unset is the common case."""
+    assert check_secret_configuration(_config(ENCRYPTION_KEY="")) == ["ENCRYPTION_KEY"]
+
+
+def test_legacy_public_encryption_key_is_still_flagged():
+    """Removing the default does not help deployments that already copied it."""
+    assert check_secret_configuration(
+        _config(ENCRYPTION_KEY=LEGACY_PUBLIC_KEY)
+    ) == ["ENCRYPTION_KEY"]
+
+
+def test_env_example_placeholder_is_flagged():
+    assert check_secret_configuration(
+        _config(ENCRYPTION_KEY="your_fernet_encryption_key_here")
+    ) == ["ENCRYPTION_KEY"]
+
+
+def test_default_jwt_secret_is_flagged():
+    assert check_secret_configuration(
+        _config(SECRET_KEY="your-secret-key")
+    ) == ["SECRET_KEY"]
+
+
+def test_development_is_exempt():
+    """Local development runs on the defaults on purpose."""
+    config = Settings(ENVIRONMENT="development", SECRET_KEY="your-secret-key",
+                      ENCRYPTION_KEY="")
+    assert check_secret_configuration(config) == []

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -14,7 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from app.core.config import Settings, check_secret_configuration
+import pytest
+
+from app.core.config import (
+    Settings,
+    check_secret_configuration,
+    verify_secret_configuration,
+)
 
 # The key that used to ship as the ENCRYPTION_KEY default and in .env.example. It
 # is public, so a deployment still using it must be flagged.
@@ -63,3 +69,55 @@ def test_development_is_exempt():
     config = Settings(ENVIRONMENT="development", SECRET_KEY="your-secret-key",
                       ENCRYPTION_KEY="")
     assert check_secret_configuration(config) == []
+
+
+def test_startup_passes_with_real_secrets():
+    verify_secret_configuration(_config())
+
+
+def test_startup_fails_on_default_jwt_secret():
+    with pytest.raises(RuntimeError, match="Refusing to start") as exc:
+        verify_secret_configuration(_config(SECRET_KEY="your-secret-key"))
+    # The env var, not the setting name, plus a command that produces a value.
+    assert "JWT_SECRET_KEY=$(openssl rand -hex 32)" in str(exc.value)
+
+
+def test_startup_fails_on_public_encryption_key():
+    with pytest.raises(RuntimeError, match="Refusing to start") as exc:
+        verify_secret_configuration(_config(ENCRYPTION_KEY=LEGACY_PUBLIC_KEY))
+    assert "Fernet.generate_key()" in str(exc.value)
+
+
+def test_startup_error_names_every_offender():
+    with pytest.raises(RuntimeError) as exc:
+        verify_secret_configuration(
+            Settings(ENVIRONMENT="production", SECRET_KEY="",
+                     CONVERSATION_SECRET_KEY="", ENCRYPTION_KEY="")
+        )
+    message = str(exc.value)
+    for name in ("SECRET_KEY", "CONVERSATION_SECRET_KEY", "ENCRYPTION_KEY"):
+        assert name in message
+
+
+def test_development_still_starts_on_defaults():
+    """The escape hatch is for production; development must stay zero-config."""
+    verify_secret_configuration(
+        Settings(ENVIRONMENT="development", SECRET_KEY="your-secret-key",
+                 ENCRYPTION_KEY="")
+    )
+
+
+def test_escape_hatch_allows_only_the_encryption_key():
+    """An instance whose data is encrypted under the public key can still boot."""
+    verify_secret_configuration(
+        _config(ENCRYPTION_KEY=LEGACY_PUBLIC_KEY, ALLOW_INSECURE_ENCRYPTION_KEY=True)
+    )
+
+
+def test_escape_hatch_does_not_excuse_the_jwt_secrets():
+    """Rotating a JWT secret only ends sessions, so it has no reason to be exempt."""
+    with pytest.raises(RuntimeError, match="SECRET_KEY"):
+        verify_secret_configuration(
+            _config(SECRET_KEY="your-secret-key", ENCRYPTION_KEY=LEGACY_PUBLIC_KEY,
+                    ALLOW_INSECURE_ENCRYPTION_KEY=True)
+        )

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -71,6 +71,15 @@ def test_development_is_exempt():
     assert check_secret_configuration(config) == []
 
 
+@pytest.mark.parametrize("environment", ["test", "testing", "Development"])
+def test_throwaway_environments_are_exempt(environment):
+    """The audit and app.core.encryption must agree on what a real deployment is;
+    they used to disagree on casing and on whether test runs counted."""
+    config = Settings(ENVIRONMENT=environment, SECRET_KEY="your-secret-key",
+                      ENCRYPTION_KEY="")
+    assert check_secret_configuration(config) == []
+
+
 def test_startup_passes_with_real_secrets():
     verify_secret_configuration(_config())
 

--- a/backend/tests/core/test_encryption.py
+++ b/backend/tests/core/test_encryption.py
@@ -14,15 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import base64
 import sys
 from pathlib import Path
 from uuid import uuid4
 
+import pytest
+from cryptography.fernet import Fernet
 from sqlalchemy import text
 
+from app.core.config import settings
 from app.core.encryption import (
     CURRENT_KEY_ID,
     ENCRYPTED_PREFIX,
+    ENCRYPTION_KEY_ENV,
     JSON_MARKER,
     SEPARATOR,
     EncryptedText,
@@ -31,6 +36,7 @@ from app.core.encryption import (
     encrypt_json,
     encrypt_value,
     is_encrypted,
+    load_key,
 )
 from app.database import Base
 from app.models.chat_history import ChatHistory
@@ -189,3 +195,46 @@ def test_legacy_plaintext_row_still_reads(db, test_organization_id):
         ChatHistory.message_type == "user"
     ).order_by(ChatHistory.id.desc()).first()
     assert stored.message == "written before encryption"
+
+
+def _double_encoded(key: bytes) -> str:
+    """The wire format ENCRYPTION_KEY uses: a Fernet key, base64-encoded again."""
+    return base64.b64encode(key).decode()
+
+
+def test_load_key_accepts_a_double_encoded_key(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    key = Fernet.generate_key()
+    monkeypatch.setenv(ENCRYPTION_KEY_ENV, _double_encoded(key))
+    assert load_key() == key
+
+
+def test_load_key_rejects_base64_that_is_not_a_fernet_key(monkeypatch):
+    """Encoding the key once instead of twice decodes cleanly but is 32 raw bytes,
+    not Fernet key material — it must fail here, not later inside Fernet()."""
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    monkeypatch.setenv(ENCRYPTION_KEY_ENV, base64.b64encode(b"x" * 32).decode())
+    with pytest.raises(RuntimeError, match="not a usable Fernet key"):
+        load_key()
+
+
+def test_load_key_rejects_the_env_example_placeholder(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    monkeypatch.setenv(ENCRYPTION_KEY_ENV, "your_fernet_encryption_key_here")
+    with pytest.raises(RuntimeError, match="not a usable Fernet key"):
+        load_key()
+
+
+def test_load_key_is_fatal_when_unset_outside_development(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    monkeypatch.delenv(ENCRYPTION_KEY_ENV, raising=False)
+    with pytest.raises(RuntimeError, match="is not set"):
+        load_key()
+
+
+def test_load_key_falls_back_to_a_throwaway_key_in_development(monkeypatch):
+    """An unusable key must not stop local development — a generated one is fine
+    there, since nothing durable is encrypted under it."""
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+    monkeypatch.setenv(ENCRYPTION_KEY_ENV, "your_fernet_encryption_key_here")
+    Fernet(load_key())  # usable, and no raise


### PR DESCRIPTION
`.env.example` shipped a real Fernet key instead of a placeholder, and `config.py` used the same value as its default. So `cp .env.example .env` gave you a deployment encrypting chat messages, session summaries, agent memory and stored provider/OAuth credentials under a key that's published in this repo. Only a log warning flagged it, and even that was suppressed because `.env.example` sets `ENVIRONMENT=development`.

Now: placeholder in `.env.example`, no default in config, and startup raises instead of warning when a secret is unset or still public — the error prints the command that generates a real value for each one. `load_key()` also validates the key is usable Fernet material, so the placeholder and the singly-encoded near-miss get that message rather than a bare ValueError from inside Fernet.

`ENCRYPTION_KEY` can be waived with `ALLOW_INSECURE_ENCRYPTION_KEY=true`, for instances that predate the key being required and have data encrypted under the public one — refusing to boot would lock them out of it. The JWT secrets get no exemption; rotating those only ends sessions.

**Before deploying:** the backend won't start unless `JWT_SECRET_KEY`, `CONVERSATION_SECRET_KEY` and `ENCRYPTION_KEY` are all set to real values. Worth checking prod's env file first — `CONVERSATION_SECRET_KEY` is the easy one to have never set. Changing it invalidates live widget conversation tokens.