### PR TITLE
Keep a handoff contact email the customer row can't take

### DIFF
--- a/backend/app/api/widget_chat.py
+++ b/backend/app/api/widget_chat.py
@@ -45,6 +45,7 @@ from app.models.session_to_agent import SessionStatus
 from app.agents.transfer_agent import get_agent_availability_response
 from app.repositories.agent import AgentRepository
 from app.services.chat_notifications import notify_new_chat
+from app.services.contact_capture import retain_unstored_email
 from app.services.lead_capture import record_lead_from_response
 from app.services.message_delivery import deliver_to_customer
 from app.repositories.rating import RatingRepository
@@ -1955,12 +1956,23 @@ async def handle_contact_info(sid, data):
         customer_repo = CustomerRepository(db)
         result = customer_repo.update_contact(customer_id, email=email or None, full_name=name or None)
 
-        # Confirm back to the visitor as a bot message
-        if result.get('email_updated') or result.get('name_updated'):
+        # The customer row can refuse the address — another customer in the org
+        # already owns it (a visitor returning anonymously, or a shared team
+        # inbox), or it is a channel identity key. Keep it on meta_data so the
+        # agent can still follow up; otherwise the visitor asked to be contacted
+        # and nothing anywhere records how.
+        email_retained = retain_unstored_email(customer_repo, customer_id, email, result)
+
+        # Confirm back to the visitor as a bot message. Retaining counts: from
+        # where they sit they gave us a good address either way, and silence
+        # after submitting the form reads as the form having failed.
+        if result.get('email_updated') or result.get('name_updated') or email_retained:
             confirm = "Thanks — a teammate will follow up"
             updated_email = result.get('email') or ''
-            if updated_email and not CustomerRepository.is_placeholder_email(updated_email):
+            if result.get('email_updated') and updated_email and not CustomerRepository.is_placeholder_email(updated_email):
                 confirm += f" at {updated_email}"
