### PR TITLE
fix(knowledge): fail empty crawls, and keep vector agent filters in step with links

### DIFF
--- a/backend/app/knowledge/enhanced_website_kb.py
+++ b/backend/app/knowledge/enhanced_website_kb.py
@@ -30,7 +30,11 @@ from app.core.config import settings
 from app.models.knowledge_queue import ProcessingStage, QueueStatus
 from pydantic import model_validator
 
-from app.knowledge.enhanced_website_reader import EnhancedWebsiteReader, BotProtectionError
+from app.knowledge.enhanced_website_reader import (
+    EnhancedWebsiteReader,
+    BotProtectionError,
+    EmptyCrawlError,
+)
 
 # Initialize logger for this module
 logger = get_logger(__name__)
@@ -296,16 +300,31 @@ class EnhancedWebsiteKnowledgeBase(AgentKnowledge):
             total_duration = total_end_time - total_start_time
             logger.info(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Completed processing all {len(self.urls)} URLs with immediate embedding (Total time: {total_duration:.2f}s)")
 
-    def _raise_if_bot_blocked(self, total_documents: int) -> None:
-        """Raise BotProtectionError if the crawl yielded nothing because a
-        bot-check blocked every page (so the queue item fails with a clear
-        reason instead of silently completing with zero pages)."""
-        if total_documents == 0 and getattr(self.reader, '_challenge_blocked', 0) > 0:
+    def _raise_if_nothing_stored(self, total_documents: int) -> None:
+        """Fail the run when it indexed nothing.
+
+        A zero-page run used to be marked COMPLETED, which made a broken crawl
+        indistinguishable from a healthy source that happens to have no sub-pages —
+        the dashboard showed success while the agent had nothing to answer from.
+        Raising here is enough: process_queue_item already turns any exception into
+        a FAILED queue item with the message shown to the user.
+        """
+        if total_documents > 0:
+            return
+
+        # Bot protection first: it is the specific, actionable cause.
+        if getattr(self.reader, '_challenge_blocked', 0) > 0:
             raise BotProtectionError(
                 "This site blocked automated crawling (its bot protection served a "
                 "“Checking your browser” page). Add the content manually with "
                 "Upload PDF or Text."
             )
+
+        raise EmptyCrawlError(
+            f"No content could be read from {self.urls[0] if self.urls else 'this source'}. "
+            "The page may be empty, require JavaScript, or be unreachable — check the "
+            "URL is correct and publicly accessible."
+        )
 
     def load(
         self,
@@ -508,10 +527,9 @@ class EnhancedWebsiteKnowledgeBase(AgentKnowledge):
         final_embedded_count = sum(1 for doc in all_documents if doc.embedding is not None)
         embedding_rate = (final_embedded_count / len(all_documents) * 100) if all_documents else 0
 
-        # If nothing was crawled solely because a bot-check blocked every page,
-        # fail loudly so the user is told to add the content manually — rather
-        # than silently "completing" with zero pages.
-        self._raise_if_bot_blocked(total_documents)
+        # A run that stored nothing is a failure. Raised before the COMPLETED
+        # write below so the queue item cannot report success for an empty crawl.
+        self._raise_if_nothing_stored(total_documents)
 
         # Mark as completed after all processing is done
         if self.queue_item and self.queue_repo:

--- a/backend/app/knowledge/enhanced_website_reader.py
+++ b/backend/app/knowledge/enhanced_website_reader.py
@@ -44,6 +44,14 @@ class BotProtectionError(Exception):
     automated browser. Signals the user should add the content manually."""
 
 
+class EmptyCrawlError(Exception):
+    """Raised when a crawl stored no pages for a reason other than bot protection.
+
+    A run that indexes nothing is a failure, not a success: without this the queue
+    item completes and the source appears in the dashboard as a healthy source with
+    zero pages, so nobody learns the agent has no content to answer from."""
+
+
 @dataclass
 class EnhancedWebsiteReader(WebsiteReader):
     """Enhanced Reader for Websites with more robust content extraction"""

--- a/backend/app/knowledge/sitemap_reader.py
+++ b/backend/app/knowledge/sitemap_reader.py
@@ -46,7 +46,7 @@ class SitemapReader(EnhancedWebsiteReader):
         url = self._normalize_url(url)
 
         # Reset per-crawl state exactly as the base crawl does — the counters are
-        # read by the progress logs and by _raise_if_bot_blocked (a fully
+        # read by the progress logs and by _raise_if_nothing_stored (a fully
         # bot-blocked sitemap must still fail with the "add manually" message).
         self._visited = set()
         self._urls_to_crawl = []

--- a/backend/app/workers/knowledge_processor.py
+++ b/backend/app/workers/knowledge_processor.py
@@ -17,7 +17,10 @@ limitations under the License.
 import asyncio
 from app.database import SessionLocal
 from app.repositories.knowledge_queue import KnowledgeQueueRepository
+from app.repositories.knowledge import KnowledgeRepository
 from app.knowledge.knowledge_base import KnowledgeManager
+from app.knowledge import page_editor
+from app.services import knowledge_vector_links
 from app.models.knowledge_queue import QueueStatus, ProcessingStage
 from app.core.logger import get_logger
 import os
@@ -66,6 +69,46 @@ def get_user_friendly_filename(source: str, source_type: str) -> str:
         return source
 
 
+def _sync_vector_agent_links(db, queue_item) -> None:
+    """Point the ingested chunks at every agent the source is linked to.
+
+    Ingestion writes ``filters.agent_id`` from the queue row's single optional
+    ``agent_id``, so a run queued without one leaves every chunk with an empty
+    list. Retrieval matches on that filter, so the source is invisible to the
+    agent while the dashboard still shows it as linked — the failure that left
+    two production sources unreadable until the links were rebuilt by hand.
+
+    The relational links are the authority, so re-derive from them. Idempotent,
+    and non-fatal: the content is already ingested, and losing the run over a
+    filter refresh would be worse than the stale filter.
+    """
+    try:
+        knowledge_repo = KnowledgeRepository(db)
+        sources = knowledge_repo.get_by_sources(
+            queue_item.organization_id, [queue_item.source]
+        )
+        if not sources:
+            return
+
+        # An org can hold more than one knowledge row for the same URL, and they
+        # share one set of vector chunks (keyed on the source name). Sync the
+        # union of their links once, rather than per row where the last write
+        # would drop the other rows' agents.
+        agent_ids = sorted({
+            agent_id
+            for knowledge in sources
+            for agent_id in page_editor.agent_ids_for(knowledge)
+        })
+        knowledge_vector_links.sync_agent_ids(db, sources[0], agent_ids)
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        logger.error(
+            f"Could not refresh vector agent filters for {queue_item.source} "
+            f"(non-fatal, content was ingested): {e}"
+        )
+
+
 async def process_queue_item(queue_item_id: int):
     """Process a single queue item"""
     with SessionLocal() as db:
@@ -92,6 +135,8 @@ async def process_queue_item(queue_item_id: int):
                 db.commit()
 
                 await knowledge.process_knowledge(queue_item)
+
+                _sync_vector_agent_links(db, queue_item)
 
                 # Create notification for successful processing
                 user_friendly_name = get_user_friendly_filename(queue_item.source, queue_item.source_type)

--- a/backend/tests/knowledge/test_enhanced_website_kb.py
+++ b/backend/tests/knowledge/test_enhanced_website_kb.py
@@ -103,25 +103,38 @@ class TestEnhancedWebsiteKnowledgeBase:
         assert kb.reader.max_depth == 4
         assert kb.reader.max_links == 15
 
-    def test_raise_if_bot_blocked(self):
-        """A fully bot-blocked crawl (0 docs, pages skipped) raises, so the queue
-        item fails with a clear reason instead of silently completing."""
-        from app.knowledge.enhanced_website_reader import BotProtectionError
+    def test_raise_if_nothing_stored(self):
+        """A run that stored no pages must raise so the queue item fails.
+
+        Previously only the bot-blocked case raised; an empty crawl for any other
+        reason was marked COMPLETED, making a broken source look identical to a
+        healthy one with no sub-pages.
+        """
+        from app.knowledge.enhanced_website_reader import (
+            BotProtectionError,
+            EmptyCrawlError,
+        )
         reader = EnhancedWebsiteReader(max_links=5)
         kb = EnhancedWebsiteKnowledgeBase(urls=TEST_URLS, reader=reader)
 
-        # Nothing blocked → never raises, regardless of doc count.
+        # Anything stored → never raises, whatever happened along the way.
         reader._challenge_blocked = 0
-        kb._raise_if_bot_blocked(0)
-        kb._raise_if_bot_blocked(5)
+        kb._raise_if_nothing_stored(5)
+        reader._challenge_blocked = 3
+        kb._raise_if_nothing_stored(2)
 
-        # Blocked pages AND zero documents extracted → raise.
+        # Zero stored because bot protection blocked every page → the specific,
+        # actionable error, which takes precedence.
         reader._challenge_blocked = 3
         with pytest.raises(BotProtectionError):
-            kb._raise_if_bot_blocked(0)
+            kb._raise_if_nothing_stored(0)
 
-        # Blocked some pages but others succeeded → don't raise.
-        kb._raise_if_bot_blocked(2)
+        # Zero stored for any other reason → still a failure, not a success.
+        reader._challenge_blocked = 0
+        with pytest.raises(EmptyCrawlError) as excinfo:
+            kb._raise_if_nothing_stored(0)
+        # The message names the source so the dashboard error is actionable.
+        assert TEST_URLS[0] in str(excinfo.value)
     
     def test_document_lists_property(self, mock_reader):
         """Test the document_lists property"""

--- a/backend/tests/workers/test_knowledge_processor.py
+++ b/backend/tests/workers/test_knowledge_processor.py
@@ -174,3 +174,136 @@ async def test_run_processor_error(mock_dependencies):
     from app.api.knowledge import PROCESSOR_STATUS
     assert not PROCESSOR_STATUS["is_running"]
     assert PROCESSOR_STATUS["error"] == error_message
+
+# ---------------------------------------------------------------------------
+# Vector agent-filter re-assert
+#
+# Ingestion writes filters.agent_id from the queue row's single optional
+# agent_id. A run queued without one leaves every chunk with an empty list, and
+# retrieval matches on that filter — so the source is invisible to the agent
+# while the dashboard shows it as linked. Two production sources were left
+# unreadable this way. The relational links are the authority, so the worker
+# re-derives the filter from them after every successful run.
+# ---------------------------------------------------------------------------
+
+def _linked_knowledge(*agent_ids):
+    """A knowledge row whose agent_links resolve to the given agent ids."""
+    knowledge = MagicMock()
+    knowledge.agent_links = [MagicMock(agent_id=a) for a in agent_ids]
+    return knowledge
+
+
+@pytest.mark.asyncio
+async def test_process_queue_item_reasserts_agent_links(mock_dependencies, mock_queue_item):
+    """After a successful run the chunks point at every linked agent."""
+    agent_a, agent_b = str(uuid4()), str(uuid4())
+    knowledge = _linked_knowledge(agent_a, agent_b)
+    repo = MagicMock()
+    repo.get_by_sources.return_value = [knowledge]
+
+    with patch('app.workers.knowledge_processor.KnowledgeRepository', return_value=repo), \
+         patch('app.workers.knowledge_processor.knowledge_vector_links.sync_agent_ids') as sync:
+        await process_queue_item(mock_queue_item.id)
+
+    sync.assert_called_once()
+    _db, synced_knowledge, agent_ids = sync.call_args[0]
+    assert synced_knowledge is knowledge
+    # Both linked agents, not just the one the queue row happened to carry.
+    assert sorted(agent_ids) == sorted([agent_a, agent_b])
+    assert mock_queue_item.status == QueueStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_reasserts_agent_links_when_queue_row_has_no_agent(mock_dependencies, mock_queue_item):
+    """The production incident: a crawl queued with agent_id=None.
+
+    Ingestion writes an empty filter, so without this the source stays
+    unreadable until someone unlinks and relinks it by hand.
+    """
+    mock_queue_item.agent_id = None
+    linked_agent = str(uuid4())
+    knowledge = _linked_knowledge(linked_agent)
+    repo = MagicMock()
+    repo.get_by_sources.return_value = [knowledge]
+
+    with patch('app.workers.knowledge_processor.KnowledgeRepository', return_value=repo), \
+         patch('app.workers.knowledge_processor.knowledge_vector_links.sync_agent_ids') as sync:
+        await process_queue_item(mock_queue_item.id)
+
+    assert sync.call_args[0][2] == [linked_agent]
+
+
+@pytest.mark.asyncio
+async def test_agent_link_sync_failure_does_not_fail_the_run(mock_dependencies, mock_queue_item):
+    """The content is already ingested — a filter refresh must not lose the run."""
+    repo = MagicMock()
+    repo.get_by_sources.return_value = [_linked_knowledge(str(uuid4()))]
+
+    with patch('app.workers.knowledge_processor.KnowledgeRepository', return_value=repo), \
+         patch('app.workers.knowledge_processor.knowledge_vector_links.sync_agent_ids',
+               side_effect=Exception("vector store unavailable")):
+        await process_queue_item(mock_queue_item.id)
+
+    assert mock_queue_item.status == QueueStatus.COMPLETED
+    mock_dependencies['fcm'].assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unknown_source_skips_sync_without_error(mock_dependencies, mock_queue_item):
+    """No knowledge row yet (e.g. the run failed before creating one)."""
+    repo = MagicMock()
+    repo.get_by_sources.return_value = []
+
+    with patch('app.workers.knowledge_processor.KnowledgeRepository', return_value=repo), \
+         patch('app.workers.knowledge_processor.knowledge_vector_links.sync_agent_ids') as sync:
+        await process_queue_item(mock_queue_item.id)
+
+    sync.assert_not_called()
+    assert mock_queue_item.status == QueueStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_empty_crawl_fails_the_queue_item(mock_dependencies, mock_queue_item):
+    """Regression: a crawl that stored nothing used to be marked COMPLETED.
+
+    Production logged "Crawling completed - 0 URLs, 0 documents, 0.00s" followed
+    by "Marked queue item as completed", so a broken source was indistinguishable
+    from a healthy one in the dashboard.
+    """
+    from app.knowledge.enhanced_website_reader import EmptyCrawlError
+
+    mock_dependencies['knowledge_manager'].process_knowledge.side_effect = EmptyCrawlError(
+        "No content could be read from https://example.com."
+    )
+
+    with pytest.raises(EmptyCrawlError):
+        await process_queue_item(mock_queue_item.id)
+
+    assert mock_queue_item.status == QueueStatus.FAILED
+    notification = mock_dependencies['db'].add.call_args[0][0]
+    assert notification.type == NotificationType.KNOWLEDGE_FAILED
+    assert "No content could be read" in notification.message
+
+
+@pytest.mark.asyncio
+async def test_duplicate_knowledge_rows_sync_the_union_of_their_agents(
+    mock_dependencies, mock_queue_item
+):
+    """Two knowledge rows can share one URL — and one set of vector chunks.
+
+    Syncing them one after another would let the last write drop the other
+    row's agents, so the union is applied once.
+    """
+    agent_a, agent_b = str(uuid4()), str(uuid4())
+    repo = MagicMock()
+    repo.get_by_sources.return_value = [
+        _linked_knowledge(agent_a),
+        _linked_knowledge(agent_b),
+    ]
+
+    with patch('app.workers.knowledge_processor.KnowledgeRepository', return_value=repo), \
+         patch('app.workers.knowledge_processor.knowledge_vector_links.sync_agent_ids') as sync:
+        await process_queue_item(mock_queue_item.id)
+
+    sync.assert_called_once()
+    assert sync.call_args[0][2] == sorted([agent_a, agent_b])


### PR DESCRIPTION
Two independent defects found while investigating the knowledge issues on 2026-07-30.

## 1. An empty crawl reported success

A crawl that stored no pages was marked `COMPLETED`. Production logged:

```
Crawling completed - 0 URLs, 0 documents, 0.00s
✓ Marked queue item 334 as completed
```

Only the bot-protection case failed loudly. Every other empty crawl — site down, WAF challenge, mistyped URL — completed silently, and the source then appeared in the dashboard as a healthy source with zero sub-pages. There was no way to tell the two apart, which is what made this expensive to debug.

Zero stored pages now raises. `process_queue_item`'s existing handler already turns any exception into a FAILED item with the message shown to the user, so no new failure plumbing was needed — it simply never received an exception.

This is the fix that stands on its own.

## 2. Vector agent filters can drift from the relational links

Ingestion builds `filters.agent_id` from the queue row's single optional `agent_id`, overwriting whatever was there:

```python
agent_id_filter = [str(self.agent_id)] if self.agent_id else []
```

Retrieval matches on that filter, so when it drifts from `knowledge_to_agents` the source is invisible to an agent the dashboard shows as linked.

**To be clear about what this does not fix:** the ordinary flows are already correct. Adding a source with an agent selected creates the link and the matching filter together (`knowledge_base.py:106-111`), and linking afterwards repairs the filter via `add_agent` (#262). Delete-and-re-add needs nothing from this PR. The production incident where two sources had 96 chunks with `agent_id: []` was caused by the link endpoint's bind-parameter bug, and was resolved when that was fixed.

What remains are two narrower paths:

- **A link added while a crawl is in flight.** Queue a crawl for agent A, link agent B before it finishes, and the crawl writes `filters.agent_id = [A]`, dropping B. B's link row survives, so it reads as linked while retrieval cannot see it.
- **Links created outside the link endpoint.** `shopify.py:852` and `page_editor.py:260` both call `link_repo.create` directly and never touch vector filters — neither imports `knowledge_vector_links`.

So: defence-in-depth against a race and two bypass paths, not a fix for the incident. The worker now re-derives the filter from the relational links after each successful run, reusing the existing `sync_agent_ids`. Idempotent, and non-fatal — the content is already ingested, and losing the run over a filter refresh would be worse than a stale filter.

One subtlety: an org can hold several knowledge rows for the same URL (prod has two for `chattermate.chat`) sharing a single set of vector chunks keyed on the source name. The union of their links is applied once, rather than per row where the last write would drop the others.

## Not included

No rescan endpoint or UI — refreshing a source stays delete-and-re-add by design.

## Testing

2342 backend tests pass. Both changes are covered by tests verified to fail without the fix: reverting the empty-crawl raise fails `test_raise_if_nothing_stored`; removing the re-assert fails `test_process_queue_item_reasserts_agent_links` and `test_reasserts_agent_links_when_queue_row_has_no_agent`.

That check mattered here — the previous guard on this code asserted the buggy behaviour, and today's `::jsonb` bug survived because its test grepped for the broken string.