### PR TITLE
Keep website crawls on the seed host, and stop crawling mailto: links

### DIFF
--- a/backend/alembic/versions/purge_mangled_crawl_pages_001.py
+++ b/backend/alembic/versions/purge_mangled_crawl_pages_001.py
@@ -1,0 +1,103 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""delete crawl pages that were never pages (mangled mailto: URLs)
+
+Revision ID: purge_mangled_crawl_pages_001
+Revises: merge_hc_url_path_001
+Create Date: 2026-08-12
+
+The website crawler followed `mailto:` hrefs: urljoin left them intact and
+_normalize_url prefixed them, so `mailto:a@example.com` became
+`https://mailto:a@example.com` — a URL whose host really is `example.com` (with
+`mailto:a` as userinfo), which passed the same-domain check, was fetched (the
+server ignores the credentials and serves the site root) and was stored as a
+knowledge page. Its body then produced more of them: `https://mailto:a@example.com/pricing`.
+
+The crawler no longer produces these (app/knowledge/crawl_scope.py); this
+removes the ones already stored, so they stop being retrieved as answers and
+stop feeding FAQ generation.
+
+Deliberately narrow. Only chunk rows are deleted whose page id is
+  * an http(s) URL carrying userinfo (`https://<something>@host/...`), which a
+    crawl never legitimately produces, or
+  * a non-HTTP scheme (`mailto:`, `tel:`, …), which is not a page at all,
+and only under a WEBSITE source. Everything else stays: PDF chunks keyed by
+UUID, text pages keyed by their title (including text pages added under a
+website source), and every real crawled URL — off-target ones included. Pages
+that are real content but outside the new default crawl scope (a marketing site
+picked up from a help-center seed) are NOT touched here: they were crawled by
+design, deleting them is a judgement call per source, and
+backend/scripts/prune_offsite_pages.py does that opt-in with a dry run.
+
+Vector tables are per-organisation and named in the `knowledge` rows, so the
+loop reads them from there rather than guessing. Tables listed but missing are
+skipped, and re-running deletes nothing.
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'purge_mangled_crawl_pages_001'
+down_revision = 'merge_hc_url_path_001'
+branch_labels = None
+depends_on = None
+
+# A page id that is not a page: userinfo before the first path segment, or a
+# scheme that is not http(s). Anchored, so a '/@handle' path does not match.
+_USERINFO_PATTERN = '^https?://[^/]*@'
+_NON_HTTP_SCHEME_PATTERN = '^(mailto|tel|sms|javascript|data|ftp):'
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        DO $$
+        DECLARE
+            r record;
+            removed bigint;
+            total bigint := 0;
+        BEGIN
+            FOR r IN
+                SELECT DISTINCT schema AS sch, table_name AS tbl
+                  FROM knowledge
+                 WHERE schema IS NOT NULL AND table_name IS NOT NULL
+            LOOP
+                BEGIN
+                    -- %L quotes each pattern, so the regexes need no escaping.
+                    EXECUTE format(
+                        'DELETE FROM %I.%I v WHERE (v.id ~ %L OR v.id ~* %L) '
+                        'AND v.name IN (SELECT source FROM knowledge '
+                        'WHERE source_type = %L)',
+                        r.sch, r.tbl,
+                        '{_USERINFO_PATTERN}', '{_NON_HTTP_SCHEME_PATTERN}', 'WEBSITE'
+                    );
+                    GET DIAGNOSTICS removed = ROW_COUNT;
+                    total := total + removed;
+                EXCEPTION
+                    WHEN undefined_table OR invalid_schema_name OR undefined_column THEN
+                        CONTINUE;
+                END;
+            END LOOP;
+            RAISE NOTICE 'Removed % mangled crawl page chunk(s)', total;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """No-op: the deleted rows were crawl artefacts of a bug, and their content
+    (a site's root page stored under a bogus URL) cannot be reconstructed. A
+    re-crawl repopulates whatever the source should legitimately contain."""

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -30,6 +30,7 @@ from app.models.agent import Agent
 from app.models.knowledge import Knowledge
 from app.repositories.knowledge import KnowledgeRepository
 from app.knowledge import page_editor
+from app.knowledge.crawl_scope import CRAWL_SCOPES
 from app.repositories.knowledge_to_agent import KnowledgeToAgentRepository
 from app.repositories.agent import AgentRepository
 from app.models.knowledge_queue import KnowledgeQueue, QueueStatus
@@ -81,15 +82,25 @@ class UrlsRequest(BaseModel):
     websites: List[str] = []
     sitemaps: List[str] = []
     agent_id: Optional[str] = None
-    # Optional crawl-scope cap for websites (e.g. 1 = "this page only"). Always
+    # Optional cap on pages per website source (e.g. 1 = "this page only"). Always
     # clamped to the plan's max_sub_pages server-side; None uses the plan limit.
     max_links: Optional[int] = None
+    # How far link-following may wander from the seed URL: 'path' | 'host' |
+    # 'domain'. None uses the default (the seed's own host).
+    crawl_scope: Optional[str] = None
 
     @field_validator('max_links')
     @classmethod
     def validate_max_links(cls, v):
         if v is not None and v < 1:
             raise ValueError('max_links must be at least 1')
+        return v
+
+    @field_validator('crawl_scope')
+    @classmethod
+    def validate_crawl_scope(cls, v):
+        if v is not None and v not in CRAWL_SCOPES:
+            raise ValueError(f"crawl_scope must be one of {', '.join(CRAWL_SCOPES)}")
         return v
 
 
