### PR TITLE
fix(frontend): normalise API URLs built by hand

### DIFF
--- a/frontend/src/__tests__/services/installUrls.spec.ts
+++ b/frontend/src/__tests__/services/installUrls.spec.ts
@@ -23,6 +23,8 @@ vi.mock('@/services/api', () => ({ default: {} }))
 
 import crmService from '@/services/crm'
 import channelsService from '@/services/channels'
+import { getJiraAuthUrl } from '@/services/jira'
+import { apiPath } from '@/config/api'
 
 type MutableWindow = { APP_CONFIG?: Record<string, string> }
 
@@ -43,6 +45,7 @@ describe('OAuth install URLs', () => {
   })
 
   const builders: Array<[string, () => string]> = [
+    ['jira/authorize', () => getJiraAuthUrl()],
     ['crm/hubspot', () => crmService.getInstallUrl('hubspot')],
     ['crm/pipedrive', () => crmService.getInstallUrl('pipedrive')],
     ['channels/slack', () => channelsService.getSlackInstallUrl()],
@@ -66,6 +69,12 @@ describe('OAuth install URLs', () => {
     expect(build()).toContain('second.example')
   })
 
+  it.each(builders)('%s survives an API_URL with a trailing slash', (_name, build) => {
+    // Starlette matches paths exactly, so a "//" from hand-concatenation 404s.
+    setRuntimeApiUrl('https://self.hosted.example/api/v1/')
+    expect(build()).not.toContain('/api/v1//')
+  })
+
   it('points at the endpoint the backend actually mounts', () => {
     setRuntimeApiUrl('https://self.hosted.example/api/v1')
     expect(crmService.getInstallUrl('pipedrive')).toBe(
@@ -74,5 +83,38 @@ describe('OAuth install URLs', () => {
     expect(channelsService.getSlackInstallUrl()).toBe(
       'https://self.hosted.example/api/v1/channels/slack/install',
     )
+    expect(getJiraAuthUrl()).toBe('https://self.hosted.example/api/v1/jira/authorize')
+  })
+})
+
+describe('apiPath', () => {
+  afterEach(() => {
+    delete (window as unknown as MutableWindow).APP_CONFIG
+  })
+
+  it('joins on exactly one slash however the two sides are punctuated', () => {
+    setRuntimeApiUrl('https://h.example/api/v1')
+    expect(apiPath('/x')).toBe('https://h.example/api/v1/x')
+    expect(apiPath('x')).toBe('https://h.example/api/v1/x')
+    setRuntimeApiUrl('https://h.example/api/v1/')
+    expect(apiPath('/x')).toBe('https://h.example/api/v1/x')
+    expect(apiPath('x')).toBe('https://h.example/api/v1/x')
+  })
+
+  it('collapses repeated slashes on either side', () => {
+    setRuntimeApiUrl('https://h.example/api/v1///')
+    expect(apiPath('///x')).toBe('https://h.example/api/v1/x')
+  })
+
+  it('leaves the query string alone', () => {
+    setRuntimeApiUrl('https://h.example/api/v1/')
+    expect(apiPath('/shopify/auth?shop=a.myshopify.com&x=1')).toBe(
+      'https://h.example/api/v1/shopify/auth?shop=a.myshopify.com&x=1',
+    )
+  })
+
+  it('does not mangle the scheme separator', () => {
+    setRuntimeApiUrl('https://h.example')
+    expect(apiPath('/x')).toBe('https://h.example/x')
   })
 })

--- a/frontend/src/composables/useConversationFiles.ts
+++ b/frontend/src/composables/useConversationFiles.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import { ref, type Ref } from 'vue'
 import type { ChatDetail } from '@/types/chat'
 import FileUpload from '@/components/common/FileUpload.vue'
-import { getApiUrl, resolveUploadUrl } from '@/config/api'
+import { apiPath, resolveUploadUrl } from '@/config/api'
 
 export function useConversationFiles(
   currentChat: Ref<ChatDetail>,
@@ -168,7 +168,7 @@ export function useConversationFiles(
     const cleanUrl = fileUrl.startsWith('/uploads/')
                      ? fileUrl.replace('/uploads/', '')
                      : fileUrl.replace('/', '')
-    return `${getApiUrl()}/files/download/${cleanUrl}`
+    return apiPath(`/files/download/${cleanUrl}`)
   }
 
   // Generate image URL for attachments. Blob previews and absolute S3 URLs pass

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -33,6 +33,19 @@ export function getWsUrl(): string {
 }
 
 /**
+ * An absolute API URL for `path`, for the places that need a real URL string
+ * rather than an axios call — browser navigations (OAuth installs), download
+ * links, webhook URLs we show the user.
+ *
+ * Use this instead of `${getApiUrl()}${path}` by hand. A self-hoster is free to
+ * set API_URL with a trailing slash, and hand-concatenation then emits
+ * `/api/v1//crm/...`; Starlette matches paths exactly, so that 404s.
+ */
+export function apiPath(path: string): string {
+  return `${getApiUrl().replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`
+}
+
+/**
  * URL for a stored upload path (avatar, attachment). Always use this instead of
  * concatenating getApiUrl() by hand — stored local paths already include the
  * /api/v1 prefix. See buildUploadUrl.
@@ -54,7 +67,7 @@ export function resolveUploadUrl(stored?: string | null): string {
  * which sign afresh every time.
  */
 export function myAvatarUrl(cacheBuster?: string | number): string {
-  const base = `${getApiUrl().replace(/\/$/, '')}/users/me/avatar`
+  const base = apiPath('/users/me/avatar')
   return cacheBuster ? `${base}?t=${cacheBuster}` : base
 }
 

--- a/frontend/src/services/channels.ts
+++ b/frontend/src/services/channels.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import api from './api'
-import { getApiUrl } from '@/config/api'
+import { apiPath } from '@/config/api'
 import type { SignupChannel } from '@/utils/metaSdk'
 
 // Types
@@ -322,7 +322,7 @@ const channelsService = {
 
   /** Browser URL that starts the Slack OAuth install (redirects to Slack) */
   getSlackInstallUrl(): string {
-    return `${getApiUrl()}/channels/slack/install`
+    return apiPath('/channels/slack/install')
   },
 
   async disconnectSlack(accountId: string): Promise<void> {

--- a/frontend/src/services/crm.ts
+++ b/frontend/src/services/crm.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import api from './api'
-import { getApiUrl } from '@/config/api'
+import { apiPath } from '@/config/api'
 
 export type CrmProvider = 'hubspot' | 'pipedrive'
 
@@ -48,7 +48,7 @@ export default {
    *  at build time, so a self-hoster's window.APP_CONFIG.API_URL never reaches
    *  it and the browser leaves for the wrong host with no session cookie. */
   getInstallUrl(provider: CrmProvider): string {
-    return `${getApiUrl()}/crm/${provider}/install`
+    return apiPath(`/crm/${provider}/install`)
   },
 
   async testConnection(provider: CrmProvider): Promise<CrmTestResult> {

--- a/frontend/src/services/jira.ts
+++ b/frontend/src/services/jira.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import api from './api'
-import { getApiUrl } from '@/config/api'
+import { apiPath } from '@/config/api'
 
 /**
  * Check if Jira is connected for the current organization
@@ -34,7 +34,7 @@ export const checkJiraConnection = async () => {
  * Get the Jira authorization URL
  */
 export const getJiraAuthUrl = () => {
-  return `${getApiUrl()}/jira/authorize`
+  return apiPath('/jira/authorize')
 }
 
 /**

--- a/frontend/src/services/shopify.ts
+++ b/frontend/src/services/shopify.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import api from './api'
-import { getApiUrl } from '@/config/api'
+import { apiPath } from '@/config/api'
 
 /**
  * Check if Shopify is connected for the current organization
@@ -58,9 +58,8 @@ export const connectToShopify = (shopDomain: string) => {
 
   // Redirect directly to the backend API for OAuth initiation
   // This bypasses the frontend router which requires authentication
-  // getApiUrl() returns the URL WITH /api/v1 already included
-  const apiUrl = getApiUrl()
-  window.location.href = `${apiUrl}/shopify/auth?shop=${encodeURIComponent(shopDomain)}`
+  // apiPath() builds on the runtime API URL, which already includes /api/v1
+  window.location.href = apiPath(`/shopify/auth?shop=${encodeURIComponent(shopDomain)}`)
 }
 
 /**

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -22,7 +22,7 @@ import { resolveLandingRoute } from '@/router/landing'
 import { useEnterpriseFeatures } from '@/composables/useEnterpriseFeatures'
 import { useForgotPassword } from '@/composables/useForgotPassword'
 import InstallPrompt from '@/components/pwa/InstallPrompt.vue'
-import { getApiUrl } from '@/config/api'
+import { apiPath, getApiUrl } from '@/config/api'
 import type { AxiosError } from 'axios'
 interface ErrorResponse {
     detail: string
@@ -177,7 +177,7 @@ const handleLogin = async () => {
                 }
                 
                 // Redirect to the backend Shopify auth endpoint
-                window.location.href = `${getApiUrl()}/shopify/auth?${queryParams.toString()}`
+                window.location.href = apiPath(`/shopify/auth?${queryParams.toString()}`)
                 return // Don't do the normal navigation
             } catch (e) {
                 console.error('Failed to parse shopifyRedirect data:', e)

--- a/frontend/src/views/settings/TicketingSettings.vue
+++ b/frontend/src/views/settings/TicketingSettings.vue
@@ -22,7 +22,7 @@ import { useTicketingSettings } from '@/composables/useTicketingSettings'
 import { PRIORITIES, priorityMeta } from '@/components/tickets/ticketMeta'
 import TicketConnectorsSection from '@/components/tickets/TicketConnectorsSection.vue'
 import TicketDbConnectorsSection from '@/components/tickets/TicketDbConnectorsSection.vue'
-import { getApiUrl } from '@/config/api'
+import { apiPath } from '@/config/api'
 import { userService } from '@/services/user'
 import type { SlaTarget, TicketPriority } from '@/types/ticket'
 
@@ -75,7 +75,7 @@ const webhookUrl = computed(() => {
   if (!settings.value?.alert_webhook_enabled || !settings.value?.alert_webhook_secret) return null
   const orgId = userService.getCurrentUser()?.organization_id
   if (!orgId) return null
-  return `${getApiUrl()}/tickets/webhooks/alerts/${orgId}/${settings.value.alert_webhook_secret}`
+  return apiPath(`/tickets/webhooks/alerts/${orgId}/${settings.value.alert_webhook_secret}`)
 })
 
 function copyWebhookUrl() {


### PR DESCRIPTION
Follow-up to #288.

Eight places built a URL as `${getApiUrl()}/path` — the cases that need a real URL string rather than an axios call: OAuth installs (CRM, Slack, Jira, Shopify), the conversation file download link, and the ticket alert webhook URL we show the user. A self-hoster is free to set `API_URL` with a trailing slash, and those all emit `/api/v1//crm/...`. Starlette matches paths exactly, so it 404s.

Adds `apiPath()` in `config/api.ts` and routes them through it. `myAvatarUrl` already stripped the trailing slash by hand and now shares the helper.

Left alone deliberately: LoginView's legacy `${getApiUrl()}${redirectPath}` branch has no separator on purpose, so normalising it would change behaviour rather than fix it.

No behaviour change for a normally-configured install — the tests pin the exact URLs. Suite green (371), typecheck and lint clean. (`LoginView.vue:254` has a pre-existing unused-var lint error, unrelated and also present on main.)