### PR TITLE
Fix MCP stdio tools in Docker, credential logging, and FAQ topics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,16 @@ ENV PIP_DEFAULT_TIMEOUT=120
 COPY backend/requirements.txt .
 RUN pip install --no-cache-dir --retries 10 -r requirements.txt
 
+# Node.js + npx and uv/uvx for STDIO MCP servers (npx @elastic/mcp-server-…,
+# uvx mcp-server-…). Copied from the official images instead of apt, which
+# only ships an EOL Node 18 on bookworm. Kept below the pip layer so an
+# upstream node/uv tag bump can't invalidate the torch-sized wheel cache.
+COPY --from=node:22-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:22-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+COPY --from=ghcr.io/astral-sh/uv:0.12 /uv /uvx /usr/local/bin/
+
 # Copy application code
 COPY backend/app ./app
 COPY backend/alembic.ini .

--- a/Dockerfile.backend.prod
+++ b/Dockerfile.backend.prod
@@ -18,6 +18,16 @@ COPY backend/requirements.txt .
 RUN pip install --no-cache-dir --retries 10 -r requirements.txt
 RUN crawl4ai-setup
 
+# Node.js + npx and uv/uvx for STDIO MCP servers (npx @elastic/mcp-server-…,
+# uvx mcp-server-…). Copied from the official images instead of apt, which
+# only ships an EOL Node 18 on bookworm. Kept below the pip layer so an
+# upstream node/uv tag bump can't invalidate the torch-sized wheel cache.
+COPY --from=node:22-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:22-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+    ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+COPY --from=ghcr.io/astral-sh/uv:0.12 /uv /uvx /usr/local/bin/
+
 # Copy application code
 COPY backend/app ./app
 COPY backend/alembic.ini .

