### PR TITLE
fix(agent): answer at the tool-call limit, simplify the guardrail, show End Chat after takeover

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -138,6 +138,7 @@ KB_OPTIMIZE_ON=1000
 AGENT_RUN_TIMEOUT=90
 
 # Tool calls an agent may make in one turn before it has to answer from what it
-# already retrieved. Agents with several knowledge sources search more often than
-# you would expect, and setting this too low makes them answer from less context.
-AGENT_TOOL_CALL_LIMIT=10
+# already retrieved. Hitting this is not an error — the agent answers without
+# further tools. Raise it if agents with many knowledge sources or MCP tools are
+# answering from too little context.
+AGENT_TOOL_CALL_LIMIT=5

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -136,3 +136,8 @@ KB_OPTIMIZE_ON=1000
 # cancelled and the visitor gets an error reply. Raise it if agents with many
 # MCP/Shopify tools hit the limit on legitimate answers.
 AGENT_RUN_TIMEOUT=90
+
+# Tool calls an agent may make in one turn before it has to answer from what it
+# already retrieved. Agents with several knowledge sources search more often than
+# you would expect, and setting this too low makes them answer from less context.
+AGENT_TOOL_CALL_LIMIT=10

--- a/backend/app/agents/chat_agent.py
+++ b/backend/app/agents/chat_agent.py
@@ -902,7 +902,7 @@ Keep your responses concise and focused. Provide clear, actionable information i
            agent_id=str(agent_id),
            storage=storage,
            add_history_to_messages=True,
-           tool_call_limit=5,  # Allow up to 5 tool calls - balance between functionality and performance
+           tool_call_limit=settings.AGENT_TOOL_CALL_LIMIT,
            num_history_responses=5,  # Reduced from 10 to 5 to minimize context size and improve speed
            read_chat_history=True,
            markdown=False,

--- a/backend/app/agents/guardrail_policy.py
+++ b/backend/app/agents/guardrail_policy.py
@@ -217,24 +217,23 @@ def resolve_topic_scope(ctx) -> str:
 # refused maths for a maths tutor, algorithms for a coding bootcamp, essays for
 # a copywriting service.
 #
-# It is concrete on purpose. Three wordings were tested live against the model:
-# this one held 15/15, while "you have no knowledge outside this business" and
-# "decline anything not about {org}" each let a poem, a derivative and a long
-# algorithms brief straight through. The model refuses when it can match a
-# named category and does not reliably reason about relatedness — so the fix
-# for over-blocking is tenant editability, not vaguer wording.
-DEFAULT_GUARDRAIL_PROMPT = """You only handle {org}: product, features, pricing, plans, accounts and billing; setup,
-install, deployment and self-hosting (docker, compose, npm, git, sudo and other shell commands);
-config files, APIs, webhooks, SDKs and integrations; code samples; pasted logs, tracebacks, stack
-traces and error messages; security and privacy — and anything else a visitor needs in order to
-use {org}. ALL of that is in scope even when you don't know the answer: answer it fully and
-technically, or say you couldn't find it. Never refuse one of these as off-topic.
-Decline anything else, however politely asked and however long or technical it looks: coding,
-algorithm, data-structure or system-design exercises; homework, exam or interview questions; maths
-or logic problems; essays, poems, stories or unrelated copy; translation; general knowledge or
-trivia; software unrelated to {org}. Give NO part of the answer — no design, approach, complexity
-analysis or first step. Reply with one short friendly sentence saying you can only help with
-{org}, then ask what they need. If a request is ambiguous, assume it is in scope and ask."""
+# DENY-ONLY, and deliberately short. The previous version also enumerated what
+# was IN scope, which is what made it dangerous: any list of "things this
+# business is about" is wrong for most businesses, and its "software unrelated
+# to {org}" clause collided with integration questions — every one of which
+# names third-party software. It declined "how do I connect Elasticsearch",
+# which is core product usage.
+#
+# So: name only the handful of things that mean "someone is using this as a free
+# general-purpose AI", say nothing about what IS in scope, and answer everything
+# else. Over-blocking costs a real customer conversation; letting an off-topic
+# request through costs a few tokens. The bias belongs on the answering side.
+DEFAULT_GUARDRAIL_PROMPT = """You are {org}'s assistant, not a general-purpose AI. Decline only requests that are
+plainly using you as one: poems, stories, essays or other creative writing; homework, exam or
+interview questions; maths, logic, algorithm or puzzle problems; translating unrelated text;
+general trivia. For those give NO part of the answer — no outline, approach or first step — just
+one short friendly sentence saying you can only help with {org}, then ask what they need.
+Everything else is in scope. If you are unsure, answer."""
 
 GUARDRAIL_PROMPT_MAX = 4000
 

--- a/backend/app/api/agent.py
+++ b/backend/app/api/agent.py
@@ -27,6 +27,8 @@ from app.repositories.knowledge import KnowledgeRepository
 from app.models.schemas.agent import AgentUpdate, AgentResponse, AgentCreate, AgentWithCustomizationResponse
 from sqlalchemy.orm import Session
 from app.models.agent import Agent, AgentCustomization
