### PR TITLE
fix(agent): drop the hard stop at the tool limit, and keep Groq able to reply

### DIFF
--- a/backend/app/agents/ticket_investigator.py
+++ b/backend/app/agents/ticket_investigator.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import asyncio
 from typing import Callable, List, Optional, Type
 
 from pydantic import BaseModel, ValidationError
@@ -246,8 +247,21 @@ class TicketInvestigatorAgent:
 
         try:
             self._count_call()
-            response = await agent.arun(message)
+            # Bounded like the chat and transfer runs. Hypothesis testing passes a
+            # tool_call_limit, and reaching it no longer terminates the run (see
+            # app.utils.agno_patches) — so the timeout is now the only thing
+            # standing between a model that keeps asking for tools and a worker
+            # that never finishes the investigation (#269).
+            response = await asyncio.wait_for(
+                agent.arun(message),
+                timeout=settings.AGENT_RUN_TIMEOUT
+            )
             self._capture_usage(agent, response)
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"{name} run timed out after {settings.AGENT_RUN_TIMEOUT}s and was cancelled"
+            )
+            return None
         except Exception as e:
             logger.error(f"{name} LLM call failed: {e}")
             return None

--- a/backend/app/utils/agno_patches.py
+++ b/backend/app/utils/agno_patches.py
@@ -33,8 +33,15 @@ limitations under the License.
 # What we actually want is a bounded run that still answers: at the limit, stop
 # offering tools and let the model reply from what it already retrieved. Clearing
 # `tools` for the next completion does exactly that, and it also makes the runaway
-# loop impossible — a model with no tools cannot call one. The hard stop is kept
-# as a backstop for the case that should now be unreachable.
+# loop impossible — a model with no tools cannot call one.
+#
+# There is deliberately NO hard-stop backstop. An earlier version kept one for the
+# case where withdrawal somehow failed, and it turned out to be the only remaining
+# producer of empty replies: it fired occasionally and cost the visitor an answer
+# every time. The hang it guarded against is already prevented by the
+# AGENT_RUN_TIMEOUT wrapper around every agno run, which does not depend on this
+# module patching the right entry points. Two locks on one door, and this was the
+# lock that slammed on the user.
 
 from agno.models.base import Model
 
@@ -44,19 +51,20 @@ logger = get_logger(__name__)
 
 _PATCHED_FLAG = "_chattermate_answers_at_limit"
 
-# Both live on the Model instance. Safe as instance state: create_model() builds
-# a fresh Model per ChatAgent and ChatAgent is built per request, so neither
-# outlives a single run.
+# Set on the Model instance once this run has spent its tool budget. Safe as
+# instance state: create_model() builds a fresh Model per ChatAgent and ChatAgent
+# is built per request, so it never outlives a single run.
 #
-# _ROUND counts model round-trips; _EXHAUSTED_AT records the round the budget ran
-# out in. The distinction is load-bearing: a model can request SEVERAL tools in
-# one assistant message, and agno walks that whole batch before calling the model
-# again. Every over-budget call in the batch arrives here, so a plain
-# "have we been here before" flag mistakes the second parallel call for a genuine
-# repeat and terminates the run — reintroducing the empty reply this patch exists
-# to prevent. Observed in local testing with tool_call_limit=1.
-_ROUND = "_chattermate_round"
-_EXHAUSTED_AT = "_chattermate_exhausted_round"
+# A model can request SEVERAL tools in one assistant message and agno walks that
+# whole batch before calling the model again, so this is hit repeatedly within a
+# single round. That is fine — setting it twice is a no-op. It mattered only while
+# there was a backstop that had to tell a parallel sibling apart from a genuine
+# repeat; without one, a plain flag is enough.
+_EXHAUSTED = "_chattermate_tools_exhausted"
+
+# Groq's structured output arrives as a tool call of this name rather than as
+# text. Kept in step with app.agents.structured_output.build_groq_json_tool.
+CAPTURE_TOOL_NAME = "json"
 
 # Replaces agno's own limit-error text, which only tells the model it may not
 # call the tool again. Left at that, gpt-4o-mini narrated the plumbing to the
@@ -74,15 +82,36 @@ _LIMIT_INSTRUCTION = (
 )
 
 