--- a/backend/alembic/versions/add_run_connector_status_001.py
+++ b/backend/alembic/versions/add_run_connector_status_001.py
@@ -1,0 +1,44 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""add investigation_runs.connector_status
+
+Revision ID: add_run_connector_status_001
+Revises: add_agent_guardrail_prompt_001
+Create Date: 2026-07-31
+
+Records the MCP connector outcome of each investigation run ({"configured": N,
+"loaded": M, "failed": [{"name", "error"}]}) so a run that quietly executed
+with 0 of its configured tools (e.g. npx missing in the image, issue #271) is
+visible on the run detail instead of only in worker logs.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSON
+
+# revision identifiers, used by Alembic.
+revision = 'add_run_connector_status_001'
+down_revision = 'add_agent_guardrail_prompt_001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('investigation_runs', sa.Column('connector_status', JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('investigation_runs', 'connector_status')

--- a/backend/app/api/mcp_tool.py
+++ b/backend/app/api/mcp_tool.py
@@ -33,8 +33,9 @@ except ImportError:
 from app.models.schemas.mcp_tool import (
     MCPToolCreate, MCPToolUpdate, MCPToolResponse,
     MCPToolToAgentCreate, MCPToolToAgentResponse,
-    AgentMCPToolsResponse
+    AgentMCPToolsResponse, MCPToolTestResponse
 )
+from app.tools.mcp_manager import MCPToolsManager
 from sqlalchemy.orm import Session
 from uuid import UUID
 
@@ -151,6 +152,42 @@ async def get_mcp_tool(
         raise e
     except Exception as e:
         logger.error(f"Error fetching MCP tool: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/{mcp_tool_id}/test", response_model=MCPToolTestResponse)
+async def test_mcp_tool(
+    mcp_tool_id: int,
+    current_user: User = Depends(require_permissions("manage_agents")),
+    db: Session = Depends(get_db)
+):
+    """Connect to a configured MCP tool once and report whether it comes up
+    and which functions it exposes — surfaces environment problems (e.g. a
+    missing npx) that otherwise only show as a silent 0-tool run."""
+    try:
+        check_mcp_feature_access(current_user, db)
+
+        mcp_tool_repo = MCPToolRepository(db)
+        mcp_tool = mcp_tool_repo.get_mcp_tool(mcp_tool_id)
+
+        if not mcp_tool:
+            raise HTTPException(
+                status_code=404,
+                detail="MCP tool not found"
+            )
+
+        if mcp_tool.organization_id != current_user.organization_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Not authorized to access this MCP tool"
+            )
+
+        return await MCPToolsManager().test_tool_config(mcp_tool)
+
+    except HTTPException as e:
+        raise e
+    except Exception as e:
+        logger.error(f"MCP tool test error: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/backend/app/models/investigation.py
+++ b/backend/app/models/investigation.py
@@ -114,6 +114,11 @@ class InvestigationRun(Base):
     # message-limit check.
     metered = Column(Boolean, nullable=False, default=False, server_default="false")
 
+    # MCP connector outcome for the run: {"configured": N, "loaded": M,
+    # "failed": [{"name", "error"}]}. Lets the dashboard show "ran with 0 of N
+    # configured tools" instead of a silently evidence-free investigation.
+    connector_status = Column(JSON, nullable=True)
+
     error = Column(Text, nullable=True)
     started_at = Column(DateTime(timezone=True), nullable=True)
     finished_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/app/models/schemas/mcp_tool.py
+++ b/backend/app/models/schemas/mcp_tool.py
@@ -130,4 +130,11 @@ class AgentMCPToolsResponse(BaseModel):
     mcp_tools: List[MCPToolResponse] = []
 
     class Config:
-        from_attributes = True 
+        from_attributes = True
+
+
+class MCPToolTestResponse(BaseModel):
+    """Result of a one-off connection test against a configured tool."""
+    success: bool
+    functions: List[str] = []
+    error: Optional[str] = None

--- a/backend/app/models/schemas/ticket.py
+++ b/backend/app/models/schemas/ticket.py
@@ -139,6 +139,8 @@ class InvestigationRunOut(BaseModel):
     output_tokens: int = 0
     metered: bool = False
     model_name: Optional[str] = None
+    # {"configured": N, "loaded": M, "failed": [{"name", "error"}]}
+    connector_status: Optional[dict] = None
     started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None
     created_at: Optional[datetime] = None

--- a/backend/app/tools/mcp_manager.py
+++ b/backend/app/tools/mcp_manager.py
@@ -33,6 +33,11 @@ class MCPToolsManager:
 
     def __init__(self):
         self.mcp_tools: List[MCPTools] = []
+        # Names of tools that connected, and {name, error} for those that
+        # didn't. Unlike mcp_tools (cleared on cleanup) these survive the run,
+        # so callers can report "loaded N of M" afterwards.
+        self.connected_tool_names: List[str] = []
+        self.failed_tools: List[dict] = []
 
     async def initialize_mcp_tools_by_ids(
         self, org_id: str, tool_ids: List[int]
@@ -51,6 +56,13 @@ class MCPToolsManager:
         except Exception as e:
             logger.error(f"Failed to load MCP tools {tool_ids} for org {org_id}: {e}")
             return []
+        found_ids = {config.id for config in configs}
+        for missing_id in tool_ids:
+            if missing_id not in found_ids:
+                self.failed_tools.append({
+                    "name": f"Tool #{missing_id}",
+                    "error": "Configured tool no longer exists or is disabled",
+                })
         return await self._initialize_from_configs(configs)
 
     async def initialize_mcp_tools(self, agent_id: str, org_id: str) -> List[MCPTools]:
@@ -79,73 +91,13 @@ class MCPToolsManager:
             for mcp_tool_config in configs:
                 try:
                     logger.debug(f"Initializing MCP tool: {mcp_tool_config.name}")
-
-                    if mcp_tool_config.transport_type == MCPTransportType.STDIO:
-                        # Build command string for STDIO transport
-                        if mcp_tool_config.command and mcp_tool_config.args:
-                            # For filesystem MCP server, ensure we have proper directory arguments
-                            command_parts = [mcp_tool_config.command] + mcp_tool_config.args
-                            
-                            # Check if we need to add directories from env_vars
-                            if "@modelcontextprotocol/server-filesystem" in str(mcp_tool_config.args):
-                                # Check if there are directory arguments after the package name
-                                args_after_package = []
-                                package_found = False
-                                for arg in mcp_tool_config.args:
-                                    if package_found:
-                                        args_after_package.append(arg)
-                                    elif arg == "@modelcontextprotocol/server-filesystem":
-                                        package_found = True
-                                
-                                # If no directories in args, check env_vars
-                                if not args_after_package and mcp_tool_config.env_vars:
-                                    allowed_dirs_env = mcp_tool_config.env_vars.get("ALLOWED_DIRECTORIES")
-                                    if allowed_dirs_env:
-                                        # Parse comma-separated directories from env_vars
-                                        directories = [dir.strip() for dir in allowed_dirs_env.split(",") if dir.strip()]
-                                        if directories:
-                                            command_parts.extend(directories)
-                                            logger.debug(f"Added directories from env_vars: {directories}")
-                                        else:
-                                            logger.warning(f"Filesystem MCP tool {mcp_tool_config.name} has empty ALLOWED_DIRECTORIES, skipping")
-                                            continue
-                                    else:
-                                        logger.warning(f"Filesystem MCP tool {mcp_tool_config.name} missing ALLOWED_DIRECTORIES in env_vars, skipping")
-                                        continue
-                                elif not args_after_package:
-                                    logger.warning(f"Filesystem MCP tool {mcp_tool_config.name} missing directory arguments, skipping")
-                                    continue
-                            
-                            # Special handling for uvx commands with Python packages
-                            if mcp_tool_config.command == "uvx":
-                                # For uvx, we might need to handle Python MCP servers differently
-                                logger.debug(f"Using uvx command for MCP tool: {mcp_tool_config.name}")
-                            
-                            command_str = " ".join(command_parts)
-                            logger.debug(f"Creating STDIO MCP tool with command: {command_str}")
-                            
-                            # Prepare environment variables if provided (excluding ALLOWED_DIRECTORIES which we handled above)
-                            env_vars_for_process = None
-                            if mcp_tool_config.env_vars:
-                                env_vars_for_process = {k: v for k, v in mcp_tool_config.env_vars.items() if k != "ALLOWED_DIRECTORIES"}
-                                if env_vars_for_process:
-                                    logger.debug(f"Environment variables configured: {env_vars_for_process}")
-                                
-                            # Create MCPTools instance with environment variables
-                            mcp_tool = MCPTools(command_str, env=env_vars_for_process)
-                            await self._connect_and_register(mcp_tool, mcp_tool_config.name)
-
-                        else:
-                            logger.warning(f"STDIO MCP tool {mcp_tool_config.name} missing command or args")
-
-                    elif mcp_tool_config.transport_type in [MCPTransportType.SSE, MCPTransportType.HTTP]:
-                        mcp_tool = self._build_remote_tool(mcp_tool_config)
-                        await self._connect_and_register(mcp_tool, mcp_tool_config.name)
-
+                    mcp_tool = self._build_tool(mcp_tool_config)
+                    await self._connect_and_register(mcp_tool, mcp_tool_config.name)
                 except Exception as e:
                     logger.error(f"Failed to initialize MCP tool {mcp_tool_config.name}: {e}")
                     import traceback
                     logger.error(f"MCP tool error traceback: {traceback.format_exc()}")
+                    self.failed_tools.append({"name": mcp_tool_config.name, "error": str(e)})
                     continue
 
         except Exception as e:
@@ -153,6 +105,78 @@ class MCPToolsManager:
 
         logger.debug(f"Initialized {len(self.mcp_tools)} MCP tools")
         return self.mcp_tools
+
+    @classmethod
+    def _build_tool(cls, config) -> Optional[MCPTools]:
+        """MCPTools for a config of any transport, or None (with a logged
+        reason) when the config is unusable."""
+        if config.transport_type == MCPTransportType.STDIO:
+            return cls._build_stdio_tool(config)
+        if config.transport_type in (MCPTransportType.SSE, MCPTransportType.HTTP):
+            return cls._build_remote_tool(config)
+        logger.warning(f"MCP tool {config.name} has unsupported transport {config.transport_type}, skipping")
+        return None
+
+    @staticmethod
+    def _build_stdio_tool(config) -> Optional[MCPTools]:
+        """MCPTools for a local subprocess server (npx/uvx/binary)."""
+        if not (config.command and config.args):
+            logger.warning(f"STDIO MCP tool {config.name} missing command or args")
+            return None
+
+        command_parts = [config.command] + config.args
+
+        # The filesystem server takes its allowed directories as trailing
+        # arguments; accept them from ALLOWED_DIRECTORIES too.
+        if "@modelcontextprotocol/server-filesystem" in str(config.args):
+            args_after_package = []
+            package_found = False
+            for arg in config.args:
+                if package_found:
+                    args_after_package.append(arg)
+                elif arg == "@modelcontextprotocol/server-filesystem":
+                    package_found = True
+
+            if not args_after_package:
+                allowed_dirs_env = (config.env_vars or {}).get("ALLOWED_DIRECTORIES")
+                directories = [d.strip() for d in (allowed_dirs_env or "").split(",") if d.strip()]
+                if not directories:
+                    logger.warning(f"Filesystem MCP tool {config.name} missing directory arguments (args or ALLOWED_DIRECTORIES), skipping")
+                    return None
+                command_parts.extend(directories)
+                logger.debug(f"Added directories from env_vars: {directories}")
+
+        command_str = " ".join(command_parts)
+        logger.debug(f"Creating STDIO MCP tool with command: {command_str}")
+
+        # Prepare environment variables if provided (excluding ALLOWED_DIRECTORIES which we handled above)
+        env_vars_for_process = None
+        if config.env_vars:
+            env_vars_for_process = {k: v for k, v in config.env_vars.items() if k != "ALLOWED_DIRECTORIES"}
+            if env_vars_for_process:
+                # Values may hold credentials (API keys, tokens) — log names only
+                logger.debug(f"Environment variables configured: {list(env_vars_for_process.keys())}")
+
+        return MCPTools(command_str, env=env_vars_for_process)
+
+    async def test_tool_config(self, config) -> dict:
+        """Connect to a configured tool once and report what happened — backs
+        the Test button on the MCP config page. Goes through the same
+        build/connect path as a real run, so the reported error is exactly
+        what a run would record. Never raises."""
+        failures_before = len(self.failed_tools)
+        try:
+            mcp_tool = self._build_tool(config)
+            connected = await self._connect_and_register(mcp_tool, config.name)
+        except Exception as e:
+            return {"success": False, "functions": [], "error": str(e)}
+        if connected:
+            functions = list(getattr(mcp_tool, "functions", None) or {})
+            await self.cleanup_mcp_tools()
+            return {"success": True, "functions": functions, "error": None}
+        new_failures = self.failed_tools[failures_before:]
+        error = new_failures[-1]["error"] if new_failures else "Failed to connect to the server"
+        return {"success": False, "functions": [], "error": error}
 
     @staticmethod
     def _build_remote_tool(config) -> Optional[MCPTools]:
@@ -188,12 +212,20 @@ class MCPToolsManager:
         """Connect a built tool, verify it exposes functions, and register it
         for use + cleanup. Failed tools are torn down, never registered."""
         if mcp_tool is None:
+            self.failed_tools.append({
+                "name": name,
+                "error": "Tool is misconfigured — check its command/args (STDIO) or URL (SSE/HTTP)",
+            })
             return False
         try:
             await asyncio.wait_for(mcp_tool.__aenter__(), timeout=CONNECT_TIMEOUT_SECONDS)
             logger.debug(f"Entered MCP tool context: {name}")
         except asyncio.TimeoutError:
             logger.error(f"Timeout connecting to MCP tool {name}")
+            self.failed_tools.append({
+                "name": name,
+                "error": f"Timed out after {CONNECT_TIMEOUT_SECONDS:.0f}s connecting to the server",
+            })
             await self._abort_tool(mcp_tool)
             return False
         except Exception as e:
@@ -201,6 +233,7 @@ class MCPToolsManager:
             # For package not found errors (like Git server), skip silently after first error
             if "404" in str(e) or "not found" in str(e).lower() or "no such package" in str(e).lower():
                 logger.warning(f"MCP tool package not found, skipping: {name}")
+            self.failed_tools.append({"name": name, "error": str(e)})
             await self._abort_tool(mcp_tool)
             return False
 
@@ -211,8 +244,10 @@ class MCPToolsManager:
             # evidence log) attribute each tool call to its connector.
             mcp_tool._connector_name = name
             self.mcp_tools.append(mcp_tool)
+            self.connected_tool_names.append(name)
             return True
         logger.warning(f"MCP tool {name} has no functions available after connection")
+        self.failed_tools.append({"name": name, "error": "Connected, but the server exposed no tools"})
         await self._abort_tool(mcp_tool)
         return False
 

--- a/backend/app/workers/ticket_investigator.py
+++ b/backend/app/workers/ticket_investigator.py
@@ -364,17 +364,17 @@ def _build_db_tools(db, ticket: Ticket, run):
 
 
 async def _investigate_with_tools(
-    db, run, service, ticket, agent, context_message, settings_row, recorder
+    db, run, service, ticket, agent, context_message, settings_row, recorder, manager
 ):
     """Connect the org's investigation tools (MCP connectors + guardrailed DB
     connectors), run the hypothesis phases, then clean the tools up — ALL in
     this one coroutine. It's driven under asyncio.wait_for (a child task), so
     MCP init, every tool call and cleanup must live in the same task or the
-    anyio cancel scope owning the MCP streams gets crossed on timeout."""
+    anyio cancel scope owning the MCP streams gets crossed on timeout. The
+    manager is caller-owned so its connect/fail bookkeeping stays readable
+    after a timeout cancels this coroutine."""
     from app.services.ticket_investigation import run_investigation_phases
-    from app.tools.mcp_manager import MCPToolsManager
 
-    manager = MCPToolsManager()
     mcp_tools = []
     try:
         tool_ids = settings_row.investigation_mcp_tool_ids or []
@@ -430,12 +430,16 @@ async def _process_investigation(db, run, service: TicketService, ticket: Ticket
         ticket.title, ticket.description, transcript, similar, extra_sections=extra_sections
     )
 
+    from app.tools.mcp_manager import MCPToolsManager
+
+    mcp_manager = MCPToolsManager()
     hypotheses = []
     partial = False
     try:
         hypotheses, budget_exhausted = await asyncio.wait_for(
             _investigate_with_tools(
-                db, run, service, ticket, agent, context_message, settings_row, recorder
+                db, run, service, ticket, agent, context_message, settings_row,
+                recorder, mcp_manager
             ),
             timeout=run.max_wall_seconds or DEFAULT_MAX_WALL_SECONDS,
         )
@@ -456,6 +460,16 @@ async def _process_investigation(db, run, service: TicketService, ticket: Ticket
         db.commit()
 
     run.tool_calls_used = recorder.tool_calls
+    # Surface the connector outcome on the run — a run that "completed" with 0
+    # of its configured MCP tools (missing npx, bad key, unreachable server)
+    # must be visible on the dashboard, not just in worker logs (issue #271).
+    configured_tool_ids = settings_row.investigation_mcp_tool_ids or []
+    if configured_tool_ids:
+        run.connector_status = {
+            "configured": len(configured_tool_ids),
+            "loaded": len(mcp_manager.connected_tool_names),
+            "failed": mcp_manager.failed_tools,
+        }
     rca = await synthesize_and_store_rca(
         db, run, ticket, agent, context_message, hypotheses, recorder, partial
     )

--- a/backend/tests/api/test_mcp_tool.py
+++ b/backend/tests/api/test_mcp_tool.py
@@ -206,3 +206,54 @@ def test_agent_association_endpoints(client: TestClient, db):
     assert resp3.json()["message"] == "MCP tool removed from agent successfully"
 
 
+
+
+def test_test_mcp_tool_endpoint(client: TestClient, db):
+    """POST /{id}/test proxies the manager's connection probe."""
+    from unittest.mock import AsyncMock, patch
+
+    mcp_api.HAS_ENTERPRISE = False
+    payload = {
+        "name": "Probe",
+        "transport_type": MCPTransportType.STDIO.value,
+        "command": "npx",
+        "args": ["-y", "@elastic/mcp-server-elasticsearch"],
+        "enabled": True,
+    }
+    tool_id = client.post("/api/mcp", json=payload).json()["id"]
+
+    with patch.object(
+        mcp_api.MCPToolsManager, "test_tool_config",
+        new=AsyncMock(return_value={"success": False, "functions": [], "error": "[Errno 2] No such file or directory: 'npx'"}),
+    ):
+        resp = client.post(f"/api/mcp/{tool_id}/test")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is False
+    assert "npx" in body["error"]
+
+    # Unknown id → 404
+    resp2 = client.post("/api/mcp/999999/test")
+    assert resp2.status_code == 404
+
+
+def test_test_mcp_tool_endpoint_other_org_forbidden(client: TestClient, db):
+    """Testing a tool owned by another organization is rejected."""
+    from app.models.mcp_tool import MCPTool
+
+    mcp_api.HAS_ENTERPRISE = False
+    other_org_tool = MCPTool(
+        name="Other org tool",
+        transport_type=MCPTransportType.STDIO,
+        command="npx",
+        args=["-y", "some-server"],
+        enabled=True,
+        organization_id=uuid4(),
+    )
+    db.add(other_org_tool)
+    db.commit()
+    db.refresh(other_org_tool)
+
+    resp = client.post(f"/api/mcp/{other_org_tool.id}/test")
+    assert resp.status_code == 403

--- a/backend/tests/tools/test_mcp_manager.py
+++ b/backend/tests/tools/test_mcp_manager.py
@@ -526,6 +526,191 @@ async def test_cleanup_mcp_tools_unexpected_error():
     assert manager.mcp_tools == []
 
 
+# ==================== Failure tracking + connection test ====================
+
+
+def _stdio_config(name="Elasticsearch", command="npx", args=None, env_vars=None):
+    config = MagicMock()
+    config.name = name
+    config.transport_type = MCPTransportType.STDIO
+    config.command = command
+    config.args = args if args is not None else ["-y", "@elastic/mcp-server-elasticsearch"]
+    config.env_vars = env_vars or {}
+    return config
+
+
+@pytest.mark.asyncio
+async def test_failed_tools_records_connect_error():
+    """A tool that can't start (e.g. npx missing) lands in failed_tools with
+    the real error, and connected_tool_names stays empty."""
+    manager = MCPToolsManager()
+
+    with patch("app.tools.mcp_manager.SessionLocal") as mock_sess_local, \
+         patch("app.tools.mcp_manager.MCPToolRepository") as mock_repo_cls, \
+         patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
+
+        mock_sess_local.return_value.__enter__.return_value = MagicMock()
+        mock_repo = MagicMock()
+        config = _stdio_config()
+        config.id = 7
+        mock_repo.get_by_ids.return_value = [config]
+        mock_repo_cls.return_value = mock_repo
+
+        mock_mcp_instance = MagicMock()
+        mock_mcp_instance.__aenter__ = AsyncMock(
+            side_effect=FileNotFoundError("[Errno 2] No such file or directory: 'npx'")
+        )
+        mock_mcp_instance.__aexit__ = AsyncMock()
+        mock_mcp_tools_cls.return_value = mock_mcp_instance
+
+        tools = await manager.initialize_mcp_tools_by_ids(str(uuid4()), [7])
+
+        assert tools == []
+        assert manager.connected_tool_names == []
+        assert len(manager.failed_tools) == 1
+        assert manager.failed_tools[0]["name"] == "Elasticsearch"
+        assert "npx" in manager.failed_tools[0]["error"]
+
+
+@pytest.mark.asyncio
+async def test_failed_tools_records_missing_ids():
+    """Requested tool ids that no longer resolve to configs are reported."""
+    manager = MCPToolsManager()
+
+    with patch("app.tools.mcp_manager.SessionLocal") as mock_sess_local, \
+         patch("app.tools.mcp_manager.MCPToolRepository") as mock_repo_cls:
+
+        mock_sess_local.return_value.__enter__.return_value = MagicMock()
+        mock_repo = MagicMock()
+        mock_repo.get_by_ids.return_value = []
+        mock_repo_cls.return_value = mock_repo
+
+        tools = await manager.initialize_mcp_tools_by_ids(str(uuid4()), [42])
+
+        assert tools == []
+        assert manager.failed_tools == [
+            {"name": "Tool #42", "error": "Configured tool no longer exists or is disabled"}
+        ]
+
+
+@pytest.mark.asyncio
+async def test_connected_tool_names_recorded_on_success():
+    manager = MCPToolsManager()
+
+    with patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
+        mock_mcp_instance = AsyncMock()
+        mock_mcp_instance.functions = {"search": MagicMock()}
+        mock_mcp_tools_cls.return_value = mock_mcp_instance
+
+        tools = await manager._initialize_from_configs([_stdio_config()])
+
+        assert len(tools) == 1
+        assert manager.connected_tool_names == ["Elasticsearch"]
+        assert manager.failed_tools == []
+
+
+@pytest.mark.asyncio
+async def test_test_tool_config_success():
+    manager = MCPToolsManager()
+
+    with patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
+        mock_mcp_instance = AsyncMock()
+        mock_mcp_instance.functions = {"search": MagicMock(), "get_index": MagicMock()}
+        mock_mcp_tools_cls.return_value = mock_mcp_instance
+
+        result = await manager.test_tool_config(_stdio_config())
+
+        assert result["success"] is True
+        assert sorted(result["functions"]) == ["get_index", "search"]
+        assert result["error"] is None
+        # The probe tool is torn down, never registered for later use.
+        assert manager.mcp_tools == []
+        mock_mcp_instance.__aexit__.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_test_tool_config_connect_failure():
+    manager = MCPToolsManager()
+
+    with patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
+        mock_mcp_instance = MagicMock()
+        mock_mcp_instance.__aenter__ = AsyncMock(
+            side_effect=FileNotFoundError("[Errno 2] No such file or directory: 'npx'")
+        )
+        mock_mcp_instance.__aexit__ = AsyncMock()
+        mock_mcp_tools_cls.return_value = mock_mcp_instance
+
+        result = await manager.test_tool_config(_stdio_config())
+
+        assert result["success"] is False
+        assert "npx" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_test_tool_config_misconfigured():
+    manager = MCPToolsManager()
+    result = await manager.test_tool_config(_stdio_config(command=None, args=None))
+    assert result["success"] is False
+    assert "misconfigured" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_test_tool_config_timeout():
+    manager = MCPToolsManager()
+
+    async def hang():
+        await asyncio.sleep(60)
+
+    with patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls, \
+         patch("app.tools.mcp_manager.CONNECT_TIMEOUT_SECONDS", 0.01):
+        mock_mcp_instance = MagicMock()
+        mock_mcp_instance.__aenter__ = MagicMock(side_effect=hang)
+        mock_mcp_instance.__aexit__ = AsyncMock()
+        mock_mcp_tools_cls.return_value = mock_mcp_instance
+
+        result = await manager.test_tool_config(_stdio_config())
+
+        assert result["success"] is False
+        assert "Timed out" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_mixed_success_and_failure_bookkeeping():
+    """With one tool connecting and one failing, both lists are accurate —
+    this is what run.connector_status is built from."""
+    manager = MCPToolsManager()
+    good = _stdio_config(name="Good")
+    bad = _stdio_config(name="Bad")
+
+    good_instance = AsyncMock()
+    good_instance.functions = {"search": MagicMock()}
+    bad_instance = MagicMock()
+    bad_instance.__aenter__ = AsyncMock(side_effect=Exception("connection refused"))
+    bad_instance.__aexit__ = AsyncMock()
+
+    with patch("app.tools.mcp_manager.MCPTools", side_effect=[good_instance, bad_instance]):
+        tools = await manager._initialize_from_configs([good, bad])
+
+    assert len(tools) == 1
+    assert manager.connected_tool_names == ["Good"]
+    assert manager.failed_tools == [{"name": "Bad", "error": "connection refused"}]
+
+
+@pytest.mark.asyncio
+async def test_test_tool_config_no_functions():
+    manager = MCPToolsManager()
+
+    with patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
+        mock_mcp_instance = AsyncMock()
+        mock_mcp_instance.functions = {}
+        mock_mcp_tools_cls.return_value = mock_mcp_instance
+
+        result = await manager.test_tool_config(_stdio_config())
+
+        assert result["success"] is False
+        assert "no tools" in result["error"]
+
+
 class TestChatAgentMCPMixin:
     """Tests for ChatAgentMCPMixin"""
 

--- a/frontend/src/__tests__/components/faq/FaqCard.spec.ts
+++ b/frontend/src/__tests__/components/faq/FaqCard.spec.ts
@@ -123,6 +123,23 @@ describe('FaqCard edit mode', () => {
     expect(wrapper.emitted('update:draftAnswer')?.[0]).toEqual(['New answer'])
   })
 
+  it('renders the topic input with existing topics as autocomplete options', () => {
+    const wrapper = createWrapper({
+      editing: true,
+      draftCategory: 'Billing',
+      categories: ['Billing', 'Getting started'],
+    })
+    expect((wrapper.find('.edit-topic__input').element as HTMLInputElement).value).toBe('Billing')
+    const options = wrapper.findAll('#faq-topic-options option')
+    expect(options.map((o) => o.attributes('value'))).toEqual(['Billing', 'Getting started'])
+  })
+
+  it('emits topic draft updates on input', async () => {
+    const wrapper = createWrapper({ editing: true })
+    await wrapper.find('.edit-topic__input').setValue('Refunds')
+    expect(wrapper.emitted('update:draftCategory')?.[0]).toEqual(['Refunds'])
+  })
+
   it('emits save and cancel', async () => {
     const wrapper = createWrapper({ editing: true })
     await wrapper.find('.btn-save').trigger('click')

--- a/frontend/src/__tests__/components/tickets/TicketInvestigationPanel.spec.ts
+++ b/frontend/src/__tests__/components/tickets/TicketInvestigationPanel.spec.ts
@@ -1,0 +1,69 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import TicketInvestigationPanel from '../../../components/tickets/TicketInvestigationPanel.vue'
+import type { InvestigationDetail, InvestigationRun } from '../../../types/ticket'
+
+const baseRun: InvestigationRun = {
+  id: 'r1',
+  run_type: 'investigation',
+  status: 'completed',
+  trigger: 'manual',
+  tool_calls_used: 0,
+}
+
+const mountPanel = (run: Partial<InvestigationRun>) =>
+  mount(TicketInvestigationPanel, {
+    props: {
+      investigation: {
+        run: { ...baseRun, ...run },
+        hypotheses: [],
+        events: [],
+      } as InvestigationDetail,
+    },
+  })
+
+describe('TicketInvestigationPanel connector warning', () => {
+  it('warns when the run loaded fewer connectors than configured', () => {
+    const wrapper = mountPanel({
+      connector_status: {
+        configured: 1,
+        loaded: 0,
+        failed: [{ name: 'Elasticsearch', error: "[Errno 2] No such file or directory: 'npx'" }],
+      },
+    })
+    const warning = wrapper.find('.connector-warning')
+    expect(warning.exists()).toBe(true)
+    expect(warning.text()).toContain('0 of 1 configured connector')
+    expect(warning.text()).toContain('Elasticsearch')
+    expect(warning.text()).toContain('npx')
+  })
+
+  it('stays silent when every configured connector loaded', () => {
+    const wrapper = mountPanel({
+      connector_status: { configured: 2, loaded: 2, failed: [] },
+    })
+    expect(wrapper.find('.connector-warning').exists()).toBe(false)
+  })
+
+  it('stays silent when the run has no connector status (older runs)', () => {
+    const wrapper = mountPanel({})
+    expect(wrapper.find('.connector-warning').exists()).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/composables/useFaqWorkspace.category.spec.ts
+++ b/frontend/src/__tests__/composables/useFaqWorkspace.category.spec.ts
@@ -1,0 +1,95 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useFaqWorkspace } from '@/composables/useFaqWorkspace'
+import { faqService } from '@/services/faq'
+import type { FaqItem } from '@/types/faq'
+
+vi.mock('@/services/faq', () => ({
+  faqService: {
+    createFaq: vi.fn(),
+    updateFaq: vi.fn(),
+  },
+}))
+vi.mock('@/services/knowledge', () => ({ knowledgeService: {} }))
+vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() } }))
+
+const existingFaq: FaqItem = {
+  id: 'f1',
+  question: 'Q?',
+  answer: 'A.',
+  category: 'Billing',
+  status: 'draft',
+  knowledge_id: null,
+  source_label: null,
+}
+
+describe('useFaqWorkspace topic (category) handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(faqService.createFaq).mockResolvedValue({ ...existingFaq, id: 'new1' })
+    vi.mocked(faqService.updateFaq).mockResolvedValue({ ...existingFaq })
+  })
+
+  it('creates with the typed topic', async () => {
+    const ws = useFaqWorkspace(() => 'org1')
+    ws.startAdd()
+    ws.draftQuestion.value = 'How do refunds work?'
+    ws.draftAnswer.value = 'Like this.'
+    ws.draftCategory.value = ' Refunds '
+    await ws.saveEdit()
+
+    expect(faqService.createFaq).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'Refunds' }),
+    )
+  })
+
+  it('creates without a category when the topic is blank (server default applies)', async () => {
+    const ws = useFaqWorkspace(() => 'org1')
+    ws.startAdd()
+    ws.draftQuestion.value = 'Q'
+    ws.draftAnswer.value = 'A'
+    await ws.saveEdit()
+
+    const payload = vi.mocked(faqService.createFaq).mock.calls[0][0]
+    expect(payload).not.toHaveProperty('category')
+  })
+
+  it('pre-fills the current topic on edit and sends a changed one', async () => {
+    const ws = useFaqWorkspace(() => 'org1')
+    ws.startEdit(existingFaq)
+    expect(ws.draftCategory.value).toBe('Billing')
+
+    ws.draftCategory.value = 'Payments'
+    await ws.saveEdit()
+
+    expect(faqService.updateFaq).toHaveBeenCalledWith(
+      'f1',
+      expect.objectContaining({ category: 'Payments' }),
+    )
+  })
+
+  it('omits the category on edit when cleared, keeping the current topic', async () => {
+    const ws = useFaqWorkspace(() => 'org1')
+    ws.startEdit(existingFaq)
+    ws.draftCategory.value = ''
+    await ws.saveEdit()
+
+    const payload = vi.mocked(faqService.updateFaq).mock.calls[0][1]
+    expect(payload).not.toHaveProperty('category')
+  })
+})

