### PR TITLE
fix(crm): resolve the CRM install URL at runtime

### DIFF
--- a/frontend/src/__tests__/services/installUrls.spec.ts
+++ b/frontend/src/__tests__/services/installUrls.spec.ts
@@ -1,0 +1,78 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+// The axios client drags in the router and the enterprise feature loader, and
+// none of that matters here: these helpers deliberately bypass it to build a
+// raw URL for window.location.href.
+vi.mock('@/services/api', () => ({ default: {} }))
+
+import crmService from '@/services/crm'
+import channelsService from '@/services/channels'
+
+type MutableWindow = { APP_CONFIG?: Record<string, string> }
+
+function setRuntimeApiUrl(url: string) {
+  ;(window as unknown as MutableWindow).APP_CONFIG = { API_URL: url }
+}
+
+/**
+ * Install URLs are browser navigations, not XHR, so they skip the axios client
+ * whose baseURL is already runtime-resolved. That makes them the one place a
+ * build-time import.meta.env.VITE_API_URL can creep back in — which sends a
+ * self-hoster to a host their session cookie was never scoped to, and the
+ * install dies on "Not authenticated". See issue #287.
+ */
+describe('OAuth install URLs', () => {
+  afterEach(() => {
+    delete (window as unknown as MutableWindow).APP_CONFIG
+  })
+
+  const builders: Array<[string, () => string]> = [
+    ['crm/hubspot', () => crmService.getInstallUrl('hubspot')],
+    ['crm/pipedrive', () => crmService.getInstallUrl('pipedrive')],
+    ['channels/slack', () => channelsService.getSlackInstallUrl()],
+  ]
+
+  it.each(builders)('%s builds on the runtime API URL', (_name, build) => {
+    setRuntimeApiUrl('https://self.hosted.example/api/v1')
+    expect(build()).toMatch(/^https:\/\/self\.hosted\.example\/api\/v1\//)
+  })
+
+  it.each(builders)('%s never emits an "undefined" segment', (_name, build) => {
+    // No APP_CONFIG and no baked VITE_API_URL: the published image's state.
+    expect(build()).not.toContain('undefined')
+  })
+
+  it.each(builders)('%s re-reads the runtime config on every call', (_name, build) => {
+    setRuntimeApiUrl('https://first.example/api/v1')
+    const first = build()
+    setRuntimeApiUrl('https://second.example/api/v1')
+    expect(build()).not.toBe(first)
+    expect(build()).toContain('second.example')
+  })
+
+  it('points at the endpoint the backend actually mounts', () => {
+    setRuntimeApiUrl('https://self.hosted.example/api/v1')
+    expect(crmService.getInstallUrl('pipedrive')).toBe(
+      'https://self.hosted.example/api/v1/crm/pipedrive/install',
+    )
+    expect(channelsService.getSlackInstallUrl()).toBe(
+      'https://self.hosted.example/api/v1/channels/slack/install',
+    )
+  })
+})

--- a/frontend/src/services/crm.ts
+++ b/frontend/src/services/crm.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import api from './api'
+import { getApiUrl } from '@/config/api'
 
 export type CrmProvider = 'hubspot' | 'pipedrive'
 
@@ -41,9 +42,13 @@ export default {
   },
 
   /** Browser-navigation URL — the install endpoint replies with a redirect
-   *  to the CRM's OAuth consent page. */
+   *  to the CRM's OAuth consent page.
+   *
+   *  Resolved at call time, like every other API URL: import.meta.env is baked
+   *  at build time, so a self-hoster's window.APP_CONFIG.API_URL never reaches
+   *  it and the browser leaves for the wrong host with no session cookie. */
   getInstallUrl(provider: CrmProvider): string {
-    return `${import.meta.env.VITE_API_URL}/crm/${provider}/install`
+    return `${getApiUrl()}/crm/${provider}/install`
   },
 
   async testConnection(provider: CrmProvider): Promise<CrmTestResult> {


### PR DESCRIPTION
Fixes #287.

**Connect** on Pipedrive/HubSpot built its URL from `import.meta.env.VITE_API_URL`, which is baked at build time and never sees a self-hoster's `window.APP_CONFIG`. The browser left for the wrong host with no session cookie and got `Not authenticated`. Slack's install URL and the axios client already used `getApiUrl()` — this was the one spot that missed it.

Note: our images don't pass `VITE_API_URL` as a build arg, so in a repo-built image it's `undefined`, not the SaaS URL the reporter saw. Same fix either way.

The spec covers both CRM providers and Slack, so the class is guarded rather than the single line. Reverting the fix fails 7 of 10.

Two follow-ups left out to keep this tight: `ShopifyAgentManagementView.vue` has the same bug for avatar URLs (enterprise submodule, currently on an in-progress branch), and an ESLint rule could ban `import.meta.env.VITE_API_URL` outside `config/api.ts`.