### PR TITLE
Stop the profile picture expiring mid-session

### DIFF
--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from fastapi import APIRouter, Depends, HTTPException, status, Response, Request, Body, File, UploadFile
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.security import HTTPBearer, OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 from typing import List, Optional
@@ -37,7 +37,7 @@ from app.repositories.user import UserRepository
 from pydantic import BaseModel
 from app.models.role import Role
 from app.services.chat_scope_roles import resolve_role
-from app.core.s3 import get_s3_signed_url, upload_file_to_s3, delete_file_from_s3
+from app.core.s3 import get_s3_signed_url, sign_s3_url, upload_file_to_s3, delete_file_from_s3
 from app.core.config import settings
 from app.repositories.shopify_shop_repository import ShopifyShopRepository
 from app.models.schemas.shopify.shopify_shop import ShopifyShopUpdate
@@ -398,6 +398,41 @@ async def list_teammates(
     """
     users = UserRepository(db).get_users_by_organization(current_user.organization_id)
     return [user for user in users if user.is_active]
+
+
+@router.get("/me/avatar")
+async def get_my_avatar(current_user: User = Depends(get_current_user)):
+    """Redirect to the caller's profile picture, signed at request time.
+
+    The dashboard used to render the URL held in the cached `user_info` blob.
+    That blob is written at login and never rewritten, but the URL inside it is
+    an S3 presigned link good for S3_PRESIGN_EXPIRY_SECONDS — an hour by
+    default. Every session outlasted its own avatar, and the only way to get a
+    working one back was to log out and in again.
+
+    A stable path fixes that for good: the browser asks us, and whatever it
+    gets handed is freshly signed. no-store because the *redirect* must not be
+    cached — the object it points at still can be.
+
+    Declared above GET /{user_id}, or "me" parses as a user id.
+    """
+    if not current_user.profile_pic:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No profile picture")
+
+    location = sign_s3_url(current_user.profile_pic)
+    if not location.startswith(("http://", "https://")):
+        # Local storage. save_upload_file stores "/uploads/user/...", but the
+        # static mount lives under the API prefix, so the bare path 404s.
+        path = location.lstrip("/")
+        if path.startswith("uploads/"):
+            path = f"{settings.API_V1_STR.strip('/')}/{path}"
+        location = f"/{path}"
+
+    return RedirectResponse(
+        url=location,
+        status_code=status.HTTP_307_TEMPORARY_REDIRECT,
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 @router.get("/{user_id}", response_model=UserResponse)

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -793,3 +793,40 @@ def test_teammates_route_is_not_shadowed_by_the_user_id_route(inbox_agent_client
 
     assert response.status_code == 200
     assert isinstance(response.json(), list)
+
+
+def test_avatar_redirects_to_a_freshly_signed_url(client: TestClient, test_user: User, db: Session):
+    """The point of the endpoint: a URL signed now, not at login.
+
+    The dashboard used to render the link held in the cached user_info blob,
+    which is written once at login. S3 presigned URLs expire an hour later, so
+    every session outlived its own avatar and only a re-login fixed it.
+    """
+    test_user.profile_pic = "/uploads/user/org/user/profile.png"
+    db.commit()
+
+    response = client.get("/api/v1/users/me/avatar", follow_redirects=False)
+
+    assert response.status_code == 307
+    # Local storage is served under the API prefix; the bare stored path 404s.
+    assert response.headers["location"] == "/api/v1/uploads/user/org/user/profile.png"
+    # The redirect must not be cached, or the browser keeps replaying a
+    # signature that has since expired — the bug all over again.
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_avatar_is_404_without_a_picture(client: TestClient, test_user: User, db: Session):
+    test_user.profile_pic = None
+    db.commit()
+
+    assert client.get("/api/v1/users/me/avatar").status_code == 404
+
+
+def test_avatar_route_is_not_shadowed_by_the_user_id_route(client: TestClient, test_user: User, db: Session):
+    """Declared above GET /{user_id}, or "me" parses as a user id."""
+    test_user.profile_pic = "/uploads/user/org/user/profile.png"
+    db.commit()
+
+    response = client.get("/api/v1/users/me/avatar", follow_redirects=False)
+
+    assert response.status_code == 307

--- a/frontend/src/components/user/UserSettings.vue
+++ b/frontend/src/components/user/UserSettings.vue
@@ -23,7 +23,7 @@ import PasswordStrengthMeter from '@/components/common/PasswordStrengthMeter.vue
 import userAvatar from '@/assets/user.svg'
 import type { User } from '@/types/user'
 import { isAbsoluteUrl } from '@/utils/avatars'
-import { resolveUploadUrl } from '@/config/api'
+import { myAvatarUrl } from '@/config/api'
 import { useNotificationSettings } from '@/composables/useNotificationSettings'
 import { useNotifications } from '@/composables/useNotifications'
 import type { NotificationSettings } from '@/services/notification'
@@ -120,17 +120,10 @@ const discardChanges = () => {
 
 const userAvatarSrc = computed(() => {
   if (profilePicPreview.value) return profilePicPreview.value
-  if (user.value?.profile_pic) {
-    // Absolute S3/CDN URL — use it directly
-    if (isAbsoluteUrl(user.value.profile_pic)) {
-      return user.value.profile_pic
-    }
-    // Local storage: resolve against the runtime API origin, cache-busted so a
-    // freshly uploaded picture replaces the one the browser already cached.
-    const timestamp = new Date().getTime()
-    return `${resolveUploadUrl(user.value.profile_pic)}?t=${timestamp}`
-  }
-  return userAvatar
+  if (!user.value?.profile_pic) return userAvatar
+  // Same reasoning as the header avatar: the stored URL was signed at login and
+  // expires within the hour, so ask the API to sign a fresh one instead.
+  return myAvatarUrl(new Date().getTime())
 })
 
 onMounted(async () => {

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -41,6 +41,23 @@ export function resolveUploadUrl(stored?: string | null): string {
   return buildUploadUrl(stored, getApiUrl())
 }
 
+/**
+ * The logged-in user's own avatar, signed when the browser asks for it.
+ *
+ * Not resolveUploadUrl(user.profile_pic): for S3 storage that value is a
+ * presigned URL, and the copy the dashboard holds comes from the `user_info`
+ * blob written at login and never rewritten. The signature dies an hour later
+ * and the avatar stays broken until the next login. This path re-signs per
+ * request, so it cannot go stale.
+ *
+ * Other people's avatars need no equivalent — those arrive on API responses,
+ * which sign afresh every time.
+ */
+export function myAvatarUrl(cacheBuster?: string | number): string {
+  const base = `${getApiUrl().replace(/\/$/, '')}/users/me/avatar`
+  return cacheBuster ? `${base}?t=${cacheBuster}` : base
+}
+
 export function getWidgetUrl(): string {
   return window.APP_CONFIG?.WIDGET_URL || import.meta.env.VITE_WIDGET_URL || 'http://localhost:8000'
 }

--- a/frontend/src/layouts/DashboardLayout.vue
+++ b/frontend/src/layouts/DashboardLayout.vue
@@ -34,8 +34,7 @@ import { notificationService } from '@/services/notification'
 import { useRoute, useRouter } from 'vue-router'
 import { updateUserStatus } from '@/services/users'
 import { useEnterpriseFeatures } from '@/composables/useEnterpriseFeatures'
-import { isAbsoluteUrl } from '@/utils/avatars'
-import { resolveUploadUrl } from '@/config/api'
+import { myAvatarUrl } from '@/config/api'
 import { useBreakpoint } from '@/composables/useBreakpoint'
 
 const props = defineProps<{
@@ -92,17 +91,11 @@ const isInTrial = computed(() => subscriptionStore.value.isInTrial)
 const trialDaysLeft = computed(() => subscriptionStore.value.trialDaysLeft)
 
 const userAvatarSrc = computed(() => {
-  if (currentUser.value?.profile_pic) {
-    // Absolute S3/CDN URL — use it directly
-    if (isAbsoluteUrl(currentUser.value.profile_pic)) {
-      return currentUser.value.profile_pic
-    }
-    // Local storage: resolve against the runtime API origin, cache-busted so a
-    // freshly uploaded picture replaces the one the browser already cached.
-    const timestamp = new Date().getTime()
-    return `${resolveUploadUrl(currentUser.value.profile_pic)}?t=${timestamp}`
-  }
-  return userAvatar
+  if (!currentUser.value?.profile_pic) return userAvatar
+  // Never the stored URL: the copy we hold was signed at login and expires an
+  // hour later. Ask the API, which signs on the spot. Cache-busted so a freshly
+  // uploaded picture replaces the one the browser already cached.
+  return myAvatarUrl(new Date().getTime())
 })
 
 const toggleOnlineStatus = async () => {


### PR DESCRIPTION
Stay logged in for an hour and your own avatar becomes a broken image. Logging out and back in fixes it until the next hour is up.

### Cause

The dashboard renders the URL held in the cached `user_info` blob. That blob is written at login and never rewritten — but on S3 storage the URL inside it is a presigned link, valid for `S3_PRESIGN_EXPIRY_SECONDS` (an hour by default). Every session outlives its own avatar.

The reported URL had `Expires=1785755735`, about an hour after that login.

### Fix

New `GET /users/me/avatar` redirects to a URL signed at request time; the header and User Settings avatars point at it. A stable path can't go stale, however long the tab stays open.

Other people's avatars need no equivalent — those arrive on API responses, which sign afresh every time. This is only a problem for the one URL we cache.

Two details worth knowing:

- The redirect is `no-store`. Cache it and the browser replays a signature that has since expired, which is the original bug.
- Local-storage installs redirect to the static mount under the API prefix. `save_upload_file` stores `/uploads/...` while the mount is at `/api/v1/uploads`, so the bare path 404s.

### Verified

Three tests for the redirect, the 404-without-a-picture case, and that the route isn't shadowed by `GET /{user_id}`.

In the browser: the `<img>` is cross-origin to the API, so the check that mattered was whether the session cookie rides along — it does, 307 → 200, avatar renders on both the header and User Settings.

### Not included

The takeover banner sends the agent's avatar to the widget from the same cached blob, so it has the same staleness. Fixing it means signing server-side in the socket handler, which currently has no user context — that's tangled up with the unauthenticated `taken_over` event and belongs in its own change.