### PR TITLE
Ask for an email when nobody can pick the chat up

### DIFF
--- a/backend/app/agents/transfer_agent.py
+++ b/backend/app/agents/transfer_agent.py
@@ -37,6 +37,11 @@ logger = get_logger(__name__)
 # timeout costs only the phrasing — the handoff still goes ahead.
 TRANSFER_TIMEOUT_MESSAGE = "Let me connect you with someone from our team."
 FOLLOW_UP_TIMEOUT_MESSAGE = "Our team will get back to you shortly."
+# Same fallback, for when nobody is available AND we have no way to reach them —
+# it still has to ask, or the follow-up it promises can never happen.
+FOLLOW_UP_NEEDS_EMAIL_TIMEOUT_MESSAGE = (
+    "Our team will get back to you shortly. What's the best email address to reach you on?"
+)
 
 class TransferResponseAgent:
     def __init__(self, api_key: str, model_name: str, model_type: str = "OPENAI", agent_id: str = None):
@@ -132,6 +137,34 @@ class TransferResponseAgent:
         
         chat_history_text = "\n".join(formatted_history[-5:])  # Get last 5 messages
         
+        will_transfer = is_business_hours and available_agents > 0
+
+        # What to say about contact details depends on whether anyone is about to
+        # pick this chat up:
+        #   - known email        -> name it, so the promise is concrete.
+        #   - nobody picking up  -> ASK for an email. Promising a follow-up with no
+        #                           way to reach them is a dead end: the visitor
+        #                           leaves, and the team opens a chat with no
+        #                           contact details at all.
+        #   - live transfer      -> stay quiet; a human is arriving in this chat,
+        #                           and the handoff form collects details anyway.
+        if customer_email:
+            contact_instruction = f"Tell them the team will follow up at {customer_email}. "
+        elif not will_transfer:
+            contact_instruction = (
+                "No email is on file and nobody is available to pick this up, so the team "
+                "has no way to reach them. ASK them to reply with their email address so the "
+                "team can follow up. Ask plainly, in one short sentence. Do NOT mention, "
+                "reference, or link to any form; never write a URL, a bracketed placeholder, "
+                "or any example email address. "
+            )
+        else:
+            contact_instruction = (
+                "No email is on file, but a human agent is joining this chat now, so do NOT "
+                "ask for an email. Do NOT mention, reference, or link to any form; never write "
+                "a URL, a bracketed placeholder, or any email address. "
+            )
+
         prompt = (
             f"Based on the following context, generate an appropriate response for communicating the transfer of the chat to the different agent:\n\n"
             f"Business Context:\n{business_context}\n"
@@ -143,15 +176,13 @@ class TransferResponseAgent:
             f"explain that you need to transfer to a human agent who can better assist them.\n"
             f"2. If outside business hours or no agents available, if jira tool is available, "
             f"create a ticket so the team can follow up. "
-            f"{('Tell them the team will follow up at ' + customer_email + '. ') if customer_email else 'No email is on file. Simply reassure them that the team will follow up. Do NOT ask for an email; do NOT mention, reference, or link to any form; and never write a URL, a bracketed placeholder, or any email address. '}"
+            f"{contact_instruction}"
             f"\n"
             f"3. Keep the response professional and empathetic.\n"
             f"4. Never show a placeholder or fake email address. Make it clear whether they should expect "
             f"immediate help (transfer) or a follow-up.\n"
             f"Generate a natural-sounding response:"
         )
-
-        will_transfer = is_business_hours and available_agents > 0
 
         # Bounded like the chat run: this call happens inside the visitor's turn,
         # so a stuck run would hang the widget even though the handoff decision
@@ -167,8 +198,14 @@ class TransferResponseAgent:
                 f"cancelled; falling back to a plain handoff line "
                 f"(will_transfer={will_transfer})"
             )
+            if will_transfer:
+                fallback = TRANSFER_TIMEOUT_MESSAGE
+            elif customer_email:
+                fallback = FOLLOW_UP_TIMEOUT_MESSAGE
+            else:
+                fallback = FOLLOW_UP_NEEDS_EMAIL_TIMEOUT_MESSAGE
             return {
-                "message": TRANSFER_TIMEOUT_MESSAGE if will_transfer else FOLLOW_UP_TIMEOUT_MESSAGE,
+                "message": fallback,
                 "transfer_to_human": will_transfer
             }
 