--- a/frontend/src/__tests__/composables/useMCPTools.spec.ts
+++ b/frontend/src/__tests__/composables/useMCPTools.spec.ts
@@ -1,0 +1,82 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useMCPTools } from '@/composables/useMCPTools'
+import { mcpService } from '@/services/mcp'
+
+vi.mock('@/services/mcp', () => ({
+  mcpService: {
+    testMCPTool: vi.fn(),
+  },
+}))
+vi.mock('vue-sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+describe('useMCPTools connection test', () => {
+  beforeEach(() => {
+    vi.mocked(mcpService.testMCPTool).mockReset()
+  })
+
+  it('stores the probe result per tool id', async () => {
+    vi.mocked(mcpService.testMCPTool).mockResolvedValue({
+      success: true,
+      functions: ['search', 'get_index'],
+      error: null,
+    })
+    const { testMCPTool, testResults, testingToolId } = useMCPTools('agent1')
+
+    await testMCPTool(7)
+
+    expect(testResults.value[7]).toEqual({
+      success: true,
+      functions: ['search', 'get_index'],
+      error: null,
+    })
+    expect(testingToolId.value).toBeNull()
+  })
+
+  it('turns a request failure into a failed result for the tool', async () => {
+    vi.mocked(mcpService.testMCPTool).mockRejectedValue({
+      response: { data: { detail: 'MCP tool not found' } },
+    })
+    const { testMCPTool, testResults, testingToolId } = useMCPTools('agent1')
+
+    await testMCPTool(9)
+
+    expect(testResults.value[9]).toEqual({
+      success: false,
+      functions: [],
+      error: 'MCP tool not found',
+    })
+    expect(testingToolId.value).toBeNull()
+  })
+
+  it('marks the tool as testing while the probe runs', async () => {
+    let resolveProbe: (v: any) => void = () => {}
+    vi.mocked(mcpService.testMCPTool).mockReturnValue(
+      new Promise((resolve) => {
+        resolveProbe = resolve
+      }),
+    )
+    const { testMCPTool, testingToolId } = useMCPTools('agent1')
+
+    const probe = testMCPTool(3)
+    expect(testingToolId.value).toBe(3)
+    resolveProbe({ success: true, functions: [], error: null })
+    await probe
+    expect(testingToolId.value).toBeNull()
+  })
+})

