### PR TITLE
fix(uploads): store local upload paths under the static mount

### DIFF
--- a/backend/alembic/versions/normalise_upload_prefix_001.py
+++ b/backend/alembic/versions/normalise_upload_prefix_001.py
@@ -1,0 +1,79 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""prefix stored local upload paths with the static mount
+
+Revision ID: normalise_upload_prefix_001
+Revises: repair_agent_role_seed_001
+Create Date: 2026-08-08
+
+The app had two conventions for a stored local upload. store_upload wrote
+`/api/v1/uploads/...`, matching the static mount; agent photos and profile
+pictures wrote a bare `/uploads/...`. The frontend resolves stored paths
+against the API origin, so the bare ones came out as `https://host/uploads/...`
+and 404'd — every agent avatar and teammate avatar was broken on a self-hosted
+install using local file storage. (S3 deployments were unaffected: those store
+absolute URLs, which pass through untouched.)
+
+The writers now emit the prefix. This brings the existing rows over.
+
+Only values starting exactly with `/uploads/` are touched, so absolute S3 URLs,
+data URIs and already-prefixed rows are left alone and re-running is a no-op.
+
+`/api/v1` is written literally rather than read from settings.API_V1_STR: the
+static mount in main.py hardcodes it too, and a migration should not change
+shape with runtime config.
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'normalise_upload_prefix_001'
+down_revision = 'repair_agent_role_seed_001'
+branch_labels = None
+depends_on = None
+
+# (table, column) pairs that hold a stored upload path written by the
+# bare-/uploads/ writers.
+_COLUMNS = [
+    ('agent_customizations', 'photo_url'),
+    ('users', 'profile_pic'),
+]
+
+
+def upgrade() -> None:
+    for table, column in _COLUMNS:
+        op.execute(
+            f"""
+            UPDATE {table}
+               SET {column} = '/api/v1' || {column}
+             WHERE {column} LIKE '/uploads/%'
+            """
+        )
+
+
+def downgrade() -> None:
+    """Strips the prefix off every local path in these two columns, including
+    rows this migration did not create. That is deliberate: the reverted code
+    writes bare paths and reads them the same way, so the column should end up
+    wholly on the old convention rather than half on each."""
+    for table, column in _COLUMNS:
+        op.execute(
+            f"""
+            UPDATE {table}
+               SET {column} = substring({column} from length('/api/v1') + 1)
+             WHERE {column} LIKE '/api/v1/uploads/%'
+            """
+        )

--- a/backend/app/api/agent.py
+++ b/backend/app/api/agent.py
@@ -42,6 +42,7 @@ from PIL import Image
 from uuid import UUID
 from app.core.s3 import upload_file_to_s3
 from app.core.config import settings
+from app.services.file_storage import local_upload_path
 from pydantic import BaseModel
 from agno.agent import Agent as AgnoAgent
 from app.utils.agno_utils import create_model
@@ -131,7 +132,9 @@ async def save_file(file: UploadFile, organization_id: UUID) -> str:
             content = await file.read()
             await f.write(content)
 
-        return f"/{file_path}"
+        # The uploads/ directory is static-mounted at {API_V1_STR}/uploads,
+        # so the stored URL must carry that prefix (same shape as store_upload).
+        return f"{settings.API_V1_STR}/{file_path}"
 
 
 @router.post("", response_model=AgentWithCustomizationResponse, status_code=status.HTTP_201_CREATED)
