### PR TITLE
feat(tickets): thread customer email replies back onto tickets

### DIFF
--- a/backend/app/api/webhooks/email.py
+++ b/backend/app/api/webhooks/email.py
@@ -27,6 +27,7 @@ from app.database import get_db
 from app.models.channels import ChannelType
 from app.repositories.channels import ChannelAccountRepository
 from app.services.channel_chat import process_channel_message
+from app.services.ticket_email_reply import find_ticket_for_reply, record_ticket_email_reply
 
 router = APIRouter()
 logger = get_logger(__name__)
@@ -64,6 +65,13 @@ async def email_webhook(
             continue
         if is_duplicate_message(ChannelType.EMAIL.value,
                                 f"{account.id}:{inbound.external_message_id}"):
+            continue
+        # A reply to a ticket notification belongs on the ticket, not in a
+        # chat session — the customer is answering the support team.
+        ticket = find_ticket_for_reply(db, account.organization_id, inbound.profile)
+        if ticket is not None:
+            background_tasks.add_task(
+                record_ticket_email_reply, account.organization_id, ticket.id, inbound)
             continue
         background_tasks.add_task(process_channel_message, account.id, inbound)
 

--- a/backend/app/channels/email.py
+++ b/backend/app/channels/email.py
@@ -225,15 +225,11 @@ class EmailAdapter(ChannelAdapter):
 
     @classmethod
     def _threading_header(cls, payload: dict, name: str) -> str:
-        """In-Reply-To/References, whether the provider passes the raw headers
-        through or promotes them to its own top-level field."""
-        flat = name.replace("-", "")
-        for key in (name, name.lower(), flat, flat.lower(),
-                    name.replace("-", "_").lower()):
-            value = payload.get(key)
-            if value:
-                return str(value)
-        return cls._header(payload, name) or ""
+        """In-Reply-To/References, read from the raw headers the provider
+        forwards (dict or string, both handled by _header). Also accepts a
+        top-level lowercased field for providers that flatten headers onto the
+        payload."""
+        return payload.get(name.lower()) or cls._header(payload, name) or ""
 
     @staticmethod
     def _header(payload: dict, name: str) -> Optional[str]:

--- a/backend/app/channels/email.py
+++ b/backend/app/channels/email.py
@@ -161,7 +161,11 @@ class EmailAdapter(ChannelAdapter):
                 f"{sender_email}:{hashlib.sha256(text.encode()).hexdigest()[:32]}",
             text=text,
             profile={"name": sender_name or None, "email": sender_email,
-                     "subject": subject, "inbound_message_id": message_id},
+                     "subject": subject, "inbound_message_id": message_id,
+                     # Threading headers, kept raw — ticket reply matching
+                     # reads the Message-IDs we minted back out of them.
+                     "in_reply_to": self._threading_header(payload, "In-Reply-To"),
+                     "references": self._threading_header(payload, "References")},
         )]
 
     def conversation_state(self, inbound: InboundMessage) -> dict:
@@ -218,6 +222,18 @@ class EmailAdapter(ChannelAdapter):
         if "x-auto-response-suppress:" in lowered:
             return True
         return False
+
+    @classmethod
+    def _threading_header(cls, payload: dict, name: str) -> str:
+        """In-Reply-To/References, whether the provider passes the raw headers
+        through or promotes them to its own top-level field."""
+        flat = name.replace("-", "")
+        for key in (name, name.lower(), flat, flat.lower(),
+                    name.replace("-", "_").lower()):
+            value = payload.get(key)
+            if value:
+                return str(value)
+        return cls._header(payload, name) or ""
 
     @staticmethod
     def _header(payload: dict, name: str) -> Optional[str]:

--- a/backend/app/services/ticket.py
+++ b/backend/app/services/ticket.py
@@ -877,7 +877,51 @@ class TicketService:
             to_email,
             subject=f"[{ticket.display_number}] {ticket.title}",
             body=message,
+            ticket_id=ticket.id,
+            in_reply_to=self.last_customer_email_message_id(ticket),
         )
+
+    def last_customer_email_message_id(self, ticket: Ticket) -> Optional[str]:
+        """Message-ID of the customer's most recent emailed reply, so the next
+        notification threads under it in their client."""
+        for activity in reversed(self.activity_repo.list_for_ticket(ticket.id)):
+            if activity.activity_type != TicketActivityType.CUSTOMER_REPLIED.value:
+                continue
+            message_id = (activity.activity_metadata or {}).get("email_message_id")
+            if message_id:
+                return message_id
+        return None
+
+    def record_customer_email_reply(
+        self, ticket: Ticket, body: str, from_email: str, message_id: Optional[str] = None
+    ) -> TicketActivity:
+        """Append a customer's emailed reply to the ticket feed, reopening it
+        when the reply lands on a resolution the customer never confirmed.
+
+        Customer-visible (is_internal=False): it is the customer's own words,
+        and the agent-facing feed is where the team reads them."""
+        activity = self._add_activity(
+            ticket,
+            TicketActivityType.CUSTOMER_REPLIED,
+            actor_type=TicketActorType.CUSTOMER,
+            body=body,
+            is_internal=False,
+            metadata={
+                "channel": "email",
+                "from": from_email,
+                "email_message_id": message_id,
+            },
+        )
+        current = TicketStatus(str(ticket.status))
+        if current == TicketStatus.RESOLVED_PENDING_CONFIRMATION and (
+            TicketStatus.REOPENED in TICKET_STATUS_TRANSITIONS.get(current, set())
+        ):
+            self.reopen(
+                ticket,
+                reason="Customer replied by email before confirming the resolution",
+                actor_type=TicketActorType.CUSTOMER,
+            )
+        return activity
 
     def _primary_session(self, ticket: Ticket) -> Optional[SessionToAgent]:
         session_ids = self.repo.get_session_ids(ticket.id)