+            elif email_retained:
+                confirm += f" at {email}"
             confirm += "."
             await sio.emit('chat_response', {
                 'message': confirm,

--- a/backend/app/services/contact_capture.py
+++ b/backend/app/services/contact_capture.py
@@ -17,6 +17,31 @@ limitations under the License.
 from typing import Optional, Dict, Any
 from app.repositories.customer import CustomerRepository
 
+# Where a handoff email goes when the customer row can't take it — another
+# customer in the org already owns that address (the (email, organization_id)
+# unique constraint), or it is a channel identity key. meta_data renders as a
+# label/value list in the inbox customer panel, so an agent still sees the
+# address and can follow up. Dropping it is how a visitor asks to be contacted
+# and then never is.
+CONTACT_EMAIL_META_KEY = "contact_email_provided"
+
+
+def retain_unstored_email(customer_repo, customer_id, submitted_email: str, update_result: dict) -> bool:
+    """Keep a submitted handoff email that ``update_contact`` could not apply.
+
+    Returns True when it was retained on meta_data. No-op when the address did
+    land on the customer, when it is already their stored address, or when
+    nothing was submitted — so a normal capture writes no metadata.
+    """
+    if not submitted_email or update_result.get('email_updated'):
+        return False
+    stored = (update_result.get('email') or '').lower()
+    if submitted_email.lower() == stored:
+        return False
+    return customer_repo.update_meta_data(
+        customer_id, {CONTACT_EMAIL_META_KEY: submitted_email}
+    ) is not None
+
 
 def build_handoff_contact_form(
     customer,

--- a/backend/tests/services/test_contact_capture.py
+++ b/backend/tests/services/test_contact_capture.py
@@ -1,0 +1,145 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Handoff contact capture: which fields the form asks for, and what happens to an
+address the customer row is not allowed to take.
+"""
+
+import pytest
+
+from app.models.customer import Customer
+from app.repositories.customer import CustomerRepository
+from app.services.contact_capture import (
+    CONTACT_EMAIL_META_KEY,
+    build_handoff_contact_form,
+    retain_unstored_email,
+)
+
+
+def _anon(db, org_id, email="1786455337798@noemail.com"):
+    c = Customer(organization_id=org_id, email=email)
+    db.add(c)
+    db.commit()
+    db.refresh(c)
+    return c
+
+
+# ---------- which fields the form asks for ----------
+
+@pytest.mark.parametrize("email,name,expected", [
+    (None, None, ["email", "name"]),                       # nothing known
+    ("abc@noemail.com", None, ["email", "name"]),          # anonymous placeholder
+    ("123@telegram.channel", None, ["email", "name"]),     # synthesized channel key
+    ("abc@noemail.com", "Arun", ["email"]),                # name already known
+    ("real@acme.com", None, ["name"]),                     # address already known
+])
+def test_form_asks_only_for_what_is_missing(email, name, expected):
+    from types import SimpleNamespace
+    form = build_handoff_contact_form(
+        SimpleNamespace(email=email, full_name=name), collect_email=True, collect_name=True
+    )
+    assert [f["name"] for f in form["fields"]] == expected
+
+
+def test_no_form_when_nothing_is_missing():
+    from types import SimpleNamespace
+    assert build_handoff_contact_form(
+        SimpleNamespace(email="real@acme.com", full_name="Arun"), True, True
+    ) is None
+
+
+def test_no_form_when_both_toggles_are_off():
+    from types import SimpleNamespace
+    assert build_handoff_contact_form(
+        SimpleNamespace(email=None, full_name=None), collect_email=False, collect_name=False
+    ) is None
+
+
+# ---------- an address the customer row cannot take ----------
+
+def test_email_owned_by_another_customer_is_kept_on_meta_data(db, test_organization):
+    """The reported bug. A returning anonymous visitor (or a shared team inbox)
+    submits an address another customer in the org already owns; update_contact
+    refuses it for the unique constraint, and it used to be dropped on the floor
+    — the visitor asked to be contacted and nothing recorded how."""
+    _anon(db, test_organization.id, email="taken@acme.com")
+    visitor = _anon(db, test_organization.id)
+    repo = CustomerRepository(db)
+
+    result = repo.update_contact(visitor.id, email="taken@acme.com", full_name=None)
+    assert result["email_updated"] is False          # constraint held, as designed
+
+    assert retain_unstored_email(repo, visitor.id, "taken@acme.com", result) is True
+
+    db.refresh(visitor)
+    assert visitor.meta_data[CONTACT_EMAIL_META_KEY] == "taken@acme.com"
+
+
+def test_name_only_submission_still_retains_the_dropped_email(db, test_organization):
+    """Submitting a name too made the panel visibly change, which is what made
+    this look name-dependent — the email was being lost either way."""
+    _anon(db, test_organization.id, email="taken2@acme.com")
+    visitor = _anon(db, test_organization.id)
+    repo = CustomerRepository(db)
+
+    result = repo.update_contact(visitor.id, email="taken2@acme.com", full_name="Runix")
+    assert result["email_updated"] is False
+    assert result["name_updated"] is True
+
+    assert retain_unstored_email(repo, visitor.id, "taken2@acme.com", result) is True
+    db.refresh(visitor)
+    assert visitor.full_name == "Runix"
+    assert visitor.meta_data[CONTACT_EMAIL_META_KEY] == "taken2@acme.com"
+
+
+def test_a_normal_capture_writes_no_metadata(db, test_organization):
+    """The address landed on the customer, so there is nothing to retain and the
+    panel shouldn't grow a duplicate line."""
+    visitor = _anon(db, test_organization.id)
+    repo = CustomerRepository(db)
+
+    result = repo.update_contact(visitor.id, email="fresh@acme.com", full_name=None)
+    assert result["email_updated"] is True
+
+    assert retain_unstored_email(repo, visitor.id, "fresh@acme.com", result) is False
+    db.refresh(visitor)
+    assert not (visitor.meta_data or {}).get(CONTACT_EMAIL_META_KEY)
+
+
+def test_resubmitting_the_address_already_on_file_is_a_no_op(db, test_organization):
+    visitor = _anon(db, test_organization.id, email="mine@acme.com")
+    repo = CustomerRepository(db)
+
+    result = repo.update_contact(visitor.id, email="mine@acme.com", full_name=None)
+
+    assert retain_unstored_email(repo, visitor.id, "mine@acme.com", result) is False
+    db.refresh(visitor)
+    assert not (visitor.meta_data or {}).get(CONTACT_EMAIL_META_KEY)
+
+
+def test_retaining_preserves_existing_meta_data(db, test_organization):
+    """Integrator-supplied custom_data must survive — update_meta_data merges."""
+    _anon(db, test_organization.id, email="taken3@acme.com")
+    visitor = _anon(db, test_organization.id)
+    visitor.meta_data = {"student_name": "Priya"}
+    db.commit()
+    repo = CustomerRepository(db)
+
+    result = repo.update_contact(visitor.id, email="taken3@acme.com", full_name=None)
+    retain_unstored_email(repo, visitor.id, "taken3@acme.com", result)
+
+    db.refresh(visitor)
+    assert visitor.meta_data["student_name"] == "Priya"
+    assert visitor.meta_data[CONTACT_EMAIL_META_KEY] == "taken3@acme.com"


### PR DESCRIPTION
## Description

A visitor submits the handoff contact form and their email is **silently dropped** whenever another customer in the org already owns that address — someone returning anonymously in a new browser, or a shared `support@`/`info@` inbox.

`update_contact` refuses the address to hold the `(email, organization_id)` unique constraint, logs a warning, and returns. Nothing else records it, so the visitor asked to be contacted and no one can. The widget also stayed silent, because the confirmation only fired when something actually updated.

It looked *name-dependent* in testing — email-only appeared to do nothing, email+name appeared to work — because submitting a name still updated the name, so the panel visibly changed. The email was being lost in both cases:

```
update_contact(email='m@g.com', full_name=None)    -> email_updated: False   (nothing commits, no confirmation)
update_contact(email='m@g.com', full_name='Runix') -> email_updated: False, name_updated: True
```

## The fix

Retain the address on `customer.meta_data`, which the inbox customer panel already renders as a label/value list — so the agent sees **Contact Email Provided: m@g.com** under Name/Email with no frontend change. Nothing is written when the address does land on the customer, so a normal capture is unchanged and the panel doesn't grow a duplicate line.

The visitor is now confirmed to in the retained case as well.

The constraint itself is untouched — a customer row still can't hold a duplicate email. This only stops the data being thrown away.

## Type of change

- [x] Bug fix

## Checklist

- [x] All commits are signed off (DCO)
- [x] My contribution is licensed under Apache-2.0
- [x] Tests added/updated where relevant and the suite passes

## Testing

This path had **no tests at all**. Adds 12: which fields the form asks for across placeholder/channel-key/known-name/known-email, and the retention behaviour — collision retained, name-only-submission still retains, a normal capture writes no metadata, resubmitting the address already on file is a no-op, and existing integrator `custom_data` survives the merge.

`NO_ENTERPRISE=1 pytest tests/services/ tests/api/test_widget_chat.py` → 629 passed, 6 failed (all `TestSSHKeyLoading`, pre-existing on main).

Verified against the original reproduction: a fresh anonymous visitor submitting an address another customer owns now ends with `meta_data = {'contact_email_provided': 'm@g.com'}`.

## Follow-up, not in here

Treating a matching email as *the same person* and re-pointing the session at the existing customer would fix the underlying duplicate-identity fragmentation. That reassigns conversation history and is an identity-model decision, so it belongs in its own change.