### PR TITLE
Fix the Agent role seed, and let admins set chat scope when adding someone

### DIFF
--- a/backend/alembic/versions/repair_agent_role_seed_001.py
+++ b/backend/alembic/versions/repair_agent_role_seed_001.py
@@ -1,0 +1,184 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""repair agent roles left behind by the hosted signup seeder
+
+Revision ID: repair_agent_role_seed_001
+Revises: add_run_connector_status_001
+Create Date: 2026-08-03
+
+Two signup paths seed an organization's starter roles, and they disagreed. The
+hosted one gave Agent only view_assigned_chats + manage_assigned_chats, and
+marked BOTH Admin and Agent is_default=true. b7c4e91a2d38 repaired the orgs
+that existed in July 2026; every org created since through hosted signup was
+seeded wrong again. The seeders now share DEFAULT_AGENT_ROLE_PERMISSIONS, so
+this is the last of it.
+
+Unlike b7c4e91a2d38 this does NOT backfill by capability. That migration
+widened every chat-capable role and promised admins the grant was theirs to
+revoke:
+
+    "an admin who wants an agent kept out can uncheck the permission in Roles"
+
+Running a capability backfill again would break that promise — a role someone
+deliberately narrowed would silently get its permissions back. So the repair
+matches the bad seed EXACTLY: a role qualifies only if its permission set is
+precisely {view_assigned_chats, manage_assigned_chats}, no more and no less.
+An edited role has a different set and is left alone. A community-seeded org
+has four permissions and never matches, which is what makes this a no-op
+outside hosted.
+
+Also does NOT promote a role to is_default where an organization has none.
+roles.py refuses to edit or delete a default role, so promoting Agent would
+make it permanently uneditable through the API.
+
+Idempotent: every insert is guarded by NOT EXISTS (role_permissions has no
+primary key or unique constraint, so that guard is the only thing standing
+between a re-run and duplicate rows), and the is_default repair is a no-op
+once an org is down to one default.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'repair_agent_role_seed_001'
+down_revision = 'add_run_connector_status_001'
+branch_labels = None
+depends_on = None
+
+
+# The exact permission set the hosted seeder produced, and what it should have
+# been. Sorted, because the match is done against a sorted aggregate.
+BAD_SEED = ('manage_assigned_chats', 'view_assigned_chats')
+MISSING_FROM_BAD_SEED = ('view_unassigned_chats', 'view_people')
+
+# view_agents and view_knowledge became real permissions in the same release
+# that this migration ships with — they were in the catalogue and the role
+# editor for months while being enforced nowhere. Anyone holding the manage_*
+# twin already passes those checks (they are OR'd), so this grant changes no
+# behaviour. It exists so the role editor stops showing an admin role with
+# "manage knowledge" ticked and "view knowledge" blank.
+IMPLIED_BY_MANAGE = (
+    ('view_agents', 'manage_agents'),
+    ('view_knowledge', 'manage_knowledge'),
+)
+
+# Permission rows themselves may be absent on a deployment whose last org was
+# created before the name was added to Permission.default_permissions().
+REQUIRED_PERMISSIONS = (
+    ('view_unassigned_chats', 'Can view unassigned AI chats'),
+    ('view_people', 'Can view the people directory'),
+    ('view_agents', 'Can view chat agents'),
+    ('view_knowledge', 'Can view knowledge base'),
+)
+
+
+BAD_SEED_SIGNATURE = ",".join(sorted(BAD_SEED))
+
+
+def _sql_list(values) -> str:
+    return ", ".join(f"'{value}'" for value in values)
+
+
+def upgrade() -> None:
+    for name, description in REQUIRED_PERMISSIONS:
+        op.execute(
+            f"""
+            INSERT INTO permissions (name, description)
+            SELECT '{name}', '{description}'
+            WHERE NOT EXISTS (SELECT 1 FROM permissions WHERE name = '{name}')
+            """
+        )
+
+    # Roles whose permission set is exactly the bad seed. HAVING on the sorted
+    # aggregate is what makes it exact — a role with one extra permission, or
+    # one fewer, produces a different string and is skipped.
+    #
+    # Both permissions go in ONE statement, deliberately. Granting them in
+    # separate statements does not work: the first grant changes the role's
+    # permission set, so it no longer matches the signature and the second
+    # statement finds nothing to do. The subquery here is evaluated once,
+    # against the pre-insert state.
+    op.execute(
+        f"""
+        INSERT INTO role_permissions (role_id, permission_id)
+        SELECT bad.role_id, target.id
+        FROM (
+            SELECT rp.role_id
+            FROM role_permissions rp
+            JOIN permissions p ON p.id = rp.permission_id
+            GROUP BY rp.role_id
+            HAVING string_agg(p.name, ',' ORDER BY p.name) = '{BAD_SEED_SIGNATURE}'
+        ) bad
+        CROSS JOIN permissions target
+        WHERE target.name IN ({_sql_list(MISSING_FROM_BAD_SEED)})
+          AND NOT EXISTS (
+              SELECT 1 FROM role_permissions existing
+              WHERE existing.role_id = bad.role_id
+                AND existing.permission_id = target.id
+          )
+        """
+    )
+
+    for implied, held in IMPLIED_BY_MANAGE:
+        op.execute(
+            f"""
+            INSERT INTO role_permissions (role_id, permission_id)
+            SELECT DISTINCT rp.role_id, target.id
+            FROM role_permissions rp
+            JOIN permissions holder ON holder.id = rp.permission_id
+            CROSS JOIN permissions target
+            WHERE holder.name = '{held}'
+              AND target.name = '{implied}'
+              AND NOT EXISTS (
+                  SELECT 1 FROM role_permissions existing
+                  WHERE existing.role_id = rp.role_id
+                    AND existing.permission_id = target.id
+              )
+            """
+        )
+
+    # One default role per organization, same repair as b7c4e91a2d38. Clearing
+    # Admin is what leaves Agent as the default; clearing Agent instead would
+    # hand every newly invited user full permissions.
+    #
+    # The COUNT(*) > 1 guard means an org whose only default is Admin keeps it
+    # rather than ending up with no default at all.
+    op.execute(
+        """
+        UPDATE roles SET is_default = false
+        WHERE name = 'Admin'
+          AND is_default = true
+          AND organization_id IN (
+              SELECT organization_id FROM roles
+              WHERE is_default = true
+              GROUP BY organization_id
+              HAVING COUNT(*) > 1
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Deliberately empty.
+
+    There is nothing safe to undo. Revoking the four permissions would strip
+    them from roles that legitimately hold them — this migration cannot tell
+    the grants it made from the ones the seeder wrote. Deleting the permission
+    rows, as b7c4e91a2d38's downgrade does, would cascade across every
+    organization. And the pre-repair is_default state was ambiguous by
+    definition, which is the whole reason for the repair.
+    """

--- a/backend/app/api/organizations.py
+++ b/backend/app/api/organizations.py
@@ -34,7 +34,7 @@ from app.core.auth import get_current_user, require_permissions
 from app.core.security import create_access_token, create_refresh_token
 from app.core.logger import get_logger
 from app.models.role import Role
-from app.models.permission import Permission
+from app.models.permission import Permission, DEFAULT_AGENT_ROLE_PERMISSIONS
 from app.repositories.organization import OrganizationRepository
 from app.models.agent import Agent
 from app.models.session_to_agent import SessionToAgent
@@ -127,12 +127,7 @@ async def create_organization(
             is_default=True
         )
         agent_role.permissions = [
-            permissions["view_assigned_chats"],
-            permissions["manage_assigned_chats"],
-            # Lets an agent see and claim chats the AI is still handling
-            permissions["view_unassigned_chats"],
-            # Read-only directory access; mutating a person still needs more
-            permissions["view_people"]
+            permissions[name] for name in DEFAULT_AGENT_ROLE_PERMISSIONS
         ]
         db.add(agent_role)
         db.flush()

--- a/backend/app/api/roles.py
+++ b/backend/app/api/roles.py
@@ -22,6 +22,7 @@ from app.models.user import User
 from app.core.auth import (
     check_permissions,
     require_any_permission,
+    require_grantable,
     require_permissions,
 )
 from app.repositories.role import RoleRepository
@@ -32,7 +33,7 @@ from app.models.schemas.role import (
     RoleResponse,
     PermissionResponse
 )
-from typing import Iterable, List
+from typing import List
 from uuid import UUID
 
 router = APIRouter()
@@ -42,25 +43,6 @@ router = APIRouter()
 # (manage_users). Gating reads on manage_roles alone breaks user invite.
 ROLE_READ_PERMISSIONS = ("manage_roles", "manage_users")
 
-
-def _require_grantable(current_user: User, permission_names: Iterable[str]) -> None:
-    """You cannot grant a permission you do not hold yourself.
-
-    Without this, manage_roles was equivalent to super_admin — and in fact so
-    was *any* authenticated session, since these endpoints carried no permission
-    check at all: POST /roles/{my_role_id}/permissions/super_admin was enough.
-    check_permissions short-circuits on super_admin, so an org owner granting
-    anything is unaffected.
-    """
-    ungrantable = sorted(
-        name for name in permission_names
-        if not check_permissions(current_user, [name])
-    )
-    if ungrantable:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Cannot grant a permission you do not hold: {', '.join(ungrantable)}"
-        )
 
 @router.post("", response_model=RoleResponse)
 async def create_role(
@@ -93,7 +75,7 @@ async def create_role(
             )
         # A new role is a grant too — otherwise the rule is one "create role,
         # then assign myself to it" away from being bypassed.
-        _require_grantable(current_user, {p.name for p in existing_permissions})
+        require_grantable(current_user, {p.name for p in existing_permissions})
 
     try:
         role = role_repo.create_role(
@@ -178,7 +160,7 @@ async def update_role(
         # Only the diff: re-saving a role that already holds a permission the
         # caller lacks is legitimate; adding one is the escalation.
         already_held = {p.name for p in role.permissions}
-        _require_grantable(
+        require_grantable(
             current_user,
             {p.name for p in existing_permissions} - already_held,
         )
@@ -240,7 +222,7 @@ async def add_role_permission(
     # reads as 404 rather than "you may not grant that".
     if not db.query(Permission).filter(Permission.name == permission).first():
         raise HTTPException(status_code=404, detail="Permission not found")
-    _require_grantable(current_user, [permission])
+    require_grantable(current_user, [permission])
 
     success = role_repo.add_permission(role_id, permission)
     if not success:

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -36,6 +36,7 @@ from app.core.logger import get_logger
 from app.repositories.user import UserRepository
 from pydantic import BaseModel
 from app.models.role import Role
+from app.services.chat_scope_roles import resolve_role
 from app.core.s3 import get_s3_signed_url, upload_file_to_s3, delete_file_from_s3
 from app.core.config import settings
 from app.repositories.shopify_shop_repository import ShopifyShopRepository
@@ -74,7 +75,7 @@ ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif"}
 MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
 
 
-def _require_role_in_org(db, role_id, org_id) -> None:
+def _require_role_in_org(db, role_id, org_id) -> Optional[Role]:
     """A user may only be given a role defined in their own organization.
 
     Role ids are sequential integers, so without this an admin could bind a
@@ -82,10 +83,11 @@ def _require_role_in_org(db, role_id, org_id) -> None:
     breaking the other org's "is this role in use" accounting.
     """
     if role_id is None:
-        return
+        return None
     role = db.query(Role).filter(Role.id == role_id).first()
     if not role or role.organization_id != org_id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
+    return role
 
 def get_file_extension(filename: str) -> str:
     return os.path.splitext(filename)[1].lower()
@@ -155,7 +157,14 @@ async def create_user(
                     )
         
         # The role must belong to the caller's own organization.
-        _require_role_in_org(db, user_data.role_id, current_user.organization_id)
+        role = _require_role_in_org(db, user_data.role_id, current_user.organization_id)
+
+        # The chat-scope toggles may point at a different role than the one
+        # picked in the dropdown. Returns the same role when they match it.
+        role = resolve_role(
+            db, current_user, role,
+            user_data.see_all_ai_chats, user_data.see_all_org_chats,
+        )
 
         # Hash the password
         hashed_password = User.get_password_hash(user_data.password)
@@ -167,7 +176,7 @@ async def create_user(
             hashed_password=hashed_password,
             organization_id=current_user.organization_id,
             is_active=user_data.is_active,
-            role_id=user_data.role_id
+            role_id=role.id
         )
 
         return new_user.to_dict()
@@ -878,7 +887,7 @@ async def update_user(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
     # A supplied role must belong to the caller's org, not another tenant's.
-    _require_role_in_org(db, user_data.role_id, current_user.organization_id)
+    role = _require_role_in_org(db, user_data.role_id, current_user.organization_id)
 
     # Check if updating email and if it's already taken
     if user_data.email and user_data.email != user.email:
@@ -914,6 +923,21 @@ async def update_user(
         # nothing. Resetting someone else's password has its own endpoint below.
         fields.pop('password', None)
         fields.pop('current_password', None)
+
+        # The toggles describe a chat scope, not a column. They resolve against
+        # whichever role the user is ending up with — the one just picked, or
+        # the one they already had when the dropdown was left alone.
+        see_all_ai_chats = fields.pop('see_all_ai_chats', None)
+        see_all_org_chats = fields.pop('see_all_org_chats', None)
+        base_role = role or user.role
+        if base_role is not None:
+            # Assigned unconditionally, not only when it differs from the role
+            # in the payload: the toggles can resolve back to a role the person
+            # is already on, and letting the dropdown's id win there would
+            # silently narrow them.
+            fields['role_id'] = resolve_role(
+                db, current_user, base_role, see_all_ai_chats, see_all_org_chats
+            ).id
 
         updated_user = user_repo.update_user(user_id, **fields)
 

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -64,6 +64,29 @@ def check_permissions(user: User, required_permissions: List[str]) -> bool:
         return True
     return all(perm in user_permissions for perm in required_permissions)
 
+
+def require_grantable(current_user: User, permission_names: Iterable[str]) -> None:
+    """You cannot grant a permission you do not hold yourself.
+
+    Without this, manage_roles was equivalent to super_admin — and in fact so
+    was *any* authenticated session, since the /roles endpoints carried no
+    permission check at all: POST /roles/{my_role_id}/permissions/super_admin
+    was enough. check_permissions short-circuits on super_admin, so an org
+    owner granting anything is unaffected.
+
+    Lives here rather than in api/roles.py because granting is not confined to
+    that router — the chat-scope toggles on the user form widen a role too.
+    """
+    ungrantable = sorted(
+        name for name in permission_names
+        if not check_permissions(current_user, [name])
+    )
+    if ungrantable:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Cannot grant a permission you do not hold: {', '.join(ungrantable)}"
+        )
+
 def require_permissions(*required_permissions: str):
     """Dependency to check user permissions"""
     async def permission_checker(

--- a/backend/app/models/permission.py
+++ b/backend/app/models/permission.py
@@ -26,6 +26,21 @@ role_permissions = Table(
 )
 
 
+# What a newly seeded "Agent" role can do: work the chats assigned to them, pick
+# up whatever the AI is still handling, and look up who they are talking to.
+#
+# Named here rather than spelled out in each signup handler because there are
+# two of them — community (api/organizations.py) and hosted (enterprise
+# signup) — and they drifted. Hosted seeded only the first two for a year, so
+# its agents could not see the unclaimed queue or open People at all.
+DEFAULT_AGENT_ROLE_PERMISSIONS = (
+    "view_assigned_chats",
+    "manage_assigned_chats",
+    "view_unassigned_chats",
+    "view_people",
+)
+
+
 class Permission(Base):
     __tablename__ = "permissions"
 

--- a/backend/app/models/schemas/user.py
+++ b/backend/app/models/schemas/user.py
@@ -35,7 +35,18 @@ class UserBase(BaseModel):
     last_seen: Optional[datetime] = None
 
 
-class UserCreate(UserBase):
+class ChatScopeFields(BaseModel):
+    """The two chat-scope toggles on the user form.
+
+    Both default to None, meaning "whatever the chosen role already grants".
+    A client that predates these fields keeps its old behaviour; the form
+    sends explicit values because it renders the role's current scope.
+    """
+    see_all_ai_chats: Optional[bool] = None
+    see_all_org_chats: Optional[bool] = None
+
+
+class UserCreate(UserBase, ChatScopeFields):
     password: str
     role_id: int
 
@@ -48,7 +59,7 @@ class UserCreate(UserBase):
         return validate_password_strength(value)
 
 
-class UserUpdate(BaseModel):
+class UserUpdate(ChatScopeFields):
     email: Optional[EmailStr] = None
     full_name: Optional[str] = None
     password: Optional[str] = None

--- a/backend/app/services/chat_scope_roles.py
+++ b/backend/app/services/chat_scope_roles.py
@@ -1,0 +1,199 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Turn the chat-scope toggles on the user form into a role.
+
+Permissions hang off roles, not off people, so "let this agent read every
+conversation while their colleague is on leave" has to resolve to *some* role.
+Rather than inventing per-user grants — which would mean every permission check
+in the codebase learning about a second source of truth — the two toggles
+describe the chat scope a person should have, and this module finds the role in
+their organization that matches. A new role is created only when no existing
+one does, so the common case adds nothing to the Roles screen.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Optional, Set
+from uuid import UUID
+
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.auth import require_grantable
+from app.core.logger import get_logger
+from app.models.permission import Permission
+from app.models.role import Role
+from app.models.user import User
+
+logger = get_logger(__name__)
+
+# The unclaimed queue: sessions the AI is still handling that nobody has taken.
+AI_QUEUE_PERMISSION = "view_unassigned_chats"
+# Every conversation in the organization, including other agents' assignments.
+ALL_CHATS_PERMISSION = "view_all_chats"
+
+
+@dataclass(frozen=True)
+class ChatScope:
+    """What the two toggles on the user form are asking for."""
+
+    see_all_ai_chats: bool
+    see_all_org_chats: bool
+
+    @classmethod
+    def of(cls, role: Role) -> "ChatScope":
+        """The scope a role already grants — what the form shows on open."""
+        names = {p.name for p in role.permissions}
+        return cls(
+            see_all_ai_chats=AI_QUEUE_PERMISSION in names,
+            see_all_org_chats=ALL_CHATS_PERMISSION in names,
+        )
+
+    def label(self) -> str:
+        if self.see_all_org_chats and self.see_all_ai_chats:
+            return "all chats"
+        if self.see_all_org_chats:
+            return "all chats, no AI queue"
+        if self.see_all_ai_chats:
+            return "assigned + AI queue"
+        return "assigned only"
+
+
+def resolve_role(
+    db: Session,
+    current_user: User,
+    base_role: Role,
+    see_all_ai_chats: Optional[bool],
+    see_all_org_chats: Optional[bool],
+) -> Role:
+    """The role that grants `base_role` plus/minus the requested chat scope.
+
+    Either toggle may be None, meaning "whatever the role already does" — an
+    API client that has never heard of these fields gets exactly the old
+    behaviour.
+    """
+    current = ChatScope.of(base_role)
+    wanted = ChatScope(
+        see_all_ai_chats=(
+            current.see_all_ai_chats if see_all_ai_chats is None else see_all_ai_chats
+        ),
+        see_all_org_chats=(
+            current.see_all_org_chats if see_all_org_chats is None else see_all_org_chats
+        ),
+    )
+    if wanted == current:
+        return base_role
+
+    held = {p.name for p in base_role.permissions}
+    # super_admin already passes every check, so widening it would create a
+    # near-duplicate role that grants nothing new.
+    if "super_admin" in held:
+        return base_role
+
+    desired = set(held)
+    for granted, permission in (
+        (wanted.see_all_ai_chats, AI_QUEUE_PERMISSION),
+        (wanted.see_all_org_chats, ALL_CHATS_PERMISSION),
+    ):
+        desired.add(permission) if granted else desired.discard(permission)
+
+    # Same rule as the Roles editor: an admin cannot hand out what they do not
+    # hold themselves.
+    require_grantable(current_user, desired - held)
+
+    existing = _role_granting(db, base_role.organization_id, desired)
+    if existing is not None:
+        return existing
+    return _create_scoped_role(db, base_role, desired, wanted)
+
+
+#: Every label label() can produce, so a name can be stripped back down again.
+SCOPE_LABELS = tuple(
+    ChatScope(ai, org).label() for ai in (True, False) for org in (True, False)
+)
+_SCOPE_SUFFIX = re.compile(
+    r" \((?:%s)\)(?: \d+)?$" % "|".join(re.escape(label) for label in SCOPE_LABELS)
+)
+
+
+def _unscoped(name: str) -> str:
+    """`Agent (all chats)` -> `Agent`.
+
+    Re-scoping someone who is already on a derived role would otherwise stack
+    suffixes: "Agent (all chats) (assigned only)".
+    """
+    return _SCOPE_SUFFIX.sub("", name)
+
+
+def _role_granting(db: Session, organization_id: UUID, desired: Set[str]) -> Optional[Role]:
+    """An existing role in the org whose permissions are exactly `desired`.
+
+    Exact, not superset: a role that also grants manage_users would hand the
+    person far more than the toggle asked for.
+    """
+    roles = (
+        db.query(Role)
+        .options(joinedload(Role.permissions))
+        .filter(Role.organization_id == organization_id)
+        .all()
+    )
+    for role in roles:
+        if {p.name for p in role.permissions} == desired:
+            return role
+    return None
+
+
+def _create_scoped_role(
+    db: Session, base_role: Role, desired: Set[str], scope: ChatScope
+) -> Role:
+    role = Role(
+        name=_available_name(db, base_role, scope),
+        description=f"{_unscoped(base_role.name)}, scoped to {scope.label()}",
+        organization_id=base_role.organization_id,
+        # Never the org default. get_default_role() picks the default for
+        # invited users, and a scope chosen for one person is not that.
+        is_default=False,
+    )
+    role.permissions = (
+        db.query(Permission).filter(Permission.name.in_(desired)).all()
+    )
+    db.add(role)
+    db.flush()
+    logger.info(
+        "Created chat-scope role %r (%s) for organization %s",
+        role.name, scope.label(), base_role.organization_id,
+    )
+    return role
+
+
+def _available_name(db: Session, base_role: Role, scope: ChatScope) -> str:
+    """`Agent (all chats)`, or the first free numbered variant of it.
+
+    Role names are not unique in the schema, but two roles sharing a name in
+    one org is confusing in every screen that lists them.
+    """
+    taken = {
+        name for (name,) in db.query(Role.name).filter(
+            Role.organization_id == base_role.organization_id
+        )
+    }
+    preferred = f"{_unscoped(base_role.name)} ({scope.label()})"
+    if preferred not in taken:
+        return preferred
+    suffix = 2
+    while f"{preferred} {suffix}" in taken:
+        suffix += 1
+    return f"{preferred} {suffix}"

--- a/backend/app/services/chat_scope_roles.py
+++ b/backend/app/services/chat_scope_roles.py
@@ -108,10 +108,15 @@ def resolve_role(
         (wanted.see_all_ai_chats, AI_QUEUE_PERMISSION),
         (wanted.see_all_org_chats, ALL_CHATS_PERMISSION),
     ):
-        desired.add(permission) if granted else desired.discard(permission)
+        if granted:
+            desired.add(permission)
+        else:
+            desired.discard(permission)
 
     # Same rule as the Roles editor: an admin cannot hand out what they do not
-    # hold themselves.
+    # hold themselves. Only the added permissions are checked, not the base
+    # role's own — someone with manage_users can already assign any role in the
+    # org as it stands, so carrying its permissions across grants nothing new.
     require_grantable(current_user, desired - held)
 
     existing = _role_granting(db, base_role.organization_id, desired)

--- a/backend/tests/api/test_chat_scope_roles.py
+++ b/backend/tests/api/test_chat_scope_roles.py
@@ -1,0 +1,340 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""The chat-scope toggles on the user form.
+
+Permissions live on roles, so ticking "can see all chats in the organization"
+for one person has to resolve to a role. These pin that it resolves to the
+RIGHT role — reusing one where possible, never widening the role the rest of
+the team is on, and never letting an admin hand out a permission they lack.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from uuid import uuid4
+
+from app.api import users as users_router
+from app.core.auth import get_current_user, require_permissions
+from app.core.config import settings
+from app.core.security import get_password_hash
+from app.database import Base, get_db
+from app.models.organization import Organization
+from app.models.permission import Permission, DEFAULT_AGENT_ROLE_PERMISSIONS
+from app.models.role import Role
+from app.models.user import User
+from tests.conftest import engine, TestingSessionLocal, create_tables
+
+users_router.HAS_ENTERPRISE = False
+
+app = FastAPI()
+app.include_router(
+    users_router.router, prefix=f"{settings.API_V1_STR}/users", tags=["users"]
+)
+
+ALL_PERMISSION_NAMES = [name for name, _ in Permission.default_permissions()]
+NEW_USER = {
+    "email": "newagent@test.com",
+    "full_name": "New Agent",
+    "password": "Str0ng!Passw0rd",
+    "is_active": True,
+}
+
+
+@pytest.fixture(scope="function")
+def db():
+    Base.metadata.drop_all(bind=engine)
+    create_tables()
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def permissions(db) -> dict:
+    rows = {}
+    for name in ALL_PERMISSION_NAMES:
+        perm = Permission(name=name, description=name)
+        db.add(perm)
+        rows[name] = perm
+    db.commit()
+    return rows
+
+
+@pytest.fixture
+def organization(db) -> Organization:
+    org = Organization(id=uuid4(), name="Scope Org", domain="scope.test")
+    db.add(org)
+    db.commit()
+    return org
+
+
+def make_role(db, organization, permissions, name, granted) -> Role:
+    role = Role(name=name, organization_id=organization.id, is_default=False)
+    role.permissions = [permissions[n] for n in granted]
+    db.add(role)
+    db.commit()
+    db.refresh(role)
+    return role
+
+
+@pytest.fixture
+def agent_role(db, organization, permissions) -> Role:
+    """The role a fresh org seeds: assigned chats, the AI queue, and People."""
+    return make_role(
+        db, organization, permissions, "Agent", DEFAULT_AGENT_ROLE_PERMISSIONS
+    )
+
+
+@pytest.fixture
+def admin(db, organization, permissions) -> User:
+    role = make_role(db, organization, permissions, "Admin", ALL_PERMISSION_NAMES)
+    user = User(
+        id=uuid4(), email="admin@test.com", full_name="Admin",
+        hashed_password=get_password_hash("x"), organization_id=organization.id,
+        role_id=role.id, is_active=True,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@pytest.fixture
+def client(db, admin) -> TestClient:
+    async def override_current_user():
+        return admin
+
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[get_current_user] = override_current_user
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def create_user(client, role_id, **scope):
+    return client.post(
+        f"{settings.API_V1_STR}/users",
+        json={**NEW_USER, "role_id": role_id, **scope},
+    )
+
+
+def role_of(db: Session, email: str) -> Role:
+    user = db.query(User).filter(User.email == email).first()
+    return db.query(Role).filter(Role.id == user.role_id).first()
+
+
+def granted(role: Role) -> set:
+    return {p.name for p in role.permissions}
+
+
+def test_toggles_matching_the_role_reuse_it(client, db, agent_role):
+    """The common case adds nothing to the Roles screen."""
+    response = create_user(
+        client, agent_role.id, see_all_ai_chats=True, see_all_org_chats=False
+    )
+    assert response.status_code == 200
+    assert role_of(db, NEW_USER["email"]).id == agent_role.id
+    assert db.query(Role).filter(Role.organization_id == agent_role.organization_id).count() == 2
+
+
+def test_omitting_the_toggles_leaves_the_role_alone(client, db, agent_role):
+    """A client that predates these fields keeps the old behaviour."""
+    assert create_user(client, agent_role.id).status_code == 200
+    assert role_of(db, NEW_USER["email"]).id == agent_role.id
+
+
+def test_all_org_chats_derives_a_role_without_touching_the_original(
+    client, db, agent_role
+):
+    response = create_user(
+        client, agent_role.id, see_all_ai_chats=True, see_all_org_chats=True
+    )
+    assert response.status_code == 200
+
+    assigned = role_of(db, NEW_USER["email"])
+    assert assigned.id != agent_role.id
+    assert assigned.name == "Agent (all chats)"
+    assert granted(assigned) == set(DEFAULT_AGENT_ROLE_PERMISSIONS) | {"view_all_chats"}
+    assert assigned.is_default is False
+
+    # Everyone else on Agent is unaffected — the whole point of deriving.
+    db.refresh(agent_role)
+    assert granted(agent_role) == set(DEFAULT_AGENT_ROLE_PERMISSIONS)
+
+
+def test_a_second_person_with_the_same_scope_reuses_the_derived_role(
+    client, db, agent_role
+):
+    """Otherwise one role per invite piles up in the Roles screen."""
+    create_user(client, agent_role.id, see_all_ai_chats=True, see_all_org_chats=True)
+    first = role_of(db, NEW_USER["email"]).id
+
+    client.post(
+        f"{settings.API_V1_STR}/users",
+        json={**NEW_USER, "email": "second@test.com", "role_id": agent_role.id,
+              "see_all_ai_chats": True, "see_all_org_chats": True},
+    )
+    assert role_of(db, "second@test.com").id == first
+    assert db.query(Role).filter(Role.name == "Agent (all chats)").count() == 1
+
+
+def test_unticking_the_ai_queue_narrows_rather_than_widens(client, db, agent_role):
+    response = create_user(
+        client, agent_role.id, see_all_ai_chats=False, see_all_org_chats=False
+    )
+    assert response.status_code == 200
+
+    assigned = role_of(db, NEW_USER["email"])
+    assert assigned.id != agent_role.id
+    assert "view_unassigned_chats" not in granted(assigned)
+    assert granted(assigned) == set(DEFAULT_AGENT_ROLE_PERMISSIONS) - {
+        "view_unassigned_chats"
+    }
+
+
+def test_cannot_grant_a_scope_you_do_not_hold(db, organization, permissions, agent_role):
+    """Same rule as the Roles editor, reached by a different door."""
+    limited_role = make_role(
+        db, organization, permissions, "Team Lead",
+        ["manage_users", "view_assigned_chats"],
+    )
+    lead = User(
+        id=uuid4(), email="lead@test.com", full_name="Lead",
+        hashed_password=get_password_hash("x"), organization_id=organization.id,
+        role_id=limited_role.id, is_active=True,
+    )
+    db.add(lead)
+    db.commit()
+
+    async def override_current_user():
+        return lead
+
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[get_current_user] = override_current_user
+    try:
+        response = create_user(
+            TestClient(app), agent_role.id,
+            see_all_ai_chats=True, see_all_org_chats=True,
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 403
+    assert "view_all_chats" in response.json()["detail"]
+    assert db.query(User).filter(User.email == NEW_USER["email"]).first() is None
+
+
+def test_super_admin_role_is_never_derived_from(client, db, organization, permissions):
+    """super_admin already passes every check; a widened copy grants nothing."""
+    owner_role = make_role(
+        db, organization, permissions, "Owner", ["super_admin", "manage_users"]
+    )
+    response = create_user(
+        client, owner_role.id, see_all_ai_chats=True, see_all_org_chats=True
+    )
+    assert response.status_code == 200
+    assert role_of(db, NEW_USER["email"]).id == owner_role.id
+
+
+def test_editing_a_person_moves_them_to_the_scoped_role(client, db, agent_role):
+    """The leave-cover case: widen one person mid-employment, not the team."""
+    create_user(client, agent_role.id, see_all_ai_chats=True, see_all_org_chats=False)
+    user = db.query(User).filter(User.email == NEW_USER["email"]).first()
+    assert user.role_id == agent_role.id
+
+    response = client.put(
+        f"{settings.API_V1_STR}/users/{user.id}",
+        json={"see_all_org_chats": True},
+    )
+    assert response.status_code == 200
+
+    db.expire_all()
+    assigned = role_of(db, NEW_USER["email"])
+    assert assigned.id != agent_role.id
+    assert "view_all_chats" in granted(assigned)
+    db.refresh(agent_role)
+    assert "view_all_chats" not in granted(agent_role)
+
+
+def test_rescoping_does_not_stack_suffixes_on_the_name(client, db, agent_role):
+    """Widen someone, then narrow them: "Agent (assigned only)", not
+    "Agent (all chats) (assigned only)"."""
+    create_user(client, agent_role.id, see_all_ai_chats=True, see_all_org_chats=True)
+    user = db.query(User).filter(User.email == NEW_USER["email"]).first()
+    assert role_of(db, NEW_USER["email"]).name == "Agent (all chats)"
+
+    response = client.put(
+        f"{settings.API_V1_STR}/users/{user.id}",
+        json={"see_all_ai_chats": False, "see_all_org_chats": False},
+    )
+    assert response.status_code == 200
+
+    db.expire_all()
+    assert role_of(db, NEW_USER["email"]).name == "Agent (assigned only)"
+
+
+def test_toggles_win_over_the_dropdown_when_they_resolve_elsewhere(
+    client, db, agent_role
+):
+    """Re-picking the base role while leaving the scope ticked must not narrow
+    someone who is already on the derived role."""
+    create_user(client, agent_role.id, see_all_ai_chats=True, see_all_org_chats=True)
+    user = db.query(User).filter(User.email == NEW_USER["email"]).first()
+    derived_id = role_of(db, NEW_USER["email"]).id
+    assert derived_id != agent_role.id
+
+    response = client.put(
+        f"{settings.API_V1_STR}/users/{user.id}",
+        json={
+            "role_id": agent_role.id,
+            "see_all_ai_chats": True,
+            "see_all_org_chats": True,
+        },
+    )
+    assert response.status_code == 200
+
+    db.expire_all()
+    assert role_of(db, NEW_USER["email"]).id == derived_id
+
+
+def test_editing_without_the_toggles_keeps_the_role(client, db, agent_role):
+    create_user(client, agent_role.id)
+    user = db.query(User).filter(User.email == NEW_USER["email"]).first()
+
+    response = client.put(
+        f"{settings.API_V1_STR}/users/{user.id}", json={"full_name": "Renamed"}
+    )
+    assert response.status_code == 200
+    db.expire_all()
+    assert role_of(db, NEW_USER["email"]).id == agent_role.id
+
+
+def test_a_foreign_orgs_role_is_still_refused(client, db, permissions):
+    """The toggles must not become a way around the tenant check."""
+    other_org = Organization(id=uuid4(), name="Other", domain="other.test")
+    db.add(other_org)
+    db.commit()
+    foreign = Role(name="Agent", organization_id=other_org.id)
+    foreign.permissions = [permissions["view_assigned_chats"]]
+    db.add(foreign)
+    db.commit()
+
+    response = create_user(client, foreign.id, see_all_org_chats=True)
+    assert response.status_code == 404

--- a/backend/tests/api/test_organizations.py
+++ b/backend/tests/api/test_organizations.py
@@ -21,7 +21,11 @@ from fastapi import FastAPI
 from app.models.user import User
 from app.models.organization import Organization
 from app.models.role import Role
-from app.models.permission import Permission, role_permissions
+from app.models.permission import (
+    Permission,
+    role_permissions,
+    DEFAULT_AGENT_ROLE_PERMISSIONS,
+)
 from uuid import UUID, uuid4
 from datetime import datetime, timezone
 from app.api import organizations as organizations_router
@@ -242,6 +246,25 @@ def test_create_organization(client, db, monkeypatch):
     # Verify the role in database
     db_role = db.query(Role).filter(Role.id == role["id"]).first()
     assert db_role is not None
+
+    # The seeded roles, pinned. The hosted seeder drifted from this one for a
+    # year — two permissions instead of four, and both roles is_default — and
+    # nothing here failed, because the only claim made was the Admin name.
+    # Every assertion below is one that drift broke.
+    roles = db.query(Role).filter(Role.organization_id == UUID(data["id"])).all()
+    by_name = {r.name: r for r in roles}
+    assert set(by_name) == {"Admin", "Agent"}
+
+    # Exactly one default: get_default_role() takes .first() with no ordering,
+    # so a second one means an invited user can land on Admin.
+    assert [r.name for r in roles if r.is_default] == ["Agent"]
+
+    assert {p.name for p in by_name["Agent"].permissions} == set(
+        DEFAULT_AGENT_ROLE_PERMISSIONS
+    )
+    assert {p.name for p in by_name["Admin"].permissions} == {
+        name for name, _ in Permission.default_permissions()
+    }
 
 
 def test_get_organization(client, test_organization):

--- a/frontend/src/__tests__/components/UserForm.chatScope.spec.ts
+++ b/frontend/src/__tests__/components/UserForm.chatScope.spec.ts
@@ -111,6 +111,23 @@ describe('UserForm – chat scope toggles', () => {
     })
   })
 
+  it('unticks both for a role that grants nothing', async () => {
+    const EMPTY_ROLE = { id: '13', name: 'Empty', permissions: [] } as unknown as Role
+    listRoles.mockResolvedValue([AGENT_ROLE, EMPTY_ROLE])
+
+    const wrapper = await mountForm()
+    await wrapper.find('#role').setValue('10')
+    await flushPromises()
+    expect((scopeBoxes(wrapper)[0].element as HTMLInputElement).checked).toBe(true)
+
+    await wrapper.find('#role').setValue('13')
+    await flushPromises()
+
+    const [aiChats, orgChats] = scopeBoxes(wrapper)
+    expect((aiChats.element as HTMLInputElement).checked).toBe(false)
+    expect((orgChats.element as HTMLInputElement).checked).toBe(false)
+  })
+
   it('hides the toggles for a super_admin role, where they grant nothing', async () => {
     const wrapper = await mountForm()
     await wrapper.find('#role').setValue('12')

--- a/frontend/src/__tests__/components/UserForm.chatScope.spec.ts
+++ b/frontend/src/__tests__/components/UserForm.chatScope.spec.ts
@@ -1,0 +1,135 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import type { Role, User } from '@/types/user'
+
+const listRoles = vi.fn()
+
+vi.mock('@/services/roles', () => ({
+  listRoles: () => listRoles(),
+}))
+
+vi.mock('vue-sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const UserForm = (await import('@/components/human-agent/UserForm.vue')).default
+
+const permission = (name: string) => ({ id: 1, name, description: name })
+
+const AGENT_ROLE = {
+  id: '10',
+  name: 'Agent',
+  permissions: [
+    'view_assigned_chats',
+    'manage_assigned_chats',
+    'view_unassigned_chats',
+    'view_people',
+  ].map(permission),
+} as unknown as Role
+
+const ASSIGNED_ONLY_ROLE = {
+  id: '11',
+  name: 'Assigned only',
+  permissions: ['view_assigned_chats', 'manage_assigned_chats'].map(permission),
+} as unknown as Role
+
+const OWNER_ROLE = {
+  id: '12',
+  name: 'Owner',
+  permissions: [permission('super_admin')],
+} as unknown as Role
+
+const mountForm = async (user?: User | null) => {
+  const wrapper = mount(UserForm, { props: { user } })
+  await flushPromises()
+  return wrapper
+}
+
+const scopeBoxes = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('input[type="checkbox"]').slice(0, 2)
+
+describe('UserForm – chat scope toggles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    listRoles.mockResolvedValue([AGENT_ROLE, ASSIGNED_ONLY_ROLE, OWNER_ROLE])
+  })
+
+  it('reflects the selected role rather than a fixed default', async () => {
+    const wrapper = await mountForm()
+    await wrapper.find('#role').setValue('10')
+    await flushPromises()
+
+    const [aiChats, orgChats] = scopeBoxes(wrapper)
+    // The seeded Agent role grants the AI queue and nothing org-wide, which is
+    // the product default: ticked, and unticked.
+    expect((aiChats.element as HTMLInputElement).checked).toBe(true)
+    expect((orgChats.element as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('unticks the AI queue for a role that does not grant it', async () => {
+    const wrapper = await mountForm()
+    await wrapper.find('#role').setValue('11')
+    await flushPromises()
+
+    expect((scopeBoxes(wrapper)[0].element as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('submits the scope alongside the role', async () => {
+    const wrapper = await mountForm()
+    await wrapper.find('#role').setValue('10')
+    await flushPromises()
+    await scopeBoxes(wrapper)[1].setValue(true)
+
+    await wrapper.find('#fullName').setValue('New Agent')
+    await wrapper.find('#email').setValue('new@test.com')
+    await wrapper.find('#password').setValue('Str0ng!Passw0rd')
+    await wrapper.find('#password').trigger('input')
+    await wrapper.find('#confirmPassword').setValue('Str0ng!Passw0rd')
+    await wrapper.find('form').trigger('submit')
+
+    const [[payload]] = wrapper.emitted('submit') as [Record<string, unknown>][]
+    expect(payload).toMatchObject({
+      role_id: 10,
+      see_all_ai_chats: true,
+      see_all_org_chats: true,
+    })
+  })
+
+  it('hides the toggles for a super_admin role, where they grant nothing', async () => {
+    const wrapper = await mountForm()
+    await wrapper.find('#role').setValue('12')
+    await flushPromises()
+
+    // Only the "Active User" box is left.
+    expect(wrapper.findAll('input[type="checkbox"]')).toHaveLength(1)
+  })
+
+  it('opens an existing agent on the scope their role already grants', async () => {
+    const wrapper = await mountForm({
+      id: 'u1',
+      full_name: 'Existing',
+      email: 'existing@test.com',
+      role: ASSIGNED_ONLY_ROLE,
+    } as unknown as User)
+
+    const [aiChats, orgChats] = scopeBoxes(wrapper)
+    expect((aiChats.element as HTMLInputElement).checked).toBe(false)
+    expect((orgChats.element as HTMLInputElement).checked).toBe(false)
+  })
+})

--- a/frontend/src/components/human-agent/UserForm.vue
+++ b/frontend/src/components/human-agent/UserForm.vue
@@ -15,8 +15,8 @@ limitations under the License.
 -->
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import type { Role, User } from '@/types/user'
+import { computed, ref, onMounted, watch } from 'vue'
+import type { ChatScopeFields, Role, User } from '@/types/user'
 import { meetsPasswordPolicy, validatePassword, type PasswordStrength } from '@/utils/validators'
 import { listRoles } from '@/services/roles'
 import PasswordStrengthMeter from '@/components/common/PasswordStrengthMeter.vue'
@@ -27,7 +27,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  submit: [userData: Partial<User> & { password?: string, role_id?: number }]
+  submit: [userData: Partial<User> & ChatScopeFields & { password?: string, role_id?: number }]
   cancel: []
 }>()
 
@@ -42,6 +42,32 @@ const error = ref('')
 const roles = ref<Role[]>([])
 const selectedRole = ref(props.user?.role?.id || '')
 const loadingRoles = ref(false)
+
+// Chat scope. A new agent starts able to pick up whatever the AI is still
+// handling, and unable to read colleagues' conversations — tick the second one
+// to let someone cover a teammate's inbox. Once roles load these re-derive from
+// whichever role is selected, so they always show what that role actually does.
+const seeAllAiChats = ref(true)
+const seeAllOrgChats = ref(false)
+
+const permissionsOfSelectedRole = computed(
+  () => roles.value.find(role => String(role.id) === String(selectedRole.value))
+    ?.permissions?.map(permission => permission.name) ?? []
+)
+
+// super_admin passes every check, so the toggles would be decorative.
+const scopeApplies = computed(
+  () => !permissionsOfSelectedRole.value.includes('super_admin')
+)
+
+const syncScopeFromRole = () => {
+  const permissions = permissionsOfSelectedRole.value
+  if (!permissions.length) return
+  seeAllAiChats.value = permissions.includes('view_unassigned_chats')
+  seeAllOrgChats.value = permissions.includes('view_all_chats')
+}
+
+watch(selectedRole, syncScopeFromRole)
 
 const passwordStrength = ref<PasswordStrength>({
   score: 0,
@@ -72,6 +98,7 @@ const fetchRoles = async () => {
   try {
     loadingRoles.value = true
     roles.value = await listRoles()
+    syncScopeFromRole()
   } catch (err) {
     console.error('Error loading roles:', err)
     toast.error('Error', {
@@ -110,6 +137,10 @@ const handleSubmit = () => {
     email: email.value,
     is_active: isActive.value,
     role_id: Number(selectedRole.value),
+    ...(scopeApplies.value && {
+      see_all_ai_chats: seeAllAiChats.value,
+      see_all_org_chats: seeAllOrgChats.value
+    }),
     ...(showPasswordFields.value && { password: password.value })
   }
 
@@ -164,6 +195,24 @@ const handleSubmit = () => {
         </option>
       </select>
       <span v-if="loadingRoles" class="loading-text">Loading roles...</span>
+    </div>
+
+    <div v-if="scopeApplies" class="form-group">
+      <label>Which chats can they see?</label>
+      <label class="checkbox-label">
+        <input type="checkbox" v-model="seeAllAiChats" />
+        <span>
+          All AI chats
+          <small>Conversations the AI is handling that nobody has picked up.</small>
+        </span>
+      </label>
+      <label class="checkbox-label">
+        <input type="checkbox" v-model="seeAllOrgChats" />
+        <span>
+          All chats in the organization
+          <small>Including other people's conversations — useful for covering leave.</small>
+        </span>
+      </label>
     </div>
 
     <template v-if="showPasswordFields">
@@ -246,10 +295,22 @@ const handleSubmit = () => {
 
 .checkbox-label {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: var(--space-sm);
   font-size: var(--text-sm);
   color: var(--text);
+}
+
+.checkbox-label input[type="checkbox"] {
+  margin-top: 2px;
+  flex-shrink: 0;
+}
+
+.checkbox-label small {
+  display: block;
+  color: var(--text3);
+  font-size: var(--text-xs);
+  margin-top: 2px;
 }
 
 .form-actions {

--- a/frontend/src/components/human-agent/UserForm.vue
+++ b/frontend/src/components/human-agent/UserForm.vue
@@ -19,6 +19,7 @@ import { computed, ref, onMounted, watch } from 'vue'
 import type { ChatScopeFields, Role, User } from '@/types/user'
 import { meetsPasswordPolicy, validatePassword, type PasswordStrength } from '@/utils/validators'
 import { listRoles } from '@/services/roles'
+import { AI_QUEUE_PERMISSION, ALL_CHATS_PERMISSION } from '@/utils/permissionGroups'
 import PasswordStrengthMeter from '@/components/common/PasswordStrengthMeter.vue'
 import { toast } from 'vue-sonner'
 
@@ -50,9 +51,12 @@ const loadingRoles = ref(false)
 const seeAllAiChats = ref(true)
 const seeAllOrgChats = ref(false)
 
-const permissionsOfSelectedRole = computed(
+const selectedRoleObject = computed(
   () => roles.value.find(role => String(role.id) === String(selectedRole.value))
-    ?.permissions?.map(permission => permission.name) ?? []
+)
+
+const permissionsOfSelectedRole = computed(
+  () => selectedRoleObject.value?.permissions?.map(permission => permission.name) ?? []
 )
 
 // super_admin passes every check, so the toggles would be decorative.
@@ -61,10 +65,13 @@ const scopeApplies = computed(
 )
 
 const syncScopeFromRole = () => {
+  // Only bail when the role itself is missing — still loading, or nothing
+  // picked yet. A role that exists and grants nothing should untick both,
+  // which testing for an empty permission list would get wrong.
+  if (!selectedRoleObject.value) return
   const permissions = permissionsOfSelectedRole.value
-  if (!permissions.length) return
-  seeAllAiChats.value = permissions.includes('view_unassigned_chats')
-  seeAllOrgChats.value = permissions.includes('view_all_chats')
+  seeAllAiChats.value = permissions.includes(AI_QUEUE_PERMISSION)
+  seeAllOrgChats.value = permissions.includes(ALL_CHATS_PERMISSION)
 }
 
 watch(selectedRole, syncScopeFromRole)

--- a/frontend/src/components/human-agent/UserList.vue
+++ b/frontend/src/components/human-agent/UserList.vue
@@ -191,13 +191,31 @@ const loadOverview = async () => {
 
 // Rows always reflect the current users list (so create/delete stays in sync),
 // merged with overview stats by id when available.
+//
+// Anything an edit can change has to be read from the users list, which the
+// update handler replaces — the overview payload is fetched once and never
+// refetched, so taking the role from it left the cell showing the old role
+// until a page reload. That matters more now the chat-scope toggles can move
+// someone to a different role without the role dropdown being touched.
 const rows = computed<AgentRow[]>(() => {
   if (usingOverview.value) {
     const userById = new Map(users.value.map((u) => [u.id, u]))
     return overviewRows.value
       // keep only agents that still exist in the CRUD list (handles deletes)
       .filter((r) => userById.has(r.id) || users.value.length === 0)
-      .map((r) => r)
+      .map((r) => {
+        const user = userById.get(r.id)
+        if (!user) return r
+        const role = user.role?.name ?? r.role
+        return {
+          ...r,
+          full_name: user.full_name ?? r.full_name,
+          email: user.email ?? r.email,
+          is_active: user.is_active ?? r.is_active,
+          role,
+          is_admin: !!role && /admin/i.test(role),
+        }
+      })
   }
   return mapUsersToRows(users.value)
 })

--- a/frontend/src/composables/useUsers.ts
+++ b/frontend/src/composables/useUsers.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { ref } from 'vue'
-import type { User } from '@/types/user'
+import type { ChatScopeFields, User } from '@/types/user'
 import { listUsers, createUser, updateUser, deleteUser, resetUserPassword } from '@/services/users'
 import { toast } from 'vue-sonner'
 
@@ -47,7 +47,7 @@ export function useUsers() {
     showEditModal.value = true
   }
 
-  const handleUpdateUser = async (userData: Partial<User>) => {
+  const handleUpdateUser = async (userData: Partial<User> & ChatScopeFields) => {
     if (!selectedUser.value) return
 
     try {
@@ -155,7 +155,7 @@ export function useUsers() {
     }
   }
 
-  const handleCreateUser = async (userData: Partial<User> & { password?: string }) => {
+  const handleCreateUser = async (userData: Partial<User> & ChatScopeFields & { password?: string }) => {
     try {
       loading.value = true
       error.value = null

--- a/frontend/src/services/users.ts
+++ b/frontend/src/services/users.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import api from './api'
-import type { User } from '@/types/user'
+import type { ChatScopeFields, User } from '@/types/user'
 
 export interface TeamAgentStats {
   id: string
@@ -94,12 +94,12 @@ export async function getUser(id: string): Promise<User> {
   return response.data
 }
 
-export async function createUser(userData: Partial<User>): Promise<User> {
+export async function createUser(userData: Partial<User> & ChatScopeFields): Promise<User> {
   const response = await api.post('users', userData)
   return response.data
 }
 
-export async function updateUser(id: string, userData: Partial<User>): Promise<User> {
+export async function updateUser(id: string, userData: Partial<User> & ChatScopeFields): Promise<User> {
   const response = await api.put(`users/${id}`, userData)
   return response.data
 }

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -23,7 +23,20 @@ export interface Role {
   permissions?: Permission[]
   created_at?: string
   updated_at?: string
-  is_default?: boolean 
+  is_default?: boolean
+}
+
+/**
+ * The two chat-scope toggles on the user form.
+ *
+ * Not properties of a user — permissions live on roles. These describe the
+ * chat scope a person should have and the API resolves them to a role,
+ * reusing an existing one where it can. Omitted means "whatever the chosen
+ * role already grants".
+ */
+export interface ChatScopeFields {
+  see_all_ai_chats?: boolean
+  see_all_org_chats?: boolean
 }
 
 export interface UserGroup {

--- a/frontend/src/utils/permissionGroups.ts
+++ b/frontend/src/utils/permissionGroups.ts
@@ -25,11 +25,19 @@ limitations under the License.
  * unit tests never see it, because they mock services/user and break the loop.
  */
 
+/**
+ * The two the user form's chat-scope toggles map to. Named individually
+ * because the form reads and writes them one at a time; they mirror
+ * AI_QUEUE_PERMISSION / ALL_CHATS_PERMISSION in services/chat_scope_roles.py.
+ */
+export const AI_QUEUE_PERMISSION = 'view_unassigned_chats'
+export const ALL_CHATS_PERMISSION = 'view_all_chats'
+
 /** Seeing conversations — CHAT_VIEW_PERMISSIONS. */
 export const CHAT_VIEW_PERMISSIONS = [
-  'view_all_chats',
+  ALL_CHATS_PERMISSION,
   'view_assigned_chats',
-  'view_unassigned_chats',
+  AI_QUEUE_PERMISSION,
 ]
 
 /** Acting on one: takeover, reassign, outbound — CHAT_MANAGE_PERMISSIONS. */


### PR DESCRIPTION
Two related things: the starter Agent role was seeded wrong in hosted orgs, and there was no way to say what a new teammate should be able to see without going to the Roles screen first.

Enterprise half: chattermate/enterprise_backend#32.

### The seed

Two signup paths create an org's starter roles and they disagreed. Community grants Agent four permissions; hosted granted two, so its agents could not see the unclaimed AI queue or open People. Hosted also marked Admin *and* Agent `is_default`, and `get_default_role()` takes `.first()` with no ordering — an invited user could land on Admin. Both seeders now share `DEFAULT_AGENT_ROLE_PERMISSIONS`.

The migration repairs existing orgs without undoing anyone's edits. It matches the bad seed exactly — a role qualifies only if its permission set is precisely `{view_assigned_chats, manage_assigned_chats}` — so a role an admin deliberately narrowed keeps its narrowing. A capability backfill like `b7c4e91a2d38` would have reversed that, and that migration's own docstring promised it wouldn't. It also does not promote a role to `is_default` where an org has none: `roles.py` refuses to edit or delete a default role, so that would make it permanently uneditable. `downgrade()` is a documented no-op.

Run against a copy of production: 25 Agent roles repaired, 25 orgs brought down to one default, none left without one, no duplicate grants after applying it twice. Community installs match nothing by construction.

### Chat scope on the user form

Two checkboxes next to the role dropdown — "all AI chats", ticked, and "all chats in the organization", not ticked. The second is for covering a colleague on leave.

Permissions live on roles, not people, so the toggles resolve to a role rather than becoming a second source of truth every permission check would have to learn about. An existing role with exactly the right permissions is reused; one is created only when none matches, named after the base role and never made the org default. The role the rest of the team is on is never widened. The boxes reflect whatever the selected role already grants, and are hidden for a `super_admin` role where they would grant nothing.

An admin still cannot hand out a permission they do not hold. That guard moved from the roles router into `core/auth` so both doors use it.

One fix fell out of testing this: the Human Agents table renders the team-overview payload, which is fetched once, so its role string survived an edit that changed the role and the cell showed the old one until a reload. Pre-existing, but easy to hit now that an edit can change someone's role without the dropdown being touched.

Both fields are optional and default to "leave the role alone", so an API client that predates them behaves exactly as before.

### Tests

12 for the scope resolution, 6 for the form, and the seeded role state is now pinned in `test_organizations.py` — it previously asserted only the Admin role's name, which is why the hosted divergence went unnoticed.

Backend: no new failures against `main` (39 pre-existing in a hosted checkout, unchanged). Frontend: 394 passed, type-check clean.