--- a/frontend/src/components/agent/AgentMCPToolsTab.vue
+++ b/frontend/src/components/agent/AgentMCPToolsTab.vue
@@ -41,6 +41,9 @@ const {
   linkMCPTool,
   unlinkMCPTool,
   deleteMCPTool,
+  testMCPTool,
+  testResults,
+  testingToolId,
   applyPreset,
   resetCreateForm,
   confirmDelete,
@@ -171,28 +174,51 @@ onMounted(() => {
       <!-- Tools List -->
       <div v-else class="tools-list">
         <div v-for="tool in agentMCPTools" :key="tool.id" class="tool-card">
-          <div class="tool-card-main">
-            <div class="tool-badge">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
-                <circle cx="12" cy="12" r="3"/>
-              </svg>
-            </div>
-            <div class="tool-meta">
-              <div class="tool-name">
-                <span class="tool-name-text">{{ tool.name }}</span>
-                <span class="transport-chip">{{ getTransportTypeInfo(tool.transport_type).label }}</span>
+          <div class="tool-card-row">
+            <div class="tool-card-main">
+              <div class="tool-badge">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
+                  <circle cx="12" cy="12" r="3"/>
+                </svg>
               </div>
-              <div class="tool-desc">{{ tool.description || 'Custom MCP tool' }}</div>
+              <div class="tool-meta">
+                <div class="tool-name">
+                  <span class="tool-name-text">{{ tool.name }}</span>
+                  <span class="transport-chip">{{ getTransportTypeInfo(tool.transport_type).label }}</span>
+                </div>
+                <div class="tool-desc">{{ tool.description || 'Custom MCP tool' }}</div>
+              </div>
+            </div>
+            <div class="tool-card-actions">
+              <span class="tool-status">
+                <span class="status-dot"></span>{{ tool.enabled ? 'connected' : 'disabled' }}
+              </span>
+              <button
+                class="test-button"
+                :disabled="testingToolId !== null"
+                @click="testMCPTool(tool.id)"
+                title="Connect to the server and list its tools"
+              >
+                {{ testingToolId === tool.id ? 'Testing…' : 'Test' }}
+              </button>
+              <button class="remove-button" @click="confirmDelete(tool.id)" title="Remove tool">
+                Remove
+              </button>
             </div>
           </div>
-          <div class="tool-card-actions">
-            <span class="tool-status">
-              <span class="status-dot"></span>{{ tool.enabled ? 'connected' : 'disabled' }}
-            </span>
-            <button class="remove-button" @click="confirmDelete(tool.id)" title="Remove tool">
-              Remove
-            </button>
+          <div
+            v-if="testResults[tool.id]"
+            class="test-result"
+            :class="testResults[tool.id].success ? 'test-result--ok' : 'test-result--fail'"
+          >
+            <template v-if="testResults[tool.id].success">
+              ✓ Connected — {{ testResults[tool.id].functions.length }} tool{{ testResults[tool.id].functions.length === 1 ? '' : 's' }} available:
+              {{ testResults[tool.id].functions.join(', ') }}
+            </template>
+            <template v-else>
+              ✕ {{ testResults[tool.id].error }}
+            </template>
           </div>
         </div>
       </div>
@@ -694,15 +720,18 @@ onMounted(() => {
   border: 1px solid var(--o08);
   border-radius: var(--radius-lg);
   padding: 18px 22px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
   transition: border-color 0.2s ease;
 }
 
 .tool-card:hover {
   border-color: var(--o14);
+}
+
+.tool-card-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
 }
 
 .tool-card-main {
@@ -802,6 +831,49 @@ onMounted(() => {
 
 .remove-button:hover {
   background: var(--coral-bg);
+}
+
+.test-button {
+  padding: 7px 13px;
+  background: transparent;
+  border: 1px solid var(--o12);
+  border-radius: 8px;
+  color: var(--text2);
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.test-button:hover:not(:disabled) {
+  background: var(--o05);
+}
+
+.test-button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.test-result {
+  margin-top: 12px;
+  padding: 9px 12px;
+  border-radius: 9px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.test-result--ok {
+  background: var(--teal-bg);
+  border: 1px solid var(--teal-border);
+  color: var(--c-teal);
+}
+
+.test-result--fail {
+  background: var(--coral-bg);
+  border: 1px solid var(--coral-border);
+  color: var(--c-coral);
 }
 
 /* ---------- Modal Shell ---------- */
@@ -1371,7 +1443,7 @@ onMounted(() => {
     flex-wrap: wrap;
   }
 
-  .tool-card {
+  .tool-card-row {
     flex-direction: column;
     align-items: flex-start;
   }

--- a/frontend/src/components/faq/FaqCard.vue
+++ b/frontend/src/components/faq/FaqCard.vue
@@ -31,6 +31,10 @@ const props = defineProps<{
   draftSlug?: string
   draftMetaTitle?: string
   draftMetaDescription?: string
+  /** Topic (category) draft plus the org's existing topics for autocomplete.
+   *  Optional for the same reason as the SEO drafts. */
+  draftCategory?: string
+  categories?: string[]
   locked?: boolean
   /** Selection mode is on somewhere in the list (keeps checkboxes visible). */
   selectable?: boolean
@@ -46,6 +50,7 @@ const emit = defineEmits<{
   'toggle-select': []
   'update:draftQuestion': [value: string]
   'update:draftAnswer': [value: string]
+  'update:draftCategory': [value: string]
   'update:draftSlug': [value: string]
   'update:draftMetaTitle': [value: string]
   'update:draftMetaDescription': [value: string]
@@ -55,7 +60,15 @@ function onQuestionInput(event: Event) {
   emit('update:draftQuestion', (event.target as HTMLInputElement).value)
 }
 
+function onCategoryInput(event: Event) {
+  emit('update:draftCategory', (event.target as HTMLInputElement).value)
+}
+
 const sourceLabel = () => props.faq.source_label || 'Generated'
+
+// Mirrors the category column width in app/models/faq.py — the API 422s
+// anything longer, so this only stops the user typing past the limit.
+const MAX_TOPIC = 100
 
 // Answers are stored as Markdown; strip the syntax and cap the length for the
 // compact, line-clamped card preview (the public article page and the editor
@@ -90,6 +103,22 @@ function answerPreview(md: string): string {
         @update:model-value="$emit('update:draftAnswer', $event)"
       />
       <p class="edit-hint">Markdown supported — headings, <strong>bold</strong>, lists, links and images.</p>
+      <label class="edit-topic">
+        <span class="edit-topic__label">Topic</span>
+        <input
+          type="text"
+          class="edit-topic__input"
+          list="faq-topic-options"
+          :maxlength="MAX_TOPIC"
+          :placeholder="isNew ? 'General' : 'Keeps the current topic if left empty'"
+          :value="draftCategory"
+          @input="onCategoryInput"
+        />
+        <datalist id="faq-topic-options">
+          <option v-for="c in categories" :key="c" :value="c" />
+        </datalist>
+        <span class="edit-topic__hint">Pick an existing topic or type a new one to create it.</span>
+      </label>
       <FaqSeoFields
         :slug="draftSlug"
         :meta-title="draftMetaTitle"
@@ -363,6 +392,43 @@ function answerPreview(md: string): string {
   font-size: 14.5px;
   font-weight: 600;
   margin-bottom: 9px;
+}
+
+.edit-topic {
+  display: block;
+  margin-top: 12px;
+}
+
+.edit-topic__label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted2);
+  margin-bottom: 6px;
+}
+
+.edit-topic__input {
+  width: 100%;
+  max-width: 320px;
+  display: block;
+  background: var(--bg);
+  border: 1px solid var(--o12);
+  border-radius: 10px;
+  padding: 9px 12px;
+  color: var(--text);
+  outline: none;
+  box-sizing: border-box;
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+}
+
+.edit-topic__hint {
+  display: block;
+  margin-top: 6px;
+  font-size: 11.5px;
+  color: var(--muted2);
 }
 
 /* .edit-answer wraps the MarkdownEditor, which supplies its own chrome. */

--- a/frontend/src/components/faq/FaqWorkspace.vue
+++ b/frontend/src/components/faq/FaqWorkspace.vue
@@ -61,6 +61,7 @@ const {
   isNewFaq,
   draftQuestion,
   draftAnswer,
+  draftCategory,
   draftSlug,
   draftMetaTitle,
   draftMetaDescription,
@@ -265,12 +266,13 @@ async function runConfirm() {
   }
 }
 
-// Placeholder card for a manually added FAQ.
+// Placeholder card for a manually added FAQ. The category mirrors the server
+// default applied when the topic field is left blank.
 const newFaqStub = computed<FaqItem>(() => ({
   id: 'new',
   question: '',
   answer: '',
-  category: 'New',
+  category: 'General',
   status: 'draft',
   knowledge_id: null,
   source_label: 'Added manually',
@@ -331,8 +333,10 @@ onUnmounted(stopPolling)
               :editing="true"
               :is-new="true"
               :saving="isSaving"
+              :categories="categories"
               v-model:draft-question="draftQuestion"
               v-model:draft-answer="draftAnswer"
+              v-model:draft-category="draftCategory"
               v-model:draft-slug="draftSlug"
               v-model:draft-meta-title="draftMetaTitle"
               v-model:draft-meta-description="draftMetaDescription"
@@ -392,13 +396,16 @@ onUnmounted(stopPolling)
                 :saving="isSaving"
                 :selectable="selectionActive"
                 :selected="selectedIds.has(faq.id)"
+                :categories="categories"
                 :draft-question="draftQuestion"
                 :draft-answer="draftAnswer"
+                :draft-category="draftCategory"
                 :draft-slug="draftSlug"
                 :draft-meta-title="draftMetaTitle"
                 :draft-meta-description="draftMetaDescription"
                 @update:draft-question="draftQuestion = $event"
                 @update:draft-answer="draftAnswer = $event"
+                @update:draft-category="draftCategory = $event"
                 @update:draft-slug="draftSlug = $event"
                 @update:draft-meta-title="draftMetaTitle = $event"
                 @update:draft-meta-description="draftMetaDescription = $event"

--- a/frontend/src/components/tickets/TicketInvestigationPanel.vue
+++ b/frontend/src/components/tickets/TicketInvestigationPanel.vue
@@ -57,6 +57,14 @@ const tokenLabel = computed(() => {
   if (!total) return ''
   return total >= 1000 ? `${(total / 1000).toFixed(1)}k tokens` : `${total} tokens`
 })
+
+// A run that finished with fewer MCP connectors than configured produced its
+// answer without the evidence those tools were meant to gather — warn.
+const connectorWarning = computed(() => {
+  const status = run.value?.connector_status
+  if (!status || status.loaded >= status.configured) return null
+  return status
+})
 </script>
 
 <template>
@@ -86,6 +94,18 @@ const tokenLabel = computed(() => {
 
     <div v-if="run.status === 'failed' && run.error" class="run-error">
       {{ run.error }}
+    </div>
+
+    <div v-if="connectorWarning" class="connector-warning">
+      <div>
+        Ran with {{ connectorWarning.loaded }} of {{ connectorWarning.configured }} configured
+        connector{{ connectorWarning.configured === 1 ? '' : 's' }} — findings may be missing evidence.
+      </div>
+      <ul v-if="connectorWarning.failed.length" class="connector-warning__list">
+        <li v-for="f in connectorWarning.failed" :key="f.name">
+          <strong>{{ f.name }}</strong>: {{ f.error }}
+        </li>
+      </ul>
     </div>
 
     <div v-if="investigation.hypotheses.length" class="hypothesis-list">
@@ -183,6 +203,22 @@ const tokenLabel = computed(() => {
   border-radius: 10px;
   font-size: 12px;
   color: var(--c-danger);
+}
+.connector-warning {
+  margin-top: 12px;
+  padding: 9px 12px;
+  background: color-mix(in srgb, var(--c-warn) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--c-warn) 35%, transparent);
+  border-radius: 10px;
+  font-size: 12px;
+  color: var(--c-warn);
+}
+.connector-warning__list {
+  margin: 6px 0 0;
+  padding-left: 18px;
+}
+.connector-warning__list li {
+  word-break: break-word;
 }
 .hypothesis-list {
   margin-top: 13px;

--- a/frontend/src/composables/useFaqWorkspace.ts
+++ b/frontend/src/composables/useFaqWorkspace.ts
@@ -100,6 +100,9 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
   const isNewFaq = ref(false)
   const draftQuestion = ref('')
   const draftAnswer = ref('')
+  // Topic (stored as the FAQ's free-form category). Empty on create means the
+  // server default; empty on edit means "keep the current topic".
+  const draftCategory = ref('')
   // Per-article SEO overrides. Empty means "derive it" — the server normalizes
   // a hand-typed slug and treats blanks as cleared, so no client-side slugify.
   const draftSlug = ref('')
@@ -357,6 +360,7 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     isNewFaq.value = false
     draftQuestion.value = faq.question
     draftAnswer.value = faq.answer
+    draftCategory.value = faq.category
     setSeoDraft(faq)
   }
 
@@ -365,6 +369,7 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     isNewFaq.value = true
     draftQuestion.value = ''
     draftAnswer.value = ''
+    draftCategory.value = ''
     setSeoDraft(null)
   }
 
@@ -373,6 +378,7 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     isNewFaq.value = false
     draftQuestion.value = ''
     draftAnswer.value = ''
+    draftCategory.value = ''
     setSeoDraft(null)
   }
 
@@ -391,13 +397,18 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
       meta_title: draftMetaTitle.value.trim(),
       meta_description: draftMetaDescription.value.trim(),
     }
+    // The server rejects a blank category, so only send one when set: on
+    // create a blank falls back to the server default, on edit it keeps the
+    // FAQ's current topic.
+    const category = draftCategory.value.trim()
+    const withCategory = category ? { category } : {}
     isSaving.value = true
     try {
       if (isNewFaq.value) {
-        const created = await faqService.createFaq({ question, answer, ...seo })
+        const created = await faqService.createFaq({ question, answer, ...withCategory, ...seo })
         faqs.value = [...faqs.value, created]
       } else if (editingId.value) {
-        const updated = await faqService.updateFaq(editingId.value, { question, answer, ...seo })
+        const updated = await faqService.updateFaq(editingId.value, { question, answer, ...withCategory, ...seo })
         faqs.value = faqs.value.map((f) => (f.id === updated.id ? updated : f))
       }
       cancelEdit()
@@ -454,6 +465,7 @@ export function useFaqWorkspace(organizationId: () => string | undefined) {
     isNewFaq,
     draftQuestion,
     draftAnswer,
+    draftCategory,
     draftSlug,
     draftMetaTitle,
     draftMetaDescription,

--- a/frontend/src/composables/useMCPTools.ts
+++ b/frontend/src/composables/useMCPTools.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { ref, reactive } from 'vue'
 import { mcpService } from '@/services/mcp'
-import type { MCPTool, MCPToolCreate, MCPToolUpdate, MCPTransportType } from '@/types/mcp'
+import type { MCPTool, MCPToolCreate, MCPToolUpdate, MCPToolTestResult, MCPTransportType } from '@/types/mcp'
 import { toast } from 'vue-sonner'
 
 export function useMCPTools(agentId: string) {
@@ -167,6 +167,24 @@ export function useMCPTools(agentId: string) {
     }
   }
 
+  // Connection test results, per tool id. A tool that saves fine can still be
+  // dead at runtime (missing npx, bad key, unreachable server) — the Test
+  // button surfaces that instead of a silent 0-tool run.
+  const testResults = ref<Record<number, MCPToolTestResult>>({})
+  const testingToolId = ref<number | null>(null)
+
+  const testMCPTool = async (toolId: number) => {
+    testingToolId.value = toolId
+    try {
+      testResults.value = { ...testResults.value, [toolId]: await mcpService.testMCPTool(toolId) }
+    } catch (err: any) {
+      const errorMessage = err.response?.data?.detail || 'Failed to test MCP tool'
+      testResults.value = { ...testResults.value, [toolId]: { success: false, functions: [], error: errorMessage } }
+    } finally {
+      testingToolId.value = null
+    }
+  }
+
   // Apply preset to form
   const applyPreset = (preset: typeof mcpPresets[0]) => {
     Object.assign(createForm, {
@@ -293,6 +311,9 @@ export function useMCPTools(agentId: string) {
     linkMCPTool,
     unlinkMCPTool,
     deleteMCPTool,
+    testMCPTool,
+    testResults,
+    testingToolId,
     applyPreset,
     resetCreateForm,
     confirmDelete,

--- a/frontend/src/services/mcp.ts
+++ b/frontend/src/services/mcp.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import api from './api'
-import type { MCPTool, MCPToolCreate, MCPToolUpdate, MCPToolToAgent, AgentMCPTools } from '@/types/mcp'
+import type { MCPTool, MCPToolCreate, MCPToolUpdate, MCPToolToAgent, AgentMCPTools, MCPToolTestResult } from '@/types/mcp'
 
 export const mcpService = {
   // MCP Tool management
@@ -43,6 +43,11 @@ export const mcpService = {
 
   async deleteMCPTool(toolId: number): Promise<void> {
     await api.delete(`/mcp-tools/${toolId}`)
+  },
+
+  async testMCPTool(toolId: number): Promise<MCPToolTestResult> {
+    const response = await api.post(`/mcp-tools/${toolId}/test`)
+    return response.data
   },
 
   // Agent-MCP Tool associations

--- a/frontend/src/types/mcp.ts
+++ b/frontend/src/types/mcp.ts
@@ -89,4 +89,10 @@ export interface AgentMCPTools {
   id: string
   name: string
   mcp_tools: MCPTool[]
-} 
+}
+
+export interface MCPToolTestResult {
+  success: boolean
+  functions: string[]
+  error: string | null
+}

--- a/frontend/src/types/ticket.ts
+++ b/frontend/src/types/ticket.ts
@@ -130,6 +130,11 @@ export interface InvestigationRun {
   output_tokens?: number
   metered?: boolean
   model_name?: string | null
+  connector_status?: {
+    configured: number
+    loaded: number
+    failed: { name: string; error: string }[]
+  } | null
   started_at?: string | null
   finished_at?: string | null
   created_at?: string | null


### PR DESCRIPTION
Fixes #271, #272 and #274.

**#271** — `npx`/`uvx` aren't in the backend image, so STDIO MCP servers never start and runs quietly proceed with 0 tools. Adds Node 22 and uv to the image, a Test button on each MCP tool that connects and reports the functions it exposes (or the real error), and a warning on the investigation run when it ran with fewer connectors than were configured.

**#272** — the MCP manager logged the whole env dict at DEBUG, API keys in plain text. It now logs variable names only. Credentials that were already logged should be rotated.

**#274** — the add and edit FAQ forms get a Topic field with autocomplete over existing topics; typing a new name creates it. Blank keeps the current topic when editing, falls back to the default when creating.

Adds a nullable `investigation_runs.connector_status` column, so this needs a migration and an image rebuild.