-def _strip_tools(self, kwargs: dict) -> dict:
-    """Drop the tool definitions from a model call once the budget is spent.
+def _tool_name(tool) -> str:
+    """Name out of a provider-format tool definition, whatever the nesting."""
+    if not isinstance(tool, dict):
+        return ""
+    fn = tool.get("function")
+    if isinstance(fn, dict):
+        return fn.get("name") or ""
+    return tool.get("name") or ""
 
-    Also counts the round, since this runs exactly once per model round-trip.
+
+def _strip_tools(self, kwargs: dict) -> dict:
+    """Withdraw the action tools once the budget is spent — but never the tool
+    the model answers THROUGH.
+
+    On Groq the structured response is not text: it is a tool call named `json`
+    whose arguments are the response fields (see app.agents.structured_output).
+    Withdrawing every tool would take away the only way that model has to reply,
+    so a Groq agent hitting the limit would return an empty turn every time —
+    precisely the failure this patch exists to remove.
     """
-    setattr(self, _ROUND, getattr(self, _ROUND, 0) + 1)
-    if getattr(self, _EXHAUSTED_AT, None) is not None and kwargs.get("tools"):
-        kwargs = {**kwargs, "tools": None, "tool_choice": None}
-    return kwargs
+    tools = kwargs.get("tools")
+    if not getattr(self, _EXHAUSTED, False) or not tools:
+        return kwargs
+
+    kept = [t for t in tools if _tool_name(t) == CAPTURE_TOOL_NAME]
+    if kept:
+        # Leave tool_choice alone: the capture tool is how the answer is emitted,
+        # so the model must still be allowed — or required — to call it.
+        return {**kwargs, "tools": kept}
+    return {**kwargs, "tools": None, "tool_choice": None}
 
 
 def apply_agno_patches() -> None:
@@ -102,8 +131,6 @@ def apply_agno_patches() -> None:
 
     def create_tool_call_limit_error_result(self, function_call):
         message = original_limit_result(self, function_call)
-        current_round = getattr(self, _ROUND, 0)
-        exhausted_at = getattr(self, _EXHAUSTED_AT, None)
 
         # Every over-budget call in the batch gets the instruction, not just the
         # first: the model reads all of the tool results, and leaving agno's
@@ -111,23 +138,12 @@ def apply_agno_patches() -> None:
         # narrating the limit to the visitor.
         message.content = _LIMIT_INSTRUCTION
 
-        if exhausted_at is None:
-            setattr(self, _EXHAUSTED_AT, current_round)
+        if not getattr(self, _EXHAUSTED, False):
+            setattr(self, _EXHAUSTED, True)
             logger.warning(
                 "Tool call limit reached; answering without further tools "
                 f"(tool={function_call.function.name})"
             )
-        elif current_round > exhausted_at:
-            # A LATER round still asking for tools means withdrawal did not take
-            # effect. Unreachable in practice — a model offered no tools cannot
-            # call one — but end the run rather than risk the #269 loop.
-            message.stop_after_tool_call = True
-            logger.warning(
-                "Tool call limit reached in a later round despite tools being "
-                f"withdrawn; terminating agent run (tool={function_call.function.name})"
-            )
-        # Same round: another tool from the same parallel batch. Already handled
-        # by the first one — say nothing and let the run continue to the answer.
         return message
 
     def _process_model_response(self, *args, **kwargs):

--- a/backend/tests/utils/test_agno_patches.py
+++ b/backend/tests/utils/test_agno_patches.py
@@ -29,11 +29,7 @@ def _model_stub():
 
 
 def _next_round(model, tools=None):
-    """Advance to the next model round-trip, the way agno's loop does.
-
-    _strip_tools runs exactly once per round, so going through it is what
-    separates a genuine later round from another tool in the same parallel batch.
-    """
+    """One model round-trip, the way agno's loop does it."""
     return _strip_tools(
         model, {"tools": tools if tools is not None else [{"name": "search"}], "tool_choice": "auto"}
     )
@@ -72,6 +68,29 @@ def test_tools_are_withdrawn_once_the_budget_is_spent():
     kwargs = _next_round(model)
     assert kwargs["tools"] is None
     assert kwargs["tool_choice"] is None
+
+
+def test_the_structured_output_tool_is_never_withdrawn():
+    """On Groq the reply IS a tool call named `json`, not text.
+
+    Withdrawing every tool would leave that model no way to answer at all, so a
+    Groq agent reaching the limit would return an empty turn every single time —
+    the exact failure this patch removes for everyone else.
+    """
+    model = _model_stub()
+    _next_round(model)
+    _limit_error_message(model)
+
+    kwargs = _strip_tools(model, {
+        "tools": [
+            {"type": "function", "function": {"name": "search_knowledge_base"}},
+            {"type": "function", "function": {"name": "json"}},
+        ],
+        "tool_choice": "auto",
+    })
+    assert [t["function"]["name"] for t in kwargs["tools"]] == ["json"]
+    # tool_choice must survive — it is how the capture tool gets called.
+    assert kwargs["tool_choice"] == "auto"
 
 
 def test_tools_survive_until_the_limit_is_hit():
