### PR TITLE
fix(db): re-parent add_run_connector_status onto the disclaimer migration

### DIFF
--- a/backend/alembic/versions/add_run_connector_status_001.py
+++ b/backend/alembic/versions/add_run_connector_status_001.py
@@ -17,7 +17,7 @@ limitations under the License.
 """add investigation_runs.connector_status
 
 Revision ID: add_run_connector_status_001
-Revises: add_agent_guardrail_prompt_001
+Revises: add_ai_disclaimer_001
 Create Date: 2026-07-31
 
 Records the MCP connector outcome of each investigation run ({"configured": N,
@@ -31,7 +31,7 @@ from sqlalchemy.dialects.postgresql import JSON
 
 # revision identifiers, used by Alembic.
 revision = 'add_run_connector_status_001'
-down_revision = 'add_agent_guardrail_prompt_001'
+down_revision = 'add_ai_disclaimer_001'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## This took the prod API down

`add_run_connector_status_001` (added in #278) declared `down_revision = 'add_agent_guardrail_prompt_001'` — the same parent as `add_ai_disclaimer_001` from #276. Two children of one parent, so main carried **two alembic heads**.

`start.sh` runs `alembic upgrade head`, which cannot resolve a single target when there are two. The backend exited before reaching gunicorn on every start:

```
Preloading embedding models...  →  FAILED: Multiple head revisions are present  →  restart
```

14 restarts, uvicorn never bound, `api.chattermate.chat` served 502 until this was applied.

## The fix

Re-parented onto `add_ai_disclaimer_001` so the chain is linear.

Re-parenting rather than adding a merge revision: the migration had **not been applied anywhere** — prod and local were both still at `add_ai_disclaimer_001` — so making it linear is safe and leaves no merge revision to reason about later.

Already applied to prod ahead of this merge to end the outage: the file was checked out from this branch, the backend image rebuilt, and the migration then ran cleanly (`add_ai_disclaimer_001 -> add_run_connector_status_001`). Prod's working tree therefore holds exactly this commit's version of the file and will go clean on the next `git pull` once this merges.

## Why it wasn't caught

Neither CI nor the test suite asserts a single alembic head, so a branch that only two PRs *together* create passes everything and fails at container start. Worth adding that check — it is a one-line test and this is the second time heads have bitten prod.