@@ -465,8 +476,8 @@ async def add_urls(
         queued_items = []
 
         # Per-source sub-page cap: the plan limit, optionally narrowed by the
-        # request's crawl scope (e.g. "this page only" -> max_links=1), never
-        # allowed to exceed the plan limit.
+        # request (e.g. "this page only" -> max_links=1), never allowed to
+        # exceed the plan limit.
         plan_sub_pages = resolve_plan_max_links(subscription)
         website_max_links = (
             min(request.max_links, plan_sub_pages) if request.max_links else plan_sub_pages
@@ -505,7 +516,11 @@ async def add_urls(
                 source_type='website',
                 source=url,
                 status=QueueStatus.PENDING,
-                queue_metadata={"max_links": website_max_links}
+                queue_metadata={
+                    "max_links": website_max_links,
+                    # Omitted (None) means the crawler's default: the seed's host.
+                    "crawl_scope": request.crawl_scope,
+                }
             )
             queued_items.append(queue_repo.create(queue_item))
 

--- a/backend/app/knowledge/README.md
+++ b/backend/app/knowledge/README.md
@@ -105,6 +105,20 @@ The `EnhancedWebsiteReader` and `EnhancedWebsiteKnowledgeBase` classes offer sev
 - **timeout**: HTTP request timeout in seconds (default: 30)
 - **max_retries**: Maximum number of retry attempts for failed requests (default: 3)
 - **max_workers**: Number of parallel workers for crawling and embedding (default: 10)
+- **crawl_scope**: How far link-following may wander from the starting URL (default: `host`)
+  - `host` — pages on the starting URL's own host only (`www.` and the bare host count as one host)
+  - `path` — that host, restricted to the starting URL's path prefix (e.g. only `/hc/…`)
+  - `domain` — every host on the registrable domain, so a `help.example.com` crawl also
+    walks `www.example.com`, `example.com/blog/…` and other subdomains
+  Only `http`/`https` links are ever followed — `mailto:`, `tel:` and friends are not pages.
+
+Content stored by earlier, wider crawls is cleaned up in two steps:
+
+- Pages that were never pages (mangled `https://mailto:a@example.com/…` URLs) are deleted
+  automatically by the `purge_mangled_crawl_pages_001` migration.
+- Real pages that are simply outside the new scope (a marketing site pulled in from a
+  help-center seed) are left alone; `scripts/prune_offsite_pages.py` reports them per
+  source and deletes them only with `--apply`.
 - **batch_size**: Size of document batches for database operations (default: 20)
 - **blacklist_tags**: HTML tags to remove before content extraction (scripts, styles, etc.)
 - **common_content_tags**: HTML tags likely to contain main content

--- a/backend/app/knowledge/crawl_scope.py
+++ b/backend/app/knowledge/crawl_scope.py
@@ -1,0 +1,160 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Which URLs a website crawl is allowed to follow.
+
+Two independent problems this decides, both seen on a real help-center import
+that stored 247 pages of which only ~102 were help articles:
+
+* **Scheme.** ``urljoin`` leaves a ``mailto:``/``tel:`` href untouched, and
+  prefixing a scheme-less value with ``https://`` turns ``mailto:a@example.com``
+  into ``https://mailto:a@example.com`` — which parses as host ``example.com``
+  with ``mailto:a`` as userinfo, so it passed the same-domain check and was
+  crawled as a page (then spawned ``https://mailto:a@example.com/pricing`` and
+  friends from the fetched body). Only http(s) URLs are crawlable.
+
+* **Reach.** Bounding a crawl by the *registrable domain* means a crawl seeded at
+  ``help.example.com`` also walks ``www.example.com``, ``example.com/blog/*`` and
+  every other host under ``example.com`` — the whole company web presence lands
+  in one knowledge source. The default is now the seed's own host; ``domain``
+  (previous behaviour) and ``path`` (seed host + seed path prefix) stay available
+  per source.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import ParseResult, urlparse
+
+from app.knowledge.domains import registrable_domain
+
+# Scope modes, narrowest first. Kept as plain strings: they travel through the
+# API request and the queue item's JSON metadata.
+SCOPE_PATH = "path"
+SCOPE_HOST = "host"
+SCOPE_DOMAIN = "domain"
+CRAWL_SCOPES = (SCOPE_PATH, SCOPE_HOST, SCOPE_DOMAIN)
+
+DEFAULT_CRAWL_SCOPE = SCOPE_HOST
+
+# Anything else (mailto:, tel:, sms:, javascript:, data:, ftp:) is a contact or
+# script action, not a page to fetch.
+CRAWLABLE_SCHEMES = ("http", "https")
+
+
+def url_scheme(url: str) -> str:
+    """Lowercased scheme of a URL, or ``''`` when it has none.
+
+    Not ``urlparse(url).scheme``: that reads the scheme-less ``example.com:8443/x``
+    as scheme ``example.com``. A real scheme has no ``.`` or ``/`` before the colon.
+    """
+    head, sep, _ = (url or "").strip().partition(":")
+    if not sep or not head or "." in head or "/" in head:
+        return ""
+    return head.lower()
+
+
+def is_crawlable_url(url: str) -> bool:
+    """True for an http(s) URL or a scheme-less one (a relative href still to be
+    resolved against its base). False for ``mailto:``/``tel:``/``javascript:``/…"""
+    scheme = url_scheme(url)
+    return scheme in CRAWLABLE_SCHEMES or not scheme
+
+
+def _parsed(url: str) -> Optional[ParseResult]:
+    """Parsed URL, or None when it can't be parsed — a malformed IPv6 literal
+    makes ``.hostname`` raise, and callers want "out of scope", not a traceback."""
+    try:
+        parsed = urlparse(url or "")
+        parsed.hostname  # raises here rather than at each use site
+    except ValueError:
+        return None
+    return parsed
+
+
+def _hostname(url: str) -> str:
+    """Host of a URL, or ``''`` if it has none / can't be parsed."""
+    parsed = _parsed(url)
+    return (parsed.hostname or "") if parsed else ""
+
+
+def _host_key(host: str) -> str:
+    """Host identity for comparisons: lowercased, ``www.`` dropped, so a site
+    linking between ``example.com`` and ``www.example.com`` stays in scope."""
+    host = (host or "").lower().strip().rstrip(".")
+    return host[4:] if host.startswith("www.") else host
+
+
+@dataclass(frozen=True)
+class CrawlScope:
+    """The boundary of one crawl, derived from its seed URL."""
+
+    mode: str
+    domain: str
+    host: str
+    path_prefix: str
+
+    @classmethod
+    def for_seed(cls, seed_url: str, mode: str = DEFAULT_CRAWL_SCOPE) -> "CrawlScope":
+        """Scope for a crawl seeded at ``seed_url``. An unknown mode falls back to
+        the default rather than failing a queued crawl."""
+        if mode not in CRAWL_SCOPES:
+            mode = DEFAULT_CRAWL_SCOPE
+        parsed = _parsed(seed_url)
+        host = (parsed.hostname or "") if parsed else ""
+        return cls(
+            mode=mode,
+            domain=registrable_domain(host),
+            host=_host_key(host),
+            path_prefix=((parsed.path or "") if parsed else "").rstrip("/"),
+        )
+
+    def allows(self, url: str) -> bool:
+        """True if ``url`` may be fetched and stored as part of this crawl."""
+        if url_scheme(url) not in CRAWLABLE_SCHEMES:
+            return False
+
+        parsed = _parsed(url)
+        if parsed is None:
+            return False
+        # No userinfo: pages are never fetched with credentials, and this is what
+        # a leftover 'https://mailto:a@example.com/x' from an older crawl looks
+        # like ('mailto:a' as user:password) once the scheme has been mangled off.
+        if parsed.username or parsed.password:
+            return False
+
+        host = parsed.hostname or ""
+        if self.mode == SCOPE_DOMAIN:
+            # Equality, not a suffix match: 'evilexample.com'.endswith('example.com')
+            # would let one plan-limited source fan out across unrelated domains.
+            return bool(self.domain) and registrable_domain(host) == self.domain
+
+        if not self.host or _host_key(host) != self.host:
+            return False
+        if self.mode == SCOPE_HOST:
+            return True
+
+        # Path scope: compare on a segment boundary so a '/hc/en' seed keeps
+        # '/hc/en/articles/1' but not '/hc/entertainment'.
+        path = (parsed.path or "").rstrip("/")
+        return path == self.path_prefix or path.startswith(f"{self.path_prefix}/")
+
+    def describe(self) -> str:
+        """Short human-readable scope, for crawl logs."""
+        if self.mode == SCOPE_DOMAIN:
+            return f"domain {self.domain}"
+        if self.mode == SCOPE_HOST:
+            return f"host {self.host}"
+        return f"host {self.host} under {self.path_prefix or '/'}"

--- a/backend/app/knowledge/crawl_scope.py
+++ b/backend/app/knowledge/crawl_scope.py
@@ -36,7 +36,7 @@ that stored 247 pages of which only ~102 were help articles:
 
 from dataclasses import dataclass
 from typing import Optional
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import ParseResult, urlparse, urlunparse
 
 from app.knowledge.domains import registrable_domain
 
@@ -104,6 +104,7 @@ class CrawlScope:
     mode: str
     domain: str
     host: str
+    seed_host: str
     path_prefix: str
 
     @classmethod
@@ -113,13 +114,37 @@ class CrawlScope:
         if mode not in CRAWL_SCOPES:
             mode = DEFAULT_CRAWL_SCOPE
         parsed = _parsed(seed_url)
-        host = (parsed.hostname or "") if parsed else ""
+        host = ((parsed.hostname or "") if parsed else "").lower()
         return cls(
             mode=mode,
             domain=registrable_domain(host),
             host=_host_key(host),
+            seed_host=host,
             path_prefix=((parsed.path or "") if parsed else "").rstrip("/"),
         )
+
+    def canonical(self, url: str) -> str:
+        """Put an in-scope URL on the seed's own spelling of the host.
+
+        ``example.com/terms`` and ``www.example.com/terms`` are one page, but
+        they are two page ids — so a site that links both ways stores the page
+        twice, burning two of the source's sub-page slots and feeding retrieval
+        and FAQ generation the same text twice.
+
+        Rewrites toward the SEED's host rather than always stripping ``www.``:
+        plenty of sites serve only one of the two, and the seed is the form the
+        user gave us and the crawl already fetched. Only the seed host's own
+        variant is touched — a genuine subdomain under ``domain`` scope is left
+        as it is.
+        """
+        parsed = _parsed(url)
+        if parsed is None or not parsed.hostname:
+            return url
+        host = parsed.hostname.lower()
+        if host == self.seed_host or _host_key(host) != self.host:
+            return url
+        netloc = f"{self.seed_host}:{parsed.port}" if parsed.port else self.seed_host
+        return urlunparse(parsed._replace(netloc=netloc))
 
     def allows(self, url: str) -> bool:
         """True if ``url`` may be fetched and stored as part of this crawl."""

--- a/backend/app/knowledge/enhanced_website_kb.py
+++ b/backend/app/knowledge/enhanced_website_kb.py
@@ -30,6 +30,7 @@ from app.core.config import settings
 from app.models.knowledge_queue import ProcessingStage, QueueStatus
 from pydantic import model_validator
 
+from app.knowledge.crawl_scope import DEFAULT_CRAWL_SCOPE
 from app.knowledge.enhanced_website_reader import (
     EnhancedWebsiteReader,
     BotProtectionError,
@@ -55,6 +56,7 @@ class EnhancedWebsiteKnowledgeBase(AgentKnowledge):
     max_workers: int = settings.KB_MAX_WORKERS
     batch_size: int = settings.KB_BATCH_SIZE
     optimize_on: Optional[int] = settings.KB_OPTIMIZE_ON
+    crawl_scope: str = DEFAULT_CRAWL_SCOPE
     
     # These are not part of the model schema, but added as instance attributes
     _queue_item = None
@@ -92,6 +94,7 @@ class EnhancedWebsiteKnowledgeBase(AgentKnowledge):
                 timeout=self.timeout,
                 max_retries=self.max_retries,
                 max_workers=self.max_workers,
+                crawl_scope=self.crawl_scope,
                 verify_ssl=False  # Disable SSL verification to handle self-signed/invalid certificates
             )
         else:

--- a/backend/app/knowledge/enhanced_website_reader.py
+++ b/backend/app/knowledge/enhanced_website_reader.py
@@ -17,6 +17,7 @@ limitations under the License.
 import random
 import re
 import time
+from copy import deepcopy
 from datetime import datetime
 from dataclasses import dataclass, field
 from typing import Dict, List, Set, Tuple, Optional, Callable
@@ -33,6 +34,13 @@ from agno.document.reader.website_reader import WebsiteReader
 from app.core.logger import get_logger
 from app.knowledge.crawl4ai_fallback import get_crawl4ai_fallback
 from app.knowledge.content_summarizer import get_content_summarizer
+from app.knowledge.crawl_scope import (
+    DEFAULT_CRAWL_SCOPE,
+    CrawlScope,
+    is_crawlable_url,
+    url_scheme,
+)
+from app.knowledge.domains import registrable_domain
 
 # Initialize logger for this module
 logger = get_logger(__name__)
@@ -92,6 +100,10 @@ class EnhancedWebsiteReader(WebsiteReader):
     max_retries: int = 3  # Maximum number of retries for failed requests
     respect_robots_txt: bool = True  # Whether to respect robots.txt
     max_workers: int = 10  # Maximum number of parallel workers for crawling
+    # How far the crawl may wander from its seed URL: 'host' (default), 'path'
+    # (seed host + seed path prefix) or 'domain' (every host on the registrable
+    # domain). See app/knowledge/crawl_scope.py.
+    crawl_scope: str = DEFAULT_CRAWL_SCOPE
     verify_ssl: bool = True  # Whether to verify SSL certificates (set to False for self-signed certs)
     
     # Track crawling statistics
@@ -105,19 +117,24 @@ class EnhancedWebsiteReader(WebsiteReader):
         """
         Normalize URL by ensuring it has a proper protocol (http:// or https://).
         If no protocol is present, https:// is added by default.
-        
+
+        A URL that already carries a scheme is returned untouched — including a
+        non-HTTP one such as ``mailto:``. Prefixing those produced
+        ``https://mailto:a@example.com``, which parses as host ``example.com``
+        with ``mailto:a`` as userinfo and so was crawled as a real page.
+
         :param url: The URL to normalize.
         :return: The normalized URL with protocol.
         """
         if not url:
             return url
-        
+
         url = url.strip()
-        
+
         # Check if URL already has a protocol
-        if url.startswith(('http://', 'https://')):
+        if url_scheme(url):
             return url
-        
+
         # Add https:// by default if no protocol is present
         logger.debug(f"URL '{url}' is missing protocol, adding 'https://'")
         return f"https://{url}"
@@ -185,8 +202,6 @@ class EnhancedWebsiteReader(WebsiteReader):
         # Delegate to the shared registrable-domain helper (ccTLD-aware,
         # port/userinfo stripped via hostname) so every same-domain check in
         # the codebase agrees.
-        from app.knowledge.domains import registrable_domain
-
         parsed_url = urlparse(self._normalize_url(url))
         return registrable_domain(parsed_url.hostname or parsed_url.netloc or "")
     
@@ -409,7 +424,6 @@ class EnhancedWebsiteReader(WebsiteReader):
         
         if include_links:
             # Create a deep copy to avoid modifying the original
-            from copy import deepcopy
             element_copy = deepcopy(element)
             
             # Find all links and append their URLs to the text
@@ -517,13 +531,13 @@ class EnhancedWebsiteReader(WebsiteReader):
         # If no good parent found, just concatenate the good paragraphs
         return " ".join([self._get_clean_text(p, include_links=True, base_url=self._current_url) for p in good_paragraphs])
 
-    def _process_url(self, url_info: Tuple[str, int], primary_domain: str) -> Optional[Tuple[str, str, List[str]]]:
+    def _process_url(self, url_info: Tuple[str, int], scope: CrawlScope) -> Optional[Tuple[str, str, List[str]]]:
         """
         Process a single URL - fetch content and extract links.
         This is used for parallel processing of URLs.
-        
+
         :param url_info: Tuple of (URL, depth)
-        :param primary_domain: Primary domain to filter links
+        :param scope: Crawl boundary the URL must fall inside
         :return: Tuple of (URL, content, new_links) or None if failed
         """
         current_url, current_depth = url_info
@@ -535,10 +549,10 @@ class EnhancedWebsiteReader(WebsiteReader):
         if current_url in self._visited:
             return None
 
-        # Same registrable domain only (equality, not a loose suffix match) —
-        # the per-URL guard that also protects sitemap-seeded crawls.
-        if self._get_primary_domain(current_url) != primary_domain:
-            logger.debug(f"Skipping cross-domain URL {current_url} (root domain {primary_domain})")
+        # In-scope http(s) URLs only — the per-URL guard that also protects
+        # sitemap-seeded crawls and anything left over in an older queue.
+        if not scope.allows(current_url):
+            logger.debug(f"Skipping out-of-scope URL {current_url} ({scope.describe()})")
             return None
 
         if current_depth > self.max_depth:
@@ -750,7 +764,7 @@ class EnhancedWebsiteReader(WebsiteReader):
                 
                 # Extract new links if not at max depth
                 if current_depth < self.max_depth:
-                    links = self._extract_links(soup, current_url)
+                    links = self._extract_links(soup, current_url, scope)
                     
                     next_depth = current_depth + 1
                     new_links = [(link, next_depth) for link in links 
@@ -819,7 +833,7 @@ class EnhancedWebsiteReader(WebsiteReader):
                         
                         # Extract links if we got content
                         if current_depth < self.max_depth and soup:
-                            links = self._extract_links(soup, current_url)
+                            links = self._extract_links(soup, current_url, scope)
                             next_depth = current_depth + 1
                             new_links = [(link, next_depth) for link in links 
                                         if link not in self._visited]
@@ -839,7 +853,7 @@ class EnhancedWebsiteReader(WebsiteReader):
                             
                             # Extract links
                             if current_depth < self.max_depth:
-                                links = self._extract_links(soup, current_url)
+                                links = self._extract_links(soup, current_url, scope)
                                 next_depth = current_depth + 1
                                 new_links = [(link, next_depth) for link in links 
                                             if link not in self._visited]
@@ -893,14 +907,16 @@ class EnhancedWebsiteReader(WebsiteReader):
         crawl_start_time = time.time()
         logger.info(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Starting parallel crawl of {url} with max_depth={self.max_depth}, max_links={self.max_links}, and max_workers={self.max_workers}")
         
-        primary_domain = self._get_primary_domain(url)
+        # Bound the crawl to the seed's own host by default — see crawl_scope.py.
+        scope = CrawlScope.for_seed(url, self.crawl_scope)
+        logger.info(f"Crawl scope for {url}: {scope.describe()}")
 
         # Add starting URL with its depth to the queue
         urls_to_process = [(url, starting_depth)]
         logger.info(f"Added starting URL to crawl queue: {url} (depth: {starting_depth})")
 
         crawler_result = self._run_crawl_queue(
-            urls_to_process, primary_domain, on_document_callback, on_url_crawled_callback
+            urls_to_process, scope, on_document_callback, on_url_crawled_callback
         )
 
         # Log crawling summary
@@ -915,7 +931,7 @@ class EnhancedWebsiteReader(WebsiteReader):
     def _run_crawl_queue(
         self,
         urls_to_process: List[Tuple[str, int]],
-        primary_domain: str,
+        scope: CrawlScope,
         on_document_callback: Optional[Callable[[str, str], None]] = None,
         on_url_crawled_callback: Optional[Callable[[str], None]] = None,
     ) -> Dict[str, str]:
@@ -937,7 +953,7 @@ class EnhancedWebsiteReader(WebsiteReader):
 
                 # Submit all URLs in the current batch for parallel processing
                 future_to_url = {
-                    executor.submit(self._process_url, url_info, primary_domain): url_info[0]
+                    executor.submit(self._process_url, url_info, scope): url_info[0]
                     for url_info in current_batch
                 }
 
@@ -977,17 +993,22 @@ class EnhancedWebsiteReader(WebsiteReader):
 
         return crawler_result
 
-    def _extract_links(self, soup: BeautifulSoup, base_url: str) -> List[str]:
+    def _extract_links(
+        self, soup: BeautifulSoup, base_url: str, scope: Optional[CrawlScope] = None
+    ) -> List[str]:
         """
         Extract links from a BeautifulSoup object.
-        
+
         :param soup: The BeautifulSoup object.
         :param base_url: The base URL to resolve relative URLs.
+        :param scope: Crawl boundary links must fall inside; defaults to this
+            reader's configured scope seeded at ``base_url``.
         :return: A list of absolute URLs.
         """
         links = []
         seen = set()
-        primary_domain = self._get_primary_domain(base_url)
+        if scope is None:
+            scope = CrawlScope.for_seed(base_url, self.crawl_scope)
         base_canonical = self._canonical_url(base_url)
 
         all_links = soup.find_all("a", href=True)
@@ -997,6 +1018,11 @@ class EnhancedWebsiteReader(WebsiteReader):
                 continue
 
             href_str = str(link["href"])
+            # Drop mailto:/tel:/sms:/javascript:/data: hrefs before urljoin —
+            # it passes them through untouched, and they are not pages.
+            if not is_crawlable_url(href_str):
+                continue
+
             full_url = urljoin(base_url, href_str)
 
             if not isinstance(full_url, str):
@@ -1017,14 +1043,8 @@ class EnhancedWebsiteReader(WebsiteReader):
             if full_url == base_canonical or full_url in seen:
                 continue
 
-            # Same REGISTRABLE domain only (equality, not suffix): a substring
-            # match like 'evilexample.com'.endswith('example.com') would let a
-            # crawl fan out across unrelated domains — a way to pull many
-            # domains' content under one plan-limited knowledge source.
-            is_same_domain = self._get_primary_domain(full_url) == primary_domain
-
             if (
-                is_same_domain
+                scope.allows(full_url)
                 and not any(parsed_url.path.endswith(ext) for ext in [
                     ".pdf", ".jpg", ".png", ".gif", ".zip", ".mp3", ".mp4", ".exe", ".dll"
                 ])

--- a/backend/app/knowledge/enhanced_website_reader.py
+++ b/backend/app/knowledge/enhanced_website_reader.py
@@ -1009,7 +1009,7 @@ class EnhancedWebsiteReader(WebsiteReader):
         seen = set()
         if scope is None:
             scope = CrawlScope.for_seed(base_url, self.crawl_scope)
-        base_canonical = self._canonical_url(base_url)
+        base_canonical = scope.canonical(self._canonical_url(base_url))
 
         all_links = soup.find_all("a", href=True)
 
@@ -1032,9 +1032,10 @@ class EnhancedWebsiteReader(WebsiteReader):
             if "?" in full_url:
                 continue
 
-            # Canonicalize (drop #fragment / trailing slash) so page variants
-            # collapse to a single link and don't get crawled/stored twice.
-            full_url = self._canonical_url(full_url)
+            # Canonicalize (drop #fragment / trailing slash, put the seed's own
+            # www/bare spelling on the host) so page variants collapse to a
+            # single link and don't get crawled/stored twice.
+            full_url = scope.canonical(self._canonical_url(full_url))
 
             # Filter out unwanted URLs
             parsed_url = urlparse(full_url)

--- a/backend/app/knowledge/knowledge_base.py
+++ b/backend/app/knowledge/knowledge_base.py
@@ -20,6 +20,7 @@ from agno.vectordb.pgvector import PgVector, SearchType
 from app.knowledge.optimized_pgvector import OptimizedPgVector
 from app.core.config import settings
 from app.core.logger import get_logger
+from app.knowledge.crawl_scope import DEFAULT_CRAWL_SCOPE
 from app.knowledge.enhanced_website_kb import EnhancedWebsiteKnowledgeBase
 from app.knowledge.enhanced_website_reader import EnhancedWebsiteReader
 from app.knowledge.sitemap_reader import SitemapReader
@@ -447,8 +448,11 @@ class KnowledgeManager:
                         ProcessingStage.CRAWLING
                     )
                     
-                    max_links = queue_item.queue_metadata.get(
-                        'max_links', settings.KB_MAX_LINKS) if queue_item.queue_metadata else settings.KB_MAX_LINKS
+                    metadata = queue_item.queue_metadata or {}
+                    max_links = metadata.get('max_links', settings.KB_MAX_LINKS)
+                    # How far link-following may wander from the seed URL; older
+                    # queue items carry no scope and get the default (seed host).
+                    crawl_scope = metadata.get('crawl_scope') or DEFAULT_CRAWL_SCOPE
 
                     # Use EnhancedWebsiteReader for all website crawling
                     logger.info(f"Using EnhancedWebsiteReader for queue item: {queue_item.source}")
@@ -459,13 +463,15 @@ class KnowledgeManager:
                         timeout=settings.KB_TIMEOUT,
                         max_retries=settings.KB_MAX_RETRIES,
                         max_workers=settings.KB_MAX_WORKERS,
+                        crawl_scope=crawl_scope,
                         verify_ssl=False  # Disable SSL verification to support websites with invalid/self-signed certificates
                     )
-                    
+
                     # Process the website - pass queue item and repo for URL tracking
                     knowledge_base = EnhancedWebsiteKnowledgeBase(
                         urls=[queue_item.source],
                         max_links=max_links,
+                        crawl_scope=crawl_scope,
                         vector_db=self.vector_db,
                         reader=reader
                     )

--- a/backend/app/knowledge/sitemap_reader.py
+++ b/backend/app/knowledge/sitemap_reader.py
@@ -17,6 +17,7 @@ limitations under the License.
 from typing import Callable, Dict, Optional
 
 from app.core.logger import get_logger
+from app.knowledge.crawl_scope import SCOPE_DOMAIN, CrawlScope
 from app.knowledge.enhanced_website_reader import EnhancedWebsiteReader
 from app.knowledge.sitemap_parser import fetch_sitemap_urls
 
@@ -55,7 +56,11 @@ class SitemapReader(EnhancedWebsiteReader):
         self._failed_crawls = 0
         self._challenge_blocked = 0
 
-        primary_domain = self._get_primary_domain(url)
+        # A sitemap index legitimately lists pages on sibling hosts
+        # (help.example.com from example.com/sitemap.xml), so the pages it names
+        # are taken at registrable-domain scope — matching the parser's own
+        # cross-domain filter. Only <a href> following is host-scoped.
+        scope = CrawlScope.for_seed(url, SCOPE_DOMAIN)
         page_urls = fetch_sitemap_urls(
             url,
             headers=self.headers,
@@ -72,5 +77,5 @@ class SitemapReader(EnhancedWebsiteReader):
 
         seeds = [(page_url, starting_depth) for page_url in page_urls]
         return self._run_crawl_queue(
-            seeds, primary_domain, on_document_callback, on_url_crawled_callback
+            seeds, scope, on_document_callback, on_url_crawled_callback
         )

--- a/backend/scripts/prune_offsite_pages.py
+++ b/backend/scripts/prune_offsite_pages.py
@@ -1,0 +1,222 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Opt-in cleanup: drop stored pages that fall outside a website source's crawl scope.
+
+Crawls used to be bounded by the registrable domain, so a source seeded at
+help.example.com also stored www.example.com, example.com/blog/* and every other
+subdomain. New crawls stay on the seed's host (app/knowledge/crawl_scope.py);
+this prunes what earlier crawls already stored.
+
+Unlike the mangled-mailto purge (alembic purge_mangled_crawl_pages_001, which runs
+automatically because those rows are provably junk), these pages are REAL content
+someone may be relying on. So this is a manual, per-source decision: it reports by
+default and only deletes with --apply.
+
+Run it on the HOST, not inside the backend container — importing the `app` package
+pulls in the FastAPI app and the ML stack, and has OOM'd production before. Nothing
+here imports it; the scope rules mirror app/knowledge/crawl_scope.py in ~20 lines of
+stdlib.
+
+    DATABASE_URL=postgresql://... python backend/scripts/prune_offsite_pages.py
+    DATABASE_URL=postgresql://... python backend/scripts/prune_offsite_pages.py \
+        --source https://help.example.com --scope path --apply
+
+Re-running is a no-op once a source is clean. Deleting a page removes it from the
+agent's retrieval immediately; FAQs already generated from it are NOT removed —
+generated FAQs record only their source, not the page they came from, so review
+them in the dashboard afterwards.
+"""
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+from urllib.parse import urlparse
+
+import psycopg
+from psycopg import sql
+
+DESCRIPTION = "Report (and optionally delete) stored pages outside a website source's crawl scope"
+
+# Mirrors PAGE_ID_EXPR in app/knowledge/page_editor.py: a chunk id is the page id
+# with an optional _<number> suffix. Only a numeric suffix is stripped, so a page
+# named 'getting_started' stays whole.
+_CHUNK_SUFFIX = re.compile(r"_[0-9]+$")
+
+SCOPE_HOST = "host"
+SCOPE_PATH = "path"
+
+
+def page_id_of(chunk_id: str) -> str:
+    return _CHUNK_SUFFIX.sub("", chunk_id)
+
+
+def host_key(host: str) -> str:
+    """www-insensitive host identity, as the crawler compares hosts."""
+    host = (host or "").lower().strip().rstrip(".")
+    return host[4:] if host.startswith("www.") else host
+
+
+def in_scope(page_url: str, seed: str, scope: str) -> bool:
+    """True if ``page_url`` is inside the seed URL's scope.
+
+    Anything that is not an http(s) URL — a text page added under a website
+    source, a PDF chunk keyed by UUID — is left alone: it is not a crawled page,
+    so it is not this script's business.
+    """
+    try:
+        page = urlparse(page_url)
+        root = urlparse(seed)
+    except ValueError:
+        return True
+    if page.scheme not in ("http", "https"):
+        return True
+    # A URL with userinfo is a mangled mailto: link, not a page. The migration
+    # purge_mangled_crawl_pages_001 removes these; catch them here too so the
+    # script gives the same answer when it runs before that migration.
+    if page.username or page.password:
+        return False
+    if host_key(page.hostname or "") != host_key(root.hostname or ""):
+        return False
+    if scope == SCOPE_HOST:
+        return True
+    prefix = (root.path or "").rstrip("/")
+    path = (page.path or "").rstrip("/")
+    return path == prefix or path.startswith(f"{prefix}/")
+
+
+def website_sources(conn, org=None, source=None):
+    query = (
+        "SELECT id, organization_id, source, schema, table_name FROM knowledge "
+        "WHERE source_type = 'WEBSITE' AND schema IS NOT NULL AND table_name IS NOT NULL"
+    )
+    params = []
+    if org:
+        # organization_id is a uuid column; compare as text so a plain --org
+        # string doesn't trip 'operator does not exist: uuid = text'.
+        query += " AND organization_id::text = %s"
+        params.append(org)
+    if source:
+        query += " AND source LIKE %s"
+        params.append(f"%{source}%")
+    with conn.cursor() as cur:
+        cur.execute(query + " ORDER BY id", params)
+        return cur.fetchall()
+
+
+def _table(schema, table):
+    """Quoted, injection-safe table reference. The names come from the knowledge
+    rows rather than the caller, but they still identify a table, not a value."""
+    return sql.Identifier(schema, table)
+
+
+def chunk_ids(conn, schema, table, source):
+    """Every chunk id stored for one source, or None if the table is gone."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass(%s)", (_table(schema, table).as_string(conn),))
+        if cur.fetchone()[0] is None:
+            return None
+        cur.execute(
+            sql.SQL("SELECT id FROM {} WHERE name = %s").format(_table(schema, table)),
+            (source,),
+        )
+        return [row[0] for row in cur.fetchall()]
+
+
+def delete_chunks(conn, schema, table, source, ids):
+    with conn.cursor() as cur:
+        cur.execute(
+            sql.SQL("DELETE FROM {} WHERE name = %s AND id = ANY(%s)").format(
+                _table(schema, table)
+            ),
+            (source, ids),
+        )
+        return cur.rowcount
+
+
+def prune(conn, scope, apply_changes, org, source_filter, samples):
+    sources = website_sources(conn, org, source_filter)
+    print(f"{len(sources)} website source(s) to inspect (scope: {scope})\n")
+
+    total_pages = total_chunks = touched_sources = 0
+    for _id, org_id, source, schema, table in sources:
+        ids = chunk_ids(conn, schema, table, source)
+        if ids is None:
+            print(f"! {source}: vector table {schema}.{table} is missing — skipped")
+            continue
+
+        offsite = defaultdict(list)
+        for chunk in ids:
+            page = page_id_of(chunk)
+            if not in_scope(page, source, scope):
+                offsite[page].append(chunk)
+        if not offsite:
+            continue
+
+        touched_sources += 1
+        pages = sorted(offsite)
+        chunks = [c for page in pages for c in offsite[page]]
+        total_pages += len(pages)
+        total_chunks += len(chunks)
+
+        kept = len({page_id_of(c) for c in ids}) - len(pages)
+        print(f"{source}  (org {org_id})")
+        print(f"    {len(pages)} off-scope page(s), {len(chunks)} chunk(s); {kept} page(s) kept")
+        for page in pages[:samples]:
+            print(f"      - {page}")
+        if len(pages) > samples:
+            print(f"      … and {len(pages) - samples} more")
+
+        if apply_changes:
+            removed = delete_chunks(conn, schema, table, source, chunks)
+            conn.commit()
+            print(f"    deleted {removed} chunk(s)")
+        print()
+
+    verb = "Deleted" if apply_changes else "Would delete"
+    print(f"{verb} {total_pages} page(s) / {total_chunks} chunk(s) across {touched_sources} source(s)")
+    if not apply_changes and total_pages:
+        print("Dry run — re-run with --apply to delete.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument(
+        "--scope",
+        choices=(SCOPE_HOST, SCOPE_PATH),
+        default=SCOPE_HOST,
+        help="host: keep pages on the source URL's host (default). "
+             "path: also require the source URL's path prefix.",
+    )
+    parser.add_argument("--apply", action="store_true", help="actually delete (default: report only)")
+    parser.add_argument("--org", help="limit to one organization id")
+    parser.add_argument("--source", help="limit to sources whose URL contains this string")
+    parser.add_argument("--samples", type=int, default=10, help="off-scope URLs to list per source")
+    args = parser.parse_args()
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        print("DATABASE_URL is required", file=sys.stderr)
+        return 2
+
+    with psycopg.connect(database_url) as conn:
+        prune(conn, args.scope, args.apply, args.org, args.source, args.samples)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/api/test_knowledge.py
+++ b/backend/tests/api/test_knowledge.py
@@ -269,6 +269,40 @@ def test_add_website_honors_kb_max_links(client: TestClient, test_organization, 
         assert item.queue_metadata.get("max_links") == 200
 
 
+def test_add_website_records_crawl_scope(client: TestClient, test_organization, db):
+    """The chosen crawl scope reaches the crawler via the queue item; omitting it
+    leaves the crawler's default (the seed's own host) in charge."""
+    response = client.post("/api/v1/knowledge/add/urls", json={
+        "org_id": str(test_organization.id),
+        "websites": ["https://help.example.com/hc/en"],
+        "crawl_scope": "path",
+    })
+    assert response.status_code == 200
+    item = db.query(KnowledgeQueue).filter(
+        KnowledgeQueue.source == "https://help.example.com/hc/en"
+    ).first()
+    assert item.queue_metadata.get("crawl_scope") == "path"
+
+    response = client.post("/api/v1/knowledge/add/urls", json={
+        "org_id": str(test_organization.id),
+        "websites": ["https://help.example.com/other"],
+    })
+    assert response.status_code == 200
+    item = db.query(KnowledgeQueue).filter(
+        KnowledgeQueue.source == "https://help.example.com/other"
+    ).first()
+    assert item.queue_metadata.get("crawl_scope") is None
+
+
+def test_add_website_rejects_unknown_crawl_scope(client: TestClient, test_organization):
+    response = client.post("/api/v1/knowledge/add/urls", json={
+        "org_id": str(test_organization.id),
+        "websites": ["https://example.com"],
+        "crawl_scope": "everything",
+    })
+    assert response.status_code == 422
+
+
 def test_link_knowledge_to_agent(client: TestClient, test_knowledge, test_agent):
     """Test linking knowledge to an agent"""
     response = client.post(

--- a/backend/tests/knowledge/test_crawl_scope.py
+++ b/backend/tests/knowledge/test_crawl_scope.py
@@ -69,6 +69,33 @@ def test_host_scope_treats_www_as_the_same_host():
     assert not scope.allows("https://blog.site.com/post")
 
 
+def test_canonical_puts_links_on_the_seeds_host_spelling():
+    """example.com/terms and www.example.com/terms are one page; storing both
+    spends two of the source's sub-page slots on the same text."""
+    bare = CrawlScope.for_seed("https://site.com/")
+    assert bare.canonical("https://www.site.com/terms") == "https://site.com/terms"
+    assert bare.canonical("https://site.com/terms") == "https://site.com/terms"
+
+    # Toward the SEED, not blindly www-stripped: a site may serve only the www
+    # form, and the seed is the spelling the crawl already fetched.
+    www = CrawlScope.for_seed("https://www.site.com/")
+    assert www.canonical("https://site.com/terms") == "https://www.site.com/terms"
+
+    # Port and path survive the rewrite.
+    assert bare.canonical("https://www.site.com:8443/a/b") == "https://site.com:8443/a/b"
+
+
+def test_canonical_leaves_other_hosts_alone():
+    scope = CrawlScope.for_seed("https://site.com/", SCOPE_DOMAIN)
+    # A real subdomain is a different site, even under domain scope.
+    assert scope.canonical("https://blog.site.com/post") == "https://blog.site.com/post"
+    assert scope.canonical("https://other.com/a") == "https://other.com/a"
+    # Nothing to rewrite, nothing to crash on.
+    assert scope.canonical("mailto:hi@site.com") == "mailto:hi@site.com"
+    assert scope.canonical("https://[bad") == "https://[bad"
+    assert scope.canonical("") == ""
+
+
 def test_domain_scope_keeps_the_previous_reach():
     scope = CrawlScope.for_seed("https://help.site.com/hc/en", SCOPE_DOMAIN)
     assert scope.allows("https://www.site.com/all-integrations")

--- a/backend/tests/knowledge/test_crawl_scope.py
+++ b/backend/tests/knowledge/test_crawl_scope.py
@@ -1,0 +1,161 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+from pathlib import Path
+
+from app.knowledge.crawl_scope import (
+    DEFAULT_CRAWL_SCOPE,
+    SCOPE_DOMAIN,
+    SCOPE_HOST,
+    SCOPE_PATH,
+    CrawlScope,
+    is_crawlable_url,
+    url_scheme,
+)
+
+
+def test_url_scheme_ignores_ports():
+    assert url_scheme("https://site.com/a") == "https"
+    assert url_scheme("HTTP://site.com") == "http"
+    assert url_scheme("mailto:hi@site.com") == "mailto"
+    assert url_scheme("tel:+441234567890") == "tel"
+    assert url_scheme("javascript:void(0)") == "javascript"
+    # A scheme-less host:port must not read as a scheme (that would make
+    # _normalize_url leave it alone and the crawl skip a real page).
+    assert url_scheme("site.com:8443/x") == ""
+    assert url_scheme("/relative/path") == ""
+    assert url_scheme("") == ""
+
+
+def test_is_crawlable_url():
+    assert is_crawlable_url("https://site.com/a")
+    assert is_crawlable_url("/relative/path")  # resolved against a base later
+    assert not is_crawlable_url("mailto:hi@site.com")
+    assert not is_crawlable_url("tel:+441234567890")
+    assert not is_crawlable_url("sms:+441234567890")
+    assert not is_crawlable_url("javascript:void(0)")
+    assert not is_crawlable_url("data:text/html,<h1>x</h1>")
+
+
+def test_host_scope_is_the_default():
+    scope = CrawlScope.for_seed("https://help.site.com/hc/en")
+    assert scope.mode == DEFAULT_CRAWL_SCOPE == SCOPE_HOST
+    assert scope.allows("https://help.site.com/hc/en/articles/1")
+    # The rest of the company web presence stays out — the reported bug.
+    assert not scope.allows("https://www.site.com/all-integrations")
+    assert not scope.allows("https://site.com/blog/announcement")
+    assert not scope.allows("https://support.site.com/hc/help-center/en")
+    assert not scope.allows("https://other.com/a")
+
+
+def test_host_scope_treats_www_as_the_same_host():
+    scope = CrawlScope.for_seed("https://site.com/")
+    assert scope.allows("https://www.site.com/pricing")
+    assert scope.allows("http://SITE.com/pricing")
+    assert not scope.allows("https://blog.site.com/post")
+
+
+def test_domain_scope_keeps_the_previous_reach():
+    scope = CrawlScope.for_seed("https://help.site.com/hc/en", SCOPE_DOMAIN)
+    assert scope.allows("https://www.site.com/all-integrations")
+    assert scope.allows("https://support.site.com/x")
+    # Equality, not a suffix match: a lookalike domain must not slip through.
+    assert not scope.allows("https://evilsite.com/c")
+    assert not scope.allows("https://other.com/a")
+
+
+def test_path_scope_matches_on_segment_boundaries():
+    scope = CrawlScope.for_seed("https://site.com/hc/en", SCOPE_PATH)
+    assert scope.allows("https://site.com/hc/en")
+    assert scope.allows("https://site.com/hc/en/")
+    assert scope.allows("https://site.com/hc/en/articles/1")
+    assert not scope.allows("https://site.com/hc/entertainment")
+    assert not scope.allows("https://site.com/blog/post")
+    # Still host-bound.
+    assert not scope.allows("https://help.site.com/hc/en/articles/1")
+
+
+def test_path_scope_from_a_root_seed_behaves_like_host_scope():
+    scope = CrawlScope.for_seed("https://site.com/", SCOPE_PATH)
+    assert scope.allows("https://site.com/anything/deep")
+
+
+def test_no_scope_allows_non_http_urls():
+    """The mailto: crawl bug: 'https://' + 'mailto:a@site.com' parses as host
+    site.com with 'mailto:a' as userinfo, so a naive domain check passed it."""
+    for mode in (SCOPE_PATH, SCOPE_HOST, SCOPE_DOMAIN):
+        scope = CrawlScope.for_seed("https://site.com/", mode)
+        assert not scope.allows("mailto:hi@site.com")
+        assert not scope.allows("tel:+441234567890")
+        assert not scope.allows("https://mailto:hi@site.com/pay-by-bank")
+
+
+def test_unknown_mode_falls_back_to_the_default():
+    scope = CrawlScope.for_seed("https://site.com/", "everything")
+    assert scope.mode == DEFAULT_CRAWL_SCOPE
+
+
+def _pruner():
+    """The cleanup script lives outside the app tree (it must not import `app`),
+    so it re-implements the scope check. Load it the way it runs on a host."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+    try:
+        import prune_offsite_pages
+
+        return prune_offsite_pages
+    finally:
+        sys.path.pop(0)
+
+
+def test_pruner_scope_agrees_with_the_crawler():
+    """The script deletes what the crawler would no longer store, so its copy of
+    the rules must not drift from CrawlScope."""
+    pruner = _pruner()
+    seed = "https://help.site.com/hc/en"
+    urls = [
+        "https://help.site.com/hc/en/articles/1",
+        "https://help.site.com/pricing",
+        "https://www.site.com/all-integrations",
+        "https://site.com/blog/post",
+        "https://support.site.com/x",
+        "https://other.com/a",
+        "https://mailto:hi@help.site.com/hc/en/pay-by-bank",
+    ]
+    for mode in (SCOPE_HOST, SCOPE_PATH):
+        scope = CrawlScope.for_seed(seed, mode)
+        for url in urls:
+            assert pruner.in_scope(url, seed, mode) == scope.allows(url), (mode, url)
+
+
+def test_pruner_leaves_non_crawled_pages_alone():
+    """Text pages and PDF chunks live in the same table under their own ids —
+    they are not crawled URLs, so the pruner must never select them."""
+    pruner = _pruner()
+    seed = "https://help.site.com/hc/en"
+    assert pruner.in_scope("Shipping Policy", seed, SCOPE_HOST)
+    assert pruner.in_scope("7acf323c-7100-4e34-b0db-bcda9f5b2ef1_1", seed, SCOPE_PATH)
+    # ...while chunk ids of a crawled page still resolve to their page.
+    assert pruner.page_id_of("https://site.com/docs_2") == "https://site.com/docs"
+    assert pruner.page_id_of("https://site.com/getting_started") == "https://site.com/getting_started"
+
+
+def test_malformed_urls_are_out_of_scope_not_crashes():
+    scope = CrawlScope.for_seed("https://site.com/")
+    assert not scope.allows("https://[not-an-ipv6/x")
+    assert not scope.allows("")
+    # A seed we can't parse a host from allows nothing (host/path modes).
+    assert not CrawlScope.for_seed("https://[bad").allows("https://site.com/a")

--- a/backend/tests/knowledge/test_enhanced_website_kb.py
+++ b/backend/tests/knowledge/test_enhanced_website_kb.py
@@ -18,6 +18,8 @@ import pytest
 import os
 from unittest.mock import MagicMock, patch, call, ANY
 from agno.document.base import Document
+from app.core.config import settings
+from app.knowledge.crawl_scope import DEFAULT_CRAWL_SCOPE
 from app.knowledge.enhanced_website_kb import EnhancedWebsiteKnowledgeBase
 from app.knowledge.enhanced_website_reader import EnhancedWebsiteReader
 
@@ -52,18 +54,19 @@ class TestEnhancedWebsiteKnowledgeBase:
     def test_initialization_with_defaults(self):
         """Test initialization with default values"""
         kb = EnhancedWebsiteKnowledgeBase(urls=TEST_URLS)
-        
-        # Get expected max_workers from environment (5 by default, can be overridden)
-        expected_max_workers = int(os.getenv("KB_MAX_WORKERS", "5"))
-        
+
+        # Against settings, not literals: every one of these is configurable per
+        # install (KB_MAX_DEPTH and friends), so hardcoding the defaults here
+        # fails on any machine whose .env tunes a crawl.
         assert kb.urls == TEST_URLS
         assert isinstance(kb.reader, EnhancedWebsiteReader)
-        assert kb.max_depth == 5
-        assert kb.max_links == 25
-        assert kb.min_content_length == 100
-        assert kb.timeout == 30
-        assert kb.max_retries == 3
-        assert kb.max_workers == expected_max_workers
+        assert kb.max_depth == settings.KB_MAX_DEPTH
+        assert kb.max_links == settings.KB_MAX_LINKS
+        assert kb.min_content_length == settings.KB_MIN_CONTENT_LENGTH
+        assert kb.timeout == settings.KB_TIMEOUT
+        assert kb.max_retries == settings.KB_MAX_RETRIES
+        assert kb.max_workers == settings.KB_MAX_WORKERS
+        assert kb.crawl_scope == DEFAULT_CRAWL_SCOPE
     
     def test_initialization_with_custom_params(self):
         """Test initialization with custom parameters"""

--- a/backend/tests/knowledge/test_enhanced_website_reader.py
+++ b/backend/tests/knowledge/test_enhanced_website_reader.py
@@ -217,26 +217,63 @@ class TestEnhancedWebsiteReader(unittest.TestCase):
         # /docs and /docs/ collapse to a single canonical link.
         self.assertEqual(links, ['https://site.com/docs'])
 
-    def test_extract_links_rejects_other_registrable_domains(self):
-        """Only same-registrable-domain links are kept — a substring match like
-        'evilsite.com'.endswith('site.com') must NOT slip through (that would let
-        one plan-limited source fan out across unrelated domains)."""
+    def test_extract_links_stays_on_the_seed_host_by_default(self):
+        """Default scope is the seed's own host: a help-center crawl must not
+        wander onto the marketing site, and a lookalike domain never matches."""
         html = """
         <html><body>
           <a href="https://site.com/a">same</a>
-          <a href="https://blog.site.com/b">subdomain (same registrable)</a>
-          <a href="https://evilsite.com/c">lookalike suffix</a>
-          <a href="https://notsite.com/d">another lookalike</a>
+          <a href="https://www.site.com/b">www of the same host</a>
+          <a href="https://blog.site.com/c">subdomain (same registrable)</a>
+          <a href="https://evilsite.com/d">lookalike suffix</a>
           <a href="https://other.com/e">unrelated</a>
         </body></html>
         """
         soup = BeautifulSoup(html, 'html.parser')
         links = self.reader._extract_links(soup, 'https://site.com')
         self.assertIn('https://site.com/a', links)
+        self.assertIn('https://www.site.com/b', links)
+        self.assertNotIn('https://blog.site.com/c', links)
+        self.assertNotIn('https://evilsite.com/d', links)
+        self.assertNotIn('https://other.com/e', links)
+
+    def test_extract_links_domain_scope_spans_subdomains(self):
+        """The opt-in 'domain' scope keeps the previous reach across subdomains,
+        still by registrable-domain equality (never a suffix match)."""
+        reader = EnhancedWebsiteReader(crawl_scope='domain')
+        html = """
+        <html><body>
+          <a href="https://blog.site.com/b">subdomain</a>
+          <a href="https://evilsite.com/c">lookalike suffix</a>
+        </body></html>
+        """
+        soup = BeautifulSoup(html, 'html.parser')
+        links = reader._extract_links(soup, 'https://site.com')
         self.assertIn('https://blog.site.com/b', links)
         self.assertNotIn('https://evilsite.com/c', links)
-        self.assertNotIn('https://notsite.com/d', links)
-        self.assertNotIn('https://other.com/e', links)
+
+    def test_extract_links_skips_non_http_schemes(self):
+        """mailto:/tel: hrefs are contact actions, not pages. urljoin leaves them
+        untouched, and 'https://' + 'mailto:a@site.com' parses as host site.com
+        with 'mailto:a' as userinfo — so they used to be crawled as pages."""
+        html = """
+        <html><body>
+          <a href="mailto:hello@site.com">Email us</a>
+          <a href="tel:+441234567890">Call us</a>
+          <a href="javascript:void(0)">Menu</a>
+          <a href="/pricing">Pricing</a>
+        </body></html>
+        """
+        soup = BeautifulSoup(html, 'html.parser')
+        links = self.reader._extract_links(soup, 'https://site.com/help')
+        self.assertEqual(links, ['https://site.com/pricing'])
+
+    def test_normalize_url_leaves_non_http_schemes_alone(self):
+        """Prefixing 'mailto:a@site.com' with https:// produced a fetchable
+        'https://mailto:a@site.com' — the source of the mangled stored pages."""
+        self.assertEqual(self.reader._normalize_url('mailto:a@site.com'), 'mailto:a@site.com')
+        self.assertEqual(self.reader._normalize_url('site.com/x'), 'https://site.com/x')
+        self.assertEqual(self.reader._normalize_url('http://site.com'), 'http://site.com')
 
     def test_get_primary_domain_strips_port_and_www(self):
         self.assertEqual(self.reader._get_primary_domain('https://www.site.com:8443/x'), 'site.com')

--- a/backend/tests/knowledge/test_enhanced_website_reader.py
+++ b/backend/tests/knowledge/test_enhanced_website_reader.py
@@ -232,7 +232,9 @@ class TestEnhancedWebsiteReader(unittest.TestCase):
         soup = BeautifulSoup(html, 'html.parser')
         links = self.reader._extract_links(soup, 'https://site.com')
         self.assertIn('https://site.com/a', links)
-        self.assertIn('https://www.site.com/b', links)
+        # In scope, and stored under the seed's spelling of the host.
+        self.assertIn('https://site.com/b', links)
+        self.assertNotIn('https://www.site.com/b', links)
         self.assertNotIn('https://blog.site.com/c', links)
         self.assertNotIn('https://evilsite.com/d', links)
         self.assertNotIn('https://other.com/e', links)
@@ -251,6 +253,25 @@ class TestEnhancedWebsiteReader(unittest.TestCase):
         links = reader._extract_links(soup, 'https://site.com')
         self.assertIn('https://blog.site.com/b', links)
         self.assertNotIn('https://evilsite.com/c', links)
+
+    def test_extract_links_collapses_www_variants_onto_the_seed_host(self):
+        """A site that links both spellings stored the page twice — 4 of the 50
+        pages in a real paywithatoa.co.uk crawl were www/bare duplicates."""
+        html = """
+        <html><body>
+          <a href="https://www.site.com/terms">terms via www</a>
+          <a href="https://site.com/terms">terms bare</a>
+          <a href="https://www.site.com/privacy">privacy via www</a>
+        </body></html>
+        """
+        soup = BeautifulSoup(html, 'html.parser')
+        links = self.reader._extract_links(soup, 'https://site.com/')
+        self.assertEqual(links, ['https://site.com/terms', 'https://site.com/privacy'])
+
+        # Seeded at the www spelling, the crawl keeps that one instead.
+        reader = EnhancedWebsiteReader()
+        links = reader._extract_links(soup, 'https://www.site.com/')
+        self.assertEqual(links, ['https://www.site.com/terms', 'https://www.site.com/privacy'])
 
     def test_extract_links_skips_non_http_schemes(self):
         """mailto:/tel: hrefs are contact actions, not pages. urljoin leaves them

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,41 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+
+
+def test_migrations_have_a_single_head():
+    """Two heads take production down: scripts/start.sh runs `alembic upgrade
+    head`, which refuses to choose between them, so the container exits before
+    gunicorn binds and restart-loops behind a 502.
+
+    It happens when two branches each add a revision off the same parent — each
+    PR is green alone and the branch only exists once both have merged, so
+    reviewing either in isolation cannot catch it. This can.
+
+    Fix by re-parenting the unapplied revision onto the other head (linear, no
+    merge revision), or with a merge revision when both have already been
+    applied somewhere.
+    """
+    heads = ScriptDirectory.from_config(
+        Config(str(BACKEND_DIR / "alembic.ini"))
+    ).get_heads()
+    assert len(heads) == 1, f"expected one migration head, found: {heads}"

--- a/frontend/src/__tests__/components/knowledge/KnowledgeAddSourceModal.scope.spec.ts
+++ b/frontend/src/__tests__/components/knowledge/KnowledgeAddSourceModal.scope.spec.ts
@@ -1,0 +1,71 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import KnowledgeAddSourceModal from '../../../components/knowledge/KnowledgeAddSourceModal.vue'
+
+const mountModal = async (url: string) => {
+  const wrapper = mount(KnowledgeAddSourceModal)
+  await wrapper.find('#kb-add-url').setValue(url)
+  return wrapper
+}
+
+const scopeTitles = (wrapper: ReturnType<typeof mount>) =>
+  wrapper.findAll('.scope__title').map((node) => node.text())
+
+const scopeOption = (wrapper: ReturnType<typeof mount>, title: string) =>
+  wrapper.findAll('.scope__opt').find((node) => node.find('.scope__title').text() === title)
+
+describe('KnowledgeAddSourceModal crawl scope', () => {
+  it('offers no section option for a homepage URL', async () => {
+    // "Pages under / " is not a section — it is the whole site, which the next
+    // option already covers.
+    const wrapper = await mountModal('https://paywithatoa.co.uk')
+    expect(scopeTitles(wrapper)).toEqual(['This page only', 'This site', 'Whole domain'])
+    expect(scopeOption(wrapper, 'This site')!.text()).toContain('Every page on paywithatoa.co.uk.')
+  })
+
+  it('names the section when the URL has a path', async () => {
+    const wrapper = await mountModal('https://help.example.com/hc/en')
+    expect(scopeTitles(wrapper)).toContain('This section')
+    expect(scopeOption(wrapper, 'This section')!.text()).toContain(
+      'Only pages under /hc/en/ on help.example.com.',
+    )
+  })
+
+  it('falls back to this-site when the section option disappears', async () => {
+    const wrapper = await mountModal('https://help.example.com/hc/en')
+    await scopeOption(wrapper, 'This section')!.trigger('click')
+
+    await wrapper.find('#kb-add-url').setValue('https://help.example.com')
+    await wrapper.find('button.btn--primary').trigger('click')
+
+    expect(wrapper.emitted('submit')![0][0]).toMatchObject({
+      type: 'website',
+      url: 'https://help.example.com',
+      scope: 'host',
+    })
+  })
+
+  it('submits the selected scope', async () => {
+    const wrapper = await mountModal('https://help.example.com/hc/en')
+    await scopeOption(wrapper, 'This section')!.trigger('click')
+    await wrapper.find('button.btn--primary').trigger('click')
+
+    expect(wrapper.emitted('submit')![0][0]).toMatchObject({ scope: 'path' })
+  })
+})

--- a/frontend/src/components/knowledge/KnowledgeAddSourceModal.vue
+++ b/frontend/src/components/knowledge/KnowledgeAddSourceModal.vue
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import type { AddSourcePayload } from '@/composables/useKnowledgeExplorer'
+import type { AddSourcePayload, CrawlScope } from '@/composables/useKnowledgeExplorer'
 
 type SourceKind = 'website' | 'sitemap' | 'pdf' | 'text'
 
@@ -33,7 +33,7 @@ const emit = defineEmits<{
 
 const kind = ref<SourceKind>('website')
 const url = ref('')
-const followLinks = ref(true)
+const scope = ref<CrawlScope>('host')
 const files = ref<File[]>([])
 const title = ref('')
 const content = ref('')
@@ -63,6 +63,38 @@ function normalizeUrl(raw: string): string {
   return v.includes('://') ? v : `https://${v}`
 }
 
+// Parsed form of what's typed so far, used to name the host/section in the
+// scope options. Null while the URL is empty or not yet valid.
+const parsedUrl = computed<URL | null>(() => {
+  if (!url.value.trim()) return null
+  try {
+    return new URL(normalizeUrl(url.value))
+  } catch {
+    return null
+  }
+})
+
+const seedHost = computed(() => parsedUrl.value?.hostname ?? 'this host')
+const seedSection = computed(() => {
+  const path = parsedUrl.value?.pathname.replace(/\/$/, '') ?? ''
+  return path || '/'
+})
+
+const scopes = computed<{ key: CrawlScope; title: string; sub: string }[]>(() => [
+  { key: 'page', title: 'This page only', sub: 'Index just the URL above.' },
+  {
+    key: 'path',
+    title: 'This section',
+    sub: `Pages under ${seedSection.value} on ${seedHost.value}.`,
+  },
+  { key: 'host', title: 'This site', sub: `Pages on ${seedHost.value} only.` },
+  {
+    key: 'domain',
+    title: 'Whole domain',
+    sub: 'Also other subdomains — blog, docs, marketing pages.',
+  },
+])
+
 function pickFiles() {
   fileInput.value?.click()
 }
@@ -86,7 +118,7 @@ function onDrop(event: DragEvent) {
 function submit() {
   if (!canSubmit.value) return
   if (kind.value === 'website') {
-    emit('submit', { type: 'website', url: normalizeUrl(url.value), followLinks: followLinks.value })
+    emit('submit', { type: 'website', url: normalizeUrl(url.value), scope: scope.value })
   } else if (kind.value === 'sitemap') {
     emit('submit', { type: 'sitemap', url: normalizeUrl(url.value) })
   } else if (kind.value === 'pdf') {
@@ -133,23 +165,18 @@ function submit() {
             placeholder="https://docs.yourcompany.com/help" @keyup.enter="submit" />
           <label class="field-label">CRAWL SCOPE</label>
           <div class="scope">
-            <button type="button" class="scope__opt" :class="{ 'scope__opt--active': !followLinks }"
-              @click="followLinks = false">
-              <span class="radio" :class="{ 'radio--on': !followLinks }"></span>
+            <button v-for="opt in scopes" :key="opt.key" type="button" class="scope__opt"
+              :class="{ 'scope__opt--active': scope === opt.key }" @click="scope = opt.key">
+              <span class="radio" :class="{ 'radio--on': scope === opt.key }"></span>
               <span>
-                <span class="scope__title">This page only</span>
-                <span class="scope__sub">Index just the URL above.</span>
-              </span>
-            </button>
-            <button type="button" class="scope__opt" :class="{ 'scope__opt--active': followLinks }"
-              @click="followLinks = true">
-              <span class="radio" :class="{ 'radio--on': followLinks }"></span>
-              <span>
-                <span class="scope__title">Follow links on this domain</span>
-                <span class="scope__sub">Discover and queue linked pages, up to your plan limit.</span>
+                <span class="scope__title">{{ opt.title }}</span>
+                <span class="scope__sub">{{ opt.sub }}</span>
               </span>
             </button>
           </div>
+          <p v-if="scope !== 'page'" class="scope__hint">
+            Linked pages are discovered and queued, up to your plan limit.
+          </p>
         </template>
 
         <!-- sitemap -->
@@ -408,6 +435,13 @@ function submit() {
   font-size: 12px;
   color: var(--muted2);
   margin-top: 1px;
+  overflow-wrap: anywhere;
+}
+
+.scope__hint {
+  margin: 8px 2px 0;
+  font-size: 12px;
+  color: var(--muted2);
 }
 
 .drop {

--- a/frontend/src/components/knowledge/KnowledgeAddSourceModal.vue
+++ b/frontend/src/components/knowledge/KnowledgeAddSourceModal.vue
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { AddSourcePayload, CrawlScope } from '@/composables/useKnowledgeExplorer'
 
 type SourceKind = 'website' | 'sitemap' | 'pdf' | 'text'
@@ -74,26 +74,46 @@ const parsedUrl = computed<URL | null>(() => {
   }
 })
 
-const seedHost = computed(() => parsedUrl.value?.hostname ?? 'this host')
-const seedSection = computed(() => {
-  const path = parsedUrl.value?.pathname.replace(/\/$/, '') ?? ''
-  return path || '/'
+const seedHost = computed(() => parsedUrl.value?.hostname ?? '')
+// The section is the URL's own path. Empty for a homepage URL — there is no
+// section to speak of, and "pages under /" would just be "This site" again.
+const seedSection = computed(() => parsedUrl.value?.pathname.replace(/\/$/, '') ?? '')
+
+const scopes = computed<{ key: CrawlScope; title: string; sub: string }[]>(() => {
+  const host = seedHost.value
+  const section = seedSection.value
+  return [
+    { key: 'page', title: 'This page only', sub: 'Index just the URL above.' },
+    ...(section
+      ? [
+          {
+            key: 'path' as CrawlScope,
+            title: 'This section',
+            sub: `Only pages under ${section}/ on ${host}.`,
+          },
+        ]
+      : []),
+    {
+      key: 'host',
+      title: 'This site',
+      sub: host ? `Every page on ${host}.` : 'Every page on the same host.',
+    },
+    {
+      key: 'domain',
+      // No domain name in the copy on purpose: working out that
+      // paywithatoa.co.uk is one registrable domain (not 'co.uk') needs the
+      // ccTLD list the backend keeps, and a second copy of it would drift.
+      title: 'Whole domain',
+      sub: 'Also other subdomains — blog, docs, app.',
+    },
+  ]
 })
 
-const scopes = computed<{ key: CrawlScope; title: string; sub: string }[]>(() => [
-  { key: 'page', title: 'This page only', sub: 'Index just the URL above.' },
-  {
-    key: 'path',
-    title: 'This section',
-    sub: `Pages under ${seedSection.value} on ${seedHost.value}.`,
-  },
-  { key: 'host', title: 'This site', sub: `Pages on ${seedHost.value} only.` },
-  {
-    key: 'domain',
-    title: 'Whole domain',
-    sub: 'Also other subdomains — blog, docs, marketing pages.',
-  },
-])
+// Editing the URL down to a homepage removes the section option; don't leave a
+// scope selected that is no longer on screen.
+watch(scopes, (options) => {
+  if (!options.some((option) => option.key === scope.value)) scope.value = 'host'
+})
 
 function pickFiles() {
   fileInput.value?.click()

--- a/frontend/src/composables/useKnowledgeExplorer.ts
+++ b/frontend/src/composables/useKnowledgeExplorer.ts
@@ -29,9 +29,13 @@ import { basePageId, groupChunksIntoPages, titleFromId } from '@/utils/knowledge
 export type ExplorerMode = 'agent' | 'org'
 export type SourceStatus = 'queued' | 'crawling' | 'synced' | 'error'
 
+// How far a website crawl may follow links from the URL it starts at.
+// 'page' indexes only that URL; the rest map to the backend's crawl scopes.
+export type CrawlScope = 'page' | 'path' | 'host' | 'domain'
+
 // What the add-source modal submits; discriminated by `type`.
 export type AddSourcePayload =
-  | { type: 'website'; url: string; followLinks: boolean }
+  | { type: 'website'; url: string; scope: CrawlScope }
   | { type: 'sitemap'; url: string }
   | { type: 'pdf'; files: File[] }
   | { type: 'text'; title: string; content: string }
@@ -536,7 +540,9 @@ export function useKnowledgeExplorer(
             [payload.url],
             linkedAgentId,
             undefined,
-            payload.followLinks ? undefined : 1,
+            // "This page only" is a one-page cap; the others are crawl scopes.
+            payload.scope === 'page' ? 1 : undefined,
+            payload.scope === 'page' ? undefined : payload.scope,
           ),
         )
         toast.success('Queued for crawling', {

--- a/frontend/src/services/knowledge.ts
+++ b/frontend/src/services/knowledge.ts
@@ -60,6 +60,7 @@ export const knowledgeService = {
     agentId?: string,
     onProgress?: (progress: number) => void,
     maxLinks?: number,
+    crawlScope?: string,
   ): Promise<KnowledgeUploadResponse> {
     try {
       let completed = 0
@@ -68,8 +69,11 @@ export const knowledgeService = {
         agent_id: agentId,
         pdf_urls: urls.filter((url) => url.toLowerCase().endsWith('.pdf')),
         websites: urls.filter((url) => !url.toLowerCase().endsWith('.pdf')),
-        // Optional crawl-scope cap for websites (e.g. 1 = "this page only").
+        // Optional page cap for websites (e.g. 1 = "this page only").
         ...(maxLinks ? { max_links: maxLinks } : {}),
+        // How far link-following may go: 'path' | 'host' | 'domain'.
+        // Omitted means the backend default (the URL's own host).
+        ...(crawlScope ? { crawl_scope: crawlScope } : {}),
       })
       if (onProgress) {
         const interval = setInterval(() => {


### PR DESCRIPTION
Fixes #290.

Two things were pulling junk into website knowledge sources. `mailto:` hrefs were being followed — `https://` + `mailto:a@example.com` parses as host `example.com` with `mailto:a` as userinfo, so it passed the same-domain check and got crawled, then spawned more mangled URLs from the page it fetched. And crawl scope was the whole registrable domain, so seeding `help.example.com` also crawled `www`, the blog and every other subdomain.

Crawls now stay on the seed's own host by default and only follow http(s) links. The add-source modal lets you pick the scope per source: this page only / this section (path prefix) / this site / whole domain. Sitemaps are unchanged — a sitemap index can legitimately list sibling hosts.

For content already stored: the migration deletes the mangled `mailto:` pages (7 rows on prod), which are provably junk. Real pages that are just off-scope are left alone — `backend/scripts/prune_offsite_pages.py` reports those per source and only deletes with `--apply`. FAQs already generated from junk pages can't be found automatically, so those need a look in the dashboard.