--- a/backend/app/services/ticket_email.py
+++ b/backend/app/services/ticket_email.py
@@ -21,9 +21,12 @@ domain), platform SMTP otherwise.
 """
 
 import asyncio
+import re
+import secrets
 from email.message import EmailMessage
 from email.utils import make_msgid
-from typing import Optional
+from typing import List, Optional
+from uuid import UUID
 
 from sqlalchemy.orm import Session
 
@@ -31,11 +34,96 @@ from app.channels.email import _open_smtp, smtp_config
 from app.core.config import settings
 from app.core.logger import get_logger
 from app.models.channels import ChannelAccount
+from app.models.ticket import TICKET_NUMBER_PREFIX
 from app.repositories.channels.accounts import ChannelAccountRepository
 
 logger = get_logger(__name__)
 
 EMAIL_CHANNEL_TYPE = "email"
+
+# Message-ID local part for ticket mail: 'ticket-<uuid hex>.<unique>'. The
+# ticket id lives in the address itself, so a reply that quotes any of our
+# Message-IDs back in References identifies its ticket with no lookup table.
+# Every sent message still gets its own unique id — reusing one id across
+# messages makes Gmail collapse them into a single copy.
+_TICKET_MSGID_RE = re.compile(r"ticket-([0-9a-f]{32})(?:\.[^@\s>]+)?@", re.I)
+# The phantom id every ticket mail references. Never sent as a message itself:
+# it is the shared thread root that ties separate notifications together.
+_ROOT_SUFFIX = "root"
+_SUBJECT_TOKEN_RE = re.compile(rf"\[{TICKET_NUMBER_PREFIX}-(\d+)\]", re.I)
+
+DEFAULT_MSGID_DOMAIN = "chattermate.chat"
+
+
+def _msgid_domain(from_email: Optional[str] = None) -> str:
+    """Right-hand side of generated Message-IDs. Cosmetic only — the parser
+    matches on the local part, so mail sent from a customer's own inbox domain
+    still threads back to its ticket."""
+    candidate = from_email or settings.FROM_EMAIL or ""
+    _, _, domain = candidate.rpartition("@")
+    return domain.strip("> ").lower() or DEFAULT_MSGID_DOMAIN
+
+
+def ticket_root_message_id(ticket_id, from_email: Optional[str] = None) -> str:
+    """The stable per-ticket thread root, carried in References on every mail."""
+    return f"<ticket-{UUID(str(ticket_id)).hex}.{_ROOT_SUFFIX}@{_msgid_domain(from_email)}>"
+
+
+def new_ticket_message_id(ticket_id, from_email: Optional[str] = None) -> str:
+    """A fresh Message-ID for one outbound ticket mail."""
+    return (
+        f"<ticket-{UUID(str(ticket_id)).hex}.{secrets.token_hex(8)}"
+        f"@{_msgid_domain(from_email)}>"
+    )
+
+
+def build_thread_headers(
+    ticket_id, in_reply_to: Optional[str] = None, from_email: Optional[str] = None
+) -> dict:
+    """Threading headers for one ticket notification.
+
+    References always starts at the ticket root so every notification for a
+    ticket lands in one client-side thread; In-Reply-To points at the
+    customer's most recent reply when we have seen one, so their client keeps
+    the conversation in order.
+    """
+    root = ticket_root_message_id(ticket_id, from_email)
+    references: List[str] = [root]
+    if in_reply_to and in_reply_to != root:
+        references.append(in_reply_to)
+    return {
+        "Message-ID": new_ticket_message_id(ticket_id, from_email),
+        "In-Reply-To": in_reply_to or root,
+        "References": " ".join(references),
+    }
+
+
+def ticket_ids_from_references(*values: Optional[str]) -> List[UUID]:
+    """Ticket ids encoded in In-Reply-To/References/Message-ID headers, most
+    recently referenced first — References lists ancestors oldest-first, and
+    the nearest ancestor is the better match."""
+    found: List[UUID] = []
+    for value in values:
+        if not value:
+            continue
+        for hex_id in _TICKET_MSGID_RE.findall(str(value)):
+            try:
+                ticket_id = UUID(hex_id)
+            except ValueError:
+                continue
+            if ticket_id not in found:
+                found.append(ticket_id)
+    found.reverse()
+    return found
+
+
+def ticket_number_from_subject(subject: Optional[str]) -> Optional[int]:
+    """The [TKT-12] token a customer's client keeps in the reply subject —
+    the fallback when a mail client drops the threading headers."""
+    if not subject:
+        return None
+    match = _SUBJECT_TOKEN_RE.search(str(subject))
+    return int(match.group(1)) if match else None
 
 
 def _org_email_account(db: Session, organization_id) -> Optional[ChannelAccount]:
@@ -66,17 +154,32 @@ def _smtp_send(cfg: dict, message: EmailMessage) -> None:
 
 
 async def send_ticket_email(
-    db: Session, organization_id, to_email: str, subject: str, body: str
+    db: Session,
+    organization_id,
+    to_email: str,
+    subject: str,
+    body: str,
+    ticket_id=None,
+    in_reply_to: Optional[str] = None,
 ) -> bool:
     """Send a plain-text ticket notification email. Returns False (and logs)