@@ -527,7 +530,7 @@ async def upload_agent_photo(
                 from app.core.s3 import delete_file_from_s3
                 await delete_file_from_s3(db_customization.photo_url)
             else:
-                old_photo_path = db_customization.photo_url.lstrip('/')
+                old_photo_path = local_upload_path(db_customization.photo_url)
                 if os.path.exists(old_photo_path):
                     os.remove(old_photo_path)
 

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -39,6 +39,7 @@ from app.models.role import Role
 from app.services.chat_scope_roles import resolve_role
 from app.core.s3 import get_s3_signed_url, sign_s3_url, upload_file_to_s3, delete_file_from_s3
 from app.core.config import settings
+from app.services.file_storage import local_upload_path
 from app.repositories.shopify_shop_repository import ShopifyShopRepository
 from app.models.schemas.shopify.shopify_shop import ShopifyShopUpdate
 from app.core.cors import update_cors_middleware
@@ -115,7 +116,8 @@ async def save_upload_file(file: UploadFile, org_id: str, user_id: str) -> str:
             content = await file.read()
             buffer.write(content)
         
-        return f"/uploads/user/{org_id}/{user_id}/{filename}"
+        # Prefixed to match the {API_V1_STR}/uploads static mount, as store_upload does.
+        return f"{settings.API_V1_STR}/uploads/user/{org_id}/{user_id}/{filename}"
 
 @router.post("", response_model=UserResponse)
 async def create_user(
@@ -421,8 +423,10 @@ async def get_my_avatar(current_user: User = Depends(get_current_user)):
 
     location = sign_s3_url(current_user.profile_pic)
     if not location.startswith(("http://", "https://")):
-        # Local storage. save_upload_file stores "/uploads/user/...", but the
-        # static mount lives under the API prefix, so the bare path 404s.
+        # Local storage is served under the API prefix, which is what
+        # save_upload_file now stores. Rows written before that normalisation
+        # carry a bare "/uploads/..." and would 404, so prefix those too —
+        # same tolerance local_upload_path applies on the way back down.
         path = location.lstrip("/")
         if path.startswith("uploads/"):
             path = f"{settings.API_V1_STR.strip('/')}/{path}"
@@ -1106,7 +1110,7 @@ async def upload_profile_pic(
             if settings.S3_FILE_STORAGE:
                 await delete_file_from_s3(current_user.profile_pic)
             else:
-                old_photo_path = current_user.profile_pic.lstrip('/')
+                old_photo_path = local_upload_path(current_user.profile_pic)
                 if os.path.exists(old_photo_path):
                     os.remove(old_photo_path)
         
@@ -1154,7 +1158,7 @@ async def delete_profile_pic(
             if settings.S3_FILE_STORAGE:
                 await delete_file_from_s3(current_user.profile_pic)
             else:
-                old_photo_path = current_user.profile_pic.lstrip('/')
+                old_photo_path = local_upload_path(current_user.profile_pic)
                 if os.path.exists(old_photo_path):
                     os.remove(old_photo_path)
 

--- a/backend/app/services/file_storage.py
+++ b/backend/app/services/file_storage.py
@@ -44,16 +44,30 @@ async def store_upload(content: bytes, folder: str, file_name: str, content_type
     return f"{settings.API_V1_STR}/uploads/{folder}/{file_name}"
 
 
+def local_upload_path(stored: str) -> str:
+    """Filesystem path under `uploads/` for a stored local upload URL.
+
+    Tolerates every shape the app has ever written: the current
+    `{API_V1_STR}/uploads/...`, the legacy bare `/uploads/...` that
+    agent photos and profile pictures carried before they were normalised,
+    and a plain relative key with no prefix at all.
+    """
+    relative = stored.lstrip("/")
+    api_prefix = f"{settings.API_V1_STR.strip('/')}/"
+    if relative.startswith(api_prefix):
+        relative = relative[len(api_prefix):]
+    if relative.startswith("uploads/"):
+        relative = relative[len("uploads/"):]
+    return os.path.join("uploads", relative)
+
+
 async def load_upload(stored: str) -> bytes:
     """Read back a previously stored upload by the URL/path store_upload
     returned. Used by workers running in a different container than the API
     (shared local uploads mount or S3)."""
     if stored.startswith("http"):
         return await download_file_from_s3(stored)
-    # `{API_V1_STR}/uploads/...` → local `uploads/...`
-    marker = f"{settings.API_V1_STR}/uploads/"
-    relative = stored.split(marker, 1)[1] if marker in stored else stored.lstrip("/")
-    async with aiofiles.open(os.path.join("uploads", relative), "rb") as f:
+    async with aiofiles.open(local_upload_path(stored), "rb") as f:
         return await f.read()
 
 
@@ -63,9 +77,7 @@ async def delete_upload(stored: str) -> None:
         if stored.startswith("http"):
             await delete_file_from_s3(stored)
             return
-        marker = f"{settings.API_V1_STR}/uploads/"
-        relative = stored.split(marker, 1)[1] if marker in stored else stored.lstrip("/")
-        os.remove(os.path.join("uploads", relative))
+        os.remove(local_upload_path(stored))
     except Exception:
         pass
 

--- a/backend/tests/services/test_upload_paths.py
+++ b/backend/tests/services/test_upload_paths.py
@@ -1,0 +1,88 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import io
+import os
+from uuid import uuid4
+
+import pytest
+from fastapi import UploadFile
+from PIL import Image
+
+from app.api.agent import save_file
+from app.api.users import save_upload_file
+from app.core.config import settings
+from app.services.file_storage import local_upload_path, store_upload
+
+MOUNT = f"{settings.API_V1_STR}/uploads"
+
+
+def _png_upload(name: str = "a.png") -> UploadFile:
+    buf = io.BytesIO()
+    Image.new("RGB", (2, 2), "red").save(buf, format="PNG")
+    buf.seek(0)
+    return UploadFile(filename=name, file=buf, headers={"content-type": "image/png"})
+
+
+class TestLocalUploadPath:
+    """The stored-URL → filesystem-path direction has to read every shape the
+    app has written, because rows predating the normalisation are still bare."""
+
+    def test_current_prefixed_shape(self):
+        assert local_upload_path(f"{MOUNT}/agents/org/a.png") == os.path.join(
+            "uploads", "agents/org/a.png")
+
+    def test_legacy_bare_shape(self):
+        # What agent photos and profile pictures carried before the migration.
+        assert local_upload_path("/uploads/agents/org/a.png") == os.path.join(
+            "uploads", "agents/org/a.png")
+
+    def test_relative_key(self):
+        assert local_upload_path("agents/org/a.png") == os.path.join(
+            "uploads", "agents/org/a.png")
+
+    def test_never_doubles_the_uploads_segment(self):
+        for stored in (f"{MOUNT}/x.png", "/uploads/x.png", "uploads/x.png", "x.png"):
+            assert local_upload_path(stored) == os.path.join("uploads", "x.png"), stored
+
+
+class TestWritersAgree:
+    """Every local writer must emit the same prefix, or the frontend resolves
+    the path against the API origin and 404s off the static mount."""
+
+    @pytest.mark.asyncio
+    async def test_store_upload_prefixes(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(settings, "S3_FILE_STORAGE", False)
+        stored = await store_upload(b"x", "help_center", "a.png", "image/png")
+        assert stored.startswith(f"{MOUNT}/")
+
+    @pytest.mark.asyncio
+    async def test_agent_photo_prefixes_and_round_trips(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(settings, "S3_FILE_STORAGE", False)
+        stored = await save_file(_png_upload(), uuid4())
+        assert stored.startswith(f"{MOUNT}/")
+        # The delete path reads it back through local_upload_path.
+        assert os.path.exists(local_upload_path(stored))
+
+    @pytest.mark.asyncio
+    async def test_profile_pic_prefixes_and_round_trips(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(settings, "S3_FILE_STORAGE", False)
+        stored = await save_upload_file(_png_upload(), str(uuid4()), str(uuid4()))
+        assert stored.startswith(f"{MOUNT}/")
+        assert os.path.exists(local_upload_path(stored))


### PR DESCRIPTION
Follow-up to #292, where this turned up.

Two conventions existed for a stored local upload. `store_upload` wrote `/api/v1/uploads/...`, matching the mount in `main.py`; agent photos and profile pictures wrote a bare `/uploads/...`. The frontend resolves stored paths against the API origin, so the bare ones became `https://host/uploads/...` and 404'd — every agent and teammate avatar broken on a self-hosted install with local file storage. S3 deployments store absolute URLs and were fine, which is why nobody hit it; `/users/me/avatar` had already grown a one-off workaround for its own case.

Both writers now emit the prefix, plus a migration for existing rows. It only touches values starting exactly `/uploads/`, so S3 URLs, data URIs, NULLs and already-prefixed rows are left alone and re-running is a no-op — I verified that against Postgres, both directions.

The three delete paths rebuilt the filesystem path with `lstrip('/')`, which the new prefix would have broken (silently orphaning files). They now share `local_upload_path()`, which also replaces the duplicated marker-stripping in `load_upload`/`delete_upload` and tolerates the legacy shape.

Scope note: you asked for `save_file`, but `users.save_upload_file` had the identical defect and the same migration covers it, so fixing one and not the other seemed worse. Chat attachments also use a bare path — left alone, since they're served through a download endpoint that expects that shape, so nothing is broken there.

Backend suite: 1440 pass, 6 pre-existing `TestSSHKeyLoading` failures that also fail on main.