--- a/backend/tests/agent/test_transfer_agent.py
+++ b/backend/tests/agent/test_transfer_agent.py
@@ -21,6 +21,7 @@ from datetime import datetime, timedelta
 from unittest.mock import patch, MagicMock, AsyncMock
 import sys
 from app.agents.transfer_agent import (
+    FOLLOW_UP_NEEDS_EMAIL_TIMEOUT_MESSAGE,
     FOLLOW_UP_TIMEOUT_MESSAGE,
     TRANSFER_TIMEOUT_MESSAGE,
     TransferResponseAgent,
@@ -337,13 +338,25 @@ async def test_get_transfer_response_timeout():
             assert response["message"] == TRANSFER_TIMEOUT_MESSAGE
             assert response["transfer_to_human"] is True
 
-            # Nobody available -> follow-up wording, no transfer
+            # Nobody available and no email on file -> the fallback has to ask
+            # for one, or the follow-up it promises can never happen.
             response = await agent.get_transfer_response(
                 chat_history=[],
                 business_hours=business_hours,
                 available_agents=0,
                 is_business_hours=False,
                 customer_email=None
+            )
+            assert response["message"] == FOLLOW_UP_NEEDS_EMAIL_TIMEOUT_MESSAGE
+            assert response["transfer_to_human"] is False
+
+            # Nobody available but we already know where to reach them -> no ask.
+            response = await agent.get_transfer_response(
+                chat_history=[],
+                business_hours=business_hours,
+                available_agents=0,
+                is_business_hours=False,
+                customer_email="known@acme.com"
             )
             assert response["message"] == FOLLOW_UP_TIMEOUT_MESSAGE
             assert response["transfer_to_human"] is False
@@ -581,3 +594,103 @@ async def test_timezone_handling(test_agent):
         
         # Verify that timezone was called with the invalid timezone
         mock_pytz.timezone.assert_called_with("Invalid/Timezone") 
+
+# ---------- asking for an email when nobody can pick the chat up ----------
+
+async def _prompt_for(available_agents, is_business_hours, customer_email):
+    """Run get_transfer_response and return the prompt the LLM was given."""
+    mock_agent_repo = MagicMock()
+    mock_agent_repo.get_by_agent_id.return_value = None
+    with patch('app.agents.transfer_agent.AgentRepository', return_value=mock_agent_repo), \
+         patch('app.utils.agno_utils.create_model', return_value=MagicMock()), \
+         patch('app.agents.transfer_agent.Agent', return_value=MockPhiAgent()):
+        agent = TransferResponseAgent(api_key="k", model_name="gpt-4", model_type="OPENAI")
+        agent.agent.arun = AsyncMock(return_value=MagicMock(content="ok"))
+        await agent.get_transfer_response(
+            chat_history=[MagicMock(message_type="user", message="I want a human")],
+            business_hours={'monday': {'start': '09:00', 'end': '17:00', 'enabled': True}},
+            available_agents=available_agents,
+            is_business_hours=is_business_hours,
+            customer_email=customer_email,
+        )
+        return agent.agent.arun.call_args.kwargs["message"]
+
+
+@pytest.mark.asyncio
+async def test_asks_for_email_when_nobody_is_available_and_none_on_file():
+    """The reported bug: out of hours with no email, the visitor was told the team
+    would follow up and never asked how. The team then opens a chat with no way to
+    reach anyone."""
+    prompt = await _prompt_for(available_agents=0, is_business_hours=False, customer_email=None)
+
+    assert "ASK them to reply with their email address" in prompt
+    assert "Do NOT ask for an email" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_asks_for_email_when_in_hours_but_no_agents_online():
+    """Same dead end — business hours don't matter if nobody is online."""
+    prompt = await _prompt_for(available_agents=0, is_business_hours=True, customer_email=None)
+
+    assert "ASK them to reply with their email address" in prompt
+
+
+@pytest.mark.asyncio
+async def test_does_not_ask_when_a_human_is_actually_joining():
+    """A live transfer needs no email — a person is arriving in this chat."""
+    prompt = await _prompt_for(available_agents=3, is_business_hours=True, customer_email=None)
+
+    assert "do NOT ask for an email" in prompt
+    assert "ASK them to reply with their email address" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_does_not_ask_when_the_email_is_already_known():
+    prompt = await _prompt_for(
+        available_agents=0, is_business_hours=False, customer_email="known@acme.com"
+    )
+
+    assert "will follow up at known@acme.com" in prompt
+    assert "ASK them to reply with their email address" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_never_invents_a_form_link_or_placeholder_address():
+    """These guards exist because the model used to emit fake addresses and
+    links to forms that don't exist; asking for an email must not lose them."""
+    prompt = await _prompt_for(available_agents=0, is_business_hours=False, customer_email=None)
+
+    assert "never write a URL" in prompt
+    assert "Do NOT mention, reference, or link to any form" in prompt
+
+
+@pytest.mark.asyncio
+async def test_timeout_fallback_still_asks_when_there_is_no_email():
+    """A stuck LLM run must not silently drop the ask — the canned line has to
+    carry it too, or a timeout reintroduces the same dead end."""
+    mock_agent_repo = MagicMock()
+    mock_agent_repo.get_by_agent_id.return_value = None
+    with patch('app.agents.transfer_agent.AgentRepository', return_value=mock_agent_repo), \
+         patch('app.utils.agno_utils.create_model', return_value=MagicMock()), \
+         patch('app.agents.transfer_agent.Agent', return_value=MockPhiAgent()):
+        agent = TransferResponseAgent(api_key="k", model_name="gpt-4", model_type="OPENAI")
+
+        async def _hang(*a, **kw):
+            await asyncio.sleep(3600)
+
+        agent.agent.arun = _hang
+        with patch.object(settings, "AGENT_RUN_TIMEOUT", 0.01):
+            no_email = await agent.get_transfer_response(
+                chat_history=[MagicMock(message_type="user", message="human please")],
+                business_hours={'monday': {'start': '09:00', 'end': '17:00', 'enabled': True}},
+                available_agents=0, is_business_hours=False, customer_email=None,
+            )
+            known = await agent.get_transfer_response(
+                chat_history=[MagicMock(message_type="user", message="human please")],
+                business_hours={'monday': {'start': '09:00', 'end': '17:00', 'enabled': True}},
+                available_agents=0, is_business_hours=False, customer_email="a@b.com",
+            )
+
+    assert no_email["message"] == FOLLOW_UP_NEEDS_EMAIL_TIMEOUT_MESSAGE
+    assert "email" in no_email["message"].lower()
+    assert known["message"] == FOLLOW_UP_TIMEOUT_MESSAGE


### PR DESCRIPTION
## Description

Out of hours with no email on file, the bot says *"our team will follow up with you shortly"* and never asks how. The team then opens the chat to **Name: N/A, Email: N/A** and no way to reach anyone — having promised a follow-up it can't make.

The prompt in `transfer_agent.py` explicitly forbade asking:

> `No email is on file. Simply reassure them that the team will follow up. Do NOT ask for an email;`

That was written on the assumption the handoff contact form collects one instead. When it doesn't, there's no fallback at all.

The instruction now depends on whether anyone is actually arriving:

| Situation | Response |
|---|---|
| Nobody available, no email known | **Asks for an email**, in one short sentence |
| Live transfer to an online agent | Stays quiet — a human is joining this chat |
| Email already known | Names the address, as before |

The timeout fallback carries the same ask (`FOLLOW_UP_NEEDS_EMAIL_TIMEOUT_MESSAGE`), so a stuck LLM run doesn't silently reintroduce the dead end.

The guards that instruction was carrying are kept — no invented addresses, no URLs, no references to a form. Those exist because the model used to emit fake addresses and links to forms that don't exist, and there's a test pinning them.

## Type of change

- [x] Bug fix

## Checklist

- [x] All commits are signed off (DCO)
- [x] My contribution is licensed under Apache-2.0
- [x] Tests added/updated where relevant and the suite passes

## Testing

The handoff path had **no tests at all**. Adds six, asserting on the prompt the agent is actually handed: asks when nobody's available (both out-of-hours and in-hours-but-nobody-online), stays quiet on a live transfer, names a known address, keeps the no-URL/no-form guards, and covers both timeout fallbacks.

One existing test (`test_get_transfer_response_timeout`) asserted the old no-email wording; updated to the new constant, with a known-email case added so the plain follow-up line is still covered.

`NO_ENTERPRISE=1 pytest tests/agent/ tests/agents/ tests/api/test_widget_chat.py` → 147 passed.