-    on failure — ticket mutations must never fail because SMTP hiccuped."""
+    on failure — ticket mutations must never fail because SMTP hiccuped.
+
+    With a ticket_id the mail carries ticket-scoped threading headers, so the
+    customer's reply comes back identifiable as a reply to that ticket."""
     try:
         cfg = _resolve_smtp(db, organization_id)
         message = EmailMessage()
         message["From"] = cfg["from_email"]
         message["To"] = to_email
         message["Subject"] = subject
-        message["Message-ID"] = make_msgid()
+        if ticket_id is not None:
+            for header, value in build_thread_headers(
+                ticket_id, in_reply_to, cfg["from_email"]
+            ).items():
+                message[header] = value
+        else:
+            message["Message-ID"] = make_msgid()
         message.set_content(body)
         await asyncio.to_thread(_smtp_send, cfg, message)
         return True

--- a/backend/app/services/ticket_email_reply.py
+++ b/backend/app/services/ticket_email_reply.py
@@ -1,0 +1,114 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Inbound side of ticket email threading: decide whether a mail arriving on the
+email channel is a reply to one of our ticket notifications, and append it to
+that ticket instead of feeding it to the chat agent.
+"""
+
+from typing import Optional
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.channels.base import InboundMessage
+from app.core.logger import get_logger
+from app.database import SessionLocal
+from app.models.ticket import Ticket
+from app.repositories.ticket import TicketRepository
+from app.services.ticket_email import (
+    ticket_ids_from_references,
+    ticket_number_from_subject,
+)
+
+logger = get_logger(__name__)
+
+
+def find_ticket_for_reply(
+    db: Session, organization_id: UUID, profile: Optional[dict]
+) -> Optional[Ticket]:
+    """The ticket an inbound email is replying to, or None.
+
+    Headers first: In-Reply-To/References carry a Message-ID we minted, and
+    the ticket id is inside it — unguessable, so a match is proof the mail
+    descends from a notification we sent.
+
+    The [TKT-n] subject token is the fallback for clients that drop threading
+    headers. It is guessable, and a ticket's feed is read by agents and by the
+    investigator AI, so that path additionally requires the sender to be the
+    ticket's own customer; anything else falls through to the chat pipeline.
+    """
+    profile = profile or {}
+    repo = TicketRepository(db)
+
+    for ticket_id in ticket_ids_from_references(
+        profile.get("in_reply_to"),
+        profile.get("references"),
+    ):
+        ticket = repo.get_by_id(ticket_id, organization_id)
+        if ticket is not None:
+            return ticket
+
+    number = ticket_number_from_subject(profile.get("subject"))
+    if number is None:
+        return None
+    ticket = repo.get_by_number(organization_id, number)
+    if ticket is None:
+        return None
+    sender = (profile.get("email") or "").strip().lower()
+    customer_email = (getattr(ticket.customer, "email", "") or "").strip().lower()
+    if sender and sender == customer_email:
+        return ticket
+    logger.info(
+        f"Subject token named {ticket.display_number} but {sender or 'an unknown sender'} "
+        "is not its customer — handling as a normal message"
+    )
+    return None
+
+
+async def record_ticket_email_reply(
+    organization_id: UUID, ticket_id: UUID, inbound: InboundMessage
+) -> None:
+    """Append an inbound email to its ticket. Runs from a BackgroundTask with
+    its own DB session, mirroring process_channel_message."""
+    db = SessionLocal()
+    try:
+        ticket = TicketRepository(db).get_by_id(ticket_id, organization_id)
+        if ticket is None:
+            logger.warning(f"Email reply for unknown ticket {ticket_id}")
+            return
+
+        from app.services.ticket import TicketService
+        service = TicketService(db)
+        profile = inbound.profile or {}
+        service.record_customer_email_reply(
+            ticket,
+            body=inbound.text or "",
+            from_email=inbound.external_user_id,
+            message_id=profile.get("inbound_message_id") or None,
+        )
+        db.commit()
+        db.refresh(ticket)
+
+        from app.services.ticket_events import emit_ticket_update
+        await emit_ticket_update(
+            organization_id, ticket.id, "comment", {"status": str(ticket.status)}
+        )
+        logger.info(f"Email reply appended to {ticket.display_number}")
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Failed to record email reply on ticket {ticket_id}: {e}")
+    finally:
+        db.close()

--- a/backend/tests/api/test_ticket_email_webhook.py
+++ b/backend/tests/api/test_ticket_email_webhook.py
@@ -1,0 +1,216 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Inbound-parse webhook routing: a reply to a ticket notification lands on the
+ticket, everything else still goes to the chat pipeline.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main  # noqa: F401 — ensures routers are registered on the FastAPI app
+from app.core.application import app
+from app.core.auth import get_current_user, get_current_organization
+from app.database import get_db
+from app.models.ticket import TicketPriority, TicketSource, TicketStatus
+from app.models.ticket_activity import TicketActivityType
+from app.repositories.channels import ChannelAccountRepository
+from app.services.ticket import TicketService
+from app.services.ticket_email import new_ticket_message_id, ticket_root_message_id
+
+WEBHOOK_BASE = "/api/v1/webhooks/email"
+
+
+@pytest.fixture(autouse=True)
+def no_embeddings():
+    with patch("app.services.ticket.embed_ticket_text", return_value=None):
+        yield
+
+
+@pytest.fixture
+def client(db, test_user, test_organization):
+    async def override_user():
+        return test_user
+
+    async def override_org():
+        return test_organization
+
+    def override_db():
+        yield db
+
+    app.dependency_overrides[get_current_user] = override_user
+    app.dependency_overrides[get_current_organization] = override_org
+    app.dependency_overrides[get_db] = override_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def email_account(db, test_organization):
+    return ChannelAccountRepository(db).create_account(
+        organization_id=test_organization.id,
+        channel_type="email",
+        external_account_id="support@acme.com",
+        credentials={},
+        display_name="Support inbox",
+    )
+
+
+@pytest.fixture
+def service(db):
+    return TicketService(db)
+
+
+@pytest.fixture
+def ticket(service, db, test_organization):
+    created, _dupes = service.create_ticket(
+        organization_id=test_organization.id,
+        title="Card declined at checkout",
+        description="Every attempt fails.",
+        priority=TicketPriority.HIGH,
+        source=TicketSource.MANUAL,
+        customer_email="ada@example.com",
+        customer_name="Ada Lovelace",
+    )
+    db.commit()
+    db.refresh(created)
+    return created
+
+
+def payload(subject="Re: Card declined", references="", sender="Ada <ada@example.com>",
+            message_id="<reply-1@mail.example.com>"):
+    return {
+        "from": sender,
+        "to": "support@acme.com",
+        "subject": subject,
+        "text": "It is still broken.\n\nOn Mon, Jul 7 2026 support wrote:\n> earlier",
+        "headers": f"Message-ID: {message_id}\nReferences: {references}",
+    }
+
+
+def post(client, account, body):
+    return client.post(f"{WEBHOOK_BASE}/{account.id}?token={account.webhook_secret}",
+                       json=body)
+
+
+class TestTicketReplyRouting:
+    def test_reply_routes_to_the_ticket_not_the_chat_agent(
+        self, client, email_account, ticket, test_organization
+    ):
+        with patch("app.api.webhooks.email.record_ticket_email_reply",
+                   AsyncMock()) as record, \
+             patch("app.api.webhooks.email.process_channel_message",
+                   AsyncMock()) as chat:
+            response = post(client, email_account,
+                            payload(references=ticket_root_message_id(ticket.id)))
+
+        assert response.status_code == 200
+        chat.assert_not_awaited()
+        record.assert_awaited_once()
+        organization_id, ticket_id, inbound = record.await_args.args
+        assert organization_id == test_organization.id
+        assert ticket_id == ticket.id
+        assert inbound.text == "It is still broken."
+
+    def test_reply_matched_by_subject_token(self, client, email_account, ticket):
+        with patch("app.api.webhooks.email.record_ticket_email_reply",
+                   AsyncMock()) as record, \
+             patch("app.api.webhooks.email.process_channel_message", AsyncMock()):
+            post(client, email_account,
+                 payload(subject=f"Re: [{ticket.display_number}] Card declined"))
+        assert record.await_args.args[1] == ticket.id
+
+    def test_subject_token_from_a_stranger_goes_to_the_chat_agent(
+        self, client, email_account, ticket
+    ):
+        with patch("app.api.webhooks.email.record_ticket_email_reply",
+                   AsyncMock()) as record, \
+             patch("app.api.webhooks.email.process_channel_message",
+                   AsyncMock()) as chat:
+            post(client, email_account,
+                 payload(subject=f"Re: [{ticket.display_number}] Card declined",
+                         sender="stranger@elsewhere.test"))
+        record.assert_not_awaited()
+        chat.assert_awaited_once()
+
+    def test_ordinary_mail_still_reaches_the_chat_agent(
+        self, client, email_account, ticket
+    ):
+        with patch("app.api.webhooks.email.record_ticket_email_reply",
+                   AsyncMock()) as record, \
+             patch("app.api.webhooks.email.process_channel_message",
+                   AsyncMock()) as chat:
+            post(client, email_account, payload(subject="A brand new question"))
+        record.assert_not_awaited()
+        chat.assert_awaited_once()
+
+    def test_bad_token_is_rejected_before_any_matching(
+        self, client, email_account, ticket
+    ):
+        with patch("app.api.webhooks.email.record_ticket_email_reply",
+                   AsyncMock()) as record:
+            response = client.post(f"{WEBHOOK_BASE}/{email_account.id}?token=wrong",
+                                   json=payload())
+        assert response.status_code == 403
+        record.assert_not_awaited()
+
+    def test_autoresponder_reply_is_dropped(self, client, email_account, ticket):
+        body = payload(references=ticket_root_message_id(ticket.id))
+        body["headers"] = f"{body['headers']}\nAuto-Submitted: auto-replied"
+        with patch("app.api.webhooks.email.record_ticket_email_reply",
+                   AsyncMock()) as record, \
+             patch("app.api.webhooks.email.process_channel_message",
+                   AsyncMock()) as chat:
+            response = post(client, email_account, body)
+        assert response.status_code == 200
+        record.assert_not_awaited()
+        chat.assert_not_awaited()
+
+
+class TestReplyEndToEnd:
+    def test_reply_appends_a_comment_and_reopens_the_ticket(
+        self, client, db, email_account, ticket, service, monkeypatch
+    ):
+        service.transition_status(ticket, TicketStatus.RESOLVED_PENDING_CONFIRMATION)
+        db.commit()
+
+        class _NonClosing:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+            def close(self):
+                pass
+
+        from app.services import ticket_email_reply
+        monkeypatch.setattr(ticket_email_reply, "SessionLocal", lambda: _NonClosing(db))
+
+        with patch("app.services.ticket_events.emit_ticket_update", AsyncMock()):
+            response = post(client, email_account,
+                            payload(references=new_ticket_message_id(ticket.id)))
+
+        assert response.status_code == 200
+        db.refresh(ticket)
+        assert ticket.status == TicketStatus.REOPENED
+        activities = service.activity_repo.list_for_ticket(ticket.id)
+        replies = [a for a in activities
+                   if a.activity_type == TicketActivityType.CUSTOMER_REPLIED.value]
+        assert len(replies) == 1
+        assert replies[0].body == "It is still broken."
+        assert replies[0].activity_metadata["from"] == "ada@example.com"

--- a/backend/tests/channels/test_email_sms_line_adapters.py
+++ b/backend/tests/channels/test_email_sms_line_adapters.py
@@ -42,6 +42,43 @@ class TestEmailAdapter:
         assert m.profile["subject"] == "Order issue"
         assert m.profile["inbound_message_id"] == "<abc123@mail.example.com>"
 
+    def test_threading_headers_from_raw_headers(self):
+        # Providers that forward the raw header block (dict or string) — the
+        # threading headers are pulled back out for ticket-reply matching.
+        string_headers = get_adapter("email").parse_inbound({
+            "from": "ada@example.com", "text": "still broken",
+            "headers": ("Message-ID: <r@mail>\n"
+                        "In-Reply-To: <ticket-1.a@acme.com>\n"
+                        "References: <ticket-1.root@acme.com> <ticket-1.a@acme.com>"),
+        })[0]
+        assert string_headers.profile["in_reply_to"] == "<ticket-1.a@acme.com>"
+        assert string_headers.profile["references"] == (
+            "<ticket-1.root@acme.com> <ticket-1.a@acme.com>")
+
+        dict_headers = get_adapter("email").parse_inbound({
+            "from": "ada@example.com", "text": "still broken",
+            "headers": {"In-Reply-To": "<ticket-2.a@acme.com>", "References": "<ticket-2.root@acme.com>"},
+        })[0]
+        assert dict_headers.profile["in_reply_to"] == "<ticket-2.a@acme.com>"
+        assert dict_headers.profile["references"] == "<ticket-2.root@acme.com>"
+
+    def test_threading_headers_from_flattened_payload(self):
+        # A provider that promotes headers to lowercased top-level fields.
+        m = get_adapter("email").parse_inbound({
+            "from": "ada@example.com", "text": "still broken",
+            "in-reply-to": "<ticket-3.a@acme.com>",
+            "references": "<ticket-3.root@acme.com> <ticket-3.a@acme.com>",
+        })[0]
+        assert m.profile["in_reply_to"] == "<ticket-3.a@acme.com>"
+        assert m.profile["references"] == "<ticket-3.root@acme.com> <ticket-3.a@acme.com>"
+
+    def test_threading_headers_absent_default_to_empty(self):
+        m = get_adapter("email").parse_inbound({
+            "from": "ada@example.com", "text": "hi", "subject": "New question",
+        })[0]
+        assert m.profile["in_reply_to"] == ""
+        assert m.profile["references"] == ""
+
     def test_parse_brevo_style(self):
         payload = {
             "From": {"Address": "Ada@Example.com", "Name": "Ada"},

--- a/backend/tests/services/test_ticket_email_threading.py
+++ b/backend/tests/services/test_ticket_email_threading.py
@@ -1,0 +1,330 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.channels import get_adapter
+from app.channels.base import InboundMessage
+from app.models.ticket import TicketPriority, TicketSource, TicketStatus
+from app.models.ticket_activity import TicketActivityType, TicketActorType
+from app.services import ticket_email, ticket_email_reply
+from app.services.ticket import TicketService
+from app.services.ticket_email import (
+    build_thread_headers,
+    new_ticket_message_id,
+    send_ticket_email,
+    ticket_ids_from_references,
+    ticket_number_from_subject,
+    ticket_root_message_id,
+)
+from app.services.ticket_email_reply import find_ticket_for_reply, record_ticket_email_reply
+
+
+@pytest.fixture(autouse=True)
+def no_embeddings():
+    with patch("app.services.ticket.embed_ticket_text", return_value=None):
+        yield
+
+
+@pytest.fixture
+def service(db):
+    return TicketService(db)
+
+
+def make_ticket(service, db, org, **overrides):
+    kwargs = dict(
+        organization_id=org.id,
+        title="Card declined at checkout",
+        description="Every attempt fails.",
+        priority=TicketPriority.HIGH,
+        source=TicketSource.MANUAL,
+        customer_email="ada@example.com",
+        customer_name="Ada Lovelace",
+    )
+    kwargs.update(overrides)
+    ticket, _dupes = service.create_ticket(**kwargs)
+    db.commit()
+    db.refresh(ticket)
+    return ticket
+
+
+def inbound_reply(ticket_id=None, subject="Re: [TKT-1] Card declined",
+                  sender="ada@example.com", message_id="<reply-1@mail.example.com>",
+                  references=None):
+    if references is None:
+        references = ticket_root_message_id(ticket_id) if ticket_id else ""
+    return InboundMessage(
+        external_account_id="",
+        external_conversation_id=sender,
+        external_user_id=sender,
+        external_message_id=message_id,
+        text="It is still broken.",
+        profile={
+            "name": "Ada", "email": sender, "subject": subject,
+            "inbound_message_id": message_id,
+            "in_reply_to": "", "references": references,
+        },
+    )
+
+
+class TestMessageIdScheme:
+    def test_root_is_stable_and_per_message_ids_are_not(self):
+        ticket_id = uuid4()
+        assert ticket_root_message_id(ticket_id) == ticket_root_message_id(ticket_id)
+        assert new_ticket_message_id(ticket_id) != new_ticket_message_id(ticket_id)
+
+    def test_every_generated_id_resolves_back_to_its_ticket(self):
+        ticket_id = uuid4()
+        for value in (ticket_root_message_id(ticket_id), new_ticket_message_id(ticket_id)):
+            assert ticket_ids_from_references(value) == [ticket_id]
+
+    def test_domain_does_not_affect_matching(self):
+        ticket_id = uuid4()
+        value = new_ticket_message_id(ticket_id, from_email="help@customer-domain.test")
+        assert value.endswith("@customer-domain.test>")
+        assert ticket_ids_from_references(value) == [ticket_id]
+
+    def test_nearest_ancestor_wins_in_references(self):
+        older, newer = uuid4(), uuid4()
+        header = f"{ticket_root_message_id(older)} {ticket_root_message_id(newer)}"
+        assert ticket_ids_from_references(header) == [newer, older]
+
+    def test_foreign_message_ids_are_ignored(self):
+        assert ticket_ids_from_references("<CAF=abc@mail.gmail.com>", None, "") == []
+
+    def test_thread_headers_reference_the_root(self):
+        ticket_id = uuid4()
+        headers = build_thread_headers(ticket_id)
+        root = ticket_root_message_id(ticket_id)
+        assert headers["In-Reply-To"] == root
+        assert headers["References"] == root
+        assert headers["Message-ID"] != root
+
+    def test_thread_headers_chain_onto_the_last_reply(self):
+        ticket_id = uuid4()
+        headers = build_thread_headers(ticket_id, in_reply_to="<reply-9@mail.example.com>")
+        assert headers["In-Reply-To"] == "<reply-9@mail.example.com>"
+        assert headers["References"] == (
+            f"{ticket_root_message_id(ticket_id)} <reply-9@mail.example.com>"
+        )
+
+    @pytest.mark.parametrize("subject,expected", [
+        ("Re: [TKT-42] Card declined", 42),
+        ("[tkt-7] lowercase still counts", 7),
+        ("Fwd: Re: [TKT-1024] deep thread", 1024),
+        ("No token here", None),
+        ("TKT-5 without brackets", None),
+        (None, None),
+    ])
+    def test_subject_token(self, subject, expected):
+        assert ticket_number_from_subject(subject) == expected
+
+
+class TestOutboundThreading:
+    @pytest.fixture
+    def sent(self, monkeypatch):
+        captured = {}
+
+        def fake_send(cfg, message):
+            captured["message"] = message
+
+        monkeypatch.setattr(ticket_email, "_smtp_send", fake_send)
+        monkeypatch.setattr(ticket_email, "_resolve_smtp", lambda db, org: {
+            "host": "smtp.test", "port": 587, "username": None, "password": None,
+            "from_email": "support@acme.com", "use_ssl": False,
+        })
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_ticket_mail_carries_threading_headers(self, sent, db):
+        ticket_id = uuid4()
+        ok = await send_ticket_email(
+            db, uuid4(), "ada@example.com", "[TKT-1] Card declined", "We are on it",
+            ticket_id=ticket_id,
+        )
+        assert ok is True
+        message = sent["message"]
+        assert ticket_ids_from_references(message["Message-ID"]) == [ticket_id]
+        assert message["References"] == ticket_root_message_id(ticket_id, "support@acme.com")
+        assert message["In-Reply-To"] == message["References"]
+
+    @pytest.mark.asyncio
+    async def test_mail_without_a_ticket_keeps_a_plain_message_id(self, sent, db):
+        await send_ticket_email(db, uuid4(), "a@b.co", "Subject", "Body")
+        assert ticket_ids_from_references(sent["message"]["Message-ID"]) == []
+        assert sent["message"]["In-Reply-To"] is None
+
+    @pytest.mark.asyncio
+    async def test_service_threads_onto_the_customers_last_reply(
+        self, service, db, test_organization
+    ):
+        ticket = make_ticket(service, db, test_organization)
+        service.record_customer_email_reply(
+            ticket, "Still broken", "ada@example.com", "<reply-1@mail.example.com>")
+        db.commit()
+
+        with patch("app.services.ticket_email.send_ticket_email",
+                   AsyncMock(return_value=True)) as send:
+            await service.send_customer_message(ticket, "Looking into it")
+
+        assert send.await_args.kwargs["ticket_id"] == ticket.id
+        assert send.await_args.kwargs["in_reply_to"] == "<reply-1@mail.example.com>"
+
+    @pytest.mark.asyncio
+    async def test_first_mail_has_no_reply_to_thread_onto(
+        self, service, db, test_organization
+    ):
+        ticket = make_ticket(service, db, test_organization)
+        with patch("app.services.ticket_email.send_ticket_email",
+                   AsyncMock(return_value=True)) as send:
+            await service.send_customer_message(ticket, "Looking into it")
+        assert send.await_args.kwargs["in_reply_to"] is None
+
+
+class TestReplyMatching:
+    def test_matches_on_references(self, service, db, test_organization):
+        ticket = make_ticket(service, db, test_organization)
+        inbound = inbound_reply(ticket.id, subject="Re: no token here")
+        found = find_ticket_for_reply(db, test_organization.id, inbound.profile)
+        assert found is not None and found.id == ticket.id
+
+    def test_matches_on_in_reply_to(self, service, db, test_organization):
+        ticket = make_ticket(service, db, test_organization)
+        profile = inbound_reply(subject="Re: no token").profile
+        profile["in_reply_to"] = new_ticket_message_id(ticket.id)
+        found = find_ticket_for_reply(db, test_organization.id, profile)
+        assert found is not None and found.id == ticket.id
+
+    def test_falls_back_to_the_subject_token(self, service, db, test_organization):
+        ticket = make_ticket(service, db, test_organization)
+        profile = inbound_reply(
+            subject=f"Re: [{ticket.display_number}] Card declined").profile
+        found = find_ticket_for_reply(db, test_organization.id, profile)
+        assert found is not None and found.id == ticket.id
+
+    def test_subject_token_from_a_stranger_is_not_a_match(
+        self, service, db, test_organization
+    ):
+        ticket = make_ticket(service, db, test_organization)
+        profile = inbound_reply(
+            subject=f"Re: [{ticket.display_number}] Card declined",
+            sender="stranger@elsewhere.test").profile
+        assert find_ticket_for_reply(db, test_organization.id, profile) is None
+
+    def test_headers_beat_a_mismatched_subject_token(
+        self, service, db, test_organization
+    ):
+        real = make_ticket(service, db, test_organization)
+        other = make_ticket(service, db, test_organization, title="Unrelated")
+        profile = inbound_reply(
+            real.id, subject=f"Re: [{other.display_number}] Unrelated").profile
+        found = find_ticket_for_reply(db, test_organization.id, profile)
+        assert found.id == real.id
+
+    def test_tickets_of_another_org_are_invisible(self, service, db, test_organization):
+        ticket = make_ticket(service, db, test_organization)
+        profile = inbound_reply(ticket.id).profile
+        assert find_ticket_for_reply(db, uuid4(), profile) is None
+
+    def test_ordinary_mail_is_not_a_ticket_reply(self, db, test_organization):
+        profile = get_adapter("email").parse_inbound({
+            "from": "ada@example.com", "text": "Hi, can you help?", "subject": "Help",
+        })[0].profile
+        assert find_ticket_for_reply(db, test_organization.id, profile) is None
+
+
+class TestRecordingReplies:
+    def test_reply_is_appended_as_a_customer_activity(
+        self, service, db, test_organization
+    ):
+        ticket = make_ticket(service, db, test_organization)
+        service.record_customer_email_reply(
+            ticket, "It is still broken.", "ada@example.com", "<reply-1@mail>")
+        db.commit()
+
+        last = service.activity_repo.list_for_ticket(ticket.id)[-1]
+        assert last.activity_type == TicketActivityType.CUSTOMER_REPLIED.value
+        assert last.actor_type == TicketActorType.CUSTOMER.value
+        assert last.body == "It is still broken."
+        assert last.is_internal is False
+        assert last.activity_metadata["channel"] == "email"
+        assert last.activity_metadata["from"] == "ada@example.com"
+        assert last.activity_metadata["email_message_id"] == "<reply-1@mail>"
+
+    def test_reply_reopens_an_unconfirmed_resolution(
+        self, service, db, test_organization
+    ):
+        ticket = make_ticket(service, db, test_organization)
+        service.transition_status(ticket, TicketStatus.RESOLVED_PENDING_CONFIRMATION)
+        db.commit()
+
+        service.record_customer_email_reply(ticket, "Not fixed", "ada@example.com", "<r@m>")
+        db.commit()
+        db.refresh(ticket)
+
+        assert ticket.status == TicketStatus.REOPENED
+        assert ticket.reopened_count == 1
+        assert ticket.confirmation_requested_at is None
+        types = [a.activity_type for a in service.activity_repo.list_for_ticket(ticket.id)]
+        assert TicketActivityType.REOPENED.value in types
+
+    def test_reply_on_an_open_ticket_leaves_the_status_alone(
+        self, service, db, test_organization
+    ):
+        ticket = make_ticket(service, db, test_organization)
+        service.transition_status(ticket, TicketStatus.IN_PROGRESS)
+        service.record_customer_email_reply(ticket, "Any news?", "ada@example.com", "<r@m>")
+        db.commit()
+        db.refresh(ticket)
+        assert ticket.status == TicketStatus.IN_PROGRESS
+        assert ticket.reopened_count == 0
+
+    @pytest.mark.asyncio
+    async def test_background_task_records_and_emits(
+        self, service, db, test_organization, monkeypatch
+    ):
+        ticket = make_ticket(service, db, test_organization)
+
+        class _NonClosing:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(ticket_email_reply, "SessionLocal", lambda: _NonClosing(db))
+        with patch("app.services.ticket_events.emit_ticket_update", AsyncMock()) as emit:
+            await record_ticket_email_reply(
+                test_organization.id, ticket.id, inbound_reply(ticket.id))
+
+        last = service.activity_repo.list_for_ticket(ticket.id)[-1]
+        assert last.activity_type == TicketActivityType.CUSTOMER_REPLIED.value
+        assert last.body == "It is still broken."
+        emit.assert_awaited_once()
+        assert emit.await_args.args[2] == "comment"
+
+    @pytest.mark.asyncio
+    async def test_background_task_survives_an_unknown_ticket(
+        self, db, test_organization, monkeypatch
+    ):
+        monkeypatch.setattr(ticket_email_reply, "SessionLocal", lambda: db)
+        await record_ticket_email_reply(test_organization.id, uuid4(), inbound_reply())

--- a/frontend/src/components/tickets/TicketActivityFeed.vue
+++ b/frontend/src/components/tickets/TicketActivityFeed.vue
@@ -78,6 +78,13 @@ function avatarText(activity: TicketActivity): string {
             >
               sent to customer
             </span>
+            <span
+              v-if="activity.activity_type === 'customer_replied'
+                && activity.activity_metadata?.channel === 'email'"
+              class="visible-tag"
+            >
+              replied by email
+            </span>
             <span class="time">{{ timeAgo(activity.created_at) }}</span>
           </div>
           <div class="item-text" :class="{ muted: activity.actor_type === 'system' }">


### PR DESCRIPTION
Replying to a ticket notification email currently goes nowhere: outbound mail sets a fresh Message-ID with no threading headers, and inbound mail has no path to match a reply back to its ticket.

**Outbound** — ticket notification emails now carry a ticket-scoped Message-ID scheme (`<ticket-<uuid>.<unique>@domain>`), with `In-Reply-To`/`References` pointing at a stable per-ticket thread root (and at the customer's last reply once there is one). The `[TKT-n]` subject token is kept. Threading is applied at the single `_email_customer_copy` send point, so both the web-widget email supplement and the no-session fallback thread.

**Inbound** — the email inbound-parse webhook now checks each parsed message for a ticket match before handing it to the chat pipeline. Matching is by threading headers first (unguessable, so a match proves the mail descends from a notification we sent), then the `[TKT-n]` subject token as a fallback. Because the subject token is guessable and ticket feeds are read by agents and the investigator AI, the subject path additionally requires the sender to be the ticket's own customer — anything else falls through to the normal chat pipeline.

A matched reply is appended as a customer-visible `CUSTOMER_REPLIED` activity, and a ticket sitting in `resolved_pending_confirmation` is reopened via the existing status-transition map.

**Tests** — service-level coverage for the Message-ID scheme, header construction, reply matching (incl. cross-org isolation and the stranger case), and reopen behaviour; API-level coverage for webhook routing end to end, the autoresponder drop, and a reply that reopens a ticket.

Note: replies only come back if the org has a connected email inbox with inbound parse pointed at `/webhooks/email/{account_id}`. Tickets notified via platform SMTP with no connected inbox thread correctly in the customer's client but have nowhere to deliver the reply.