### PR TITLE
Make roles mean what they say

### DIFF
--- a/backend/app/api/agent.py
+++ b/backend/app/api/agent.py
@@ -20,8 +20,7 @@ from typing import List, Union
 from app.core.logger import get_logger
 from app.database import get_db
 from app.models.user import User, UserGroup
-from app.core.auth import get_current_user, require_permissions, get_unified_auth, get_auth_info_from_request
-from app.services.shopify_session import require_shopify_or_jwt_auth
+from app.core.auth import get_current_user, require_permissions, require_unified_permissions
 from app.repositories.agent import AgentRepository
 from app.repositories.knowledge import KnowledgeRepository
 from app.models.schemas.agent import AgentUpdate, AgentResponse, AgentCreate, AgentWithCustomizationResponse
@@ -236,7 +235,7 @@ async def create_agent(
 async def update_agent(
     agent_id: UUID,
     update_data: AgentUpdate,
-    auth_info: dict = Depends(get_unified_auth),
+    auth_info: dict = Depends(require_unified_permissions("manage_agents")),
     db: Session = Depends(get_db)
 ):
     """Update agent details - supports both JWT and Shopify session token auth"""
@@ -336,7 +335,7 @@ async def update_agent(
 
 @router.get("/guardrail-default")
 async def get_guardrail_default(
-    auth_info: dict = Depends(get_unified_auth),
+    auth_info: dict = Depends(require_unified_permissions("manage_agents")),
     db: Session = Depends(get_db)
 ):
     """The shipped scope rule, with {org} already filled in.
@@ -358,7 +357,7 @@ async def get_guardrail_default(
 @router.get("/list/shopify", response_model=List[AgentWithCustomizationResponse])
 @router.get("/list", response_model=List[AgentWithCustomizationResponse])
 async def get_organization_agents(
-    auth_info: dict = Depends(get_unified_auth),
+    auth_info: dict = Depends(require_unified_permissions("manage_agents")),
     db: Session = Depends(get_db)
 ):
     """Get organization agents - supports both JWT and Shopify session token auth"""
@@ -424,7 +423,7 @@ async def get_organization_agents(
 async def create_agent_customization(
     agent_id: UUID,
     customization_data: CustomizationCreate,
-    auth_info: dict = Depends(get_unified_auth),
+    auth_info: dict = Depends(require_unified_permissions("manage_agents")),
     db: Session = Depends(get_db)
 ):
     """Create or update agent customization - supports both JWT and Shopify session token auth"""
@@ -477,7 +476,7 @@ async def create_agent_customization(
 async def upload_agent_photo(
     agent_id: str,
     photo: UploadFile = File(...),
-    auth_info: dict = Depends(get_unified_auth),
+    auth_info: dict = Depends(require_unified_permissions("manage_agents")),
     db: Session = Depends(get_db)
 ):
     """Upload agent profile photo - supports both JWT and Shopify session token auth"""
@@ -616,7 +615,7 @@ async def update_agent_groups(
 @router.get("/{agent_id}", response_model=AgentWithCustomizationResponse)
 async def get_agent_by_id(
     agent_id: UUID,
-    auth_info: dict = Depends(get_unified_auth),
+    auth_info: dict = Depends(require_unified_permissions("manage_agents")),
     db: Session = Depends(get_db)
 ):
     """Get agent by ID with customization - supports both JWT and Shopify session token auth"""

--- a/backend/app/api/agent.py
+++ b/backend/app/api/agent.py
@@ -20,10 +20,17 @@ from typing import List, Union
 from app.core.logger import get_logger
 from app.database import get_db
 from app.models.user import User, UserGroup
-from app.core.auth import get_current_user, require_permissions, require_unified_permissions
+from app.core.auth import (
+    INBOX_PERMISSIONS,
+    get_current_user,
+    require_any_permission,
+    require_any_unified_permission,
+    require_permissions,
+    require_unified_permissions,
+)
 from app.repositories.agent import AgentRepository
 from app.repositories.knowledge import KnowledgeRepository
-from app.models.schemas.agent import AgentUpdate, AgentResponse, AgentCreate, AgentWithCustomizationResponse
+from app.models.schemas.agent import AgentUpdate, AgentResponse, AgentCreate, AgentRosterItem, AgentWithCustomizationResponse
 from sqlalchemy.orm import Session
 from app.models.agent import Agent, AgentCustomization
 from app.models.organization import Organization
@@ -333,9 +340,28 @@ async def update_agent(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/roster", response_model=List[AgentRosterItem])
+async def get_agent_roster(
+    current_user: User = Depends(require_any_permission(*INBOX_PERMISSIONS)),
+    db: Session = Depends(get_db)
+):
+    """Names of the org's AI agents, for the inbox filter.
+
+    Declared above GET /{agent_id}, which takes a UUID — below it, "roster"
+    fails UUID parsing and 422s.
+
+    Deliberately not GET /agent/list: AgentResponse carries `instructions` and
+    `guardrail_prompt`, and the guardrail prompt tells a reader exactly how to
+    phrase a bypass. Filtering conversations needs a name.
+    """
+    agents = AgentRepository(db).get_all_agents(current_user.organization_id)
+    return agents
+
+
 @router.get("/guardrail-default")
 async def get_guardrail_default(
-    auth_info: dict = Depends(require_unified_permissions("manage_agents")),
+    auth_info: dict = Depends(
+        require_any_unified_permission("view_agents", "manage_agents")),
     db: Session = Depends(get_db)
 ):
     """The shipped scope rule, with {org} already filled in.
@@ -357,7 +383,8 @@ async def get_guardrail_default(
 @router.get("/list/shopify", response_model=List[AgentWithCustomizationResponse])
 @router.get("/list", response_model=List[AgentWithCustomizationResponse])
 async def get_organization_agents(
-    auth_info: dict = Depends(require_unified_permissions("manage_agents")),
+    auth_info: dict = Depends(
+        require_any_unified_permission("view_agents", "manage_agents")),
     db: Session = Depends(get_db)
 ):
     """Get organization agents - supports both JWT and Shopify session token auth"""
@@ -615,7 +642,8 @@ async def update_agent_groups(
 @router.get("/{agent_id}", response_model=AgentWithCustomizationResponse)
 async def get_agent_by_id(
     agent_id: UUID,
-    auth_info: dict = Depends(require_unified_permissions("manage_agents")),
+    auth_info: dict = Depends(
+        require_any_unified_permission("view_agents", "manage_agents")),
     db: Session = Depends(get_db)
 ):
     """Get agent by ID with customization - supports both JWT and Shopify session token auth"""

--- a/backend/app/api/channels/accounts.py
+++ b/backend/app/api/channels/accounts.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session
 
 from app.core.auth import (
     INBOX_PERMISSIONS,
+    check_permissions,
     get_current_organization,
     require_any_permission,
     require_permissions,
@@ -62,12 +63,22 @@ def get_org_account_or_404(db: Session, account_id: UUID, organization: Organiza
     return account
 
 
-def to_account_out(db: Session, account, config=_UNRESOLVED) -> ChannelAccountOut:
+def to_account_out(
+    db: Session, account, config=_UNRESOLVED, include_webhook_url: bool = True
+) -> ChannelAccountOut:
+    """Serialise a channel account.
+
+    Pass include_webhook_url=False for callers who are not org admins: the URL
+    embeds `webhook_secret`, which is the ONLY authentication on the inbound
+    email and SMS webhooks (api/webhooks/email.py, api/webhooks/sms.py).
+    Handing it to an agent would let them post forged inbound messages into any
+    of the org's conversations.
+    """
     if config is _UNRESOLVED:
         config = AgentChannelConfigRepository(db).get_by_account(account.id)
     out = ChannelAccountOut.model_validate(account)
     out.agent_id = config.agent_id if config and config.is_active else None
-    out.webhook_url = channel_webhook_url(account)
+    out.webhook_url = channel_webhook_url(account) if include_webhook_url else None
     return out
 
 
@@ -76,7 +87,6 @@ async def list_channel_accounts(
     # Org admins (Integrations settings) OR inbox agents: the inbox reads this
     # to know whether there is a WhatsApp number to start a conversation from,
     # so gating it admin-only hid the feature from the people it is for.
-    # ChannelAccountOut carries no secrets — ids, names, and the webhook URL.
     current_user: User = Depends(
         require_any_permission("manage_organization", *INBOX_PERMISSIONS)),
     organization: Organization = Depends(get_current_organization),
@@ -85,4 +95,10 @@ async def list_channel_accounts(
     """All connected channel accounts for the organization."""
     accounts = ChannelAccountRepository(db).list_by_org(organization.id)
     configs = AgentChannelConfigRepository(db).map_by_accounts([a.id for a in accounts])
-    return [to_account_out(db, account, configs.get(account.id)) for account in accounts]
+    # Only the Integrations settings screen needs the webhook URL, and only an
+    # org admin can act on it — see to_account_out.
+    include_webhook_url = check_permissions(current_user, ["manage_organization"])
+    return [
+        to_account_out(db, account, configs.get(account.id), include_webhook_url)
+        for account in accounts
+    ]

--- a/backend/app/api/channels/whatsapp_messaging.py
+++ b/backend/app/api/channels/whatsapp_messaging.py
@@ -33,6 +33,7 @@ from app.api.channels.accounts import get_org_account_or_404
 from app.channels import get_adapter
 from app.channels.meta_base import fetch_message_templates, graph_detail, graph_get
 from app.core.auth import (
+    CHAT_MANAGE_PERMISSIONS,
     INBOX_PERMISSIONS,
     get_current_organization,
     require_any_permission,
@@ -57,10 +58,16 @@ router = APIRouter()
 # Meta's own template authoring UI, which is where we send people to write one.
 TEMPLATE_LIBRARY_URL = "https://business.facebook.com/latest/whatsapp_manager/template_library"
 
-# Template sending is inbox work — reopening a window, starting a conversation
-# — done by support agents, not org admins. INBOX_PERMISSIONS is shared with
-# the People page so the two surfaces can't disagree about who works the inbox.
+# Reading the template list is inbox work — the picker needs it — so any role
+# that works the inbox qualifies. INBOX_PERMISSIONS is shared with the People
+# page so the two surfaces can't disagree about who that is.
 require_inbox_agent = require_any_permission(*INBOX_PERMISSIONS)
+
+# Sending is not: an outbound template is a billable Meta message to a phone
+# number, with opt-in obligations attached. It takes the same grant as taking
+# over or reassigning a chat, so a view-only role can browse templates without
+# being able to fire one.
+require_inbox_sender = require_any_permission(*CHAT_MANAGE_PERMISSIONS)
 
 
 def _whatsapp_account_or_404(db: Session, account_id: UUID, organization: Organization):
@@ -101,7 +108,7 @@ def _waba_credentials(db: Session, account) -> tuple[str, str]:
 async def start_whatsapp_conversation(
     account_id: UUID,
     request: OutboundConversationRequest,
-    current_user: User = Depends(require_inbox_agent),
+    current_user: User = Depends(require_inbox_sender),
     organization: Organization = Depends(get_current_organization),
     db: Session = Depends(get_db),
 ):
@@ -128,7 +135,7 @@ async def start_whatsapp_conversation(
 async def send_whatsapp_template(
     account_id: UUID,
     request: TemplateSendRequest,
-    current_user: User = Depends(require_inbox_agent),
+    current_user: User = Depends(require_inbox_sender),
     organization: Organization = Depends(get_current_organization),
     db: Session = Depends(get_db),
 ):

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -17,7 +17,7 @@ limitations under the License.
 from fastapi import APIRouter, HTTPException, UploadFile, File, Form, Depends, Body, Query, status
 from typing import List, Optional
 from app.models.user import User
-from app.core.auth import get_current_user, require_permissions
+from app.core.auth import get_current_user, require_any_permission, require_permissions
 from app.core.logger import get_logger
 import os
 import asyncio
@@ -745,7 +745,8 @@ async def get_knowledge_by_agent(
     agent_id: str,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=10, ge=1, le=100),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(
+        require_any_permission("view_knowledge", "manage_knowledge")),
     db: Session = Depends(get_db)
 ):
     """Get knowledge sources and their data for an agent with pagination"""
@@ -755,6 +756,14 @@ async def get_knowledge_by_agent(
             agent_uuid = UUID(agent_id)
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid agent ID format")
+
+        # The agent must belong to the caller's organization. count_by_agent and
+        # get_by_agent below filter on agent_uuid alone, so without this an id
+        # from another tenant returns that tenant's knowledge inventory — the
+        # link/unlink routes have always checked this; this read never did.
+        agent = db.query(Agent).filter(Agent.id == agent_uuid).first()
+        if not agent or agent.organization_id != current_user.organization_id:
+            raise HTTPException(status_code=404, detail="Agent not found")
 
         logger.debug(f"Getting knowledge for agent {agent_uuid}")
         knowledge_repo = KnowledgeRepository(db)
@@ -893,7 +902,8 @@ async def get_agent_queue_items(
 @router.get("/queue/organization/{org_id}")
 async def get_organization_queue_items(
     org_id: UUID,
-    current_user: User = Depends(require_permissions("manage_knowledge")),
+    current_user: User = Depends(
+        require_any_permission("view_knowledge", "manage_knowledge")),
     db: Session = Depends(get_db)
 ):
     """Get all in-flight queue items (pending, processing, failed) for an org."""
@@ -958,7 +968,8 @@ async def get_knowledge_by_organization(
     org_id: str,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=10, ge=1, le=100),
-    current_user: User = Depends(require_permissions("manage_knowledge")),
+    current_user: User = Depends(
+        require_any_permission("view_knowledge", "manage_knowledge")),
     db: Session = Depends(get_db)
 ):
     """Get knowledge sources and their data for an organization with pagination"""
@@ -1057,7 +1068,8 @@ async def get_knowledge_by_organization(
 @router.get("/queue/{queue_id}")
 async def get_queue_status(
     queue_id: int,
-    current_user: User = Depends(require_permissions("manage_knowledge")),
+    current_user: User = Depends(
+        require_any_permission("view_knowledge", "manage_knowledge")),
     db: Session = Depends(get_db)
 ):
     """Get status of a queued knowledge item"""
@@ -1087,7 +1099,8 @@ async def get_queue_status(
 
 @router.get("/processor/status")
 async def get_processor_status(
-    current_user: User = Depends(require_permissions("manage_knowledge")),
+    current_user: User = Depends(
+        require_any_permission("view_knowledge", "manage_knowledge")),
     db: Session = Depends(get_db)
 ):
     """Get status of the knowledge processor for user's organization"""

--- a/backend/app/api/lead_capture.py
+++ b/backend/app/api/lead_capture.py
@@ -20,7 +20,7 @@ from uuid import UUID
 
 from app.core.logger import get_logger
 from app.database import get_db
-from app.core.auth import require_permissions
+from app.core.auth import require_any_permission, require_permissions
 from app.models.user import User
 from app.models.agent import Agent
 from app.repositories.lead_capture import LeadCaptureConfigRepository
@@ -68,7 +68,8 @@ def _get_owned_agent(agent_id: UUID, current_user: User, db: Session) -> Agent:
 @router.get("/{agent_id}/lead-capture", response_model=LeadCaptureConfigResponse)
 async def get_lead_capture_config(
     agent_id: UUID,
-    current_user: User = Depends(require_permissions("manage_agents")),
+    current_user: User = Depends(
+        require_any_permission("view_agents", "manage_agents")),
     db: Session = Depends(get_db),
 ):
     """Fetch the agent's lead-capture config, lazily creating a default (OFF) row."""

--- a/backend/app/api/roles.py
+++ b/backend/app/api/roles.py
@@ -19,7 +19,11 @@ from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from app.database import get_db
 from app.models.user import User
-from app.core.auth import get_current_user, require_permissions
+from app.core.auth import (
+    check_permissions,
+    require_any_permission,
+    require_permissions,
+)
 from app.repositories.role import RoleRepository
 from app.models.permission import Permission
 from app.models.schemas.role import (
@@ -28,10 +32,35 @@ from app.models.schemas.role import (
     RoleResponse,
     PermissionResponse
 )
-from typing import List
+from typing import Iterable, List
 from uuid import UUID
 
 router = APIRouter()
+
+# Reading the role catalogue is part of two surfaces: the Roles editor
+# (manage_roles) and the invite form, which needs the role dropdown
+# (manage_users). Gating reads on manage_roles alone breaks user invite.
+ROLE_READ_PERMISSIONS = ("manage_roles", "manage_users")
+
+
+def _require_grantable(current_user: User, permission_names: Iterable[str]) -> None:
+    """You cannot grant a permission you do not hold yourself.
+
+    Without this, manage_roles was equivalent to super_admin — and in fact so
+    was *any* authenticated session, since these endpoints carried no permission
+    check at all: POST /roles/{my_role_id}/permissions/super_admin was enough.
+    check_permissions short-circuits on super_admin, so an org owner granting
+    anything is unaffected.
+    """
+    ungrantable = sorted(
+        name for name in permission_names
+        if not check_permissions(current_user, [name])
+    )
+    if ungrantable:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Cannot grant a permission you do not hold: {', '.join(ungrantable)}"
+        )
 
 @router.post("", response_model=RoleResponse)
 async def create_role(
@@ -62,7 +91,10 @@ async def create_role(
                 status_code=400,
                 detail="Invalid permission"
             )
-    
+        # A new role is a grant too — otherwise the rule is one "create role,
+        # then assign myself to it" away from being bypassed.
+        _require_grantable(current_user, {p.name for p in existing_permissions})
+
     try:
         role = role_repo.create_role(
             name=role_data.name,
@@ -80,7 +112,7 @@ async def create_role(
 
 @router.get("", response_model=List[RoleResponse])
 async def list_roles(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_any_permission(*ROLE_READ_PERMISSIONS)),
     db: Session = Depends(get_db)
 ):
     """List all roles in the organization"""
@@ -90,7 +122,7 @@ async def list_roles(
 @router.get("/{role_id}", response_model=RoleResponse)
 async def get_role(
     role_id: int,  # Changed from UUID to int
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_any_permission(*ROLE_READ_PERMISSIONS)),
     db: Session = Depends(get_db)
 ):
     """Get role details including permissions"""
@@ -106,7 +138,7 @@ async def get_role(
 async def update_role(
     role_id: int,
     role_data: RoleUpdate,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_permissions("manage_roles")),
     db: Session = Depends(get_db)
 ):
     """Update role details"""
@@ -143,7 +175,14 @@ async def update_role(
                 status_code=400,
                 detail="Invalid permission"
             )
-    
+        # Only the diff: re-saving a role that already holds a permission the
+        # caller lacks is legitimate; adding one is the escalation.
+        already_held = {p.name for p in role.permissions}
+        _require_grantable(
+            current_user,
+            {p.name for p in existing_permissions} - already_held,
+        )
+
     try:
         updated_role = role_repo.update_role(
             role_id,
@@ -159,7 +198,7 @@ async def update_role(
 @router.delete("/{role_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_role(
     role_id: int,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_permissions("manage_roles")),
     db: Session = Depends(get_db)
 ):
     """Delete a role"""
@@ -187,16 +226,22 @@ async def delete_role(
 async def add_role_permission(
     role_id: int,
     permission: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_permissions("manage_roles")),
     db: Session = Depends(get_db)
 ):
     """Add a permission to a role"""
     role_repo = RoleRepository(db)
     role = role_repo.get_role(role_id)
-    
+
     if not role or role.organization_id != current_user.organization_id:
         raise HTTPException(status_code=404, detail="Role not found")
-        
+
+    # Resolve the name before the grant check so an unknown permission still
+    # reads as 404 rather than "you may not grant that".
+    if not db.query(Permission).filter(Permission.name == permission).first():
+        raise HTTPException(status_code=404, detail="Permission not found")
+    _require_grantable(current_user, [permission])
+
     success = role_repo.add_permission(role_id, permission)
     if not success:
         raise HTTPException(status_code=404, detail="Permission not found")
@@ -206,7 +251,7 @@ async def add_role_permission(
 async def remove_role_permission(
     role_id: int,
     permission: str,
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_permissions("manage_roles")),
     db: Session = Depends(get_db)
 ):
     """Remove a permission from a role"""
@@ -223,7 +268,7 @@ async def remove_role_permission(
 
 @router.get("/permissions/all", response_model=List[PermissionResponse])
 async def list_permissions(
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(require_any_permission(*ROLE_READ_PERMISSIONS)),
     db: Session = Depends(get_db)
 ):
     """List all available permissions"""

--- a/backend/app/api/session_to_agent.py
+++ b/backend/app/api/session_to_agent.py
@@ -25,7 +25,7 @@ from fastapi import APIRouter, HTTPException, Depends, status
 from sqlalchemy.orm import Session
 from app.core.logger import get_logger
 from app.models.user import User
-from app.core.auth import get_current_user, has_any_permission
+from app.core.auth import CHAT_MANAGE_PERMISSIONS, get_current_user, has_any_permission
 from app.database import get_db
 from app.services.chat_notifications import notify_chat_assigned
 from app.services.message_delivery import deliver_to_customer
@@ -34,10 +34,6 @@ from app.services.message_delivery import deliver_to_customer
 logger = get_logger(__name__)
 
 router = APIRouter()
-
-# Claiming or handing on a chat is a "manage" action: either the org-wide
-# grant or the assigned-chats one an agent holds.
-MANAGE_CHAT_PERMISSIONS = ("manage_all_chats", "manage_assigned_chats")
 
 # Shown to the customer when a human takes over an external-channel chat. The
 # widget surfaces the handover in its own UI, so only channels need a message.
@@ -91,7 +87,7 @@ async def takeover_chat(
         # manage_all_chats, not "manage_chats" — the latter is not a real
         # permission and never matched. has_any_permission also honours the
         # super_admin bypass the previous hand-rolled set check ignored.
-        if not has_any_permission(current_user, MANAGE_CHAT_PERMISSIONS):
+        if not has_any_permission(current_user, CHAT_MANAGE_PERMISSIONS):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Not enough permissions"
@@ -193,7 +189,7 @@ async def reassign_chat(
         # super_admin bypass the previous hand-rolled set check ignored. It
         # also checked "manage_chats", which is not a real permission and so
         # never matched.
-        if not has_any_permission(current_user, MANAGE_CHAT_PERMISSIONS):
+        if not has_any_permission(current_user, CHAT_MANAGE_PERMISSIONS):
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Not enough permissions"

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -28,9 +28,9 @@ from uuid import UUID
 from app.database import get_db
 from app.models.user import User
 from app.models.session_to_agent import SessionToAgent, SessionStatus
-from app.models.schemas.user import UserCreate, UserStatusUpdate, UserUpdate, UserResponse, TokenResponse
+from app.models.schemas.user import AdminPasswordReset, UserCreate, UserStatusUpdate, UserUpdate, UserResponse, TokenResponse
 from datetime import datetime, timezone
-from app.core.security import create_access_token, create_refresh_token, verify_token
+from app.core.security import create_access_token, create_refresh_token, validate_password_strength, verify_token
 from app.core.auth import get_current_user, require_permissions
 from app.core.logger import get_logger
 from app.repositories.user import UserRepository
@@ -789,29 +789,40 @@ async def update_profile(
                     detail="Email already registered"
                 )
         
-        # Verify current password if updating password
-        if data.password:
-            if not data.current_password:
+        fields = data.dict(exclude_unset=True)
+        # `password` and `current_password` are request-only fields; the column
+        # is `hashed_password`. Passing `password` through wrote a stray
+        # attribute onto the ORM object that was never persisted, so changing
+        # your own password quietly did nothing while returning 200.
+        new_password = fields.pop('password', None)
+        current_password = fields.pop('current_password', None)
+
+        if new_password:
+            if not current_password:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Current password is required"
                 )
-            if not current_user.verify_password(data.current_password):
+            if not current_user.verify_password(current_password):
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Incorrect current password"
                 )
-            
-            # Hash new password
-            data.password = User.get_password_hash(data.password)
-        
-        # Remove current_password from update data
-        if hasattr(data, 'current_password'):
-            delattr(data, 'current_password')
-        
+            # Same bar an admin-set password has to clear — otherwise the
+            # policy is one self-service change away from being bypassed.
+            try:
+                validate_password_strength(new_password)
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=str(e)
+                )
+
+            fields['hashed_password'] = User.get_password_hash(new_password)
+
         updated_user = user_repo.update_user(
             current_user.id,
-            **data.dict(exclude_unset=True)
+            **fields
         )
                 # Generate signed URL if using S3 and user has a profile picture
         if settings.S3_FILE_STORAGE and updated_user.profile_pic:
@@ -878,8 +889,15 @@ async def update_user(
                     )
     
     try:
-        updated_user = user_repo.update_user(user_id, **user_data.dict(exclude_unset=True))
-        
+        fields = user_data.dict(exclude_unset=True)
+        # A password sent here used to be written straight onto the ORM object as
+        # a `password` attribute the User model does not have — silently doing
+        # nothing. Resetting someone else's password has its own endpoint below.
+        fields.pop('password', None)
+        fields.pop('current_password', None)
+
+        updated_user = user_repo.update_user(user_id, **fields)
+
         # Generate signed URL if using S3 and user has a profile picture
         if settings.S3_FILE_STORAGE and updated_user.profile_pic:
             signed_url = await get_s3_signed_url(updated_user.profile_pic)
@@ -895,6 +913,47 @@ async def update_user(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to update user"
         )
+
+
+@router.post("/{user_id}/reset-password")
+async def reset_user_password(
+    user_id: str,
+    data: AdminPasswordReset,
+    current_user: User = Depends(require_permissions("manage_users")),
+    db: Session = Depends(get_db)
+):
+    """Set a new password for another user in the caller's organization.
+
+    For the common case of an agent locked out of their account: the admin sets
+    a password and hands it over, rather than the agent going through the
+    email OTP flow (which the community edition does not ship).
+    """
+    user_repo = UserRepository(db)
+    user = user_repo.get_user(user_id)
+
+    if not user or user.organization_id != current_user.organization_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    # Changing your own password still goes through /users/me, which proves you
+    # know the current one. Allowing it here would let anyone holding a stolen
+    # admin session lock the real admin out without ever learning their password.
+    if user.id == current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Use your profile settings to change your own password"
+        )
+
+    try:
+        user_repo.update_user(user_id, hashed_password=User.get_password_hash(data.new_password))
+    except Exception as e:
+        logger.error(f"Failed to reset password for user {user_id}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to reset password"
+        )
+
+    logger.info(f"User {current_user.id} reset the password of user {user_id}")
+    return {"message": "Password reset successfully"}
 
 
 @router.post("/{user_id}/status")

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -28,10 +28,10 @@ from uuid import UUID
 from app.database import get_db
 from app.models.user import User
 from app.models.session_to_agent import SessionToAgent, SessionStatus
-from app.models.schemas.user import AdminPasswordReset, UserCreate, UserStatusUpdate, UserUpdate, UserResponse, TokenResponse
+from app.models.schemas.user import AdminPasswordReset, TeammateResponse, UserCreate, UserStatusUpdate, UserUpdate, UserResponse, TokenResponse
 from datetime import datetime, timezone
 from app.core.security import create_access_token, create_refresh_token, validate_password_strength, verify_token
-from app.core.auth import get_current_user, require_permissions
+from app.core.auth import INBOX_PERMISSIONS, get_current_user, require_any_permission, require_permissions
 from app.core.logger import get_logger
 from app.repositories.user import UserRepository
 from pydantic import BaseModel
@@ -370,6 +370,25 @@ async def get_team_overview(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=str(e)
         )
+
+
+@router.get("/teammates", response_model=List[TeammateResponse])
+async def list_teammates(
+    current_user: User = Depends(require_any_permission(*INBOX_PERMISSIONS)),
+    db: Session = Depends(get_db)
+):
+    """The colleagues an inbox user can hand a conversation to.
+
+    Declared above GET /{user_id}: below it, "teammates" parses as a user id
+    and the request lands on the manage_users route — a 403 for exactly the
+    agents this exists for.
+
+    Deliberately not a relaxation of GET /users, which returns each teammate's
+    role and its full permission list. Reassigning a chat needs a name and a
+    face, so that is all this returns.
+    """
+    users = UserRepository(db).get_users_by_organization(current_user.organization_id)
+    return [user for user in users if user.is_active]
 
 
 @router.get("/{user_id}", response_model=UserResponse)

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -17,7 +17,7 @@ limitations under the License.
 from fastapi import Depends, HTTPException, status, Cookie, Request
 from fastapi.security import HTTPBearer
 from sqlalchemy.orm import Session
-from typing import Iterable, Optional, List
+from typing import Callable, Iterable, Optional, List
 
 from app.database import get_db
 from app.models.user import User
@@ -264,7 +264,12 @@ def get_auth_info_from_request(request: Request) -> dict:
 
 
 async def get_unified_auth(request: Request, db: Session = Depends(get_db)) -> dict:
-    """Unified authentication that handles both regular JWT and Shopify session tokens"""
+    """Authenticate a JWT, a PAT, or a Shopify session token.
+
+    Authentication only — it deliberately holds no permission check. Wrap it in
+    require_unified_permissions / require_any_unified_permission to declare what
+    a route needs.
+    """
     from app.services.shopify_session import require_shopify_or_jwt_auth
 
     try:
@@ -314,8 +319,6 @@ async def get_unified_auth(request: Request, db: Session = Depends(get_db)) -> d
                             detail="Invalid or revoked access token",
                             headers={"WWW-Authenticate": "Bearer"},
                         )
-                    if not check_permissions(current_user, ["manage_agents"]):
-                        raise HTTPException(status_code=403, detail="Not enough permissions")
                     return {
                         "auth_type": "pat",
                         "organization_id": current_user.organization_id,
@@ -354,13 +357,6 @@ async def get_unified_auth(request: Request, db: Session = Depends(get_db)) -> d
                         headers={"WWW-Authenticate": "Bearer"},
                     )
 
-                # Check permissions
-                if not check_permissions(current_user, ["manage_agents"]):
-                    raise HTTPException(
-                        status_code=403,
-                        detail="Not enough permissions"
-                    )
-                
                 return {
                     "auth_type": "jwt",
                     "organization_id": current_user.organization_id,  # Keep as UUID
@@ -382,6 +378,54 @@ async def get_unified_auth(request: Request, db: Session = Depends(get_db)) -> d
     except Exception as e:
         logger.error(f"Authentication error: {str(e)}")
         raise HTTPException(status_code=401, detail="Authentication failed")
+
+
+def _authorize_unified(auth_info: dict, permitted: Callable[[User], bool]) -> dict:
+    """Apply a permission check to a get_unified_auth result.
+
+    A Shopify shop session authenticates a *store*, not a person, so it carries
+    no `current_user` and there is no role to check — those requests pass
+    through exactly as they did before authorization moved out of the helper.
+    """
+    current_user = auth_info.get("current_user")
+    if current_user is None:
+        return auth_info
+    if not permitted(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not enough permissions"
+        )
+    return auth_info
+
+
+def require_unified_permissions(*required_permissions: str):
+    """get_unified_auth + AND-semantics permissions, for JWT/PAT callers.
+
+    get_unified_auth used to hardcode a manage_agents check, which meant every
+    route sharing the helper inherited it — including reading your own org's
+    subscription, which locked every non-admin out of the whole app. The helper
+    now only authenticates; each route declares what it needs.
+    """
+    async def permission_checker(
+        auth_info: dict = Depends(get_unified_auth)
+    ) -> dict:
+        return _authorize_unified(
+            auth_info,
+            lambda user: check_permissions(user, list(required_permissions)),
+        )
+    return permission_checker
+
+
+def require_any_unified_permission(*permissions: str):
+    """The OR counterpart of require_unified_permissions."""
+    async def permission_checker(
+        auth_info: dict = Depends(get_unified_auth)
+    ) -> dict:
+        return _authorize_unified(
+            auth_info,
+            lambda user: has_any_permission(user, permissions),
+        )
+    return permission_checker
 
 
 async def get_unified_chat_auth(request: Request, db: Session = Depends(get_db)) -> dict:

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -78,25 +78,42 @@ def require_permissions(*required_permissions: str):
     return permission_checker
 
 
-# Working the inbox: seeing conversations and the people in them. Either chat
-# capability grants it — which require_permissions, whose semantics are AND,
-# cannot express. Defined once because it gates two surfaces (the WhatsApp
-# template/outbound endpoints and the People page) that must agree: a role
-# that can open a conversation but not read the templates it needs to answer
-# one has the feature only in theory.
+# Seeing conversations. Either scope grants it — which require_permissions,
+# whose semantics are AND, cannot express.
 #
 # manage_all_chats, not "manage_chats" — the latter appears in several hand-
 # rolled checks but is not in Permission.default_permissions(), so it has
 # never matched anyone.
-INBOX_PERMISSIONS = ("view_all_chats", "manage_all_chats")
+CHAT_VIEW_PERMISSIONS = (
+    "view_all_chats",
+    "view_assigned_chats",
+    "view_unassigned_chats",
+)
 
-# The people directory. view_people is the read-only grant handed to agents;
-# the org-wide chat permissions imply it, so admins keep access unchanged.
+# Acting on a conversation: taking it over, reassigning it, sending outbound.
+# Deliberately NOT derived from INBOX_PERMISSIONS — folding the view grants in
+# here would let a read-only role reassign other people's conversations.
+CHAT_MANAGE_PERMISSIONS = ("manage_all_chats", "manage_assigned_chats")
+
+# Working the inbox, in the sense the surfaces around it mean it: an agent who
+# can open a conversation must also be able to read the channel accounts and
+# message templates needed to answer one, or the feature exists only in theory.
+# This used to be just the two org-wide grants, which excluded the very agents
+# the comment described.
+INBOX_PERMISSIONS = CHAT_VIEW_PERMISSIONS + CHAT_MANAGE_PERMISSIONS
+
+# The narrower org-wide scope, for the places that genuinely mean "can see the
+# whole org's chats" rather than "works the inbox".
+ORG_CHAT_PERMISSIONS = ("view_all_chats", "manage_all_chats")
+
+# The people directory.
 PEOPLE_READ_PERMISSIONS = ("view_people",) + INBOX_PERMISSIONS
 
-# Mutating a person (marking a customer, editing attributes) stays with the
-# roles that can already manage the whole inbox.
-PEOPLE_WRITE_PERMISSIONS = INBOX_PERMISSIONS
+# Correcting a person's details, marking them a customer and pushing them to a
+# connected CRM are inbox work, not administration — people.py documents the
+# PATCH as the agent's identification tool. So view_people grants both; there
+# is no separate read-only directory role today.
+PEOPLE_WRITE_PERMISSIONS = PEOPLE_READ_PERMISSIONS
 
 
 def has_any_permission(user: User, permissions: Iterable[str]) -> bool:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict
+import re
 import uuid
 from jose import JWTError, jwt
 from passlib.context import CryptContext
@@ -34,6 +35,33 @@ ACCESS_TOKEN_EXPIRE_MINUTES = 30
 REFRESH_TOKEN_EXPIRE_DAYS = 7
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# Password policy for passwords one person sets on behalf of another (today:
+# an admin resetting an agent's password). Mirrors the strength meter the UI
+# draws — minimum length plus three of the four character classes — so the
+# form and the API agree on what "strong enough" means.
+MIN_PASSWORD_LENGTH = 8
+MIN_PASSWORD_CHARACTER_CLASSES = 3
+
+_PASSWORD_CHARACTER_CLASSES = (r"[A-Z]", r"[a-z]", r"[0-9]", r"[^A-Za-z0-9]")
+
+
+def validate_password_strength(password: str) -> str:
+    """Return the password, or raise ValueError describing what it is missing."""
+    if len(password or "") < MIN_PASSWORD_LENGTH:
+        raise ValueError(
+            f"Password must be at least {MIN_PASSWORD_LENGTH} characters long"
+        )
+
+    classes = sum(1 for pattern in _PASSWORD_CHARACTER_CLASSES if re.search(pattern, password))
+    if classes < MIN_PASSWORD_CHARACTER_CLASSES:
+        raise ValueError(
+            f"Password must include at least {MIN_PASSWORD_CHARACTER_CLASSES} of: "
+            "uppercase letter, lowercase letter, number, special character"
+        )
+
+    return password
+
 
 def _fernet():
     """The shared encryption-at-rest key, loaded by app.core.encryption.

--- a/backend/app/models/schemas/agent.py
+++ b/backend/app/models/schemas/agent.py
@@ -104,6 +104,21 @@ class AgentKnowledge(BaseModel):
     type: str
 
 
+class AgentRosterItem(BaseModel):
+    """An AI agent as the inbox filter needs it: a name to group chats by.
+
+    Deliberately none of AgentResponse's configuration — `instructions`, and
+    especially `guardrail_prompt`, which tells a reader how to phrase a bypass.
+    """
+    id: UUID
+    name: str
+    display_name: Optional[str] = None
+    is_active: bool = True
+
+    class Config:
+        from_attributes = True
+
+
 class AgentResponse(BaseModel):
     id: UUID
     name: str

--- a/backend/app/models/schemas/user.py
+++ b/backend/app/models/schemas/user.py
@@ -58,6 +58,27 @@ class UserUpdate(BaseModel):
     profile_pic: Optional[str] = None
     is_online: Optional[bool] = None
 
+class TeammateResponse(BaseModel):
+    """A colleague as the inbox needs them: enough to pick one and render them.
+
+    No role, no permissions, no timestamps — an agent listing who they can hand
+    a chat to has no business reading the org's permission matrix, which is
+    what UserResponse would give them.
+    """
+    id: UUID
+    full_name: Optional[str] = None
+    email: EmailStr
+    profile_pic: Optional[str] = None
+    is_online: Optional[bool] = False
+
+    @field_serializer('profile_pic')
+    def _sign_profile_pic(self, v: Optional[str]) -> Optional[str]:
+        return sign_s3_url(v) if v else v
+
+    class Config:
+        from_attributes = True
+
+
 class AdminPasswordReset(BaseModel):
     """An admin setting a new password for someone else in their organization.
 

--- a/backend/app/models/schemas/user.py
+++ b/backend/app/models/schemas/user.py
@@ -14,12 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from pydantic import BaseModel, EmailStr, field_serializer
+from pydantic import BaseModel, EmailStr, field_serializer, field_validator
 from typing import Optional, List
 from uuid import UUID
 from datetime import datetime
 
 from app.core.s3 import sign_s3_url
+from app.core.security import validate_password_strength
 
 from app.models.schemas.role import RoleResponse
 
@@ -38,6 +39,14 @@ class UserCreate(UserBase):
     password: str
     role_id: int
 
+    @field_validator('password')
+    @classmethod
+    def _check_strength(cls, value: str) -> str:
+        # The password an admin picks for a new teammate clears the same bar as
+        # one set by a reset — otherwise the policy is one invite away from
+        # being bypassed.
+        return validate_password_strength(value)
+
 
 class UserUpdate(BaseModel):
     email: Optional[EmailStr] = None
@@ -48,6 +57,21 @@ class UserUpdate(BaseModel):
     role_id: Optional[int] = None
     profile_pic: Optional[str] = None
     is_online: Optional[bool] = None
+
+class AdminPasswordReset(BaseModel):
+    """An admin setting a new password for someone else in their organization.
+
+    No current_password: the admin does not know it — that is the point of a
+    reset. The policy check lives here because nobody is around to see the
+    form's strength meter when the call arrives from a script.
+    """
+    new_password: str
+
+    @field_validator('new_password')
+    @classmethod
+    def _check_strength(cls, value: str) -> str:
+        return validate_password_strength(value)
+
 
 class UserStatusUpdate(BaseModel):
     is_online: bool

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -1743,3 +1743,136 @@ def test_agent_customization_requires_manage_agents(unprivileged_client: TestCli
 def test_guardrail_default_requires_manage_agents(unprivileged_client: TestClient):
     """The default guardrail prompt tells a reader how to phrase a bypass"""
     assert unprivileged_client.get("/api/agents/guardrail-default").status_code == 403
+
+
+# -------------------------------------------------------------------- roster
+
+@pytest.fixture
+def inbox_agent_client(db, test_organization_id) -> TestClient:
+    """A seeded Human Agent: works the inbox, manages no AI agents."""
+    role = Role(name="Human Agent", organization_id=test_organization_id)
+    db.add(role)
+    db.commit()
+    for name in ("view_assigned_chats", "manage_assigned_chats", "view_people"):
+        perm = Permission(name=name, description=name)
+        db.add(perm)
+        db.commit()
+        db.execute(role_permissions.insert().values(role_id=role.id, permission_id=perm.id))
+    db.commit()
+    user = User(
+        id=uuid4(),
+        email="inboxagent@example.com",
+        hashed_password="hashed_password",
+        is_active=True,
+        organization_id=test_organization_id,
+        full_name="Inbox Agent",
+        role_id=role.id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    async def override_get_current_user():
+        return user
+
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_db] = override_get_db
+
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_roster_readable_by_inbox_roles(inbox_agent_client: TestClient, test_agent: Agent):
+    """The inbox filter needs agent names; it does not need manage_agents"""
+    response = inbox_agent_client.get("/api/agents/roster")
+
+    assert response.status_code == 200
+    assert [a["name"] for a in response.json()] == [test_agent.name]
+
+
+def test_roster_withholds_instructions_and_guardrail(inbox_agent_client: TestClient, test_agent: Agent):
+    """A guardrail prompt tells a reader how to phrase a bypass"""
+    response = inbox_agent_client.get("/api/agents/roster")
+
+    assert response.status_code == 200
+    for item in response.json():
+        assert set(item) == {"id", "name", "display_name", "is_active"}
+
+
+def test_roster_is_org_scoped(inbox_agent_client: TestClient, db, test_agent: Agent):
+    """Another tenant's agents are not on this roster"""
+    other_org = Organization(id=uuid4(), name="Other", domain="other-roster.example.com")
+    db.add(other_org)
+    db.commit()
+    db.add(Agent(
+        id=uuid4(),
+        name="Foreign Agent",
+        display_name="Foreign",
+        agent_type=AgentType.CUSTOMER_SUPPORT,
+        instructions=["secret"],
+        is_active=True,
+        organization_id=other_org.id,
+    ))
+    db.commit()
+
+    response = inbox_agent_client.get("/api/agents/roster")
+
+    assert response.status_code == 200
+    assert "Foreign Agent" not in [a["name"] for a in response.json()]
+
+
+def test_roster_route_is_not_shadowed_by_the_agent_id_route(inbox_agent_client: TestClient):
+    """Declared above GET /{agent_id}, which takes a UUID — below it, 422"""
+    assert inbox_agent_client.get("/api/agents/roster").status_code == 200
+
+
+def test_view_agents_grants_the_reads(db, test_organization_id, test_agent: Agent):
+    """view_agents was declared in the catalogue but enforced nowhere.
+
+    An admin could tick it on a role and nothing happened: every /agent read
+    still demanded manage_agents, so the page rendered and then 403'd.
+    """
+    role = Role(name="Agent Viewer", organization_id=test_organization_id)
+    db.add(role)
+    db.commit()
+    perm = Permission(name="view_agents", description="Can view chat agents")
+    db.add(perm)
+    db.commit()
+    db.execute(role_permissions.insert().values(role_id=role.id, permission_id=perm.id))
+    db.commit()
+    viewer = User(
+        id=uuid4(),
+        email="viewer@example.com",
+        hashed_password="hashed_password",
+        is_active=True,
+        organization_id=test_organization_id,
+        full_name="Viewer",
+        role_id=role.id,
+    )
+    db.add(viewer)
+    db.commit()
+
+    async def override_get_unified_auth():
+        return {
+            "auth_type": "jwt",
+            "organization_id": viewer.organization_id,
+            "user_id": viewer.id,
+            "current_user": viewer,
+        }
+
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_unified_auth] = override_get_unified_auth
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        client = TestClient(app)
+        assert client.get("/api/agents/list").status_code == 200
+        assert client.get(f"/api/agents/{test_agent.id}").status_code == 200
+        # Reading is not managing
+        assert client.put(f"/api/agents/{test_agent.id}", json={"name": "X"}).status_code == 403
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -156,21 +156,12 @@ def client(db, test_user) -> TestClient:
         return test_user
 
     async def override_get_unified_auth():
-        # Refresh the user to get the latest role and permissions from the database
+        # Authentication only — the permission check belongs to
+        # require_unified_permissions, which wraps this. Re-implementing it here
+        # made these tests pass whether or not the routes were actually gated.
         db.refresh(test_user)
         db.refresh(test_user.role)
-        
-        # Get user permissions
-        user_permissions = {p.name for p in test_user.role.permissions}
-        
-        # Check if user has manage_agents permission
-        if "manage_agents" not in user_permissions:
-            from fastapi import HTTPException
-            raise HTTPException(
-                status_code=403,
-                detail="Not enough permissions"
-            )
-        
+
         return {
             "auth_type": "jwt",
             "organization_id": test_user.organization_id,  # Keep as UUID, not string
@@ -1676,3 +1667,79 @@ def test_performance_with_complex_agent_data(
     
     assert response.status_code == 200
     assert retrieval_time < 2.0  # Should complete within 2 seconds
+
+
+# ---------------------------------------------------------------- permissions
+
+@pytest.fixture
+def unprivileged_client(db, test_organization_id) -> TestClient:
+    """A client whose role grants nothing.
+
+    get_unified_auth authenticates only; require_unified_permissions is what
+    refuses. Before that split the check lived inside the auth helper, so every
+    route sharing it — including reading your own org's subscription — demanded
+    manage_agents.
+    """
+    role = Role(name="No Permissions", organization_id=test_organization_id)
+    db.add(role)
+    db.commit()
+    user = User(
+        id=uuid4(),
+        email="nopermissions@example.com",
+        hashed_password="hashed_password",
+        is_active=True,
+        organization_id=test_organization_id,
+        full_name="No Permissions",
+        role_id=role.id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    async def override_get_unified_auth():
+        return {
+            "auth_type": "jwt",
+            "organization_id": user.organization_id,
+            "user_id": user.id,
+            "current_user": user,
+        }
+
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_unified_auth] = override_get_unified_auth
+    app.dependency_overrides[get_db] = override_get_db
+
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_agent_list_requires_manage_agents(unprivileged_client: TestClient):
+    """Reading the agent list still needs manage_agents after the authn/authz split"""
+    assert unprivileged_client.get("/api/agents/list").status_code == 403
+
+
+def test_agent_detail_requires_manage_agents(unprivileged_client: TestClient, test_agent: Agent):
+    """Agent config carries instructions and the guardrail prompt — not for everyone"""
+    assert unprivileged_client.get(f"/api/agents/{test_agent.id}").status_code == 403
+
+
+def test_agent_update_requires_manage_agents(unprivileged_client: TestClient, test_agent: Agent):
+    """A missed wrapper here would let any org member rewrite an agent"""
+    response = unprivileged_client.put(
+        f"/api/agents/{test_agent.id}", json={"name": "Hijacked"}
+    )
+    assert response.status_code == 403
+
+
+def test_agent_customization_requires_manage_agents(unprivileged_client: TestClient, test_agent: Agent):
+    """Customization is customer-facing branding"""
+    response = unprivileged_client.post(
+        f"/api/agents/{test_agent.id}/customization", json={"chat_bubble_color": "#000000"}
+    )
+    assert response.status_code == 403
+
+
+def test_guardrail_default_requires_manage_agents(unprivileged_client: TestClient):
+    """The default guardrail prompt tells a reader how to phrase a bypass"""
+    assert unprivileged_client.get("/api/agents/guardrail-default").status_code == 403

--- a/backend/tests/api/test_agent_workflow.py
+++ b/backend/tests/api/test_agent_workflow.py
@@ -152,21 +152,10 @@ def client(db, test_user) -> TestClient:
         return test_user
 
     async def override_get_unified_auth():
-        # Refresh the user to get the latest role and permissions from the database
+        # Authentication only — see the note in tests/api/test_agent.py.
         db.refresh(test_user)
         db.refresh(test_user.role)
-        
-        # Get user permissions
-        user_permissions = {p.name for p in test_user.role.permissions}
-        
-        # Check if user has manage_agents permission
-        if "manage_agents" not in user_permissions:
-            from fastapi import HTTPException
-            raise HTTPException(
-                status_code=403,
-                detail="Not enough permissions"
-            )
-        
+
         return {
             "auth_type": "jwt",
             "organization_id": test_user.organization_id,  # Keep as UUID

--- a/backend/tests/api/test_meta_channels_api.py
+++ b/backend/tests/api/test_meta_channels_api.py
@@ -21,6 +21,12 @@ from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
+
+from app.core.security import get_password_hash
+from app.models.channels import ChannelAccount, ChannelType
+from app.models.permission import Permission
+from app.models.role import Role
+from app.models.user import User
 from fastapi.testclient import TestClient
 
 import app.main  # noqa: F401 — ensures routers are registered on the FastAPI app
@@ -43,12 +49,14 @@ def client(db, test_user, test_organization, monkeypatch):
     monkeypatch.setattr(settings, "META_APP_SECRET", APP_SECRET)
     monkeypatch.setattr(settings, "META_WEBHOOK_VERIFY_TOKEN", "vtok")
 
-    # Template sending is inbox-agent work (require_inbox_agent), not an
-    # org-admin capability; the shared test_role only carries admin perms.
+    # Reading templates is inbox work; SENDING one is a manage action — a
+    # billable Meta message with opt-in obligations, gated like takeover and
+    # reassign. The shared test_role only carries admin perms, so grant both.
     from app.models.permission import Permission
-    inbox_perm = Permission(name="view_all_chats")
-    db.add(inbox_perm)
-    test_user.role.permissions.append(inbox_perm)
+    for name in ("view_all_chats", "manage_all_chats"):
+        perm = Permission(name=name)
+        db.add(perm)
+        test_user.role.permissions.append(perm)
     db.commit()
 
     async def override_user():
@@ -1169,3 +1177,95 @@ class TestInboxAgentCanActuallyReachTheFeature:
         WhatsApp Manager, where templates are written, stays org-admin."""
         r = inbox_client.get(f"{BASE}/whatsapp/{waba_account.id}/template-library")
         assert r.status_code == 403
+
+    def test_a_view_only_role_cannot_send(self, inbox_client, waba_account):
+        """Reading the picker is not permission to fire a billable message.
+
+        This role holds view_all_chats and nothing else. Sending takes the same
+        grant as taking a chat over, so a read-only observer can browse the
+        templates without being able to message a customer.
+        """
+        r = inbox_client.post(
+            f"{BASE}/whatsapp/{waba_account.id}/conversations",
+            json={"phone": "+15551234567", "template_name": "order_update",
+                  "language": "en_US", "body_params": []},
+        )
+        assert r.status_code == 403
+
+    def test_an_assigned_chats_agent_can_send(
+            self, db, test_organization, waba_account, test_agent, monkeypatch):
+        """manage_assigned_chats — what the seeded Agent role holds — is enough."""
+        monkeypatch.setattr(settings, "META_APP_SECRET", APP_SECRET)
+        role = Role(name="Sending Agent", organization_id=test_organization.id)
+        role.permissions = [
+            Permission(name="view_assigned_chats"),
+            Permission(name="manage_assigned_chats"),
+        ]
+        db.add(role); db.commit(); db.refresh(role)
+        sender = User(
+            id=uuid4(), organization_id=test_organization.id,
+            email="sender@example.com", full_name="Sender",
+            hashed_password=get_password_hash("pw"), is_active=True,
+            role_id=role.id)
+        db.add(sender); db.commit()
+
+        app.dependency_overrides[get_current_user] = lambda: sender
+        app.dependency_overrides[get_current_organization] = lambda: test_organization
+        app.dependency_overrides[get_db] = lambda: (yield db)
+        try:
+            r = TestClient(app).post(
+                f"{BASE}/whatsapp/{waba_account.id}/conversations",
+                json={"phone": "+15551234567", "template_name": "nope",
+                      "language": "en_US", "body_params": []},
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        # Past the permission gate — it fails on the unapproved template, not 403.
+        assert r.status_code != 403
+
+
+class TestChannelAccountSecrets:
+    """The webhook URL in a channel account embeds `webhook_secret`, which is
+    the only authentication on the inbound email and SMS webhooks. Widening the
+    accounts list to inbox agents must not hand that to them."""
+
+    @pytest.fixture
+    def inbox_client(self, db, test_organization, monkeypatch):
+        role = Role(name="Inbox Only", organization_id=test_organization.id)
+        role.permissions = [Permission(name="view_assigned_chats")]
+        db.add(role); db.commit(); db.refresh(role)
+        agent_user = User(
+            id=uuid4(), organization_id=test_organization.id,
+            email="secrets@example.com", full_name="Agent",
+            hashed_password=get_password_hash("pw"), is_active=True,
+            role_id=role.id)
+        db.add(agent_user); db.commit()
+
+        app.dependency_overrides[get_current_user] = lambda: agent_user
+        app.dependency_overrides[get_current_organization] = lambda: test_organization
+        app.dependency_overrides[get_db] = lambda: (yield db)
+        yield TestClient(app)
+        app.dependency_overrides.clear()
+
+    def test_agent_sees_accounts_without_the_webhook_secret(self, inbox_client, waba_account):
+        r = inbox_client.get("/api/v1/channels/accounts")
+
+        assert r.status_code == 200
+        assert r.json(), "the agent should still see the accounts"
+        for account in r.json():
+            assert account["webhook_url"] is None
+
+    def test_admin_still_gets_the_webhook_url(self, client, waba_account, db, test_organization):
+        db.add(ChannelAccount(
+            id=uuid4(), organization_id=test_organization.id,
+            channel_type=ChannelType.EMAIL.value, display_name="Support Inbox",
+            external_account_id="support@example.com", is_active=True,
+            encrypted_credentials="{}", webhook_secret="s3cret"))
+        db.commit()
+
+        r = client.get("/api/v1/channels/accounts")
+
+        assert r.status_code == 200
+        email_account = next(a for a in r.json() if a["channel_type"] == "email")
+        assert "s3cret" in email_account["webhook_url"]

--- a/backend/tests/api/test_org_scoping_guards.py
+++ b/backend/tests/api/test_org_scoping_guards.py
@@ -30,6 +30,14 @@ from app.repositories.agent import AgentRepository
 from app.api.shopify import _require_shopify_agent_in_org
 from app.api.jira import _require_jira_agent_in_org
 from app.api.tickets import _validate_assignment_references
+from app.api import knowledge as knowledge_router
+from app.core.auth import get_current_user
+from app.database import get_db
+from app.models.permission import Permission
+from app.models.role import Role
+from app.models.user import User
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture
@@ -114,3 +122,54 @@ class TestTicketAssignmentGuard:
         db.add(foreign_group)
         db.commit()
         _raises_404(_validate_assignment_references, db, test_organization.id, None, foreign_group.id)
+
+
+class TestKnowledgeByAgentScoping:
+    """GET /knowledge/agent/{agent_id} filtered on the agent id alone.
+
+    count_by_agent/get_by_agent take a UUID and no organization, so any
+    authenticated user who knew another tenant's agent id read that tenant's
+    knowledge inventory. link/unlink on the same router have always checked
+    agent.organization_id; this read never did.
+    """
+
+    def _client(self, db, user):
+        api = FastAPI()
+        api.include_router(knowledge_router.router, prefix="/api/v1/knowledge")
+        api.dependency_overrides[get_current_user] = lambda: user
+        api.dependency_overrides[get_db] = lambda: (yield db)
+        return TestClient(api)
+
+    def _knowledge_reader(self, db, organization):
+        role = Role(name="Knowledge Reader", organization_id=organization.id)
+        role.permissions = [Permission(name="view_knowledge")]
+        db.add(role)
+        db.commit()
+        db.refresh(role)
+        user = User(
+            id=uuid4(),
+            email=f"reader-{uuid4().hex[:6]}@example.com",
+            full_name="Reader",
+            hashed_password="x",
+            is_active=True,
+            organization_id=organization.id,
+            role_id=role.id,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        return user
+
+    def test_rejects_another_orgs_agent(self, db, test_organization, foreign_agent):
+        user = self._knowledge_reader(db, test_organization)
+
+        response = self._client(db, user).get(f"/api/v1/knowledge/agent/{foreign_agent.id}")
+
+        assert response.status_code == 404
+
+    def test_allows_an_agent_in_the_callers_org(self, db, test_organization, test_agent):
+        user = self._knowledge_reader(db, test_organization)
+
+        response = self._client(db, user).get(f"/api/v1/knowledge/agent/{test_agent.id}")
+
+        assert response.status_code == 200

--- a/backend/tests/api/test_people_permissions.py
+++ b/backend/tests/api/test_people_permissions.py
@@ -1,0 +1,163 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Permission coverage for the People directory.
+
+Deliberately a separate module from test_people_crm_api.py: that file's autouse
+fixture stubs `_require_people_access` out entirely so it can focus on CRM
+behaviour, which means no permission assertion made there can ever fail.
+"""
+
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api import people as people_api
+from app.core.auth import get_current_user
+from app.database import get_db
+from app.models.customer import Customer
+from app.models.organization import Organization
+from app.models.permission import Permission
+from app.models.role import Role
+from app.models.user import User
+
+BASE = "/api/v1/people"
+
+@pytest.fixture(autouse=True)
+def without_the_plan_gate(monkeypatch):
+    """The Pro (lead_capture) gate runs after the permission check and would
+    otherwise answer first in an enterprise checkout, so these would silently
+    skip exactly where the hosted product runs. Permissions are the subject."""
+    monkeypatch.setattr(people_api, "HAS_ENTERPRISE", False)
+
+
+@pytest.fixture
+def api() -> FastAPI:
+    app = FastAPI()
+    app.include_router(people_api.router, prefix=BASE)
+    return app
+
+
+@pytest.fixture
+def person(db, test_organization) -> Customer:
+    customer = Customer(
+        organization_id=test_organization.id,
+        email="nadia@example.com",
+        full_name="Nadia Rahman",
+    )
+    db.add(customer)
+    db.commit()
+    db.refresh(customer)
+    return customer
+
+
+def _user_with(db, organization, permission_names) -> User:
+    role = Role(name=f"Role {uuid4().hex[:6]}", organization_id=organization.id)
+    role.permissions = [Permission(name=name) for name in permission_names]
+    db.add(role)
+    db.commit()
+    db.refresh(role)
+    user = User(
+        id=uuid4(),
+        email=f"person-{uuid4().hex[:6]}@example.com",
+        full_name="Someone",
+        hashed_password="x",
+        is_active=True,
+        organization_id=organization.id,
+        role_id=role.id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _client(api: FastAPI, db, user: User) -> TestClient:
+    async def override_user():
+        return user
+
+    def override_db():
+        yield db
+
+    api.dependency_overrides[get_current_user] = override_user
+    api.dependency_overrides[get_db] = override_db
+    return TestClient(api)
+
+
+def test_view_people_can_read_the_directory(api, db, test_organization, person):
+    user = _user_with(db, test_organization, ["view_people"])
+
+    response = _client(api, db, user).get(BASE)
+
+    assert response.status_code == 200
+
+
+def test_view_people_can_correct_a_person(api, db, test_organization, person):
+    """people.py documents the PATCH as the agent's identification tool — the
+    one path allowed to correct a wrong phone number. It used to need the
+    org-wide chat grants, so the Edit button rendered for an agent and 403'd."""
+    user = _user_with(db, test_organization, ["view_people"])
+
+    response = _client(api, db, user).patch(
+        f"{BASE}/{person.id}", json={"full_name": "Corrected Name"}
+    )
+
+    assert response.status_code == 200
+
+
+def test_view_people_can_mark_a_customer(api, db, test_organization, person):
+    user = _user_with(db, test_organization, ["view_people"])
+
+    response = _client(api, db, user).post(f"{BASE}/{person.id}/mark-customer")
+
+    assert response.status_code == 200
+
+
+def test_an_assigned_chats_agent_can_read_the_directory(api, db, test_organization, person):
+    """PEOPLE_READ includes the inbox grants, not just view_people"""
+    user = _user_with(db, test_organization, ["view_assigned_chats"])
+
+    assert _client(api, db, user).get(BASE).status_code == 200
+
+
+def test_a_role_without_a_people_grant_is_refused(api, db, test_organization, person):
+    """Widening the write set must not widen who gets in at all"""
+    user = _user_with(db, test_organization, ["manage_knowledge"])
+    client = _client(api, db, user)
+
+    assert client.get(BASE).status_code == 403
+    assert client.patch(f"{BASE}/{person.id}", json={"full_name": "Nope"}).status_code == 403
+    assert client.post(f"{BASE}/{person.id}/mark-customer").status_code == 403
+
+
+def test_people_are_org_scoped(api, db, test_organization, person):
+    """A person from another tenant is not in this directory"""
+    other_org = Organization(id=uuid4(), name="Other", domain="other-people.example.com")
+    db.add(other_org)
+    db.commit()
+    db.add(Customer(
+        organization_id=other_org.id,
+        email="outsider@example.com",
+        full_name="Outsider",
+    ))
+    db.commit()
+    user = _user_with(db, test_organization, ["view_people"])
+
+    response = _client(api, db, user).get(BASE)
+
+    assert response.status_code == 200
+    assert "outsider@example.com" not in str(response.json())

--- a/backend/tests/api/test_roles.py
+++ b/backend/tests/api/test_roles.py
@@ -24,7 +24,7 @@ from app.models.role import Role
 from app.models.permission import Permission, role_permissions
 from uuid import UUID, uuid4
 from app.api import roles as roles_router
-from app.core.auth import get_current_user, require_permissions
+from app.core.auth import get_current_user
 from app.main import app
 from app.core.config import settings
 from tests.conftest import engine, TestingSessionLocal, create_tables
@@ -108,11 +108,14 @@ def test_user(db: Session, test_organization, test_role: Role) -> User:
 
 @pytest.fixture
 def client(test_user: User) -> TestClient:
-    """Create test client with mocked dependencies"""
-    async def override_get_current_user():
-        return test_user
+    """Client authenticated as a user whose role really holds manage_roles.
 
-    async def override_require_permissions(*args, **kwargs):
+    There used to be a `dependency_overrides[require_permissions]` line here.
+    It never did anything — require_permissions is a factory and FastAPI keys
+    overrides on the closure it returns — so it read as coverage while the real
+    gates ran unchecked. The fixture role grants the permissions instead.
+    """
+    async def override_get_current_user():
         return test_user
 
     def override_get_db():
@@ -123,10 +126,10 @@ def client(test_user: User) -> TestClient:
             db.close()
 
     app.dependency_overrides[get_current_user] = override_get_current_user
-    app.dependency_overrides[require_permissions] = lambda x: override_require_permissions
     app.dependency_overrides[get_db] = override_get_db
-    
-    return TestClient(app)
+
+    yield TestClient(app)
+    app.dependency_overrides.clear()
 
 def test_create_role(client: TestClient, test_permissions):
     """Test creating a new role"""
@@ -313,3 +316,173 @@ def test_remove_invalid_permission(client: TestClient, test_role):
     response = client.delete(f"/api/v1/roles/{test_role.id}/permissions/invalid_permission")
     assert response.status_code == 404
     assert "Permission not found" in response.json()["detail"] 
+
+# ------------------------------------------------- permission gating & escalation
+
+@pytest.fixture
+def unprivileged_client(db: Session, test_organization) -> TestClient:
+    """A client whose role grants nothing.
+
+    Every endpoint here except POST used to be Depends(get_current_user) with
+    only an org check, so any authenticated user could rewrite roles — including
+    granting their own role super_admin.
+    """
+    # Explicit id: the test_role fixture hardcodes id=1, so an autoincrement
+    # here collides depending on which fixture resolves first.
+    role = Role(id=99, name="No Permissions", organization_id=test_organization.id)
+    db.add(role)
+    db.commit()
+    user = User(
+        id=uuid4(),
+        email="nopermissions@test.com",
+        hashed_password="hashed_password",
+        organization_id=test_organization.id,
+        role_id=role.id,
+        is_active=True,
+        full_name="No Permissions",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    async def override_get_current_user():
+        return user
+
+    def override_get_db():
+        session = TestingSessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_db] = override_get_db
+
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_role_endpoints_require_permissions(unprivileged_client: TestClient, test_role: Role):
+    """None of the role endpoints are reachable without manage_roles/manage_users"""
+    role_id = test_role.id
+    assert unprivileged_client.get("/api/v1/roles").status_code == 403
+    assert unprivileged_client.get(f"/api/v1/roles/{role_id}").status_code == 403
+    assert unprivileged_client.get("/api/v1/roles/permissions/all").status_code == 403
+    assert unprivileged_client.post("/api/v1/roles", json={"name": "X", "permissions": []}).status_code == 403
+    assert unprivileged_client.put(f"/api/v1/roles/{role_id}", json={"name": "X"}).status_code == 403
+    assert unprivileged_client.delete(f"/api/v1/roles/{role_id}").status_code == 403
+    assert unprivileged_client.post(f"/api/v1/roles/{role_id}/permissions/manage_roles").status_code == 403
+    assert unprivileged_client.delete(f"/api/v1/roles/{role_id}/permissions/manage_roles").status_code == 403
+
+
+def test_cannot_grant_permission_caller_does_not_hold(client: TestClient, db: Session, test_role: Role):
+    """The reported hole: POST /roles/{own_role_id}/permissions/super_admin"""
+    db.add(Permission(name="super_admin", description="Has all permissions"))
+    db.commit()
+
+    response = client.post(f"/api/v1/roles/{test_role.id}/permissions/super_admin")
+
+    assert response.status_code == 403
+    assert "do not hold" in response.json()["detail"]
+    db.refresh(test_role)
+    assert "super_admin" not in {p.name for p in test_role.permissions}
+
+
+def test_cannot_grant_unheld_permission_via_update(client: TestClient, db: Session, test_role: Role):
+    """The same escalation through PUT rather than the permissions route"""
+    super_admin = Permission(name="super_admin", description="Has all permissions")
+    db.add(super_admin)
+    db.commit()
+    db.refresh(super_admin)
+
+    response = client.put(
+        f"/api/v1/roles/{test_role.id}",
+        json={
+            "name": test_role.name,
+            "permissions": [
+                {"id": super_admin.id, "name": "super_admin", "description": "Has all permissions"}
+            ],
+        },
+    )
+
+    assert response.status_code == 403
+    db.refresh(test_role)
+    assert "super_admin" not in {p.name for p in test_role.permissions}
+
+
+def test_cannot_create_role_with_unheld_permission(client: TestClient, db: Session):
+    """Creating a role is a grant too — otherwise the rule is trivially bypassed"""
+    super_admin = Permission(name="super_admin", description="Has all permissions")
+    db.add(super_admin)
+    db.commit()
+    db.refresh(super_admin)
+
+    response = client.post(
+        "/api/v1/roles",
+        json={
+            "name": "Backdoor",
+            "description": "",
+            "permissions": [{"id": super_admin.id, "name": "super_admin", "description": "Has all permissions"}],
+        },
+    )
+
+    assert response.status_code == 403
+
+
+def test_can_grant_permission_caller_holds(client: TestClient, db: Session, test_organization):
+    """Granting something you do hold is unaffected"""
+    other_role = Role(name="Other Role", organization_id=test_organization.id)
+    db.add(other_role)
+    db.commit()
+    db.refresh(other_role)
+
+    response = client.post(f"/api/v1/roles/{other_role.id}/permissions/manage_users")
+
+    assert response.status_code == 200
+    db.refresh(other_role)
+    assert "manage_users" in {p.name for p in other_role.permissions}
+
+
+def test_super_admin_can_grant_anything(db: Session, test_organization):
+    """check_permissions short-circuits on super_admin, so an owner is unaffected"""
+    super_admin = Permission(name="super_admin", description="Has all permissions")
+    db.add(super_admin)
+    db.commit()
+    owner_role = Role(name="Owner", organization_id=test_organization.id)
+    db.add(owner_role)
+    db.commit()
+    db.execute(role_permissions.insert().values(role_id=owner_role.id, permission_id=super_admin.id))
+    db.commit()
+    owner = User(
+        id=uuid4(),
+        email="owner@test.com",
+        hashed_password="hashed_password",
+        organization_id=test_organization.id,
+        role_id=owner_role.id,
+        is_active=True,
+        full_name="Owner",
+    )
+    db.add(owner)
+    target = Role(name="Target", organization_id=test_organization.id)
+    db.add(target)
+    db.commit()
+    db.refresh(target)
+
+    async def override_get_current_user():
+        return owner
+
+    def override_get_db():
+        session = TestingSessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        response = TestClient(app).post(f"/api/v1/roles/{target.id}/permissions/super_admin")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -648,3 +648,148 @@ def test_update_user_ignores_password_field(admin_client: TestClient, db: Sessio
     db.refresh(agent_user)
     assert agent_user.full_name == "Renamed"
     assert verify_password("oldpassword", agent_user.hashed_password)
+
+
+# ------------------------------------------------------------------ teammates
+
+@pytest.fixture
+def inbox_agent_client(db: Session, test_organization, agent_user: User) -> TestClient:
+    """Authenticated as a seeded Human Agent — the four permissions and no more."""
+    role = Role(id=88, name="Human Agent", organization_id=test_organization.id)
+    db.add(role)
+    db.commit()
+    for name in ("view_assigned_chats", "manage_assigned_chats",
+                 "view_unassigned_chats", "view_people"):
+        perm = db.query(Permission).filter(Permission.name == name).first()
+        if perm is None:
+            perm = Permission(name=name, description=name)
+            db.add(perm)
+            db.commit()
+            db.refresh(perm)
+        db.execute(role_permissions.insert().values(role_id=role.id, permission_id=perm.id))
+    db.commit()
+    agent_user.role_id = role.id
+    db.commit()
+    db.refresh(agent_user)
+
+    async def override_get_current_user():
+        return agent_user
+
+    def override_get_db():
+        session = TestingSessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_db] = override_get_db
+
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_teammates_visible_to_inbox_roles(inbox_agent_client: TestClient, db: Session, test_organization, test_role: Role):
+    """An agent can list who to hand a chat to, without manage_users.
+
+    The inbox used to call GET /users for this, which 403'd — so Reassign, an
+    action the API allows an agent to perform, had an empty dropdown.
+    """
+    colleague = User(
+        id=uuid4(),
+        email="colleague@test.com",
+        hashed_password=get_password_hash("pw"),
+        organization_id=test_organization.id,
+        role_id=test_role.id,
+        is_active=True,
+        full_name="Colleague",
+    )
+    db.add(colleague)
+    db.commit()
+
+    response = inbox_agent_client.get("/api/v1/users/teammates")
+
+    assert response.status_code == 200
+    emails = {u["email"] for u in response.json()}
+    assert "colleague@test.com" in emails
+
+
+def test_teammates_does_not_leak_roles_or_permissions(inbox_agent_client: TestClient):
+    """The payload is a name and a face — not the org's permission matrix"""
+    response = inbox_agent_client.get("/api/v1/users/teammates")
+
+    assert response.status_code == 200
+    for teammate in response.json():
+        assert set(teammate) <= {"id", "full_name", "email", "profile_pic", "is_online"}
+
+
+def test_teammates_is_org_scoped(inbox_agent_client: TestClient, db: Session):
+    """A teammate from another organization is not a teammate"""
+    other_org = Organization(id=uuid4(), name="Other", domain="other-teammates.example.com")
+    db.add(other_org)
+    db.commit()
+    outsider = User(
+        id=uuid4(),
+        email="outsider@other.com",
+        hashed_password=get_password_hash("pw"),
+        organization_id=other_org.id,
+        is_active=True,
+        full_name="Outsider",
+    )
+    db.add(outsider)
+    db.commit()
+
+    response = inbox_agent_client.get("/api/v1/users/teammates")
+
+    assert response.status_code == 200
+    assert "outsider@other.com" not in {u["email"] for u in response.json()}
+
+
+def test_teammates_requires_an_inbox_permission(db: Session, test_organization) -> None:
+    """Someone with no chat grant at all has no business reading the directory"""
+    role = Role(id=77, name="Nothing", organization_id=test_organization.id)
+    db.add(role)
+    db.commit()
+    user = User(
+        id=uuid4(),
+        email="nothing@test.com",
+        hashed_password=get_password_hash("pw"),
+        organization_id=test_organization.id,
+        role_id=role.id,
+        is_active=True,
+        full_name="Nothing",
+    )
+    db.add(user)
+    db.commit()
+
+    async def override_get_current_user():
+        return user
+
+    def override_get_db():
+        session = TestingSessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        response = TestClient(app).get("/api/v1/users/teammates")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 403
+
+
+def test_teammates_route_is_not_shadowed_by_the_user_id_route(inbox_agent_client: TestClient):
+    """Declared above GET /{user_id}.
+
+    Below it, "teammates" parses as a user id and the request lands on the
+    manage_users route — a 403 for exactly the agents the endpoint is for. A
+    200 here is the proof it resolved to the right handler.
+    """
+    response = inbox_agent_client.get("/api/v1/users/teammates")
+
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -22,6 +22,7 @@ from unittest.mock import patch, MagicMock
 from app.database import Base, get_db
 from fastapi import FastAPI, HTTPException
 from app.models.user import User, UserGroup
+from app.models.organization import Organization
 from app.models.role import Role
 from app.models.permission import Permission, role_permissions
 from uuid import UUID, uuid4
@@ -189,7 +190,7 @@ def test_create_user(admin_client: TestClient, test_role: Role, test_organizatio
     user_data = {
         "email": "newuser@test.com",
         "full_name": "New Test User",
-        "password": "testpassword123",
+        "password": "TestPassw0rd!",
         "is_active": True,
         "role_id": test_role.id,
         "organization_id": str(test_organization.id)
@@ -201,12 +202,28 @@ def test_create_user(admin_client: TestClient, test_role: Role, test_organizatio
     assert data["full_name"] == user_data["full_name"]
     assert data["is_active"] == user_data["is_active"]
 
+def test_create_user_rejects_weak_password(admin_client: TestClient, db: Session, test_role: Role, test_organization):
+    """An invite has to clear the same password policy as a reset"""
+    user_data = {
+        "email": "weakpass@test.com",
+        "full_name": "Weak Password User",
+        "password": "short1",
+        "is_active": True,
+        "role_id": test_role.id,
+        "organization_id": str(test_organization.id)
+    }
+    response = admin_client.post("/api/v1/users", json=user_data)
+
+    assert response.status_code == 422
+    assert db.query(User).filter(User.email == "weakpass@test.com").first() is None
+
+
 def test_create_user_duplicate_email(client: TestClient, test_user: User, test_role: Role):
     """Test creating a user with duplicate email"""
     user_data = {
         "email": test_user.email,
         "full_name": "Another User",
-        "password": "testpassword123",
+        "password": "TestPassw0rd!",
         "is_active": True,
         "role_id": test_role.id
     }
@@ -220,7 +237,7 @@ def test_create_user_rejects_disposable_email(admin_client: TestClient, test_rol
     user_data = {
         "email": "someone@yopmail.com",
         "full_name": "Throwaway User",
-        "password": "testpassword123",
+        "password": "TestPassw0rd!",
         "is_active": True,
         "role_id": test_role.id,
         "organization_id": str(test_organization.id)
@@ -364,14 +381,42 @@ def test_update_profile(client: TestClient, test_user: User):
     assert data["full_name"] == update_data["full_name"]
     assert data["email"] == update_data["email"]
 
-def test_update_password(client: TestClient, test_user: User):
+def test_update_password(client: TestClient, db: Session, test_user: User):
     """Test updating user's password"""
     update_data = {
         "current_password": "testpassword",
-        "password": "newpassword123"
+        "password": "NewPassw0rd!"
     }
     response = client.patch("/api/v1/users/me", json=update_data)
     assert response.status_code == 200
+    # The new hash has to reach the column, not a stray ORM attribute
+    db.refresh(test_user)
+    assert verify_password("NewPassw0rd!", test_user.hashed_password)
+
+
+def test_update_password_rejects_weak_password(client: TestClient, db: Session, test_user: User):
+    """A self-service change has to clear the same policy as an admin reset"""
+    response = client.patch(
+        "/api/v1/users/me",
+        json={"current_password": "testpassword", "password": "short1"},
+    )
+
+    assert response.status_code == 400
+    db.refresh(test_user)
+    assert verify_password("testpassword", test_user.hashed_password)
+
+
+def test_update_password_rejects_wrong_current_password(client: TestClient, db: Session, test_user: User):
+    """The old password still has to be proven"""
+    response = client.patch(
+        "/api/v1/users/me",
+        json={"current_password": "wrongpassword", "password": "NewPassw0rd!"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Incorrect current password"
+    db.refresh(test_user)
+    assert verify_password("testpassword", test_user.hashed_password)
 
 def test_update_status(client: TestClient, test_user: User):
     """Test updating user's online status"""
@@ -429,7 +474,6 @@ def test_clear_fcm_token(client: TestClient, test_user: User, db: Session):
 @pytest.fixture
 def foreign_role(db) -> Role:
     """A role defined in a different organization."""
-    from app.models.organization import Organization
     other_org = Organization(id=uuid4(), name="Other Org", domain="other-role.example.com")
     db.add(other_org)
     db.commit()
@@ -445,7 +489,7 @@ def test_create_user_rejects_foreign_role(admin_client, foreign_role, test_organ
     user_data = {
         "email": "roletest@test.com",
         "full_name": "Role Test",
-        "password": "testpassword123",
+        "password": "TestPassw0rd!",
         "is_active": True,
         "role_id": foreign_role.id,
         "organization_id": str(test_organization.id),
@@ -467,3 +511,140 @@ def test_update_user_rejects_foreign_role(admin_client, db, test_user, foreign_r
     assert response.json()["detail"] == "Role not found"
     db.refresh(test_user)
     assert test_user.role_id != foreign_role.id
+
+
+# ---------------------------------------------------------------- admin reset
+
+@pytest.fixture
+def agent_user(db: Session, test_organization, test_role: Role) -> User:
+    """A second user in the same org — the one an admin resets."""
+    user = User(
+        id=uuid4(),
+        email="agent@test.com",
+        hashed_password=get_password_hash("oldpassword"),
+        organization_id=test_organization.id,
+        role_id=test_role.id,
+        is_active=True,
+        full_name="Agent User",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def test_reset_user_password(admin_client: TestClient, db: Session, agent_user: User):
+    """An admin can set a new password for an agent in their organization"""
+    response = admin_client.post(
+        f"/api/v1/users/{agent_user.id}/reset-password",
+        json={"new_password": "NewPassw0rd!"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "Password reset successfully"
+    db.refresh(agent_user)
+    assert verify_password("NewPassw0rd!", agent_user.hashed_password)
+    assert not verify_password("oldpassword", agent_user.hashed_password)
+
+
+@pytest.fixture
+def agent_client(db: Session, test_organization, agent_user: User) -> TestClient:
+    """A client authenticated as a user whose role grants nothing.
+
+    The `client` fixture's require_permissions override targets the factory
+    rather than the closure Depends() actually calls, so it authenticates as a
+    user who *does* hold manage_users. Gate tests need a real unprivileged user.
+    """
+    plain_role = Role(name="Agent Only", organization_id=test_organization.id)
+    db.add(plain_role)
+    db.commit()
+    agent_user.role_id = plain_role.id
+    db.commit()
+    db.refresh(agent_user)
+
+    async def override_get_current_user():
+        return agent_user
+
+    def override_get_db():
+        try:
+            session = TestingSessionLocal()
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_db] = override_get_db
+
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_reset_user_password_requires_permission(agent_client: TestClient, test_user: User):
+    """Without manage_users the reset is refused"""
+    response = agent_client.post(
+        f"/api/v1/users/{test_user.id}/reset-password",
+        json={"new_password": "NewPassw0rd!"},
+    )
+    assert response.status_code == 403
+
+
+def test_reset_user_password_rejects_weak_password(admin_client: TestClient, db: Session, agent_user: User):
+    """A password below the policy is rejected and nothing is written"""
+    response = admin_client.post(
+        f"/api/v1/users/{agent_user.id}/reset-password",
+        json={"new_password": "short1"},
+    )
+
+    assert response.status_code == 422
+    db.refresh(agent_user)
+    assert verify_password("oldpassword", agent_user.hashed_password)
+
+
+def test_reset_own_password_rejected(admin_client: TestClient, test_user: User):
+    """Changing your own password still requires proving the current one"""
+    response = admin_client.post(
+        f"/api/v1/users/{test_user.id}/reset-password",
+        json={"new_password": "NewPassw0rd!"},
+    )
+
+    assert response.status_code == 400
+    assert "profile settings" in response.json()["detail"]
+
+
+def test_reset_password_rejects_other_org_user(admin_client: TestClient, db: Session, test_role: Role):
+    """A user in another organization is invisible, not resettable"""
+    other_org = Organization(id=uuid4(), name="Other Org", domain="other-reset.example.com")
+    db.add(other_org)
+    db.commit()
+    outsider = User(
+        id=uuid4(),
+        email="outsider@test.com",
+        hashed_password=get_password_hash("oldpassword"),
+        organization_id=other_org.id,
+        is_active=True,
+        full_name="Outsider",
+    )
+    db.add(outsider)
+    db.commit()
+
+    response = admin_client.post(
+        f"/api/v1/users/{outsider.id}/reset-password",
+        json={"new_password": "NewPassw0rd!"},
+    )
+
+    assert response.status_code == 404
+    db.refresh(outsider)
+    assert verify_password("oldpassword", outsider.hashed_password)
+
+
+def test_update_user_ignores_password_field(admin_client: TestClient, db: Session, agent_user: User):
+    """PUT /users/{id} no longer pretends to accept a password"""
+    response = admin_client.put(
+        f"/api/v1/users/{agent_user.id}",
+        json={"full_name": "Renamed", "password": "IgnoredPassw0rd!"},
+    )
+
+    assert response.status_code == 200
+    db.refresh(agent_user)
+    assert agent_user.full_name == "Renamed"
+    assert verify_password("oldpassword", agent_user.hashed_password)

--- a/backend/tests/core/test_auth.py
+++ b/backend/tests/core/test_auth.py
@@ -26,7 +26,9 @@ from app.core.auth import (
     get_current_organization,
     require_permissions,
     require_permission,
-    require_subscription_management
+    require_subscription_management,
+    require_unified_permissions,
+    require_any_unified_permission
 )
 from app.models.user import User
 from app.models.organization import Organization
@@ -601,27 +603,85 @@ async def test_get_unified_auth_jwt_inactive_user(mock_db, mock_user):
 
 
 @pytest.mark.asyncio
-async def test_get_unified_auth_jwt_no_permissions(mock_db, mock_user):
-    """Test get_unified_auth without manage_agents permission"""
+async def test_get_unified_auth_authenticates_without_permissions(mock_db, mock_user):
+    """get_unified_auth authenticates; it does not authorize.
+
+    It used to hardcode a manage_agents check, so every route sharing the helper
+    inherited it — including reading your own org's subscription, which locked
+    every non-admin out of the entire app.
+    """
     request = MagicMock(spec=Request)
     request.url = "https://example.com/api/agents"
     request.query_params = {}
     request.cookies.get.return_value = "valid_token"
     request.headers.get.return_value = None
 
-    # Remove manage_agents permission
-    view_only_perm = Permission(id=1, name="view_only")
-    mock_user.role.permissions = [view_only_perm]
+    mock_user.role.permissions = [Permission(id=1, name="view_only")]
 
     payload = {"sub": str(mock_user.id)}
     mock_db.query.return_value.filter.return_value.first.return_value = mock_user
 
     with patch('app.core.auth.verify_token', return_value=payload):
-        with pytest.raises(HTTPException) as exc_info:
-            await get_unified_auth(request, mock_db)
+        result = await get_unified_auth(request, mock_db)
+
+    assert result["auth_type"] == "jwt"
+    assert result["current_user"] is mock_user
+
+
+@pytest.mark.asyncio
+async def test_require_unified_permissions_rejects_missing_permission(mock_user):
+    """The wrapper is what enforces the route's requirement."""
+    mock_user.role.permissions = [Permission(id=1, name="view_only")]
+
+    checker = require_unified_permissions("manage_agents")
+    with pytest.raises(HTTPException) as exc_info:
+        await checker(auth_info={"auth_type": "jwt", "current_user": mock_user})
 
     assert exc_info.value.status_code == 403
     assert exc_info.value.detail == "Not enough permissions"
+
+
+@pytest.mark.asyncio
+async def test_require_unified_permissions_allows_holder(mock_user):
+    """A user holding the permission passes through unchanged."""
+    mock_user.role.permissions = [Permission(id=1, name="manage_agents")]
+    auth_info = {"auth_type": "jwt", "current_user": mock_user}
+
+    checker = require_unified_permissions("manage_agents")
+
+    assert await checker(auth_info=auth_info) is auth_info
+
+
+@pytest.mark.asyncio
+async def test_require_any_unified_permission_is_or_semantics(mock_user):
+    """Any one of the listed permissions is enough."""
+    mock_user.role.permissions = [Permission(id=1, name="view_agents")]
+
+    checker = require_any_unified_permission("view_agents", "manage_agents")
+    result = await checker(auth_info={"auth_type": "jwt", "current_user": mock_user})
+
+    assert result["auth_type"] == "jwt"
+
+
+@pytest.mark.asyncio
+async def test_unified_permissions_pass_through_shop_session():
+    """A Shopify shop session authenticates a store, not a person.
+
+    It carries no current_user and no role, so there is nothing to check — it
+    must pass through exactly as it did before authorization moved out.
+    """
+    auth_info = {"auth_type": "shopify", "organization_id": uuid4()}
+
+    assert await require_unified_permissions("manage_agents")(auth_info=auth_info) is auth_info
+    assert await require_any_unified_permission("manage_agents")(auth_info=auth_info) is auth_info
+
+
+@pytest.mark.asyncio
+async def test_unified_permissions_tolerate_absent_current_user_key():
+    """Callers that omit the key entirely must not blow up with a KeyError."""
+    auth_info = {"auth_type": "jwt", "organization_id": uuid4()}
+
+    assert await require_unified_permissions("manage_agents")(auth_info=auth_info) is auth_info
 
 
 @pytest.mark.asyncio

--- a/frontend/src/__tests__/components/layout/BottomNav.spec.ts
+++ b/frontend/src/__tests__/components/layout/BottomNav.spec.ts
@@ -19,9 +19,16 @@ import { mount } from '@vue/test-utils'
 import { createRouter, createWebHistory } from 'vue-router'
 import BottomNav from '@/components/layout/BottomNav.vue'
 
-vi.mock('@/utils/permissions', async () => {
-  const { createPermissionMocks } = await import('../../fixtures/permissions')
-  return { permissionChecks: createPermissionMocks() }
+// Nav visibility comes from the real permission checks reading the cached
+// user, so give this spec a user who holds everything.
+vi.mock('@/services/user', async () => {
+  const { userWithPermissions } = await import('../../fixtures/permissions')
+  const user = userWithPermissions([
+    'manage_agents', 'manage_users', 'view_all_chats', 'manage_all_chats', 'view_people',
+    'manage_knowledge', 'view_analytics', 'view_tickets', 'manage_organization',
+    'manage_ai_config', 'manage_subscription',
+  ])
+  return { userService: { getCurrentUser: () => user } }
 })
 
 vi.mock('@/composables/useEnterpriseFeatures', () => ({

--- a/frontend/src/__tests__/components/layout/navItems.spec.ts
+++ b/frontend/src/__tests__/components/layout/navItems.spec.ts
@@ -16,13 +16,15 @@ limitations under the License.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const permissions = await vi.hoisted(async () => {
-  const { createPermissionMocks } = await import('../../fixtures/permissions')
-  return createPermissionMocks()
-})
+// Drive the REAL permission checks from a cached user, rather than mocking
+// permissionChecks. Nav visibility and the router now read the same map, and a
+// mock of the checks cannot catch the two disagreeing — which is exactly the
+// bug this suite missed: People was listed for anyone with a chat grant while
+// the route required view_people, so the link bounced.
+const currentUser = await vi.hoisted(async () => ({ value: null as unknown }))
 
-vi.mock('@/utils/permissions', () => ({
-  permissionChecks: permissions,
+vi.mock('@/services/user', () => ({
+  userService: { getCurrentUser: () => currentUser.value },
 }))
 
 vi.mock('@/composables/useEnterpriseFeatures', () => ({
@@ -30,11 +32,22 @@ vi.mock('@/composables/useEnterpriseFeatures', () => ({
 }))
 
 import { useNavItems, PRIMARY_NAV_PATHS } from '@/components/layout/navItems'
+import { userWithPermissions, HUMAN_AGENT_PERMISSIONS } from '../../fixtures/permissions'
+
+const ALL_PERMISSIONS = [
+  'manage_agents', 'view_agents', 'manage_users', 'view_all_chats', 'manage_all_chats',
+  'view_assigned_chats', 'manage_assigned_chats', 'view_unassigned_chats', 'view_people',
+  'manage_knowledge', 'view_knowledge', 'view_analytics', 'view_tickets', 'manage_tickets',
+  'manage_organization', 'view_organization', 'manage_ai_config', 'view_ai_config',
+  'manage_subscription', 'view_subscription',
+]
+
+const asUser = (permissions: string[]) => {
+  currentUser.value = userWithPermissions(permissions)
+}
 
 describe('useNavItems', () => {
-  beforeEach(() => {
-    Object.values(permissions).forEach((fn) => fn.mockReturnValue(true))
-  })
+  beforeEach(() => asUser(ALL_PERMISSIONS))
 
   it('splits primary (bottom-nav) and overflow (More sheet) items', () => {
     const { primaryNavItems, moreNavItems } = useNavItems()
@@ -45,7 +58,6 @@ describe('useNavItems', () => {
       '/ai-agents',
       '/analytics',
     ])
-    // Overflow contains the rest, never a primary path or a section header
     const morePaths = moreNavItems.value.map((i) => i.to)
     expect(morePaths).toContain('/human-agents')
     expect(morePaths).toContain('/knowledge')
@@ -55,9 +67,7 @@ describe('useNavItems', () => {
   })
 
   it('hides permission-gated items for restricted users', () => {
-    permissions.canViewChats.mockReturnValue(false)
-    permissions.canViewAnalytics.mockReturnValue(false)
-    permissions.canManageUsers.mockReturnValue(false)
+    asUser(['manage_agents'])
 
     const { primaryNavItems, moreNavItems, navItems } = useNavItems()
 
@@ -70,6 +80,47 @@ describe('useNavItems', () => {
     expect(moreNavItems.value.map((i) => i.to)).not.toContain('/human-agents')
     // User settings is always available
     expect(navItems.value.map((i) => i.to)).toContain('/settings/user')
+  })
+
+  // The product requirement, as a test: a Human Agent sees the inbox, the
+  // people they talk to, and their own settings. Nothing else.
+  it('shows a Human Agent exactly Inbox, People and User Settings', () => {
+    asUser(HUMAN_AGENT_PERMISSIONS)
+
+    const { navItems } = useNavItems()
+
+    expect(navItems.value.filter((i) => i.to).map((i) => i.to)).toEqual([
+      '/conversations',
+      '/people',
+      '/settings/user',
+    ])
+  })
+
+  // A role with only view_people gets the People link; one with only a chat
+  // grant does not. The nav used to gate People on chat permissions while the
+  // route required view_people, so both cases were wrong in opposite ways.
+  it('gates People on the same permissions as its route', () => {
+    asUser(['view_people'])
+    expect(useNavItems().navItems.value.map((i) => i.to)).toContain('/people')
+
+    asUser(['view_assigned_chats'])
+    expect(useNavItems().navItems.value.map((i) => i.to)).toContain('/people')
+
+    asUser(['manage_knowledge'])
+    expect(useNavItems().navItems.value.map((i) => i.to)).not.toContain('/people')
+  })
+
+  // super_admin bypasses every check on the backend; a frontend check that
+  // does not bypass gives that role an almost-empty sidebar.
+  it('shows everything to a super_admin', () => {
+    asUser(['super_admin'])
+
+    const paths = useNavItems().navItems.value.filter((i) => i.to).map((i) => i.to)
+
+    expect(paths).toContain('/ai-agents')
+    expect(paths).toContain('/human-agents')
+    expect(paths).toContain('/knowledge')
+    expect(paths).toContain('/settings/organization')
   })
 
   it('excludes enterprise subscription when enterprise module is absent', () => {
@@ -102,9 +153,9 @@ describe('useNavItems', () => {
   // User Settings is always visible while the Settings heading used to be
   // permission-gated separately, which orphaned the item into Main Menu.
   it('keeps always-visible settings items under Settings for restricted users', () => {
-    permissions.canViewOrganization.mockReturnValue(false)
-    permissions.canManageOrganization.mockReturnValue(false)
-    permissions.canViewAIConfig.mockReturnValue(false)
+    // Knowledge, so Main Menu still has a non-primary item to group; no
+    // settings grants, so Settings holds only the always-visible entry.
+    asUser(['manage_knowledge'])
 
     const { moreNavGroups } = useNavItems()
     const settings = moreNavGroups.value.find((g) => g.section === 'Settings')
@@ -115,7 +166,7 @@ describe('useNavItems', () => {
   })
 
   it('drops a section whose every item is permission-hidden', () => {
-    Object.values(permissions).forEach((fn) => fn.mockReturnValue(false))
+    asUser([])
 
     const { moreNavGroups, navItems } = useNavItems()
 

--- a/frontend/src/__tests__/composables/useUsers.resetPassword.spec.ts
+++ b/frontend/src/__tests__/composables/useUsers.resetPassword.spec.ts
@@ -1,0 +1,88 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { User } from '@/types/user'
+
+const resetUserPassword = vi.fn()
+const toastSuccess = vi.fn()
+const toastError = vi.fn()
+
+vi.mock('@/services/users', () => ({
+  listUsers: vi.fn(),
+  createUser: vi.fn(),
+  updateUser: vi.fn(),
+  deleteUser: vi.fn(),
+  resetUserPassword: (...args: unknown[]) => resetUserPassword(...args),
+}))
+
+vi.mock('vue-sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}))
+
+const { useUsers } = await import('@/composables/useUsers')
+
+const agent = { id: 'agent-1', full_name: 'Agent One', email: 'agent@test.com' } as User
+
+describe('useUsers – admin password reset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('opens the modal for the selected user', () => {
+    const users = useUsers()
+    users.handleResetPassword(agent)
+
+    expect(users.showResetPasswordModal.value).toBe(true)
+    expect(users.selectedUser.value).toEqual(agent)
+  })
+
+  it('resets the password and closes the modal', async () => {
+    resetUserPassword.mockResolvedValueOnce(undefined)
+    const users = useUsers()
+    users.handleResetPassword(agent)
+
+    await users.confirmResetPassword('NewPassw0rd!')
+
+    expect(resetUserPassword).toHaveBeenCalledWith('agent-1', 'NewPassw0rd!')
+    expect(users.showResetPasswordModal.value).toBe(false)
+    expect(users.selectedUser.value).toBeNull()
+    expect(toastSuccess).toHaveBeenCalled()
+    expect(users.resettingPassword.value).toBe(false)
+  })
+
+  it('keeps the modal open and surfaces the API message on failure', async () => {
+    resetUserPassword.mockRejectedValueOnce({
+      response: { data: { detail: [{ msg: 'Password must be at least 8 characters long' }] } },
+    })
+    const users = useUsers()
+    users.handleResetPassword(agent)
+
+    await users.confirmResetPassword('short')
+
+    expect(users.showResetPasswordModal.value).toBe(true)
+    expect(toastError).toHaveBeenCalledWith(
+      'Error',
+      expect.objectContaining({
+        description: 'Failed to reset password - Password must be at least 8 characters long',
+      }),
+    )
+    expect(users.resettingPassword.value).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/fixtures/permissions.ts
+++ b/frontend/src/__tests__/fixtures/permissions.ts
@@ -20,17 +20,55 @@ import { vi } from 'vitest'
  * Mock map for @/utils/permissions' permissionChecks — one place to extend
  * when a new check is added, instead of every spec enumerating all methods.
  * Use inside vi.hoisted() so it exists before vi.mock factories run.
+ *
+ * The keys are asserted against the real permissionChecks in
+ * utils/permissions.spec.ts, so a check added to the app but not here fails
+ * that test instead of silently returning undefined in some other spec.
  */
 export const createPermissionMocks = (defaultValue = true) => ({
   canViewAgents: vi.fn(() => defaultValue),
+  canManageAgents: vi.fn(() => defaultValue),
   canManageUsers: vi.fn(() => defaultValue),
   canViewChats: vi.fn(() => defaultValue),
+  canViewPeople: vi.fn(() => defaultValue),
+  canManagePeople: vi.fn(() => defaultValue),
+  canTakeOverChats: vi.fn(() => defaultValue),
   canManageKnowledge: vi.fn(() => defaultValue),
+  canViewKnowledge: vi.fn(() => defaultValue),
   canViewAnalytics: vi.fn(() => defaultValue),
   canViewOrganization: vi.fn(() => defaultValue),
   canManageOrganization: vi.fn(() => defaultValue),
+  canManageAIConfig: vi.fn(() => defaultValue),
   canViewAIConfig: vi.fn(() => defaultValue),
   canViewTickets: vi.fn(() => defaultValue),
   canManageTickets: vi.fn(() => defaultValue),
   canApproveTicketActions: vi.fn(() => defaultValue),
+  canViewSubscription: vi.fn(() => defaultValue),
+  canManageSubscription: vi.fn(() => defaultValue),
 })
+
+/**
+ * A cached-user blob shaped like the API's, for specs that want the REAL
+ * permission checks to run instead of mocking them away. Mocking
+ * permissionChecks cannot catch a nav item and its route disagreeing about
+ * which permission they need — only driving both from one user can.
+ */
+export const userWithPermissions = (permissions: string[]) => ({
+  id: 'user-1',
+  email: 'someone@example.com',
+  full_name: 'Someone',
+  organization_id: 'org-1',
+  role: {
+    id: 1,
+    name: 'Test Role',
+    permissions: permissions.map((name, id) => ({ id, name, description: name })),
+  },
+})
+
+/** Exactly what a seeded Human Agent role holds. */
+export const HUMAN_AGENT_PERMISSIONS = [
+  'view_assigned_chats',
+  'manage_assigned_chats',
+  'view_unassigned_chats',
+  'view_people',
+]

--- a/frontend/src/__tests__/router/routePermissions.spec.ts
+++ b/frontend/src/__tests__/router/routePermissions.spec.ts
@@ -1,0 +1,142 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, vi } from 'vitest'
+
+const currentUser = await vi.hoisted(async () => ({ value: null as unknown }))
+
+vi.mock('@/services/user', () => ({
+  userService: { getCurrentUser: () => currentUser.value },
+}))
+
+vi.mock('@/composables/useEnterpriseFeatures', () => ({
+  useEnterpriseFeatures: () => ({ hasEnterpriseModule: false }),
+}))
+
+import { ROUTE_PERMISSIONS, canAccessPath, canAccessMatchedPaths } from '@/router/routePermissions'
+import { resolveLandingRoute } from '@/router/landing'
+import { useNavItems } from '@/components/layout/navItems'
+import { userWithPermissions, HUMAN_AGENT_PERMISSIONS } from '../fixtures/permissions'
+
+const asUser = (permissions: string[]) => {
+  currentUser.value = userWithPermissions(permissions)
+}
+
+describe('canAccessPath', () => {
+  it('allows unmapped paths — the map lists what is restricted', () => {
+    asUser([])
+    expect(canAccessPath('/login')).toBe(true)
+    expect(canAccessPath('/widget/abc')).toBe(true)
+  })
+
+  it('never denies /403 or /settings/user, whatever the role', () => {
+    asUser([])
+    expect(canAccessPath('/403')).toBe(true)
+    expect(canAccessPath('/settings/user')).toBe(true)
+  })
+
+  it('lets Shopify embedded routes through without a user', () => {
+    currentUser.value = null
+    expect(canAccessPath('/shopify/agent-management')).toBe(true)
+  })
+
+  it('honours super_admin everywhere', () => {
+    asUser(['super_admin'])
+    Object.keys(ROUTE_PERMISSIONS).forEach((path) => {
+      expect(canAccessPath(path)).toBe(true)
+    })
+  })
+
+  it('matches a parameterised route by its pattern, not its URL', () => {
+    asUser(['view_tickets'])
+    expect(canAccessMatchedPaths(['/tickets/:id'])).toBe(true)
+
+    asUser(['view_people'])
+    expect(canAccessMatchedPaths(['/tickets/:id'])).toBe(false)
+  })
+})
+
+describe('nav and route agreement', () => {
+  // The bug this suite exists for: the sidebar and the router each named their
+  // own permissions, so People was listed for anyone with a chat grant while
+  // the route wanted view_people — the link bounced the user to a page they
+  // had no rights to either.
+  it('never shows a link the router would refuse', () => {
+    const roles = [
+      HUMAN_AGENT_PERMISSIONS,
+      ['view_people'],
+      ['manage_agents'],
+      ['manage_knowledge'],
+      ['view_analytics'],
+      ['manage_users'],
+      ['super_admin'],
+      [],
+    ]
+
+    roles.forEach((permissions) => {
+      asUser(permissions)
+      useNavItems()
+        .navItems.value.filter((item) => item.to)
+        .forEach((item) => {
+          expect(canAccessPath(item.to as string), `${item.to} for [${permissions}]`).toBe(true)
+        })
+    })
+  })
+})
+
+describe('the map covers the routes that need it', () => {
+  // Both findings this suite was written for came from a route the map did not
+  // describe: the nav offered it and the guard let it through, or vice versa.
+  it('names permissions for every gated destination the sidebar can show', () => {
+    asUser(['super_admin'])
+    const navPaths = useNavItems()
+      .navItems.value.filter((i) => i.to)
+      .map((i) => i.to as string)
+
+    const ungoverned = navPaths.filter(
+      (path) => !(path in ROUTE_PERMISSIONS) && !path.startsWith('/settings/subscription'),
+    )
+
+    expect(ungoverned).toEqual([])
+  })
+})
+
+describe('resolveLandingRoute', () => {
+  it('sends an admin to AI Agents, unchanged', () => {
+    asUser(['manage_agents'])
+    expect(resolveLandingRoute()).toBe('/ai-agents')
+  })
+
+  it('sends a Human Agent to the inbox', () => {
+    asUser(HUMAN_AGENT_PERMISSIONS)
+    expect(resolveLandingRoute()).toBe('/conversations')
+  })
+
+  it('floors at the user\'s own settings and never returns 403', () => {
+    asUser([])
+    expect(resolveLandingRoute()).toBe('/settings/user')
+  })
+
+  it('only ever resolves somewhere the user can open', () => {
+    const roles = [HUMAN_AGENT_PERMISSIONS, ['view_people'], ['manage_knowledge'], []]
+    roles.forEach((permissions) => {
+      asUser(permissions)
+      const landing = resolveLandingRoute()
+      expect(landing).not.toBe('/403')
+      expect(canAccessPath(landing), `${landing} for [${permissions}]`).toBe(true)
+    })
+  })
+})

--- a/frontend/src/__tests__/utils/permissions.spec.ts
+++ b/frontend/src/__tests__/utils/permissions.spec.ts
@@ -1,0 +1,84 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, vi } from 'vitest'
+
+const currentUser = await vi.hoisted(async () => ({ value: null as unknown }))
+
+vi.mock('@/services/user', () => ({
+  userService: { getCurrentUser: () => currentUser.value },
+}))
+
+import { hasPermission, hasAnyPermission, permissionChecks } from '@/utils/permissions'
+import { createPermissionMocks, userWithPermissions } from '../fixtures/permissions'
+
+describe('permission primitives', () => {
+  it('is false when nobody is signed in', () => {
+    currentUser.value = null
+    expect(hasPermission('manage_agents')).toBe(false)
+    expect(hasAnyPermission(['manage_agents'])).toBe(false)
+  })
+
+  it('is false for a user whose role carries no permissions', () => {
+    currentUser.value = { id: '1', role: { id: 1, name: 'Empty' } }
+    expect(hasAnyPermission(['manage_agents'])).toBe(false)
+  })
+
+  // A check that does not bypass gives super_admin an almost-empty sidebar
+  // while the API happily serves every request — the two layers disagreeing is
+  // exactly what produces "the page renders, then 403s".
+  it('grants every check to super_admin', () => {
+    currentUser.value = userWithPermissions(['super_admin'])
+    Object.entries(permissionChecks).forEach(([name, check]) => {
+      expect(check(), name).toBe(true)
+    })
+  })
+
+  it('denies every check to a role with nothing', () => {
+    currentUser.value = userWithPermissions([])
+    Object.entries(permissionChecks).forEach(([name, check]) => {
+      expect(check(), name).toBe(false)
+    })
+  })
+
+  it('grants exactly what a Human Agent should have', () => {
+    currentUser.value = userWithPermissions([
+      'view_assigned_chats',
+      'manage_assigned_chats',
+      'view_unassigned_chats',
+      'view_people',
+    ])
+
+    expect(permissionChecks.canViewChats()).toBe(true)
+    expect(permissionChecks.canViewPeople()).toBe(true)
+    expect(permissionChecks.canManagePeople()).toBe(true)
+    expect(permissionChecks.canTakeOverChats()).toBe(true)
+
+    expect(permissionChecks.canViewAgents()).toBe(false)
+    expect(permissionChecks.canManageUsers()).toBe(false)
+    expect(permissionChecks.canViewSubscription()).toBe(false)
+    expect(permissionChecks.canManageKnowledge()).toBe(false)
+  })
+})
+
+describe('the shared test fixture', () => {
+  // Without this, a check added to the app but not to the fixture returns
+  // undefined in whichever spec mocks permissions next, and that spec fails
+  // somewhere unrelated and confusing.
+  it('mocks every check the app defines', () => {
+    expect(Object.keys(createPermissionMocks()).sort()).toEqual(Object.keys(permissionChecks).sort())
+  })
+})

--- a/frontend/src/__tests__/views/403.spec.ts
+++ b/frontend/src/__tests__/views/403.spec.ts
@@ -77,11 +77,14 @@ describe('403 View', () => {
     expect(dashboardLayout.exists()).toBe(true)
   })
 
-  it('contains a link back to dashboard', () => {
+  // Not '/': that redirects to the landing route, which for someone who was
+  // just denied is frequently another denial. With no permissions the floor is
+  // /settings/user, which requires none.
+  it('links somewhere the denied user can actually open', () => {
     const backLink = wrapper.find('.back-link')
     expect(backLink.exists()).toBe(true)
-    expect(backLink.text()).toBe('Return to Dashboard')
-    expect(backLink.attributes('href')).toBe('/')
+    expect(backLink.attributes('href')).toBe('/settings/user')
+    expect(backLink.attributes('href')).not.toBe('/')
   })
 
   it('applies correct styling', () => {

--- a/frontend/src/__tests__/views/LoginView.spec.ts
+++ b/frontend/src/__tests__/views/LoginView.spec.ts
@@ -28,15 +28,16 @@ vi.mock('@/services/auth', () => ({
   }
 }))
 
-// Mock the permission checks
-vi.mock('@/utils/permissions', () => ({
-  permissionChecks: {
-    canManageAgents: vi.fn().mockReturnValue(false),
-    canViewChats: vi.fn().mockReturnValue(false),
-    canManageUsers: vi.fn().mockReturnValue(false),
-    canViewOrganization: vi.fn().mockReturnValue(false),
-    canViewAIConfig: vi.fn().mockReturnValue(false)
-  }
+// The landing route is resolved from the real permission checks reading the
+// cached user, so this drives the user rather than mocking the checks away.
+const currentUser = vi.hoisted(() => ({ value: null as unknown }))
+
+vi.mock('@/services/user', () => ({
+  userService: {
+    getCurrentUser: () => currentUser.value,
+    setCurrentUser: vi.fn(),
+    getUserId: () => 'user-1',
+  },
 }))
 
 // Mock enterprise features
@@ -81,7 +82,7 @@ vi.mock('@/composables/useNotifications', () => ({
 
 // Import the mocked modules
 import { authService } from '@/services/auth'
-import { permissionChecks } from '@/utils/permissions'
+import { userWithPermissions } from '../fixtures/permissions'
 
 describe('LoginView', () => {
   let wrapper: VueWrapper
@@ -98,6 +99,7 @@ describe('LoginView', () => {
         { path: '/human-agents', name: 'human-agents', component: { template: '<div>Human Agents</div>' } },
         { path: '/settings/organization', name: 'org-settings', component: { template: '<div>Organization Settings</div>' } },
         { path: '/settings/ai-config', name: 'ai-config', component: { template: '<div>AI Config</div>' } },
+        { path: '/settings/user', name: 'user-settings', component: { template: '<div>User Settings</div>' } },
         { path: '/403', name: 'forbidden', component: { template: '<div>403</div>' } }
       ]
     })
@@ -109,10 +111,8 @@ describe('LoginView', () => {
     await router.push('/')
     await router.isReady()
     
-    // Reset all permission checks to false
-    Object.keys(permissionChecks).forEach(key => {
-      ;(permissionChecks[key as keyof typeof permissionChecks] as any).mockReturnValue(false)
-    })
+    // A user with no grants unless a test says otherwise
+    currentUser.value = userWithPermissions([])
     
     wrapper = mount(LoginView, {
       global: {
@@ -163,8 +163,8 @@ describe('LoginView', () => {
     // Mock successful login
     ;(authService.login as any).mockResolvedValue({ id: 1, email: 'test@example.com' })
     
-    // Mock permissions - user can manage agents
-    ;(permissionChecks.canManageAgents as any).mockReturnValue(true)
+    // User can manage agents
+    currentUser.value = userWithPermissions(['manage_agents'])
 
     await wrapper.find('input[type="email"]').setValue('test@example.com')
     await wrapper.find('input[type="password"]').setValue('password123')
@@ -202,36 +202,15 @@ describe('LoginView', () => {
     ;(authService.login as any).mockResolvedValue({ id: 1, email: 'test@example.com' })
 
     const testCases = [
-      {
-        permission: 'canManageAgents',
-        route: '/ai-agents'
-      },
-      {
-        permission: 'canViewChats',
-        route: '/conversations'
-      },
-      {
-        permission: 'canManageUsers',
-        route: '/human-agents'
-      },
-      {
-        permission: 'canViewOrganization',
-        route: '/settings/organization'
-      },
-      {
-        permission: 'canViewAIConfig',
-        route: '/settings/ai-config'
-      }
+      { permission: 'manage_agents', route: '/ai-agents' },
+      { permission: 'view_assigned_chats', route: '/conversations' },
+      { permission: 'manage_users', route: '/human-agents' },
+      { permission: 'view_organization', route: '/settings/organization' },
+      { permission: 'view_ai_config', route: '/settings/ai-config' },
     ]
 
     for (const testCase of testCases) {
-      // Reset all permission checks to false
-      Object.keys(permissionChecks).forEach(key => {
-        ;(permissionChecks[key as keyof typeof permissionChecks] as any).mockReturnValue(false)
-      })
-      
-      // Set the current permission to true
-      ;(permissionChecks[testCase.permission as keyof typeof permissionChecks] as any).mockReturnValue(true)
+      currentUser.value = userWithPermissions([testCase.permission])
 
       // Reset router and wait for it to be ready
       await router.push('/')
@@ -249,13 +228,11 @@ describe('LoginView', () => {
     }
   })
 
-  it('redirects to 403 when no permissions are granted', async () => {
+  // Used to land on /403 — which was not a registered route, so the user
+  // silently ended up on /ai-agents, a page they had just been refused.
+  it('lands a permissionless user on their own settings, never on 403', async () => {
     ;(authService.login as any).mockResolvedValue({ id: 1, email: 'test@example.com' })
-    
-    // Set all permissions to false
-    Object.keys(permissionChecks).forEach(key => {
-      ;(permissionChecks[key as keyof typeof permissionChecks] as any).mockReturnValue(false)
-    })
+    currentUser.value = userWithPermissions([])
 
     await wrapper.find('input[type="email"]').setValue('test@example.com')
     await wrapper.find('input[type="password"]').setValue('password123')
@@ -264,6 +241,6 @@ describe('LoginView', () => {
     // Wait for all promises to resolve
     await flushPromises()
     
-    expect(router.currentRoute.value.path).toBe('/403')
+    expect(router.currentRoute.value.path).toBe('/settings/user')
   })
 }) 

--- a/frontend/src/components/agent/AgentList.vue
+++ b/frontend/src/components/agent/AgentList.vue
@@ -23,6 +23,7 @@ import { resolveOrbStyle } from '@/utils/orb'
 import { useAgentStorage, useSubscriptionStorage } from '@/utils/storage'
 import { onMounted, onUnmounted, ref, computed } from 'vue';
 import { agentService } from '@/services/agent'
+import { permissionChecks } from '@/utils/permissions'
 import AgentDetail from './AgentDetail.vue'
 import CreateAgentModal from './CreateAgentModal.vue'
 import { widgetService } from '@/services/widget'
@@ -116,6 +117,10 @@ const filteredAgents = computed(() => {
         (a.description || '').toLowerCase().includes(q)
     )
 })
+
+// A view_agents role can read the list; it cannot create. Gating only the
+// first-run wizard left these three doing the same job for the same user.
+const canManageAgents = permissionChecks.canManageAgents()
 
 const isAgentCreationLocked = computed(() => {
     if (!hasEnterpriseModule) return false
@@ -281,7 +286,11 @@ const getOrbStyle = (agent: Agent): Record<string, string> => {
                 </div>
                 <div class="resume-actions">
                     <button class="resume-dismiss" @click="dismissBanner">Dismiss</button>
-                    <button class="resume-cta" @click="emit('resume-onboarding')">Resume setup →</button>
+                    <button
+                        v-if="canManageAgents"
+                        class="resume-cta"
+                        @click="emit('resume-onboarding')"
+                    >Resume setup →</button>
                 </div>
             </div>
 
@@ -299,6 +308,7 @@ const getOrbStyle = (agent: Agent): Record<string, string> => {
                     />
                 </div>
                 <button
+                    v-if="canManageAgents"
                     class="create-agent-button"
                     :class="{ 'locked': isAgentCreationLocked }"
                     :disabled="isAgentCreationLocked"
@@ -452,7 +462,7 @@ const getOrbStyle = (agent: Agent): Record<string, string> => {
                 <div class="empty-orb"></div>
                 <h3>No agents yet</h3>
                 <p>Create your first AI agent to start handling conversations automatically.</p>
-                <button class="create-agent-button" @click="handleCreateAgent">
+                <button v-if="canManageAgents" class="create-agent-button" @click="handleCreateAgent">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
                     Create Agent
                 </button>

--- a/frontend/src/components/aiagent/AIAgentSetup.vue
+++ b/frontend/src/components/aiagent/AIAgentSetup.vue
@@ -26,6 +26,7 @@ const AIAgentOnboarding = defineAsyncComponent(() => import('./onboarding/AIAgen
 import { useAgentStorage } from '@/utils/storage'
 import { aiService } from '@/services/ai'
 import { agentService } from '@/services/agent'
+import { permissionChecks } from '@/utils/permissions'
 import { AxiosError } from 'axios'
 
 const agentStorage = useAgentStorage()
@@ -103,10 +104,10 @@ onMounted(async () => {
             agentStorage.setAgents(agents)
             return
         }
-        // No agents yet → always show the guided first-agent setup. "Skip for
-        // now" only dismisses it for the current view; it returns on reload /
-        // re-entry until the first agent actually exists.
-        showOnboarding.value = true
+        // No agents yet → show the guided first-agent setup, but only to
+        // someone who can actually create one. A view-only role was being
+        // dropped into a creation wizard whose every step would 403.
+        showOnboarding.value = permissionChecks.canManageAgents()
     } catch (err) {
         error.value = 'Failed to load agents'
         console.error(err)

--- a/frontend/src/components/common/PasswordStrengthMeter.vue
+++ b/frontend/src/components/common/PasswordStrengthMeter.vue
@@ -1,0 +1,114 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { PasswordStrength } from '@/utils/validators'
+
+const props = defineProps<{
+  strength: PasswordStrength
+}>()
+
+const TOTAL_CHECKS = 5
+
+const strengthClass = computed(() => {
+  if (props.strength.score >= 4) return 'strong'
+  if (props.strength.score >= 3) return 'medium'
+  return 'weak'
+})
+
+const requirements = computed(() => [
+  { label: 'At least 8 characters', met: props.strength.hasMinLength },
+  { label: 'At least one uppercase letter', met: props.strength.hasUpperCase },
+  { label: 'At least one lowercase letter', met: props.strength.hasLowerCase },
+  { label: 'At least one number', met: props.strength.hasNumber },
+  { label: 'At least one special character', met: props.strength.hasSpecialChar },
+])
+</script>
+
+<template>
+  <div class="password-strength">
+    <div class="strength-meter">
+      <div
+        class="strength-bar"
+        :class="strengthClass"
+        :style="{ width: `${(strength.score / TOTAL_CHECKS) * 100}%` }"
+      />
+    </div>
+    <ul class="strength-requirements">
+      <li v-for="req in requirements" :key="req.label" :class="{ met: req.met }">
+        {{ req.label }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.password-strength {
+  margin-top: var(--space-sm);
+}
+
+.strength-meter {
+  height: 4px;
+  background: var(--background-mute);
+  border-radius: var(--radius-full);
+  margin-bottom: var(--space-sm);
+}
+
+.strength-bar {
+  height: 100%;
+  border-radius: var(--radius-full);
+  transition: width var(--transition-normal);
+}
+
+.strength-bar.weak {
+  background: var(--error-color);
+}
+
+.strength-bar.medium {
+  background: var(--warning-color);
+}
+
+.strength-bar.strong {
+  background: var(--success-color);
+}
+
+.strength-requirements {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--text-color);
+  opacity: 0.7;
+}
+
+.strength-requirements li {
+  margin-bottom: var(--space-xs);
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.strength-requirements li::before {
+  content: '×';
+  color: var(--error-color);
+}
+
+.strength-requirements li.met::before {
+  content: '✓';
+  color: var(--success-color);
+}
+</style>

--- a/frontend/src/components/conversations/ChatInfoPanel.vue
+++ b/frontend/src/components/conversations/ChatInfoPanel.vue
@@ -21,18 +21,18 @@ import { chatService } from '@/services/chat'
 import { userService } from '@/services/user'
 import { socketService } from '@/services/socket'
 import { toast } from 'vue-sonner'
-import api from '@/services/api'
 import LinkedTicketCard from '@/components/tickets/LinkedTicketCard.vue'
 import { permissionChecks } from '@/utils/permissions'
 import { canRequestRating, endChatMessage as endChatMessageFor } from '@/utils/endChat'
 import { getInitials } from '@/utils/text'
+import type { Teammate } from '@/services/users'
 import { canTakeOverChat } from '@/utils/chatState'
 
 const canViewTickets = permissionChecks.canViewTickets()
 
 interface Props {
   chatInfo: ChatDetail | null
-  users: Array<{id: string, full_name: string, email: string}>
+  users: Teammate[]
   isLoading?: boolean
 }
 
@@ -51,8 +51,8 @@ const actionLoading = ref(false)
 const reassigning = ref(false)
 const showReassign = ref(false)
 const selectedUserId = ref('')
-const users = ref<Array<{id: string, full_name: string, email: string}>>([])
-const loadingUsers = ref(false)
+// Reassigning is a manage-chat action; the parent supplies the teammate list.
+const canReassign = permissionChecks.canTakeOverChats()
 
 // Chat action functions
 const currentUserId = userService.getUserId()
@@ -194,7 +194,7 @@ const getUserNameById = (userId: string | null): string => {
     return props.chatInfo?.agent?.name || 'AI Agent'
   }
   const user = props.users.find(u => u.id === userId)
-  return user ? user.full_name : 'Unknown User'
+  return user?.full_name || 'Assigned teammate'
 }
 
 // Helper function to format date
@@ -223,22 +223,12 @@ const customerInitials = computed(() =>
   getInitials(props.chatInfo?.customer?.full_name || props.chatInfo?.customer?.email)
 )
 
-// Load users for reassign dropdown
-const loadUsers = async () => {
-  if (loadingUsers.value) return
-  loadingUsers.value = true
-  try {
-    const response = await api.get('/users')
-    users.value = response.data
-  } catch (e) {
-    console.error('Failed to load users', e)
-  } finally {
-    loadingUsers.value = false
-  }
-}
-
-const openReassign = async () => {
-  await loadUsers()
+// The teammate list arrives as a prop (ConversationsView loads it once from
+// /users/teammates). This component used to fetch /users itself into a local
+// ref that shadowed the prop — which needed manage_users, so for an agent the
+// dropdown was always empty even though the API would have allowed the
+// reassign.
+const openReassign = () => {
   showReassign.value = true
 }
 
@@ -371,9 +361,9 @@ const confirmReassign = async () => {
           </button>
           
           <button 
-            v-if="chatInfo.status === 'open' && chatInfo.user_id"
+            v-if="canReassign && chatInfo.status === 'open' && chatInfo.user_id && users.length"
             class="action-btn"
-            :disabled="reassigning || loadingUsers"
+            :disabled="reassigning"
             @click="openReassign"
           >
             Reassign Chat

--- a/frontend/src/components/conversations/ConversationFilters.vue
+++ b/frontend/src/components/conversations/ConversationFilters.vue
@@ -15,6 +15,7 @@ limitations under the License.
 -->
 
 <script setup lang="ts">
+import type { Teammate } from '@/services/users'
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 
 interface FilterValues {
@@ -28,7 +29,7 @@ interface FilterValues {
 interface Props {
   showFilters: boolean
   filterValues: FilterValues
-  users: Array<{id: string, full_name: string, email: string}>
+  users: Teammate[]
   agents: Array<{id: string, name: string, display_name: string | null}>
   loadingUsers?: boolean
   loadingAgents?: boolean

--- a/frontend/src/components/human-agent/ResetPasswordForm.vue
+++ b/frontend/src/components/human-agent/ResetPasswordForm.vue
@@ -1,0 +1,181 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { User } from '@/types/user'
+import { meetsPasswordPolicy, validatePassword, type PasswordStrength } from '@/utils/validators'
+import PasswordStrengthMeter from '@/components/common/PasswordStrengthMeter.vue'
+
+const props = defineProps<{
+  user: User
+  submitting?: boolean
+}>()
+
+const emit = defineEmits<{
+  submit: [newPassword: string]
+  cancel: []
+}>()
+
+const password = ref('')
+const confirmPassword = ref('')
+const passwordTouched = ref(false)
+const error = ref('')
+
+const passwordStrength = ref<PasswordStrength>({
+  score: 0,
+  hasMinLength: false,
+  hasUpperCase: false,
+  hasLowerCase: false,
+  hasNumber: false,
+  hasSpecialChar: false,
+})
+
+const handlePasswordInput = () => {
+  passwordTouched.value = passwordTouched.value || password.value.length > 0
+  passwordStrength.value = validatePassword(password.value)
+  error.value = ''
+}
+
+const handleConfirmPasswordInput = () => {
+  error.value =
+    confirmPassword.value && password.value !== confirmPassword.value
+      ? 'Passwords do not match'
+      : ''
+}
+
+const handleSubmit = () => {
+  if (password.value !== confirmPassword.value) {
+    error.value = 'Passwords do not match'
+    return
+  }
+  if (!meetsPasswordPolicy(passwordStrength.value)) {
+    error.value = 'Password is not strong enough'
+    return
+  }
+
+  emit('submit', password.value)
+}
+</script>
+
+<template>
+  <form @submit.prevent="handleSubmit" class="reset-password-form">
+    <p class="intro">
+      Set a new password for <strong>{{ props.user.full_name }}</strong>
+      ({{ props.user.email }}). They aren't notified — share it with them
+      directly and ask them to change it after signing in.
+    </p>
+
+    <div v-if="error" class="error-message">
+      {{ error }}
+    </div>
+
+    <div class="form-group">
+      <label for="newPassword">New Password</label>
+      <input
+        id="newPassword"
+        v-model="password"
+        type="password"
+        required
+        class="form-input"
+        autocomplete="new-password"
+        @input="handlePasswordInput"
+      />
+      <PasswordStrengthMeter v-if="passwordTouched" :strength="passwordStrength" />
+    </div>
+
+    <div class="form-group">
+      <label for="confirmNewPassword">Confirm New Password</label>
+      <input
+        id="confirmNewPassword"
+        v-model="confirmPassword"
+        type="password"
+        required
+        class="form-input"
+        autocomplete="new-password"
+        :class="{ error: error.includes('match') }"
+        @input="handleConfirmPasswordInput"
+      />
+    </div>
+
+    <div class="form-actions">
+      <button type="button" class="btn btn-secondary" @click="emit('cancel')">
+        Cancel
+      </button>
+      <button type="submit" class="btn btn-primary" :disabled="props.submitting">
+        {{ props.submitting ? 'Resetting...' : 'Reset Password' }}
+      </button>
+    </div>
+  </form>
+</template>
+
+<style scoped>
+.reset-password-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.intro {
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--text3);
+}
+
+/* Matches UserForm: the global .form-group margin plus the flex gap above
+   would otherwise double the spacing between fields. */
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 0;
+}
+
+.form-group label {
+  font-size: 13.5px;
+  font-weight: var(--font-weight-medium);
+  color: var(--text3);
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+}
+
+.error-message {
+  color: var(--error-color);
+  font-size: var(--text-sm);
+  padding: var(--space-sm);
+  background: var(--error-soft);
+  border-radius: var(--radius-sm);
+}
+
+.form-input.error {
+  border-color: var(--error-color);
+}
+
+.form-input.error:focus {
+  box-shadow: 0 0 0 2px var(--error-soft);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/components/human-agent/UserForm.vue
+++ b/frontend/src/components/human-agent/UserForm.vue
@@ -15,10 +15,11 @@ limitations under the License.
 -->
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import type { Role, User } from '@/types/user'
-import { validatePassword, type PasswordStrength } from '@/utils/validators'
+import { meetsPasswordPolicy, validatePassword, type PasswordStrength } from '@/utils/validators'
 import { listRoles } from '@/services/roles'
+import PasswordStrengthMeter from '@/components/common/PasswordStrengthMeter.vue'
 import { toast } from 'vue-sonner'
 
 const props = defineProps<{
@@ -67,12 +68,6 @@ const handleConfirmPasswordInput = () => {
   }
 }
 
-const strengthClass = computed(() => {
-  if (passwordStrength.value.score >= 4) return 'strong'
-  if (passwordStrength.value.score >= 3) return 'medium'
-  return 'weak'
-})
-
 const fetchRoles = async () => {
   try {
     loadingRoles.value = true
@@ -97,7 +92,9 @@ const handleSubmit = () => {
       error.value = 'Passwords do not match'
       return
     }
-    if (passwordStrength.value.score < 3) {
+    // The initial password an admin picks clears the same bar as a reset —
+    // three surfaces used to disagree on what "strong enough" meant.
+    if (!meetsPasswordPolicy(passwordStrength.value)) {
       error.value = 'Password is not strong enough'
       return
     }
@@ -181,32 +178,7 @@ const handleSubmit = () => {
           autocomplete="new-password"
           @input="handlePasswordInput(password)"
         />
-        <div v-if="passwordTouched" class="password-strength">
-          <div class="strength-meter">
-            <div 
-              class="strength-bar" 
-              :class="strengthClass"
-              :style="{ width: `${(passwordStrength.score / 4) * 100}%` }"
-            />
-          </div>
-          <ul class="strength-requirements">
-            <li :class="{ met: passwordStrength.hasMinLength }">
-              At least 8 characters
-            </li>
-            <li :class="{ met: passwordStrength.hasUpperCase }">
-              At least one uppercase letter
-            </li>
-            <li :class="{ met: passwordStrength.hasLowerCase }">
-              At least one lowercase letter
-            </li>
-            <li :class="{ met: passwordStrength.hasNumber }">
-              At least one number
-            </li>
-            <li :class="{ met: passwordStrength.hasSpecialChar }">
-              At least one special character
-            </li>
-          </ul>
-        </div>
+        <PasswordStrengthMeter v-if="passwordTouched" :strength="passwordStrength" />
       </div>
 
       <div class="form-group">
@@ -285,61 +257,6 @@ const handleSubmit = () => {
   justify-content: flex-end;
   gap: var(--space-sm);
   margin-top: var(--space-sm);
-}
-
-.password-strength {
-  margin-top: var(--space-sm);
-}
-
-.strength-meter {
-  height: 4px;
-  background: var(--background-mute);
-  border-radius: var(--radius-full);
-  margin-bottom: var(--space-sm);
-}
-
-.strength-bar {
-  height: 100%;
-  border-radius: var(--radius-full);
-  transition: width var(--transition-normal);
-}
-
-.strength-bar.weak {
-  background: var(--error-color);
-}
-
-.strength-bar.medium {
-  background: var(--warning-color);
-}
-
-.strength-bar.strong {
-  background: var(--success-color);
-}
-
-.strength-requirements {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  font-size: var(--text-sm);
-  color: var(--text-color);
-  opacity: 0.7;
-}
-
-.strength-requirements li {
-  margin-bottom: var(--space-xs);
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-}
-
-.strength-requirements li::before {
-  content: '×';
-  color: var(--error-color);
-}
-
-.strength-requirements li.met::before {
-  content: '✓';
-  color: var(--success-color);
 }
 
 .error-message {

--- a/frontend/src/components/human-agent/UserList.vue
+++ b/frontend/src/components/human-agent/UserList.vue
@@ -21,6 +21,7 @@ import { Menu, MenuButton, MenuItems, MenuItem } from '@headlessui/vue'
 import { EllipsisVerticalIcon } from '@heroicons/vue/24/outline'
 import { useUsers } from '@/composables/useUsers'
 import UserForm from './UserForm.vue'
+import ResetPasswordForm from './ResetPasswordForm.vue'
 import Modal from '@/components/common/Modal.vue'
 import { userService } from '@/services/user'
 import { useRouter } from 'vue-router'
@@ -45,13 +46,17 @@ const {
   showEditModal,
   showDeleteModal,
   showCreateModal,
+  showResetPasswordModal,
+  resettingPassword,
   selectedUser,
   fetchUsers,
   handleEditUser,
   handleUpdateUser,
   handleDeleteUser,
   confirmDeleteUser,
-  handleCreateUser
+  handleCreateUser,
+  handleResetPassword,
+  confirmResetPassword
 } = useUsers()
 
 const currentUser = userService.getCurrentUser()
@@ -291,6 +296,14 @@ const onDeleteRow = (row: AgentRow) => {
   handleDeleteUser(user)
 }
 
+// Your own password goes through profile settings, which asks for the current
+// one — the API rejects a self-reset, so the row menu doesn't offer it either.
+const onResetPasswordRow = (row: AgentRow) => {
+  const user = findUser(row.id)
+  if (!user) return
+  handleResetPassword(user)
+}
+
 // Wrap the CRUD handlers so the parent gets notified to reload counts.
 const handleCreateUserAndNotify = async (
   userData: Partial<User> & { password?: string },
@@ -439,6 +452,11 @@ onMounted(async () => {
                 </button>
               </MenuItem>
               <MenuItem v-if="row.id !== currentUser?.id" v-slot="{ active }">
+                <button :class="['menu-item', { active }]" @click="onResetPasswordRow(row)">
+                  Reset Password
+                </button>
+              </MenuItem>
+              <MenuItem v-if="row.id !== currentUser?.id" v-slot="{ active }">
                 <button :class="['menu-item', { active }]" @click="onDeleteRow(row)">
                   Delete
                 </button>
@@ -461,6 +479,19 @@ onMounted(async () => {
           :user="selectedUser"
           @submit="handleUpdateUser"
           @cancel="showEditModal = false"
+        />
+      </template>
+    </Modal>
+
+    <!-- Reset Password Modal -->
+    <Modal v-if="showResetPasswordModal && selectedUser" persistent @close="showResetPasswordModal = false">
+      <template #title>Reset Password</template>
+      <template #content>
+        <ResetPasswordForm
+          :user="selectedUser"
+          :submitting="resettingPassword"
+          @submit="confirmResetPassword"
+          @cancel="showResetPasswordModal = false"
         />
       </template>
     </Modal>

--- a/frontend/src/components/layout/navItems.ts
+++ b/frontend/src/components/layout/navItems.ts
@@ -16,6 +16,9 @@ limitations under the License.
 
 import { computed } from 'vue'
 import { permissionChecks } from '@/utils/permissions'
+// Visibility comes from the same map the router enforces, so a link can never
+// appear for a page the guard will refuse (People used to do exactly that).
+import { canAccessPath } from '@/router/routePermissions'
 import { useEnterpriseFeatures } from '@/composables/useEnterpriseFeatures'
 
 // Re-exported so nav consumers keep a single import site
@@ -57,49 +60,49 @@ export function useNavItems() {
             to: '/ai-agents',
             icon: 'agents',
             label: 'AI Agents',
-            show: permissionChecks.canViewAgents(),
+            show: canAccessPath('/ai-agents'),
           },
           {
             to: '/human-agents',
             icon: 'humans',
             label: 'Human Agents',
-            show: permissionChecks.canManageUsers(),
+            show: canAccessPath('/human-agents'),
           },
           {
             to: '/conversations',
             icon: 'inbox',
             label: 'Inbox',
-            show: permissionChecks.canViewChats(),
+            show: canAccessPath('/conversations'),
           },
           {
             to: '/tickets',
             icon: 'tickets',
             label: 'Tickets',
-            show: permissionChecks.canViewTickets(),
+            show: canAccessPath('/tickets'),
           },
           {
             to: '/people',
             icon: 'people',
             label: 'People',
-            show: permissionChecks.canViewChats(),
+            show: canAccessPath('/people'),
           },
           {
             to: '/knowledge',
             icon: 'knowledge',
             label: 'Knowledge',
-            show: permissionChecks.canManageKnowledge(),
+            show: canAccessPath('/knowledge'),
           },
           {
             to: '/faq',
             icon: 'faq',
             label: 'Help center',
-            show: permissionChecks.canManageKnowledge(),
+            show: canAccessPath('/faq'),
           },
           {
             to: '/analytics',
             icon: 'analytics',
             label: 'Analytics',
-            show: permissionChecks.canViewAnalytics(),
+            show: canAccessPath('/analytics'),
           },
         ],
       },
@@ -110,37 +113,37 @@ export function useNavItems() {
             to: '/settings/organization',
             icon: 'org',
             label: 'Organization',
-            show: permissionChecks.canViewOrganization(),
+            show: canAccessPath('/settings/organization'),
           },
           {
             to: '/settings/subscription',
             icon: 'subscription',
             label: 'Subscription',
-            show: hasEnterpriseModule && permissionChecks.canViewOrganization(),
+            show: hasEnterpriseModule && permissionChecks.canViewSubscription(),
           },
           {
             to: '/settings/ticketing',
             icon: 'ticketing',
             label: 'Ticketing',
-            show: permissionChecks.canManageOrganization(),
+            show: canAccessPath('/settings/ticketing'),
           },
           {
             to: '/settings/integrations',
             icon: 'integrations',
             label: 'Integrations',
-            show: permissionChecks.canViewOrganization(),
+            show: canAccessPath('/settings/integrations'),
           },
           {
             to: '/settings/widget-apps',
             icon: 'widgets',
             label: 'Widget Apps',
-            show: permissionChecks.canManageOrganization(),
+            show: canAccessPath('/settings/widget-apps'),
           },
           {
             to: '/settings/ai-config',
             icon: 'aiconfig',
             label: 'AI Configuration',
-            show: permissionChecks.canViewAIConfig(),
+            show: canAccessPath('/settings/ai-config'),
           },
           {
             to: '/settings/user',

--- a/frontend/src/components/people/PersonDetailDrawer.vue
+++ b/frontend/src/components/people/PersonDetailDrawer.vue
@@ -21,6 +21,7 @@ import { peopleService, type PersonCrmStatus } from '@/services/people'
 import channelsService, { type ChannelAccount } from '@/services/channels'
 import NewWhatsAppConversation from '@/components/conversations/NewWhatsAppConversation.vue'
 import type { PersonDetail } from '@/types/people'
+import { permissionChecks } from '@/utils/permissions'
 
 const PROVIDER_LABELS: Record<string, string> = { hubspot: 'HubSpot', pipedrive: 'Pipedrive' }
 const providerLabel = (p: string) => PROVIDER_LABELS[p] || p
@@ -76,7 +77,12 @@ const syncedSummary = computed(() =>
 const connectedSummary = computed(() =>
   (crm.value?.connected_providers || []).map(providerLabel).join(', '))
 // The CRM dedupes on email, so a person needs one before they can sync.
-const canSync = computed(() => !!person.value?.email)
+// Editing a person, marking them a customer and pushing to CRM all take the
+// same grant the API requires (PEOPLE_WRITE_PERMISSIONS). These buttons used to
+// render for everyone who could read the directory and 403 on click.
+const canEditPeople = permissionChecks.canManagePeople()
+
+const canSync = computed(() => !!person.value?.email && canEditPeople)
 
 async function loadCrm() {
   try { crm.value = await peopleService.getCrmStatus(props.customerId) }
@@ -210,7 +216,7 @@ onMounted(() => { load(); loadWhatsAppAccounts(); loadCrm() })
         </div>
 
         <button
-          v-if="person.lead_stage !== 'customer'"
+          v-if="canEditPeople && person.lead_stage !== 'customer'"
           class="pdd-mark"
           :disabled="marking || !person.identified"
           :title="person.identified ? '' : 'Add an email or phone first — this person is anonymous'"
@@ -235,7 +241,12 @@ onMounted(() => { load(); loadWhatsAppAccounts(); loadCrm() })
         <!-- Contact edit: the one place a wrong phone can be corrected -->
         <div class="pdd-section-title">
           CONTACT
-          <button v-if="!editing" type="button" class="pdd-edit-link" @click="startEdit">Edit</button>
+          <button
+            v-if="canEditPeople && !editing"
+            type="button"
+            class="pdd-edit-link"
+            @click="startEdit"
+          >Edit</button>
         </div>
         <div v-if="editing" class="pdd-edit">
           <label class="pdd-edit-field">

--- a/frontend/src/components/user/UserSettings.vue
+++ b/frontend/src/components/user/UserSettings.vue
@@ -18,7 +18,8 @@ limitations under the License.
 import { ref, onMounted, inject, computed, watch } from 'vue'
 import { useAuth } from '@/composables/useAuth'
 import { userService } from '@/services/user'
-import { validatePassword, type PasswordStrength } from '@/utils/validators'
+import { meetsPasswordPolicy, validatePassword, type PasswordStrength } from '@/utils/validators'
+import PasswordStrengthMeter from '@/components/common/PasswordStrengthMeter.vue'
 import userAvatar from '@/assets/user.svg'
 import type { User } from '@/types/user'
 import { isAbsoluteUrl } from '@/utils/avatars'
@@ -249,7 +250,7 @@ const updateProfile = async () => {
       if (!formData.value.current_password) {
         throw new Error('Current password is required to set new password')
       }
-      if (passwordStrength.value.score < 3) {
+      if (!meetsPasswordPolicy(passwordStrength.value)) {
         throw new Error('Password is not strong enough')
       }
       updateData.password = formData.value.new_password
@@ -404,25 +405,10 @@ const handleProfilePicClick = () => {
           </div>
         </div>
 
-        <div v-if="passwordTouched && formData.new_password" class="password-strength">
-          <div class="strength-meter">
-            <div
-              class="strength-bar"
-              :style="{ width: `${(passwordStrength.score / 5) * 100}%` }"
-              :class="[
-                passwordStrength.score < 3 ? 'weak' :
-                passwordStrength.score < 4 ? 'medium' : 'strong'
-              ]"
-            ></div>
-          </div>
-          <ul class="strength-requirements">
-            <li :class="{ met: passwordStrength.hasMinLength }">At least 8 characters</li>
-            <li :class="{ met: passwordStrength.hasUpperCase }">Contains uppercase letter</li>
-            <li :class="{ met: passwordStrength.hasLowerCase }">Contains lowercase letter</li>
-            <li :class="{ met: passwordStrength.hasNumber }">Contains number</li>
-            <li :class="{ met: passwordStrength.hasSpecialChar }">Contains special character (!@#$%^&*)</li>
-          </ul>
-        </div>
+        <PasswordStrengthMeter
+          v-if="passwordTouched && formData.new_password"
+          :strength="passwordStrength"
+        />
       </div>
 
       <div v-if="error" class="error-message">{{ error }}</div>
@@ -954,58 +940,4 @@ input:checked + .slider:before {
   }
 }
 
-.password-strength {
-  margin-top: var(--space-md);
-}
-
-.strength-meter {
-  height: 4px;
-  background: var(--o10);
-  border-radius: var(--radius-full);
-  margin-bottom: var(--space-sm);
-}
-
-.strength-bar {
-  height: 100%;
-  border-radius: var(--radius-full);
-  transition: width var(--transition-normal);
-}
-
-.strength-bar.weak {
-  background: var(--error-color);
-}
-
-.strength-bar.medium {
-  background: var(--warning-color);
-}
-
-.strength-bar.strong {
-  background: var(--success-color);
-}
-
-.strength-requirements {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  font-size: var(--text-sm);
-  color: var(--text-color);
-  opacity: 0.7;
-}
-
-.strength-requirements li {
-  margin-bottom: var(--space-xs);
-  display: flex;
-  align-items: center;
-  gap: var(--space-xs);
-}
-
-.strength-requirements li::before {
-  content: '×';
-  color: var(--error-color);
-}
-
-.strength-requirements li.met::before {
-  content: '✓';
-  color: var(--success-color);
-}
 </style> 

--- a/frontend/src/composables/useUsers.ts
+++ b/frontend/src/composables/useUsers.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { ref } from 'vue'
 import type { User } from '@/types/user'
-import { listUsers, createUser, updateUser, deleteUser } from '@/services/users'
+import { listUsers, createUser, updateUser, deleteUser, resetUserPassword } from '@/services/users'
 import { toast } from 'vue-sonner'
 
 export function useUsers() {
@@ -27,6 +27,8 @@ export function useUsers() {
   const showDeleteModal = ref(false)
   const selectedUser = ref<User | null>(null)
   const showCreateModal = ref(false)
+  const showResetPasswordModal = ref(false)
+  const resettingPassword = ref(false)
 
   const fetchUsers = async () => {
     try {
@@ -76,6 +78,44 @@ export function useUsers() {
       })
     } finally {
       loading.value = false
+    }
+  }
+
+  const handleResetPassword = (user: User) => {
+    selectedUser.value = user
+    showResetPasswordModal.value = true
+  }
+
+  const confirmResetPassword = async (newPassword: string) => {
+    if (!selectedUser.value) return
+
+    try {
+      resettingPassword.value = true
+      error.value = null
+      await resetUserPassword(selectedUser.value.id, newPassword)
+
+      showResetPasswordModal.value = false
+      selectedUser.value = null
+      toast.success('Success', {
+        description: 'Password reset successfully',
+        duration: 4000,
+        closeButton: true
+      })
+    } catch (err: any) {
+      const detail = err.response?.data?.detail
+      // A rejected password comes back as FastAPI's validation-error array.
+      const description = Array.isArray(detail) ? detail[0]?.msg : detail
+      error.value = 'Failed to reset password'
+      // Never the raw axios error: its `config.data` carries the plaintext
+      // password, which would land in the browser console on a network failure.
+      console.error('Error resetting password:', description ?? err.message)
+      toast.error('Error', {
+        description: 'Failed to reset password' + (description ? ' - ' + description : ''),
+        duration: 4000,
+        closeButton: true
+      })
+    } finally {
+      resettingPassword.value = false
     }
   }
 
@@ -148,11 +188,15 @@ export function useUsers() {
     showDeleteModal,
     selectedUser,
     showCreateModal,
+    showResetPasswordModal,
+    resettingPassword,
     fetchUsers,
     handleEditUser,
     handleUpdateUser,
     handleDeleteUser,
     confirmDeleteUser,
-    handleCreateUser
+    handleCreateUser,
+    handleResetPassword,
+    confirmResetPassword
   }
 } 

--- a/frontend/src/layouts/DashboardLayout.vue
+++ b/frontend/src/layouts/DashboardLayout.vue
@@ -27,6 +27,7 @@ import notificationIcon from '@/assets/notification.svg'
 import NotificationList from '@/components/notifications/NotificationList.vue'
 import EnablePushPrompt from '@/components/notifications/EnablePushPrompt.vue'
 import { userService } from '@/services/user'
+import { permissionChecks } from '@/utils/permissions'
 import type { User } from '@/types/user'
 import { useNotifications } from '@/composables/useNotifications'
 import { notificationService } from '@/services/notification'
@@ -202,6 +203,12 @@ const navigateToUpgrade = () => {
     router.push('/settings/subscription')
 }
 
+// The usage warning is for everyone — an agent hitting a message ceiling needs
+// to know why replies stop. The two remedies are not: both lead to pages a
+// non-admin cannot open, so they rendered as doors into a 403.
+const canManageSubscription = permissionChecks.canManageSubscription()
+const canViewAIConfig = permissionChecks.canViewAIConfig()
+
 // Computed for layout classes
 const layoutClasses = computed(() => ({
     'sidebar-collapsed': !isSidebarOpen.value || props.hideSidebar,
@@ -244,11 +251,19 @@ const openNotificationsFromSheet = () => {
                         <span class="banner-icon" v-else>ℹ️</span>
                         {{ messageLimitStatus.message }}
                     </div>
-                    <div class="banner-actions">
-                        <button class="action-button" @click="navigateToUpgrade">
+                    <div v-if="canManageSubscription || canViewAIConfig" class="banner-actions">
+                        <button
+                            v-if="canManageSubscription"
+                            class="action-button"
+                            @click="navigateToUpgrade"
+                        >
                             Upgrade Plan
                         </button>
-                        <button class="action-button secondary" @click="router.push('/settings/ai-config')">
+                        <button
+                            v-if="canViewAIConfig"
+                            class="action-button secondary"
+                            @click="router.push('/settings/ai-config')"
+                        >
                             Configure Own Model
                         </button>
                     </div>
@@ -284,8 +299,9 @@ const openNotificationsFromSheet = () => {
                             </div>
                             <div v-else-if="isInTrial" class="trial-info">
                                 <span
-                                    class="trial-badge clickable"
-                                    @click="navigateToUpgrade"
+                                    class="trial-badge"
+                                    :class="{ clickable: canManageSubscription }"
+                                    @click="canManageSubscription && navigateToUpgrade()"
                                 >
                                     Trial ({{ trialDaysLeft }} days left)
                                 </span>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -18,7 +18,8 @@ import { createRouter, createWebHistory } from 'vue-router'
 import type { RouteLocationNormalized, NavigationGuardNext } from 'vue-router'
 import { userService } from '@/services/user'
 import { getSetupStatus } from '@/services/organization'
-import { permissionChecks, hasAnyPermission } from '@/utils/permissions'
+import { canAccessMatchedPaths } from '@/router/routePermissions'
+import { resolveLandingRoute } from '@/router/landing'
 import { getApiUrl } from '@/config/api'
 import HumanAgentView from '@/views/HumanAgentView.vue'
 import OrganizationSettings from '@/views/settings/OrganizationSettings.vue'
@@ -36,7 +37,14 @@ const { hasEnterpriseModule, loadModule, moduleImports, NotAvailableComponent } 
 const baseRoutes = [
   {
     path: '/',
-    redirect: '/ai-agents',
+    // A function, not a string: permissions live in localStorage and are not
+    // readable when this module is first evaluated. Also the landing spot for
+    // an installed PWA (manifest start_url) and for pushes with no session.
+    //
+    // Only resolve with a session in hand. Resolving for a signed-out visitor
+    // yields the no-permission floor, which the guard then carries into
+    // ?redirect= and honours after login — landing an admin on User Settings.
+    redirect: () => (userService.isAuthenticated() ? resolveLandingRoute() : '/login'),
   },
   {
     path: '/login',
@@ -64,7 +72,6 @@ const baseRoutes = [
       requiresAuth: true,
       layout: 'dashboard',
       title: 'Analytics Dashboard',
-      permissions: ['view_analytics'],
     },
   },
   {
@@ -75,7 +82,6 @@ const baseRoutes = [
       requiresAuth: true,
       layout: 'dashboard',
       title: 'Knowledge Base',
-      permissions: ['manage_knowledge'],
     },
   },
   {
@@ -86,7 +92,6 @@ const baseRoutes = [
       requiresAuth: true,
       layout: 'dashboard',
       title: 'FAQ & Help Center',
-      permissions: ['manage_knowledge'],
     },
   },
   {
@@ -97,7 +102,6 @@ const baseRoutes = [
       requiresAuth: true,
       layout: 'dashboard',
       title: 'Tickets',
-      permissions: ['view_tickets', 'manage_tickets'],
     },
   },
   {
@@ -108,7 +112,6 @@ const baseRoutes = [
       requiresAuth: true,
       layout: 'dashboard',
       title: 'Ticket',
-      permissions: ['view_tickets', 'manage_tickets'],
     },
   },
   {
@@ -119,7 +122,6 @@ const baseRoutes = [
       requiresAuth: true,
       layout: 'dashboard',
       title: 'Ticketing Settings',
-      permissions: ['manage_organization'],
     },
   },
   {
@@ -135,7 +137,6 @@ const baseRoutes = [
     // Any inbox grant — own/group chats, the unclaimed queue, or everything
     meta: {
       requiresAuth: true,
-      permissions: ['view_all_chats', 'view_assigned_chats', 'view_unassigned_chats'],
     },
   },
   {
@@ -146,14 +147,13 @@ const baseRoutes = [
     component: () => import('../views/PeopleView.vue'),
     meta: {
       requiresAuth: true,
-      permissions: ['view_people', 'view_all_chats', 'manage_all_chats'],
     },
   },
   {
     path: '/human-agents',
     name: 'human-agents',
     component: HumanAgentView,
-    meta: { requiresAuth: true, permissions: ['manage_users'] },
+    meta: { requiresAuth: true },
   },
   {
     path: '/settings/organization',
@@ -162,7 +162,6 @@ const baseRoutes = [
     meta: {
       requiresAuth: true,
       layout: 'dashboard',
-      permissions: ['manage_organization', 'view_organization'],
     },
   },
   {
@@ -172,7 +171,6 @@ const baseRoutes = [
     meta: {
       requiresAuth: true,
       layout: 'dashboard',
-      permissions: ['manage_ai_config', 'view_ai_config'],
     },
   },
   {
@@ -182,7 +180,6 @@ const baseRoutes = [
     meta: {
       requiresAuth: true,
       layout: 'dashboard',
-      permissions: ['manage_organization'],
     },
   },
   {
@@ -192,7 +189,6 @@ const baseRoutes = [
     meta: {
       requiresAuth: true,
       layout: 'dashboard',
-      permissions: ['manage_organization'],
     },
   },
   {
@@ -205,8 +201,18 @@ const baseRoutes = [
     },
   },
   {
+    // Registered, and reachable: the guard used to send denials to /403 with
+    // no such route, so they fell through this catch-all onto /ai-agents —
+    // which had no meta.permissions and therefore always rendered. A user was
+    // silently dropped on a page they had just been refused.
+    path: '/403',
+    name: 'forbidden',
+    component: () => import('@/views/403.vue'),
+    meta: { requiresAuth: true, layout: 'dashboard' },
+  },
+  {
     path: '/:pathMatch(.*)*',
-    redirect: '/ai-agents',
+    redirect: () => (userService.isAuthenticated() ? resolveLandingRoute() : '/login'),
   },
 ]
 
@@ -330,7 +336,6 @@ router.beforeEach(async (to, from, next) => {
   // Always check setup status to decide between Setup vs Login/Signup
   const isSetupComplete = await getSetupStatus()
   const requiresAuth = to.matched.some((record) => record.meta.requiresAuth)
-  const requiredPermissions = to.meta.permissions as string[] | undefined
 
   // Standard app navigation logic
   if (!isAuthenticated) {
@@ -350,9 +355,10 @@ router.beforeEach(async (to, from, next) => {
     }
   }
 
-  if (requiredPermissions && !hasAnyPermission(requiredPermissions)) {
-    // Redirect to 403 page or dashboard if user lacks required permissions
-    return next('/403')
+  // ROUTE_PERMISSIONS is the single source of truth, shared with the sidebar
+  // so a visible link can never lead to a refusal.
+  if (!canAccessMatchedPaths(to.matched.map((record) => record.path))) {
+    return next({ name: 'forbidden' })
   }
 
   return next()

--- a/frontend/src/router/landing.ts
+++ b/frontend/src/router/landing.ts
@@ -1,0 +1,51 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { canAccessPath } from '@/router/routePermissions'
+
+/**
+ * Where to send someone who has not asked for a particular page: after login,
+ * from `/`, from the catch-all, and from the 403 page.
+ *
+ * Order matters — /ai-agents stays first so an admin's landing page is
+ * unchanged. The list ends at /settings/user, which requires nothing, so this
+ * always resolves to somewhere the user can actually open.
+ */
+const LANDING_CANDIDATES = [
+  '/ai-agents',
+  '/conversations',
+  '/tickets',
+  '/people',
+  '/human-agents',
+  '/analytics',
+  '/knowledge',
+  '/settings/organization',
+  '/settings/ai-config',
+  '/settings/user',
+]
+
+/**
+ * The first landing candidate this user may open.
+ *
+ * Never returns /403: bouncing someone to an error page as their *destination*
+ * is what made a permission denial look like a broken app.
+ *
+ * Call this at navigation time, never at module scope — permissions are read
+ * from localStorage, which is empty when the router module is first evaluated.
+ */
+export function resolveLandingRoute(): string {
+  return LANDING_CANDIDATES.find(canAccessPath) ?? '/settings/user'
+}

--- a/frontend/src/router/routePermissions.ts
+++ b/frontend/src/router/routePermissions.ts
@@ -1,0 +1,92 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {
+  AGENT_PERMISSIONS,
+  AI_CONFIG_PERMISSIONS,
+  CHAT_VIEW_PERMISSIONS,
+  KNOWLEDGE_PERMISSIONS,
+  ORGANIZATION_PERMISSIONS,
+  PEOPLE_PERMISSIONS,
+  TICKET_PERMISSIONS,
+  hasAnyPermission,
+} from '@/utils/permissions'
+
+/**
+ * The one place a route's required permissions are written down.
+ *
+ * Both the router guard and the sidebar (navItems `show`) read this. They used to name permissions independently and had drifted: People
+ * was listed in the nav for anyone with a chat grant but the route required
+ * view_people, so an assigned-chats-only agent saw a link that bounced them.
+ *
+ * An empty array means "any authenticated user".
+ */
+export const ROUTE_PERMISSIONS: Record<string, readonly string[]> = {
+  '/ai-agents': AGENT_PERMISSIONS,
+  '/analytics': ['view_analytics'],
+  '/knowledge': KNOWLEDGE_PERMISSIONS,
+  // manage_knowledge, not the read pair: every /help-center endpoint the page
+  // calls requires manage_knowledge, so a view_knowledge role would get the
+  // link and a page that 403s on its first request.
+  '/faq': ['manage_knowledge'],
+  '/tickets': TICKET_PERMISSIONS,
+  '/tickets/:id': TICKET_PERMISSIONS,
+  '/settings/ticketing': ['manage_organization'],
+  '/conversations': CHAT_VIEW_PERMISSIONS,
+  '/people': PEOPLE_PERMISSIONS,
+  '/human-agents': ['manage_users'],
+  '/settings/organization': ORGANIZATION_PERMISSIONS,
+  '/settings/ai-config': AI_CONFIG_PERMISSIONS,
+  '/settings/integrations': ['manage_organization'],
+  '/settings/widget-apps': ['manage_organization'],
+  // Everyone can reach their own profile, and 403 must never deny itself or
+  // the guard has nowhere to send anyone.
+  '/settings/user': [],
+  '/403': [],
+}
+
+// Deliberately absent: /settings/subscription and its billing-setup child.
+// The enterprise subscription guard redirects an expired org THERE, so gating
+// it here would ping-pong (guard sends you to billing, this sends you to /403,
+// guard sends you back) until Vue Router aborts. The nav hides it via
+// canViewSubscription instead; gating the route needs the guard fixed first,
+// which is an enterprise-submodule change.
+
+/** Shopify embedded routes authenticate by session token, not by user role. */
+const isShopifyPath = (path: string) => path.startsWith('/shopify')
+
+/**
+ * Whether the current user may open `path`.
+ *
+ * Unknown paths are allowed: the map lists what is restricted, so a public or
+ * not-yet-mapped route must not become unreachable by omission.
+ */
+export function canAccessPath(path: string): boolean {
+  if (isShopifyPath(path)) return true
+  const required = ROUTE_PERMISSIONS[path]
+  if (!required || required.length === 0) return true
+  return hasAnyPermission([...required])
+}
+
+/**
+ * Whether the user may open a resolved route.
+ *
+ * Takes the matched record paths rather than the URL so a parameterised route
+ * is looked up by its pattern ('/tickets/:id'), not by '/tickets/42'.
+ */
+export function canAccessMatchedPaths(matchedPaths: string[]): boolean {
+  return matchedPaths.every(canAccessPath)
+}

--- a/frontend/src/router/routePermissions.ts
+++ b/frontend/src/router/routePermissions.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Groups from the leaf module, not from permissions.ts: this map is built at
+// module scope, and permissions.ts sits inside the router import cycle.
 import {
   AGENT_PERMISSIONS,
   AI_CONFIG_PERMISSIONS,
@@ -22,8 +24,9 @@ import {
   ORGANIZATION_PERMISSIONS,
   PEOPLE_PERMISSIONS,
   TICKET_PERMISSIONS,
-  hasAnyPermission,
-} from '@/utils/permissions'
+} from '@/utils/permissionGroups'
+// Only ever called at runtime, so a partially-initialised module is harmless.
+import { hasAnyPermission } from '@/utils/permissions'
 
 /**
  * The one place a route's required permissions are written down.

--- a/frontend/src/services/agent.ts
+++ b/frontend/src/services/agent.ts
@@ -19,6 +19,17 @@ import type { AgentCustomization, Agent, AgentUpdate } from '@/types/agent'
 import { agentStorage } from '@/utils/storage'
 
 export const agentService = {
+  /**
+   * Names of the org's AI agents, for the inbox filter.
+   *
+   * Not getOrganizationAgents: that needs manage_agents and returns each
+   * agent's instructions and guardrail prompt. Filtering needs a name.
+   */
+  async getAgentRoster(): Promise<Array<{ id: string; name: string; display_name: string | null }>> {
+    const response = await api.get('/agent/roster')
+    return response.data
+  },
+
   async getOrganizationAgents(): Promise<Agent[]> {
     // Check if we're in a Shopify context (has shop query param or session token)
     const urlParams = new URLSearchParams(window.location.search)

--- a/frontend/src/services/users.ts
+++ b/frontend/src/services/users.ts
@@ -54,6 +54,28 @@ export async function listUsers(): Promise<User[]> {
   return response.data
 }
 
+/** A colleague as the inbox needs them, from GET /users/teammates. */
+export interface Teammate {
+  id: string
+  full_name: string | null
+  email: string
+  profile_pic?: string | null
+  is_online?: boolean
+}
+
+/**
+ * Who a conversation can be handed to.
+ *
+ * The inbox used to call GET /users for this, which needs manage_users — so an
+ * agent got a 403 and an empty Reassign dropdown for an action the API would
+ * have allowed. This endpoint is gated on the inbox permissions instead, and
+ * returns no roles or permission lists.
+ */
+export async function listTeammates(): Promise<Teammate[]> {
+  const response = await api.get('users/teammates')
+  return response.data
+}
+
 /**
  * Aggregated Human-Agents dashboard (KPIs + per-agent load/resolved).
  * Returns null if the backend endpoint isn't available yet (graceful fallback).

--- a/frontend/src/services/users.ts
+++ b/frontend/src/services/users.ts
@@ -86,11 +86,14 @@ export async function deleteUser(id: string): Promise<void> {
   await api.delete(`users/${id}`)
 }
 
-export async function updateUserPassword(id: string, currentPassword: string, newPassword: string): Promise<void> {
-  await api.put(`users/${id}/password`, {
-    current_password: currentPassword,
-    new_password: newPassword
-  })
+/**
+ * Admin-set password for another user in the organization. The admin never
+ * knows the old one, so nothing is verified here — `manage_users` is the gate,
+ * and the API refuses to reset your own password (that goes through profile
+ * settings, which does ask for the current password).
+ */
+export async function resetUserPassword(id: string, newPassword: string): Promise<void> {
+  await api.post(`users/${id}/reset-password`, { new_password: newPassword })
 }
 
 export async function updateUserProfile(id: string, profileData: Partial<User>): Promise<User> {

--- a/frontend/src/utils/permissionGroups.ts
+++ b/frontend/src/utils/permissionGroups.ts
@@ -1,0 +1,51 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Permission groups, mirroring the constants in backend/app/core/auth.py.
+ *
+ * A leaf module on purpose: it imports nothing. The route map reads these at
+ * module scope, and there is an import cycle around the router
+ * (router -> routePermissions -> permissions -> services/user -> services/api
+ * -> router). Reading a constant from anywhere inside that cycle at module
+ * scope throws "Cannot access X before initialization" in the browser — where
+ * unit tests never see it, because they mock services/user and break the loop.
+ */
+
+/** Seeing conversations — CHAT_VIEW_PERMISSIONS. */
+export const CHAT_VIEW_PERMISSIONS = [
+  'view_all_chats',
+  'view_assigned_chats',
+  'view_unassigned_chats',
+]
+
+/** Acting on one: takeover, reassign, outbound — CHAT_MANAGE_PERMISSIONS. */
+export const CHAT_MANAGE_PERMISSIONS = ['manage_all_chats', 'manage_assigned_chats']
+
+/** Working the inbox at all — INBOX_PERMISSIONS. */
+export const INBOX_PERMISSIONS = [...CHAT_VIEW_PERMISSIONS, ...CHAT_MANAGE_PERMISSIONS]
+
+/** The people directory — PEOPLE_READ_PERMISSIONS. Writes match reads. */
+export const PEOPLE_PERMISSIONS = ['view_people', ...INBOX_PERMISSIONS]
+
+// The remaining view/manage pairs, named once so the route map and the
+// permission checks cannot drift apart.
+export const AGENT_PERMISSIONS = ['manage_agents', 'view_agents']
+export const KNOWLEDGE_PERMISSIONS = ['manage_knowledge', 'view_knowledge']
+export const TICKET_PERMISSIONS = ['view_tickets', 'manage_tickets']
+export const ORGANIZATION_PERMISSIONS = ['manage_organization', 'view_organization']
+export const AI_CONFIG_PERMISSIONS = ['manage_ai_config', 'view_ai_config']
+export const SUBSCRIPTION_PERMISSIONS = ['manage_subscription', 'view_subscription']

--- a/frontend/src/utils/permissions.ts
+++ b/frontend/src/utils/permissions.ts
@@ -27,32 +27,59 @@ export function hasAnyPermission(permissions: string[]): boolean {
   return hasPermission('super_admin') || permissions.some(permission => hasPermission(permission))
 }
 
-// Common permission checks
+// Permission groups, mirroring the constants in backend/app/core/auth.py.
+// Exported so the route map can name the same sets the API enforces.
+
+/** Seeing conversations — CHAT_VIEW_PERMISSIONS. */
+export const CHAT_VIEW_PERMISSIONS = [
+  'view_all_chats',
+  'view_assigned_chats',
+  'view_unassigned_chats',
+]
+
+/** Acting on one: takeover, reassign, outbound — CHAT_MANAGE_PERMISSIONS. */
+export const CHAT_MANAGE_PERMISSIONS = ['manage_all_chats', 'manage_assigned_chats']
+
+/** Working the inbox at all — INBOX_PERMISSIONS. */
+export const INBOX_PERMISSIONS = [...CHAT_VIEW_PERMISSIONS, ...CHAT_MANAGE_PERMISSIONS]
+
+/** The people directory — PEOPLE_READ_PERMISSIONS. Writes match reads. */
+export const PEOPLE_PERMISSIONS = ['view_people', ...INBOX_PERMISSIONS]
+
+// The remaining view/manage pairs, named once so the route map and the checks
+// below cannot drift apart.
+export const AGENT_PERMISSIONS = ['manage_agents', 'view_agents']
+export const KNOWLEDGE_PERMISSIONS = ['manage_knowledge', 'view_knowledge']
+export const TICKET_PERMISSIONS = ['view_tickets', 'manage_tickets']
+export const ORGANIZATION_PERMISSIONS = ['manage_organization', 'view_organization']
+export const AI_CONFIG_PERMISSIONS = ['manage_ai_config', 'view_ai_config']
+export const SUBSCRIPTION_PERMISSIONS = ['manage_subscription', 'view_subscription']
+
+// Common permission checks.
+//
+// Every check goes through hasAnyPermission, never bare hasPermission: it is
+// the only one that honours super_admin, and the backend's check_permissions
+// bypasses on it. When the two layers disagree the page renders and then 403s.
 export const permissionChecks = {
-  canManageOrganization: () => hasPermission('manage_organization'),
-  canViewOrganization: () => hasAnyPermission(['manage_organization', 'view_organization']),
-  canManageAIConfig: () => hasPermission('manage_ai_config'),
-  canViewAIConfig: () => hasAnyPermission(['manage_ai_config', 'view_ai_config']),
-  canManageUsers: () => hasPermission('manage_users'),
-  canViewAgents: () => hasAnyPermission(['manage_agents', 'view_agents']),
-  canManageAgents: () => hasPermission('manage_agents'),
-  // Any inbox grant opens the Inbox: own/group chats, the unclaimed AI queue,
-  // or everything. Keep in sync with get_unified_chat_auth in core/auth.py.
-  canViewChats: () =>
-    hasAnyPermission(['view_all_chats', 'view_assigned_chats', 'view_unassigned_chats']),
-  // The people directory is its own read grant; the org-wide chat permissions
-  // imply it. Mirrors PEOPLE_READ_PERMISSIONS in core/auth.py.
-  canViewPeople: () => hasAnyPermission(['view_people', 'view_all_chats', 'manage_all_chats']),
-  // Editing a person (mark customer, correct a phone) needs the stronger grant
-  canManagePeople: () => hasAnyPermission(['view_all_chats', 'manage_all_chats']),
-  // Claiming a chat. Mirrors TAKEOVER_PERMISSIONS in api/session_to_agent.py
-  canTakeOverChats: () => hasAnyPermission(['manage_all_chats', 'manage_assigned_chats']),
-  canManageKnowledge: () => hasPermission('manage_knowledge'),
-  canViewAnalytics: () => hasPermission('view_analytics'),
-  canViewTickets: () => hasAnyPermission(['view_tickets', 'manage_tickets']),
-  // hasAnyPermission, not hasPermission: the backend's approve check bypasses
-  // on super_admin, so the frontend must too or the banner hides Approve/Reject
-  // for an admin the API would happily let approve (two layers disagreeing).
+  canManageOrganization: () => hasAnyPermission(['manage_organization']),
+  canViewOrganization: () => hasAnyPermission(ORGANIZATION_PERMISSIONS),
+  canManageAIConfig: () => hasAnyPermission(['manage_ai_config']),
+  canViewAIConfig: () => hasAnyPermission(AI_CONFIG_PERMISSIONS),
+  canManageUsers: () => hasAnyPermission(['manage_users']),
+  canViewAgents: () => hasAnyPermission(AGENT_PERMISSIONS),
+  canManageAgents: () => hasAnyPermission(['manage_agents']),
+  canViewChats: () => hasAnyPermission(CHAT_VIEW_PERMISSIONS),
+  canViewPeople: () => hasAnyPermission(PEOPLE_PERMISSIONS),
+  // Correcting a person or marking them a customer is inbox work, not
+  // administration — PEOPLE_WRITE_PERMISSIONS equals the read set.
+  canManagePeople: () => hasAnyPermission(PEOPLE_PERMISSIONS),
+  canTakeOverChats: () => hasAnyPermission(CHAT_MANAGE_PERMISSIONS),
+  canManageKnowledge: () => hasAnyPermission(['manage_knowledge']),
+  canViewKnowledge: () => hasAnyPermission(KNOWLEDGE_PERMISSIONS),
+  canViewAnalytics: () => hasAnyPermission(['view_analytics']),
+  canViewTickets: () => hasAnyPermission(TICKET_PERMISSIONS),
   canManageTickets: () => hasAnyPermission(['manage_tickets']),
   canApproveTicketActions: () => hasAnyPermission(['approve_ticket_actions']),
+  canViewSubscription: () => hasAnyPermission(SUBSCRIPTION_PERMISSIONS),
+  canManageSubscription: () => hasAnyPermission(['manage_subscription']),
 }

--- a/frontend/src/utils/permissions.ts
+++ b/frontend/src/utils/permissions.ts
@@ -15,6 +15,17 @@ limitations under the License.
 */
 
 import { userService } from '@/services/user'
+import {
+  AGENT_PERMISSIONS,
+  AI_CONFIG_PERMISSIONS,
+  CHAT_MANAGE_PERMISSIONS,
+  CHAT_VIEW_PERMISSIONS,
+  KNOWLEDGE_PERMISSIONS,
+  ORGANIZATION_PERMISSIONS,
+  PEOPLE_PERMISSIONS,
+  SUBSCRIPTION_PERMISSIONS,
+  TICKET_PERMISSIONS,
+} from '@/utils/permissionGroups'
 
 export function hasPermission(permission: string): boolean {
   const user = userService.getCurrentUser()
@@ -27,33 +38,9 @@ export function hasAnyPermission(permissions: string[]): boolean {
   return hasPermission('super_admin') || permissions.some(permission => hasPermission(permission))
 }
 
-// Permission groups, mirroring the constants in backend/app/core/auth.py.
-// Exported so the route map can name the same sets the API enforces.
-
-/** Seeing conversations — CHAT_VIEW_PERMISSIONS. */
-export const CHAT_VIEW_PERMISSIONS = [
-  'view_all_chats',
-  'view_assigned_chats',
-  'view_unassigned_chats',
-]
-
-/** Acting on one: takeover, reassign, outbound — CHAT_MANAGE_PERMISSIONS. */
-export const CHAT_MANAGE_PERMISSIONS = ['manage_all_chats', 'manage_assigned_chats']
-
-/** Working the inbox at all — INBOX_PERMISSIONS. */
-export const INBOX_PERMISSIONS = [...CHAT_VIEW_PERMISSIONS, ...CHAT_MANAGE_PERMISSIONS]
-
-/** The people directory — PEOPLE_READ_PERMISSIONS. Writes match reads. */
-export const PEOPLE_PERMISSIONS = ['view_people', ...INBOX_PERMISSIONS]
-
-// The remaining view/manage pairs, named once so the route map and the checks
-// below cannot drift apart.
-export const AGENT_PERMISSIONS = ['manage_agents', 'view_agents']
-export const KNOWLEDGE_PERMISSIONS = ['manage_knowledge', 'view_knowledge']
-export const TICKET_PERMISSIONS = ['view_tickets', 'manage_tickets']
-export const ORGANIZATION_PERMISSIONS = ['manage_organization', 'view_organization']
-export const AI_CONFIG_PERMISSIONS = ['manage_ai_config', 'view_ai_config']
-export const SUBSCRIPTION_PERMISSIONS = ['manage_subscription', 'view_subscription']
+// The groups live in a leaf module (see permissionGroups.ts for why) and are
+// re-exported here so existing importers keep working.
+export * from '@/utils/permissionGroups'
 
 // Common permission checks.
 //

--- a/frontend/src/utils/validators.ts
+++ b/frontend/src/utils/validators.ts
@@ -44,6 +44,15 @@ export const validatePassword = (password: string): PasswordStrength => {
   return strength
 }
 
+/**
+ * The bar the API enforces (app/core/security.py: validate_password_strength):
+ * 8 characters plus at least three of the four character classes. Since the
+ * length check is one of the five criteria the meter counts, "length met and
+ * score >= 4" is exactly that rule. Keep the two in step.
+ */
+export const meetsPasswordPolicy = (strength: PasswordStrength): boolean =>
+  strength.hasMinLength && strength.score >= 4
+
 export const validateDomain = (domain: string): boolean => {
   const domainRegex = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$/
   return domainRegex.test(domain)

--- a/frontend/src/views/403.vue
+++ b/frontend/src/views/403.vue
@@ -14,13 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+<script setup lang="ts">
+import DashboardLayout from '@/layouts/DashboardLayout.vue'
+import { resolveLandingRoute } from '@/router/landing'
+
+// Not '/': that redirects to the landing route, which for a user who was just
+// denied is often another denial. Resolved once — the component is created
+// fresh per visit, and permissions do not change mid-render.
+const landingRoute = resolveLandingRoute()
+</script>
+
 <template>
   <DashboardLayout>
     <div class="unauthorized">
       <h1>Access Denied</h1>
       <p>You don't have permission to access this page.</p>
-      <router-link to="/" class="back-link">
-        Return to Dashboard
+      <router-link :to="landingRoute" class="back-link">
+        Go to a page you can open
       </router-link>
     </div>
   </DashboardLayout>

--- a/frontend/src/views/ConversationsView.vue
+++ b/frontend/src/views/ConversationsView.vue
@@ -24,7 +24,7 @@ import ChatInfoPanel from '@/components/conversations/ChatInfoPanel.vue'
 import type { Conversation, ChatDetail } from '@/types/chat'
 import { chatService } from '@/services/chat'
 import { agentService } from '@/services/agent'
-import api from '@/services/api'
+import { listTeammates, type Teammate } from '@/services/users'
 import channelsService, { type ChannelAccount } from '@/services/channels'
 import NewWhatsAppConversation from '@/components/conversations/NewWhatsAppConversation.vue'
 import { useBreakpoint } from '@/composables/useBreakpoint'
@@ -104,7 +104,7 @@ const filterValues = ref({
   userFilter: ''
 })
 const showFilters = ref(false)
-const users = ref<Array<{id: string, full_name: string, email: string}>>([])
+const users = ref<Teammate[]>([])
 const loadingUsers = ref(false)
 const agents = ref<Array<{id: string, name: string, display_name: string | null}>>([])
 const loadingAgents = ref(false)
@@ -222,13 +222,15 @@ const toggleFilters = () => {
 
 const loadUsers = async () => {
   if (loadingUsers.value) return
-  
+
   loadingUsers.value = true
   try {
-    const response = await api.get('/users')
-    users.value = response.data
+    // /users/teammates, not /users: the latter needs manage_users, so this
+    // 403'd on every inbox mount for an agent and left the assignee filter and
+    // the Reassign dropdown empty.
+    users.value = await listTeammates()
   } catch (error) {
-    console.error('Failed to load users:', error)
+    console.error('Failed to load teammates:', error)
   } finally {
     loadingUsers.value = false
   }
@@ -239,8 +241,9 @@ const loadAgents = async () => {
   
   loadingAgents.value = true
   try {
-    const agentsList = await agentService.getOrganizationAgents()
-    agents.value = agentsList
+    // The roster, not the full agent list: filtering needs names, and
+    // getOrganizationAgents needs manage_agents.
+    agents.value = await agentService.getAgentRoster()
   } catch (error) {
     console.error('Failed to load agents:', error)
   } finally {

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -18,7 +18,7 @@ limitations under the License.
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { authService } from '@/services/auth'
-import { permissionChecks } from '@/utils/permissions'
+import { resolveLandingRoute } from '@/router/landing'
 import { useEnterpriseFeatures } from '@/composables/useEnterpriseFeatures'
 import { useForgotPassword } from '@/composables/useForgotPassword'
 import InstallPrompt from '@/components/pwa/InstallPrompt.vue'
@@ -69,26 +69,10 @@ const verifyAndResetPassword = forgotPassword?.verifyAndResetPassword ?? (() => 
 const resetForgotPasswordForm = forgotPassword?.resetForm ?? (() => {})
 const goBackToEmailStep = forgotPassword?.goBackToEmailStep ?? (() => {})
 
-const getInitialRoute = () => {
-    // Check permissions in order of priority
-    if (permissionChecks.canManageAgents()) {
-        return '/ai-agents'
-    }
-    if (permissionChecks.canViewChats()) {
-        return '/conversations'
-    }
-    if (permissionChecks.canManageUsers()) {
-        return '/human-agents'
-    }
-    if (permissionChecks.canViewOrganization()) {
-        return '/settings/organization'
-    }
-    if (permissionChecks.canViewAIConfig()) {
-        return '/settings/ai-config'
-    }
-    // Default route if no specific permissions
-    return '/403'
-}
+// One ordered candidate list, shared with '/', the catch-all and the 403 page.
+// It used to end at '/403', which is not somewhere to land — and the route was
+// not even registered, so the user silently ended up on /ai-agents instead.
+const getInitialRoute = () => resolveLandingRoute()
 
 const handleLogin = async () => {
     try {


### PR DESCRIPTION
A Human Agent could not load any page — every navigation bounced to `/settings/subscription?error=Not+enough+permissions`. Looking into it turned up a wider problem: ticking a permission on a role often did nothing, and hiding a menu item did not protect the page behind it.

Also includes the admin password reset (`POST /users/{id}/reset-password`) from the branch this stacks on.

### The lockout

`get_unified_auth` is an authentication helper, but it hardcoded a `manage_agents` check. Every route using it inherited that, including `GET /enterprise/subscriptions/current` — which the subscription guard calls on every navigation and treats any failure as expired. Hosted only; community builds register no guard.

### Backend

- Permission groups defined once in `core/auth.py`. `INBOX_PERMISSIONS` now covers everyone who works the inbox, not just the two org-wide grants.
- Sending a WhatsApp template needs a manage grant; browsing templates does not.
- New `GET /users/teammates` and `GET /agent/roster`, so the inbox stops calling admin endpoints just to get names. Neither returns roles, permissions, agent instructions or guardrail prompts.
- `webhook_url` is no longer returned to non-admins. It embeds `webhook_secret`, the only authentication on the inbound email and SMS webhooks.
- `view_agents` and `view_knowledge` are enforced. They were in the catalogue and the role editor, checked nowhere.
- All `/roles` endpoints are gated. Only `POST` was before, so any authenticated user could grant their own role `super_admin`. You also cannot grant a permission you do not hold.
- `GET /knowledge/agent/{id}` checks the agent belongs to your org. It filtered on the agent id alone.

Removing the `manage_agents` check also closes a bypass: it never ran on the Shopify branch, so `GET /agent/list?host=1` skipped it.

### Frontend

- One route → permission map, read by both the router guard and the sidebar. They named permissions separately and had drifted.
- `/403` is a registered route. Denials fell through the catch-all onto `/ai-agents`, where an agent landed in the first-run agent wizard.
- One ordered landing list behind `/`, the catch-all, login and 403, floored at User Settings.
- Permission checks honour `super_admin`, matching the backend.
- Reassign, the People writes, agent creation and the upgrade buttons are hidden from roles that cannot use them.

### Tests

Agent and People routes had no 403 coverage, and three fixtures re-implemented the check they were meant to test. The nav specs now drive real permissions from a cached user.

Backend: 892 pass in a community checkout; a hosted checkout has the same 33 pre-existing failures as `main`. Frontend: 389 pass, type-check clean.

### Follow-ups

- Field redaction on `GET /subscriptions/current`, so a non-billing role does not see `unit_price`: chattermate/enterprise_backend#31.
- The hosted signup seeder still creates a 2-permission Agent role and two `is_default` rows. That fix and its repair migration are separate.