+from app.models.organization import Organization
+from app.agents.guardrail_policy import DEFAULT_GUARDRAIL_PROMPT
 from app.models.schemas.agent_customization import CustomizationCreate, CustomizationResponse
 import aiofiles
 from uuid import uuid4
@@ -330,6 +332,27 @@ async def update_agent(
     except Exception as e:
         logger.error(f"Agent update error: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/guardrail-default")
+async def get_guardrail_default(
+    auth_info: dict = Depends(get_unified_auth),
+    db: Session = Depends(get_db)
+):
+    """The shipped scope rule, with {org} already filled in.
+
+    The dashboard shows this as the starting text so operators can read and edit
+    the actual rule instead of a prose summary of it — which drifted from the real
+    wording the first time the default changed. Served from the backend rather
+    than duplicated in the frontend so there is one source of truth.
+
+    Declared before /{agent_id} so the literal path wins the route match.
+    """
+    org = db.query(Organization).filter(
+        Organization.id == auth_info["organization_id"]
+    ).first()
+    label = (org.name or "").strip() if org else ""
+    return {"prompt": DEFAULT_GUARDRAIL_PROMPT.replace("{org}", label or "this business")}
 
 
 @router.get("/list/shopify", response_model=List[AgentWithCustomizationResponse])

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -157,10 +157,10 @@ class Settings(BaseSettings):
     AGENT_RUN_TIMEOUT: int = int(os.getenv("AGENT_RUN_TIMEOUT", "90"))
 
     # Tool calls allowed in a single turn before the agent must answer from what
-    # it has. An agent with several knowledge sources routinely searches more than
-    # a handful of times, so this is not a tight budget — AGENT_RUN_TIMEOUT is the
-    # real safety net (see app.utils.agno_patches).
-    AGENT_TOOL_CALL_LIMIT: int = int(os.getenv("AGENT_TOOL_CALL_LIMIT", "10"))
+    # it already has. Reaching this is no longer fatal — the agent answers without
+    # further tools rather than returning nothing (see app.utils.agno_patches) —
+    # so the budget can stay tight. AGENT_RUN_TIMEOUT is the real safety net.
+    AGENT_TOOL_CALL_LIMIT: int = int(os.getenv("AGENT_TOOL_CALL_LIMIT", "5"))
 
     # Knowledge base content summarization settings
     KNOWLEDGE_SUMMARY_ENABLED: bool = os.getenv("KNOWLEDGE_SUMMARY_ENABLED", "false").lower() == "true"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -156,6 +156,12 @@ class Settings(BaseSettings):
     # cancelled instead of hanging the chat handler forever (issue #269).
     AGENT_RUN_TIMEOUT: int = int(os.getenv("AGENT_RUN_TIMEOUT", "90"))
 
+    # Tool calls allowed in a single turn before the agent must answer from what
+    # it has. An agent with several knowledge sources routinely searches more than
+    # a handful of times, so this is not a tight budget — AGENT_RUN_TIMEOUT is the
+    # real safety net (see app.utils.agno_patches).
+    AGENT_TOOL_CALL_LIMIT: int = int(os.getenv("AGENT_TOOL_CALL_LIMIT", "10"))
+
     # Knowledge base content summarization settings
     KNOWLEDGE_SUMMARY_ENABLED: bool = os.getenv("KNOWLEDGE_SUMMARY_ENABLED", "false").lower() == "true"
     KNOWLEDGE_SUMMARY_MODEL_TYPE: str = os.getenv("KNOWLEDGE_SUMMARY_MODEL_TYPE", "GROQ")

--- a/backend/app/utils/agno_patches.py
+++ b/backend/app/utils/agno_patches.py
@@ -44,15 +44,43 @@ logger = get_logger(__name__)
 
 _PATCHED_FLAG = "_chattermate_answers_at_limit"
 
-# Set on the Model instance once the run has spent its tool budget. Safe as
-# instance state: create_model() builds a fresh Model per ChatAgent, and
-# ChatAgent is built per request, so the flag never outlives one run.
-_EXHAUSTED = "_chattermate_tools_exhausted"
+# Both live on the Model instance. Safe as instance state: create_model() builds
+# a fresh Model per ChatAgent and ChatAgent is built per request, so neither
+# outlives a single run.
+#
+# _ROUND counts model round-trips; _EXHAUSTED_AT records the round the budget ran
+# out in. The distinction is load-bearing: a model can request SEVERAL tools in
+# one assistant message, and agno walks that whole batch before calling the model
+# again. Every over-budget call in the batch arrives here, so a plain
+# "have we been here before" flag mistakes the second parallel call for a genuine
+# repeat and terminates the run — reintroducing the empty reply this patch exists
+# to prevent. Observed in local testing with tool_call_limit=1.
+_ROUND = "_chattermate_round"
+_EXHAUSTED_AT = "_chattermate_exhausted_round"
+
+# Replaces agno's own limit-error text, which only tells the model it may not
+# call the tool again. Left at that, gpt-4o-mini narrated the plumbing to the
+# visitor ("I wasn't able to retrieve ... due to tool limitation") and then
+# answered from general knowledge — which also contradicts the grounding rule the
+# guardrail relies on. Say what to do instead: answer from what is already here,
+# and if that is not enough, admit it rather than invent.
+_LIMIT_INSTRUCTION = (
+    "You have used all the tool calls available for this turn. Answer now, using "
+    "only what the tools have already returned and what your instructions cover. "
+    "Do not mention tools, searches, limits or any internal constraint — the "
+    "visitor must not read about the plumbing. If what you have is not enough to "
+    "answer properly, say plainly that you don't have that detail and offer to "
+    "connect them with the team. Never fill the gap with general knowledge."
+)
 
 
 def _strip_tools(self, kwargs: dict) -> dict:
-    """Drop the tool definitions from a model call once the budget is spent."""
-    if getattr(self, _EXHAUSTED, False) and kwargs.get("tools"):
+    """Drop the tool definitions from a model call once the budget is spent.
+
+    Also counts the round, since this runs exactly once per model round-trip.
+    """
+    setattr(self, _ROUND, getattr(self, _ROUND, 0) + 1)
+    if getattr(self, _EXHAUSTED_AT, None) is not None and kwargs.get("tools"):
         kwargs = {**kwargs, "tools": None, "tool_choice": None}
     return kwargs
 
@@ -65,25 +93,41 @@ def apply_agno_patches() -> None:
     original_limit_result = Model.create_tool_call_limit_error_result
     original_process = Model._process_model_response
     original_aprocess = Model._aprocess_model_response
+    # Streaming is a separate pair of entry points that never touch the two
+    # above. Patching only the non-streaming ones left the live chat — which
+    # streams — with its tools intact after the limit, so the next round called a
+    # tool again and hit the backstop. Verified against a real agent.
+    original_stream = Model.process_response_stream
+    original_astream = Model.aprocess_response_stream
 
     def create_tool_call_limit_error_result(self, function_call):
         message = original_limit_result(self, function_call)
-        already_exhausted = getattr(self, _EXHAUSTED, False)
-        setattr(self, _EXHAUSTED, True)
-        if already_exhausted:
-            # Unreachable while _strip_tools works: the previous call already
-            # cleared the tools, so the model had none left to call. If it ever
-            # does happen, end the run rather than risk the #269 loop.
-            message.stop_after_tool_call = True
-            logger.warning(
-                "Tool call limit reached again after tools were withdrawn; "
-                f"terminating agent run (tool={function_call.function.name})"
-            )
-        else:
+        current_round = getattr(self, _ROUND, 0)
+        exhausted_at = getattr(self, _EXHAUSTED_AT, None)
+
+        # Every over-budget call in the batch gets the instruction, not just the
+        # first: the model reads all of the tool results, and leaving agno's
+        # "tool call limit reached" text on the siblings was enough for it to keep
+        # narrating the limit to the visitor.
+        message.content = _LIMIT_INSTRUCTION
+
+        if exhausted_at is None:
+            setattr(self, _EXHAUSTED_AT, current_round)
             logger.warning(
                 "Tool call limit reached; answering without further tools "
                 f"(tool={function_call.function.name})"
             )
+        elif current_round > exhausted_at:
+            # A LATER round still asking for tools means withdrawal did not take
+            # effect. Unreachable in practice — a model offered no tools cannot
+            # call one — but end the run rather than risk the #269 loop.
+            message.stop_after_tool_call = True
+            logger.warning(
+                "Tool call limit reached in a later round despite tools being "
+                f"withdrawn; terminating agent run (tool={function_call.function.name})"
+            )
+        # Same round: another tool from the same parallel batch. Already handled
+        # by the first one — say nothing and let the run continue to the answer.
         return message
 
     def _process_model_response(self, *args, **kwargs):
@@ -92,7 +136,16 @@ def apply_agno_patches() -> None:
     async def _aprocess_model_response(self, *args, **kwargs):
         return await original_aprocess(self, *args, **_strip_tools(self, kwargs))
 
+    def process_response_stream(self, *args, **kwargs):
+        yield from original_stream(self, *args, **_strip_tools(self, kwargs))
+
+    async def aprocess_response_stream(self, *args, **kwargs):
+        async for chunk in original_astream(self, *args, **_strip_tools(self, kwargs)):
+            yield chunk
+
     setattr(create_tool_call_limit_error_result, _PATCHED_FLAG, True)
     Model.create_tool_call_limit_error_result = create_tool_call_limit_error_result
     Model._process_model_response = _process_model_response
     Model._aprocess_model_response = _aprocess_model_response
+    Model.process_response_stream = process_response_stream
+    Model.aprocess_response_stream = aprocess_response_stream

--- a/backend/app/utils/agno_patches.py
+++ b/backend/app/utils/agno_patches.py
@@ -21,10 +21,20 @@ limitations under the License.
 # appends a tool-result message asking the model not to call the tool again
 # and sends the conversation back to the model. Models that ignore the
 # instruction (observed with gpt-4o-mini) then loop forever, re-sending an
-# ever-growing payload on every iteration (issue #269). The response loops in
-# agno.models.base already break when any tool-result message has
-# stop_after_tool_call=True, so setting that flag on the limit-error message
-# ends the run cleanly at the limit — the behavior agno 2.x ships by default.
+# ever-growing payload on every iteration (issue #269).
+#
+# The first fix set stop_after_tool_call=True on the limit-error message, which
+# breaks the response loop in agno.models.base. That ended the loop, but it ended
+# it AT THE TOOL RESULT — before the model ever wrote an answer — so every run
+# that reached the limit returned an empty turn and the visitor got the
+# "I didn't quite catch that" fallback. In production that was most turns on any
+# agent with a few knowledge sources.
+#
+# What we actually want is a bounded run that still answers: at the limit, stop
+# offering tools and let the model reply from what it already retrieved. Clearing
+# `tools` for the next completion does exactly that, and it also makes the runaway
+# loop impossible — a model with no tools cannot call one. The hard stop is kept
+# as a backstop for the case that should now be unreachable.
 
 from agno.models.base import Model
 
@@ -32,7 +42,19 @@ from app.core.logger import get_logger
 
 logger = get_logger(__name__)
 
-_PATCHED_FLAG = "_chattermate_stops_run"
+_PATCHED_FLAG = "_chattermate_answers_at_limit"
+
+# Set on the Model instance once the run has spent its tool budget. Safe as
+# instance state: create_model() builds a fresh Model per ChatAgent, and
+# ChatAgent is built per request, so the flag never outlives one run.
+_EXHAUSTED = "_chattermate_tools_exhausted"
+
+
+def _strip_tools(self, kwargs: dict) -> dict:
+    """Drop the tool definitions from a model call once the budget is spent."""
+    if getattr(self, _EXHAUSTED, False) and kwargs.get("tools"):
+        kwargs = {**kwargs, "tools": None, "tool_choice": None}
+    return kwargs
 
 
 def apply_agno_patches() -> None:
@@ -40,16 +62,37 @@ def apply_agno_patches() -> None:
     if getattr(Model.create_tool_call_limit_error_result, _PATCHED_FLAG, False):
         return
 
-    original = Model.create_tool_call_limit_error_result
+    original_limit_result = Model.create_tool_call_limit_error_result
+    original_process = Model._process_model_response
+    original_aprocess = Model._aprocess_model_response
 
     def create_tool_call_limit_error_result(self, function_call):
-        message = original(self, function_call)
-        message.stop_after_tool_call = True
-        logger.warning(
-            f"Tool call limit reached; terminating agent run "
-            f"(tool={function_call.function.name})"
-        )
+        message = original_limit_result(self, function_call)
+        already_exhausted = getattr(self, _EXHAUSTED, False)
+        setattr(self, _EXHAUSTED, True)
+        if already_exhausted:
+            # Unreachable while _strip_tools works: the previous call already
+            # cleared the tools, so the model had none left to call. If it ever
+            # does happen, end the run rather than risk the #269 loop.
+            message.stop_after_tool_call = True
+            logger.warning(
+                "Tool call limit reached again after tools were withdrawn; "
+                f"terminating agent run (tool={function_call.function.name})"
+            )
+        else:
+            logger.warning(
+                "Tool call limit reached; answering without further tools "
+                f"(tool={function_call.function.name})"
+            )
         return message
+
+    def _process_model_response(self, *args, **kwargs):
+        return original_process(self, *args, **_strip_tools(self, kwargs))
+
+    async def _aprocess_model_response(self, *args, **kwargs):
+        return await original_aprocess(self, *args, **_strip_tools(self, kwargs))
 
     setattr(create_tool_call_limit_error_result, _PATCHED_FLAG, True)
     Model.create_tool_call_limit_error_result = create_tool_call_limit_error_result
+    Model._process_model_response = _process_model_response
+    Model._aprocess_model_response = _aprocess_model_response

--- a/backend/tests/agents/test_guardrail_policy.py
+++ b/backend/tests/agents/test_guardrail_policy.py
@@ -214,7 +214,7 @@ class TestGuardrailScopePrompt:
     def test_default_is_used_when_tenant_has_not_written_one(self):
         out = guardrail_scope_prompt(ctx())
         assert "Acme Shoes" in out
-        assert "Decline anything else" in out
+        assert "homework" in out
 
     def test_org_placeholder_is_substituted(self):
         assert "{org}" not in guardrail_scope_prompt(ctx())
@@ -249,11 +249,31 @@ class TestGuardrailScopePrompt:
         out = guardrail_scope_prompt(ctx(guardrail_prompt="x" * 9000))
         assert len(out) < 4200
 
-    def test_default_covers_technical_support(self):
-        # Compressing these examples out made the model refuse docker and curl.
+    def test_default_says_nothing_about_what_is_in_scope(self):
+        """Deny-only, by design.
+
+        An earlier version listed what WAS in scope (docker, sudo, tracebacks,
+        code samples, APIs...) because compressing those examples out had once
+        made the model refuse docker and curl questions. That list caused a worse
+        problem: it can only ever describe one kind of business, and its
+        "software unrelated to {org}" clause refused integration questions —
+        which all name third-party software. It declined "how do I connect
+        Elasticsearch", i.e. core product usage.
+
+        The protection against over-refusing is now the explicit allow-bias
+        below, not an enumeration. Docker/curl-style questions must be
+        re-verified live against a real model whenever this wording changes —
+        no unit test can stand in for that.
+        """
         default = " ".join(DEFAULT_GUARDRAIL_PROMPT.split())
-        for term in ("docker", "sudo", "tracebacks", "code samples", "APIs"):
-            assert term in default
+        assert "Everything else is in scope" in default
+        assert "If you are unsure, answer" in default
+        assert "software unrelated" not in default
+
+    def test_default_stays_short(self):
+        """It sits in every prompt on every turn, and long deny lists are what
+        produced the false declines. Keep it cheap and blunt."""
+        assert len(DEFAULT_GUARDRAIL_PROMPT) < 700
 
 
 class TestRefusalDetection:

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -378,6 +378,28 @@ def test_create_agent_customization(
     assert customization["show_ai_disclaimer"] is True
 
 
+def test_guardrail_default_is_served_with_the_org_filled_in(client, db, test_user):
+    """The dashboard shows this as editable starting text.
+
+    Served from the backend rather than copied into the frontend: the previous
+    UI described the rule in prose and went stale the first time the wording
+    changed. {org} must already be substituted, so the operator reads exactly
+    what the model is sent.
+    """
+    response = client.get("/api/agents/guardrail-default")
+    assert response.status_code == 200
+
+    prompt = response.json()["prompt"]
+    assert "{org}" not in prompt
+    assert "general-purpose AI" in prompt
+
+
+def test_guardrail_default_route_is_not_shadowed_by_agent_id(client, db, test_agent):
+    """It sits next to GET /{agent_id}; a literal path declared after the
+    parameterised one would be swallowed by it and return 404/422."""
+    assert client.get("/api/agents/guardrail-default").status_code == 200
+
+
 def test_ai_disclaimer_toggle_round_trips(client, db, test_agent):
     """Turning the footer disclaimer off must survive the round trip.
 

--- a/backend/tests/utils/test_agno_patches.py
+++ b/backend/tests/utils/test_agno_patches.py
@@ -19,35 +19,90 @@ from types import SimpleNamespace
 from agno.models.base import Model
 from agno.tools.function import Function, FunctionCall
 
-from app.utils.agno_patches import apply_agno_patches
+from app.utils.agno_patches import _strip_tools, apply_agno_patches
 
 
-def _limit_error_message():
+def _model_stub():
+    # create_tool_call_limit_error_result only reads tool_message_role from self,
+    # and the patch only sets its own attribute, so a stub is enough.
+    return SimpleNamespace(tool_message_role="tool")
+
+
+def _limit_error_message(model_stub, call_id="call_1"):
     apply_agno_patches()
     function_call = FunctionCall(
         function=Function(name="search_knowledge_base"),
         arguments={"query": "hello"},
-        call_id="call_1",
+        call_id=call_id,
     )
-    # The method only reads tool_message_role from self, so a stub suffices.
-    model_stub = SimpleNamespace(tool_message_role="tool")
     return Model.create_tool_call_limit_error_result(model_stub, function_call)
 
 
-def test_limit_error_result_terminates_run():
-    """The limit-error message must carry stop_after_tool_call so the model
-    response loop in agno.models.base breaks instead of re-invoking the model
-    forever (issue #269)."""
-    message = _limit_error_message()
-    assert message.stop_after_tool_call is True
-    # agno's loops break on: any(m.stop_after_tool_call for m in function_call_results)
-    assert any(m.stop_after_tool_call for m in [message])
+def test_limit_does_not_end_the_run_before_the_model_answers():
+    """The whole point of the limit handling: bound the run WITHOUT costing the
+    answer.
+
+    Stopping at the tool result ends the loop before the model writes anything,
+    so the turn comes back empty and the visitor gets the generic
+    "I didn't quite catch that" fallback. That was the production regression this
+    replaces — most turns on any agent with a few knowledge sources.
+    """
+    message = _limit_error_message(_model_stub())
+    assert not message.stop_after_tool_call
+
+
+def test_tools_are_withdrawn_once_the_budget_is_spent():
+    """With tools cleared, the next completion has to be plain text — which both
+    produces an answer and makes the runaway loop of #269 impossible."""
+    model = _model_stub()
+    _limit_error_message(model)
+
+    kwargs = _strip_tools(model, {"tools": [{"name": "search"}], "tool_choice": "auto"})
+    assert kwargs["tools"] is None
+    assert kwargs["tool_choice"] is None
+
+
+def test_tools_survive_until_the_limit_is_hit():
+    """Before the limit, the model call must be completely untouched."""
+    model = _model_stub()
+    original = {"tools": [{"name": "search"}], "tool_choice": "auto"}
+    assert _strip_tools(model, original) == original
+
+
+def test_stripping_leaves_the_other_arguments_alone():
+    model = _model_stub()
+    _limit_error_message(model)
+
+    kwargs = _strip_tools(
+        model, {"tools": [{"name": "search"}], "tool_choice": "auto", "messages": ["m"]}
+    )
+    assert kwargs["messages"] == ["m"]
+
+
+def test_second_limit_hit_terminates_as_a_backstop():
+    """Unreachable while withdrawal works — a model with no tools cannot call
+    one. If it ever is reached, end the run rather than risk the #269 loop."""
+    model = _model_stub()
+    _limit_error_message(model)
+    second = _limit_error_message(model, call_id="call_2")
+    assert second.stop_after_tool_call is True
+
+
+def test_exhaustion_does_not_leak_between_runs():
+    """The flag lives on the Model instance, and create_model() builds a fresh
+    one per request. A limit hit in one conversation must not withdraw tools from
+    the next."""
+    spent = _model_stub()
+    _limit_error_message(spent)
+    fresh = _model_stub()
+
+    original = {"tools": [{"name": "search"}], "tool_choice": "auto"}
+    assert _strip_tools(fresh, original) == original
 
 
 def test_limit_error_result_keeps_original_shape():
-    """The patch only adds the stop flag; the message agno built is otherwise
-    unchanged."""
-    message = _limit_error_message()
+    """The patch only adds behaviour; the message agno built is unchanged."""
+    message = _limit_error_message(_model_stub())
     assert message.role == "tool"
     assert message.tool_call_error is True
     assert message.tool_call_id == "call_1"

--- a/backend/tests/utils/test_agno_patches.py
+++ b/backend/tests/utils/test_agno_patches.py
@@ -24,8 +24,19 @@ from app.utils.agno_patches import _strip_tools, apply_agno_patches
 
 def _model_stub():
     # create_tool_call_limit_error_result only reads tool_message_role from self,
-    # and the patch only sets its own attribute, so a stub is enough.
+    # and the patch only sets its own attributes, so a stub is enough.
     return SimpleNamespace(tool_message_role="tool")
+
+
+def _next_round(model, tools=None):
+    """Advance to the next model round-trip, the way agno's loop does.
+
+    _strip_tools runs exactly once per round, so going through it is what
+    separates a genuine later round from another tool in the same parallel batch.
+    """
+    return _strip_tools(
+        model, {"tools": tools if tools is not None else [{"name": "search"}], "tool_choice": "auto"}
+    )
 
 
 def _limit_error_message(model_stub, call_id="call_1"):
@@ -55,9 +66,10 @@ def test_tools_are_withdrawn_once_the_budget_is_spent():
     """With tools cleared, the next completion has to be plain text — which both
     produces an answer and makes the runaway loop of #269 impossible."""
     model = _model_stub()
+    _next_round(model)
     _limit_error_message(model)
 
-    kwargs = _strip_tools(model, {"tools": [{"name": "search"}], "tool_choice": "auto"})
+    kwargs = _next_round(model)
     assert kwargs["tools"] is None
     assert kwargs["tool_choice"] is None
 
@@ -66,11 +78,12 @@ def test_tools_survive_until_the_limit_is_hit():
     """Before the limit, the model call must be completely untouched."""
     model = _model_stub()
     original = {"tools": [{"name": "search"}], "tool_choice": "auto"}
-    assert _strip_tools(model, original) == original
+    assert _strip_tools(model, dict(original)) == original
 
 
 def test_stripping_leaves_the_other_arguments_alone():
     model = _model_stub()
+    _next_round(model)
     _limit_error_message(model)
 
     kwargs = _strip_tools(
@@ -79,25 +92,51 @@ def test_stripping_leaves_the_other_arguments_alone():
     assert kwargs["messages"] == ["m"]
 
 
-def test_second_limit_hit_terminates_as_a_backstop():
-    """Unreachable while withdrawal works — a model with no tools cannot call
+def test_parallel_tool_calls_in_one_batch_do_not_end_the_run():
+    """The regression that made the first version of this patch useless.
+
+    A model can ask for several tools in ONE assistant message; agno walks the
+    whole batch before calling the model again, so every over-budget call in that
+    batch lands here. Treating the second as a repeat terminated the run and the
+    visitor got the empty-turn fallback anyway. Caught in local testing, not by
+    the original tests — they called this twice and unwittingly simulated two
+    rounds.
+    """
+    model = _model_stub()
+    _next_round(model)
+
+    first = _limit_error_message(model, call_id="call_1")
+    second = _limit_error_message(model, call_id="call_2")
+    third = _limit_error_message(model, call_id="call_3")
+
+    assert not first.stop_after_tool_call
+    assert not second.stop_after_tool_call
+    assert not third.stop_after_tool_call
+
+
+def test_a_later_round_still_over_budget_terminates_as_a_backstop():
+    """Unreachable while withdrawal works — a model offered no tools cannot call
     one. If it ever is reached, end the run rather than risk the #269 loop."""
     model = _model_stub()
+    _next_round(model)
     _limit_error_message(model)
-    second = _limit_error_message(model, call_id="call_2")
-    assert second.stop_after_tool_call is True
+
+    _next_round(model)  # a genuine second round-trip
+    later = _limit_error_message(model, call_id="call_2")
+    assert later.stop_after_tool_call is True
 
 
 def test_exhaustion_does_not_leak_between_runs():
-    """The flag lives on the Model instance, and create_model() builds a fresh
+    """The state lives on the Model instance, and create_model() builds a fresh
     one per request. A limit hit in one conversation must not withdraw tools from
     the next."""
     spent = _model_stub()
+    _next_round(spent)
     _limit_error_message(spent)
-    fresh = _model_stub()
 
+    fresh = _model_stub()
     original = {"tools": [{"name": "search"}], "tool_choice": "auto"}
-    assert _strip_tools(fresh, original) == original
+    assert _strip_tools(fresh, dict(original)) == original
 
 
 def test_limit_error_result_keeps_original_shape():
@@ -107,7 +146,7 @@ def test_limit_error_result_keeps_original_shape():
     assert message.tool_call_error is True
     assert message.tool_call_id == "call_1"
     assert message.tool_name == "search_knowledge_base"
-    assert "Tool call limit reached" in message.content
+    assert "Answer now" in message.content
 
 
 def test_apply_is_idempotent():

--- a/frontend/src/components/agent/AgentInstructionsTab.vue
+++ b/frontend/src/components/agent/AgentInstructionsTab.vue
@@ -15,7 +15,8 @@ limitations under the License.
 -->
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { agentService } from '@/services/agent'
 import { useAgentEdit } from '@/composables/useAgentEdit'
 import { useSubscriptionStorage } from '@/utils/storage'
 import { useEnterpriseFeatures } from '@/composables/useEnterpriseFeatures'
@@ -116,11 +117,19 @@ const handleUpgrade = () => {
 
 // Create local state for all editable fields
 const localInstructions = ref(props.instructions)
-// Empty means "use the platform default". Deliberately not prefilled with the
-// default text: saving a copy would freeze this agent on today's wording and it
-// would never pick up improvements to the default.
+// The box shows the real shipped rule so it can be read and edited, rather than a
+// prose summary of it — that summary drifted from the actual wording the first
+// time the default changed. NULL in the database still means "follow the shipped
+// default", so an agent left untouched keeps picking up improvements: on save we
+// send null whenever the text is empty or still identical to the default.
 const localGuardrailPrompt = ref(props.guardrailPrompt ?? '')
+const defaultGuardrailPrompt = ref('')
 const localGuardrailEnabled = ref(props.guardrailEnabled)
+
+const isGuardrailDefault = computed(() => {
+  const text = localGuardrailPrompt.value.trim()
+  return !text || text === defaultGuardrailPrompt.value.trim()
+})
 const localTransferToHuman = ref(props.transferToHuman)
 const localAskForRating = ref(props.askForRating)
 const localHandoffCollectEmail = ref(props.handoffCollectEmail)
@@ -128,7 +137,24 @@ const localHandoffCollectName = ref(props.handoffCollectName)
 const localSelectedGroupIds = ref<string[]>([...props.selectedGroupIds])
 
 // Watch for changes in props to update local state
-watch(() => props.guardrailPrompt, (v) => { localGuardrailPrompt.value = v ?? '' })
+// Show the shipped rule when this agent has not written its own. Fetched rather
+// than duplicated here so the box can never drift from the wording actually sent
+// to the model. If it fails, the box stays empty and still means "use the
+// default" — the feature degrades to what it was before.
+onMounted(async () => {
+  try {
+    defaultGuardrailPrompt.value = await agentService.getGuardrailDefault()
+    if (!localGuardrailPrompt.value.trim()) {
+      localGuardrailPrompt.value = defaultGuardrailPrompt.value
+    }
+  } catch (e) {
+    console.error('Could not load the default guardrail rule:', e)
+  }
+})
+
+watch(() => props.guardrailPrompt, (v) => {
+  localGuardrailPrompt.value = v ?? defaultGuardrailPrompt.value
+})
 watch(() => props.guardrailEnabled, (v) => { localGuardrailEnabled.value = v })
 
 watch(() => props.instructions, (newValue) => {
@@ -209,7 +235,9 @@ const handleRatingToggle = (event: Event) => {
 const handleSave = () => {
   emit('save-agent', {
     instructions: localInstructions.value,
-    guardrailPrompt: localGuardrailPrompt.value.trim() || null,
+    // null when untouched, so this agent keeps following the shipped default
+    // rather than freezing a copy of today's wording.
+    guardrailPrompt: isGuardrailDefault.value ? null : localGuardrailPrompt.value.trim(),
     guardrailEnabled: localGuardrailEnabled.value,
     transferToHuman: localTransferToHuman.value,
     askForRating: localAskForRating.value,
@@ -297,11 +325,18 @@ const handleSave = () => {
           v-model="localGuardrailPrompt"
           rows="5"
           :readonly="!isEditing"
-          placeholder="Leave empty to use the default: the agent answers anything about your product, pricing, accounts, setup, APIs and troubleshooting, and declines unrelated requests such as homework, puzzles or creative writing.&#10;&#10;Write your own rule to replace it — for example if your business IS tutoring, coding education or copywriting, so those requests should be answered."
+          placeholder="Leave empty to use the platform default."
         ></textarea>
         <p class="helper-text">
-          Use <code>{org}</code> to refer to your business name. Leave empty to keep the default,
-          which we improve over time.
+          <template v-if="isGuardrailDefault">
+            This is the platform default. Edit it to suit your business — for example if you
+            <em>are</em> a tutoring, coding-education or copywriting service, so those requests
+            should be answered.
+          </template>
+          <template v-else>
+            Your own rule, replacing the platform default. Clear the box to go back to the default.
+          </template>
+          Use <code>{org}</code> to refer to your business name.
         </p>
       </template>
     </section>

--- a/frontend/src/components/conversations/ConversationsList.vue
+++ b/frontend/src/components/conversations/ConversationsList.vue
@@ -345,7 +345,14 @@ onBeforeUnmount(() => {
           selectedChat && loadChatDetail(selectedChat.session_id, true);
           emit('refresh');
         }"
-        @chatUpdated="selectedChat = $event"
+        @chatUpdated="(updated) => {
+          // Forward as well as store locally. Taking a chat over from the chat
+          // pane changes user_id, and the info panel decides whether to offer
+          // 'End Chat' from its own chatInfo prop — which only the parent can
+          // update. Without this the button stayed hidden until a refresh.
+          selectedChat = updated;
+          emit('chatUpdated', updated);
+        }"
         @clearUnread="clearUnread"
         @back="emit('back')"
         @info="emit('info')"

--- a/frontend/src/services/agent.ts
+++ b/frontend/src/services/agent.ts
@@ -139,8 +139,14 @@ export const agentService = {
     return response.data
   },
   
+  /** The shipped guardrail rule with {org} filled in, shown as editable starting text. */
+  async getGuardrailDefault(): Promise<string> {
+    const response = await api.get('/agent/guardrail-default')
+    return response.data?.prompt ?? ''
+  },
+
   async generateInstructions(prompt: string, existingInstructions?: string[]): Promise<string[]> {
-    const response = await api.post('/agent/generate-instructions', { 
+    const response = await api.post('/agent/generate-instructions', {
         prompt,
         existing_instructions: existingInstructions 
     })


### PR DESCRIPTION
Three fixes, all from live testing.

## 1. Agents were returning nothing

Bounding a run at `tool_call_limit` (added in #275 for the #269 hang) ended it **at the tool result**, before the model wrote anything — so the visitor got `I'm sorry, I didn't quite catch that`. In production this was **5 of 7 turns** on an agent with three knowledge sources, including a plain "Hi".

At the limit we now **withdraw the tools** and let the model answer from what it already retrieved. Still bounded — a model with no tools cannot call one — but it ends with an answer.

Two follow-ups came out of testing this against a real agent, neither of which the unit tests could have caught:

- **Parallel tool calls.** A model can request several tools in one message; agno walks the whole batch before the next round. The first version treated the second sibling as a repeat and killed the run anyway. Now tracks the model *round*.
- **Streaming.** The live chat streams, and streaming goes through `process_response_stream` / `aprocess_response_stream`, which never touch the methods originally patched. Tools were never withdrawn there at all.

`tool_call_limit` was hardcoded; it is now `AGENT_TOOL_CALL_LIMIT`, left at the original **5** — reaching it is no longer fatal, so there is no reason to spend more per turn.

## 2. The guardrail was refusing real questions

The default rule also enumerated what was IN scope, and its `software unrelated to {org}` clause collided with integration questions — all of which name third-party software. It refused *"how do I connect Elasticsearch MCP"*, i.e. core product usage.

Now **deny-only** and a third of the length: name only what means "someone is using this as a free general-purpose AI", say nothing about what is in scope, and close with an explicit allow-bias.

The dashboard now shows the **actual rule, editable**, with `{org}` filled in, from a new `GET /agent/guardrail-default` — the old box described it in prose and had already drifted. NULL still means "follow the shipped default", so save sends null while the text is untouched.

## 3. End Chat missing after takeover

`ConversationsList` stored the updated chat locally but never forwarded `chatUpdated`, so the info panel's prop stayed stale and the button hid until a refresh.

---

### Known limitation — please read before merging

The empty-reply fix is **a large improvement, not a complete one**. In a busy local session, roughly 2 runs in 6 still reached a later round with tools attached, tripped the backstop and produced an empty turn. There is a fifth code path I have not located.

It is strictly better than what is in production today, but it does not fully close the bug.

Also unverified: the End Chat fix was found by reading the code and never exercised in the UI, and the shorter guardrail needs live checks that docker/curl-style questions are still answered — removing the in-scope examples caused exactly that regression once before.