### PR TITLE
Match S3 URLs on the host, and lock CI workflow to read-only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches: [ main ]
 
+# Both jobs only check out code and run tests. Declaring this at the top level
+# makes every job's GITHUB_TOKEN read-only, so a compromised action or
+# dependency can't use it to write to the repo.
+permissions:
+  contents: read
+
 jobs:
   backend-test:
     name: Run Backend Tests

--- a/backend/app/core/s3.py
+++ b/backend/app/core/s3.py
@@ -18,6 +18,7 @@ limitations under the License.
 S3 Storage Utilities
 """
 import asyncio
+import re
 from functools import lru_cache, partial
 import boto3
 from app.core.config import settings
@@ -51,6 +52,29 @@ def strip_s3_signature(url: Optional[str]) -> Optional[str]:
     if not url or 'amazonaws.com' not in url:
         return url
     return urlunparse(urlparse(url)._replace(query='', fragment=''))
+
+
+# Matches an S3 endpoint in the HOST position, in every shape AWS serves: the
+# global endpoint, regional ones (dot or legacy dash), and the virtual-hosted
+# forms that put the bucket in front, including dotted bucket names. Anchored at
+# both ends so "evil.com/s3.amazonaws.com/x" and "s3.amazonaws.com.attacker.com"
+# do not match, and neither does "foos3.amazonaws.com".
+_S3_HOST_RE = re.compile(r"(^|\.)s3([.-][a-z0-9-]+)?\.amazonaws\.com$", re.IGNORECASE)
+
+
+def is_s3_url(url: Optional[str]) -> bool:
+    """True when this URL's HOST is an S3 endpoint.
+
+    Checks the parsed hostname, never a substring of the whole URL: any
+    attacker-supplied URL can carry "s3.amazonaws.com" in its path, and treating
+    that as one of ours is how a delete or a key extraction ends up pointed
+    somewhere it shouldn't be. A substring test is also INCOMPLETE — it misses
+    the regional virtual-hosted form url_for_s3_key actually produces
+    (bucket.s3.<region>.amazonaws.com), which contains no "s3.amazonaws.com".
+    """
+    if not url:
+        return False
+    return bool(_S3_HOST_RE.search(urlparse(url).hostname or ""))
 
 
 def url_for_s3_key(s3_key: str) -> str:

--- a/backend/app/knowledge/knowledge_base.py
+++ b/backend/app/knowledge/knowledge_base.py
@@ -25,7 +25,7 @@ from app.knowledge.enhanced_website_reader import EnhancedWebsiteReader
 from app.knowledge.sitemap_reader import SitemapReader
 from app.knowledge.enhanced_pdf_kb import EnhancedPDFKnowledgeBase
 from app.knowledge.enhanced_pdf_url_kb import EnhancedPDFUrlKnowledgeBase
-from app.core.s3 import delete_file_from_s3
+from app.core.s3 import delete_file_from_s3, is_s3_url
 from app.models.knowledge import Knowledge, SourceType
 from app.models.knowledge_to_agent import KnowledgeToAgent
 from app.models.knowledge_queue import ProcessingStage, QueueStatus
@@ -152,7 +152,7 @@ class KnowledgeManager:
                         parsed_url = urlparse(url)
                         
                         # Parse filename from URL, handling S3 URLs specially
-                        if "s3.amazonaws.com" in url:
+                        if is_s3_url(url):
                             # Extract the actual filename from S3 URL path
                             path_parts = parsed_url.path.split('/')
                             # Get the last part of the path and decode URL encoded characters
@@ -198,7 +198,7 @@ class KnowledgeManager:
                         await self.add_pdf_files([temp_path], filename=filename)
                         
                         # Delete the S3 URL from storage if it's an S3 URL
-                        if "s3.amazonaws.com" in url:
+                        if is_s3_url(url):
                             try:
                                 # Delete the file from S3 using the centralized utility function
                                 success = await delete_file_from_s3(url)

--- a/backend/tests/core/test_s3.py
+++ b/backend/tests/core/test_s3.py
@@ -25,6 +25,7 @@ from app.core.s3 import (
     delete_file_from_s3,
     get_s3_client,
     get_s3_signed_url,
+    is_s3_url,
     strip_s3_signature,
     upload_file_to_s3,
 )
@@ -300,4 +301,43 @@ async def test_delete_file_from_s3_exception():
         
         result = await delete_file_from_s3(test_s3_url)
         
-        assert result is False 
+        assert result is False
+
+# ---------- is_s3_url ----------
+
+@pytest.mark.parametrize("url", [
+    # Every shape AWS serves, including the regional virtual-hosted form
+    # url_for_s3_key produces and a dotted bucket name.
+    "https://s3.amazonaws.com/bucket/key.pdf",
+    "https://s3.us-east-1.amazonaws.com/bucket/key.pdf",
+    "https://s3-us-west-2.amazonaws.com/bucket/key.pdf",
+    "https://bucket.s3.amazonaws.com/key.pdf",
+    "https://bucket.s3.us-east-1.amazonaws.com/key.pdf",
+    "https://my.bucket.s3.us-east-1.amazonaws.com/key.pdf",
+    "https://BUCKET.S3.AMAZONAWS.COM/key.pdf",
+])
+def test_is_s3_url_accepts_every_s3_endpoint_shape(url):
+    assert is_s3_url(url) is True
+
+
+@pytest.mark.parametrize("url", [
+    None, "",
+    # The whole point: an attacker-supplied URL can carry the string anywhere
+    # outside the host, and a substring check would call these ours.
+    "https://evil.com/s3.amazonaws.com/key.pdf",
+    "https://evil.com/?x=s3.amazonaws.com",
+    "https://evil.com/#s3.amazonaws.com",
+    "https://s3.amazonaws.com.attacker.com/key.pdf",
+    "https://foos3.amazonaws.com/key.pdf",
+    "https://notamazonaws.com/key.pdf",
+    "https://example.com/file.pdf",
+])
+def test_is_s3_url_rejects_lookalikes(url):
+    assert is_s3_url(url) is False
+
+
+def test_is_s3_url_matches_what_url_for_s3_key_produces():
+    """Round-trip guard: whatever we generate must be recognised as ours."""
+    from app.core.s3 import url_for_s3_key
+
+    assert is_s3_url(url_for_s3_key("some/key.pdf")) is True


### PR DESCRIPTION
## Description

Two CodeQL findings, both small.

**`py/incomplete-url-substring-sanitization` (high) — `knowledge_base.py:155`, `:201`**

Both sites decided "is this an S3 URL?" with `"s3.amazonaws.com" in url`. Any attacker-supplied URL can carry that string in its path (`https://evil.com/s3.amazonaws.com/x`), and line 201 feeds the result straight to `delete_file_from_s3` — so a crafted knowledge-source URL could point a delete somewhere it shouldn't go.

The substring test was **also wrong in the other direction**: it never matches `bucket.s3.<region>.amazonaws.com`, which is the form `url_for_s3_key` actually produces for a normal bucket. So regional S3 objects were silently never cleaned up after knowledge processing — an orphaned-object leak.

Adds `is_s3_url()` to `core/s3.py`, alongside the existing URL-shape helpers, matching the parsed **hostname** against every endpoint form AWS serves (global, regional dot and legacy dash, virtual-hosted, dotted bucket names). Both call sites now use it. There's a round-trip test asserting whatever `url_for_s3_key` generates is recognised, so the two can't drift.

**`actions/missing-workflow-permissions` (medium) — `test.yml:11`, `:38`**

No `permissions:` declared, so both jobs got a default `GITHUB_TOKEN` wider than they need. They only check out code and run tests, so `contents: read` at the top level covers both.

## Type of change

- [x] Bug fix

## Checklist

- [x] All commits are signed off (DCO)
- [x] My contribution is licensed under Apache-2.0
- [x] Tests added/updated where relevant and the suite passes

## Testing

17 new `is_s3_url` cases covering every accepted endpoint shape and the lookalikes a substring check would wrongly accept (`evil.com/s3.amazonaws.com/…`, `s3.amazonaws.com.attacker.com`, `foos3.amazonaws.com`).

`NO_ENTERPRISE=1 pytest tests/core/test_s3.py tests/knowledge/` → 155 passed, 1 failed. That failure (`test_upload_file_to_s3_success`) is pre-existing on main — verified by stashing these changes and re-running. It asserts a virtual-hosted URL and fails whenever the local `S3_BUCKET` contains a dot, which forces path-style.