@@ -114,16 +133,27 @@ def test_parallel_tool_calls_in_one_batch_do_not_end_the_run():
     assert not third.stop_after_tool_call
 
 
-def test_a_later_round_still_over_budget_terminates_as_a_backstop():
-    """Unreachable while withdrawal works — a model offered no tools cannot call
-    one. If it ever is reached, end the run rather than risk the #269 loop."""
+def test_the_run_is_never_hard_stopped():
+    """No branch may set stop_after_tool_call — that is what cost the answer.
+
+    A previous version kept a hard stop for the case where tool withdrawal
+    somehow failed. It fired occasionally in real traffic and every time it did,
+    the visitor got the empty-turn fallback instead of a reply. The hang it
+    guarded is already prevented by the AGENT_RUN_TIMEOUT wrapper around every
+    agno run, which does not depend on this module patching the right methods.
+
+    Covers a later round as well as the same batch, since the old backstop keyed
+    on exactly that distinction.
+    """
     model = _model_stub()
     _next_round(model)
-    _limit_error_message(model)
+    assert not _limit_error_message(model).stop_after_tool_call
 
-    _next_round(model)  # a genuine second round-trip
-    later = _limit_error_message(model, call_id="call_2")
-    assert later.stop_after_tool_call is True
+    _next_round(model)
+    assert not _limit_error_message(model, call_id="call_2").stop_after_tool_call
+
+    _next_round(model)
+    assert not _limit_error_message(model, call_id="call_3").stop_after_tool_call
 
 
 def test_exhaustion_does_not_leak_between_runs():


### PR DESCRIPTION
Follow-up to #279, which left the empty-reply bug improved but not closed.

## The backstop had to go

#279 kept a hard stop for the case where tool withdrawal failed. It fired in real traffic, ended the run **at the tool result** before the model wrote anything, and the visitor got `I'm sorry, I didn't quite catch that` — the exact failure the PR was fixing.

The hang it guarded against is already prevented by the `AGENT_RUN_TIMEOUT` wrapper around every agno run, which doesn't depend on this module patching the right entry points. Two locks on one door, and this was the one that slammed on the user.

Removing it exposed two problems that had to be fixed first.

## 1. One agno run had no timeout

`ticket_investigation.py` passes a `tool_call_limit` for hypothesis testing, and `ticket_investigator.py` was the single `arun` in the codebase with no `asyncio.wait_for` around it. Without the backstop that path could loop unbounded on the investigator worker. Now bounded like the chat and transfer runs.

## 2. Groq agents would have broken outright

On Groq the reply isn't text — it's a tool call named `json` whose arguments are the response fields, because Groq rejects JSON mode when tools are present ([structured_output.py](backend/app/agents/structured_output.py)).

Withdrawing *every* tool removes the only channel that model has to answer, so a Groq agent hitting the limit would return an empty turn **every single time**. Withdrawal now keeps the capture tool and removes only the action tools. This would not have shown up on OpenAI — it would have hit self-hosted GPT-OSS/Llama users.

## Measured, not assumed

Same prompt, `AGENT_TOOL_CALL_LIMIT=1`:

| | limit hits | timeouts (90s) | empty turns | visitor gets |
|---|---|---|---|---|
| tools kept, instruction only | **31** | **8** | **6** | nothing, after 90s |
| tools withdrawn | 2 | 0 | **0** | a correct answer |

The first row is the simpler design — leave the tools and just tell the model to stop. The model ignored the instruction and called the tool 31 more times, i.e. #269 all over again. Worth recording so nobody retries it.

Limit stays at **5**: reaching it is no longer fatal, so a bigger budget buys only latency and tokens.

## Notes

Round tracking is gone with the backstop — it existed only to tell a parallel sibling apart from a genuine repeat.

Verified at limit=1 on a real agent: 2 limit hits, 0 empty turns, 0 timeouts, and a correct grounded answer. Caveat: that was a quiet session. The earlier residual failures appeared under 6 concurrent runs, and with no backstop an unwithdrawn path can no longer produce an empty turn — worst case it burns rounds until the timeout — but I have not reproduced load to confirm.

Backend 2524 passed; the 33 failures are the known enterprise-gating/S3 set.