### PR TITLE
fix: per-device push tokens, and an update prompt that actually clears

### DIFF
--- a/backend/alembic/versions/fcm_tokens_per_device_001.py
+++ b/backend/alembic/versions/fcm_tokens_per_device_001.py
@@ -1,0 +1,88 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""per-device fcm_tokens table, replacing users.fcm_token_web
+
+Revision ID: fcm_tokens_per_device_001
+Revises: add_agent_ai_replies_001
+Create Date: 2026-08-20
+
+The old single column held one push token for the whole account, so signing in
+on a second device overwrote the first one's token and signing out anywhere
+cleared it for every device. Existing tokens are carried over, one row each, so
+already-registered browsers keep receiving pushes across the deploy.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'fcm_tokens_per_device_001'
+down_revision = 'add_agent_ai_replies_001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'fcm_tokens',
+        sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('user_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('token', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True),
+                  server_default=sa.text('now()'), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True),
+                  server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('token', name='uq_fcm_tokens_token'),
+    )
+    op.create_index('ix_fcm_tokens_user_id', 'fcm_tokens', ['user_id'])
+
+    # Carry over the tokens already registered. DISTINCT ON keeps the unique
+    # constraint safe in the unlikely case two accounts share a token — the
+    # most recently updated row wins, which is the one FCM would deliver to.
+    op.execute(
+        """
+        INSERT INTO fcm_tokens (id, user_id, token)
+        SELECT DISTINCT ON (fcm_token_web) gen_random_uuid(), id, fcm_token_web
+        FROM users
+        WHERE fcm_token_web IS NOT NULL AND fcm_token_web <> ''
+        ORDER BY fcm_token_web, updated_at DESC NULLS LAST
+        """
+    )
+
+    op.drop_column('users', 'fcm_token_web')
+
+
+def downgrade() -> None:
+    op.add_column('users', sa.Column(
+        'fcm_token_web', sa.String(), nullable=True))
+    # Only one token per user fits in the old column; keep the newest.
+    op.execute(
+        """
+        UPDATE users u
+        SET fcm_token_web = t.token
+        FROM (
+            SELECT DISTINCT ON (user_id) user_id, token
+            FROM fcm_tokens
+            ORDER BY user_id, created_at DESC
+        ) t
+        WHERE t.user_id = u.id
+        """
+    )
+    op.drop_index('ix_fcm_tokens_user_id', table_name='fcm_tokens')
+    op.drop_table('fcm_tokens')

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -34,6 +34,7 @@ from app.core.security import create_access_token, create_refresh_token, validat
 from app.core.auth import INBOX_PERMISSIONS, get_current_user, require_any_permission, require_permissions
 from app.core.logger import get_logger
 from app.repositories.user import UserRepository
+from app.repositories.fcm_token import FCMTokenRepository
 from pydantic import BaseModel
 from app.models.role import Role
 from app.services.chat_scope_roles import resolve_role
@@ -785,42 +786,52 @@ class FCMTokenUpdate(BaseModel):
 
 
 @router.post("/token/fcm-token")
-async def update_fcm_token(
+async def register_fcm_token(
     token_data: FCMTokenUpdate = Body(...),
     current_user: User = Depends(get_current_user),
     db=Depends(get_db)
 ):
-    """Update user's FCM token for web notifications"""
+    """Register this browser's web-push token for the signed-in user."""
     try:
-        user_repo = UserRepository(db)
-        success = user_repo.update_fcm_token(current_user.id, token_data.token)
+        token_repo = FCMTokenRepository(db)
+        success = token_repo.register(current_user.id, token_data.token)
 
         if success:
-            return {"message": "FCM token updated successfully"}
-        return {"error": "Failed to update FCM token"}
+            return {"message": "FCM token registered successfully"}
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to register FCM token"
+        )
 
+    except HTTPException:
+        raise
     except Exception as e:
-        logger.error(f"Error updating FCM token: {str(e)}")
-        return {"error": str(e)}
+        logger.error(f"Error registering FCM token: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e)
+        )
 
 
 @router.delete("/token/fcm-token")
-async def clear_fcm_token(
+async def unregister_fcm_token(
+    token_data: FCMTokenUpdate = Body(...),
     current_user: User = Depends(get_current_user),
     db=Depends(get_db)
 ):
-    """Clear user's FCM token"""
-    try:
-        user_repo = UserRepository(db)
-        print(current_user.id)
-        success = user_repo.clear_fcm_token(current_user.id)
+    """Drop this browser's token on logout.
 
-        if success:
-            return {"message": "FCM token cleared successfully"}
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Failed to clear FCM token"
-        )
+    The token is required: clearing every token for the account (what this used
+    to do) meant signing out on a laptop silently killed push on the user's
+    phone. A device that can no longer produce its token is cleaned up instead
+    by the dead-token pruning in send_fcm_notification.
+    """
+    try:
+        token_repo = FCMTokenRepository(db)
+        token_repo.remove(current_user.id, token_data.token)
+        # Absent rows are not an error: logging out twice, or after the token
+        # was already pruned, should still succeed.
+        return {"message": "FCM token cleared successfully"}
 
     except Exception as e:
         logger.error(f"Error clearing FCM token: {str(e)}")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -17,6 +17,7 @@ limitations under the License.
 from app.database import Base
 from .organization import Organization
 from .user import User
+from .fcm_token import FCMToken
 from .customer import Customer
 from .role import Role
 from .permission import Permission
@@ -73,6 +74,7 @@ from app.models.guardrail_event import GuardrailEvent
 __all__ = [
     "Organization",
     "User",
+    "FCMToken",
     "Customer",
     "Permission",
     "Role",

--- a/backend/app/models/fcm_token.py
+++ b/backend/app/models/fcm_token.py
@@ -1,0 +1,55 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from sqlalchemy import Column, String, DateTime, ForeignKey, func
+from sqlalchemy.orm import relationship
+from sqlalchemy.dialects.postgresql import UUID
+import uuid
+
+from app.database import Base
+
+
+class FCMToken(Base):
+    """One web-push token per signed-in browser.
+
+    Replaces the old single `users.fcm_token_web` column, which held one token
+    for the whole account: signing in on a laptop overwrote the phone's token
+    and signing out anywhere cleared it for every device, so the phone silently
+    stopped receiving pushes.
+
+    The token is minted by the browser, not by us, and FCM returns the *same*
+    value for a given browser install regardless of who is signed in — hence the
+    unique constraint plus reassign-on-register in the repository, so a shared
+    browser moves its token to the new owner instead of delivering that user's
+    notifications to the previous one.
+    """
+
+    __tablename__ = "fcm_tokens"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    token = Column(String, nullable=False, unique=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    user = relationship("User", back_populates="fcm_tokens")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -73,7 +73,6 @@ class User(Base):
     role_id = Column(Integer, ForeignKey("roles.id"), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
-    fcm_token_web = Column(String, nullable=True)
 
     # Define relationships
     organization = relationship("Organization", back_populates="users")
@@ -85,6 +84,9 @@ class User(Base):
     )
     notifications = relationship(
         "Notification", back_populates="user", cascade="all, delete-orphan")
+    # One row per signed-in browser; see app/models/fcm_token.py
+    fcm_tokens = relationship(
+        "FCMToken", back_populates="user", cascade="all, delete-orphan")
     chat_histories = relationship("ChatHistory", back_populates="user")
     
     # Add groups relationship

--- a/backend/app/repositories/fcm_token.py
+++ b/backend/app/repositories/fcm_token.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from uuid import UUID
 from typing import List, Sequence
@@ -39,23 +40,36 @@ class FCMTokenRepository:
         previous account's notifications.
         """
         try:
-            existing = self.db.query(FCMToken).filter(
-                FCMToken.token == token).first()
-
-            if existing:
-                if existing.user_id == user_id:
-                    return True
-                logger.info(
-                    f"Reassigning FCM token from user {existing.user_id} to {user_id}")
-                existing.user_id = user_id
-            else:
-                self.db.add(FCMToken(user_id=user_id, token=token))
-
-            self.db.commit()
-            return True
+            if self._claim(user_id, token):
+                return True
+            # Lost the insert race: the client posts on every app load, so two
+            # tabs opening together both see no row and both insert. Re-run
+            # against the row the winner committed instead of failing the
+            # request and leaving this browser unregistered for the session.
+            self.db.rollback()
+            return self._claim(user_id, token)
         except Exception as e:
             logger.error(f"Error registering FCM token: {str(e)}")
             self.db.rollback()
+            return False
+
+    def _claim(self, user_id: UUID, token: str) -> bool:
+        """Point `token` at `user_id`. False if a concurrent insert won."""
+        existing = self.db.query(FCMToken).filter(
+            FCMToken.token == token).first()
+
+        if existing:
+            if existing.user_id != user_id:
+                logger.info(
+                    f"Reassigning FCM token from user {existing.user_id} to {user_id}")
+                existing.user_id = user_id
+        else:
+            self.db.add(FCMToken(user_id=user_id, token=token))
+
+        try:
+            self.db.commit()
+            return True
+        except IntegrityError:
             return False
 
     def get_tokens(self, user_id: UUID) -> List[str]:

--- a/backend/app/repositories/fcm_token.py
+++ b/backend/app/repositories/fcm_token.py
@@ -1,0 +1,101 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from sqlalchemy.orm import Session
+from uuid import UUID
+from typing import List, Sequence
+
+from app.models.fcm_token import FCMToken
+from app.core.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class FCMTokenRepository:
+    """Web-push tokens, one row per signed-in browser."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    def register(self, user_id: UUID, token: str) -> bool:
+        """Store `token` for `user_id`, creating or reassigning its row.
+
+        FCM hands the same token back to a given browser install no matter who
+        is signed in, so an existing row is moved to the current user rather
+        than duplicated — otherwise a shared browser would keep receiving the
+        previous account's notifications.
+        """
+        try:
+            existing = self.db.query(FCMToken).filter(
+                FCMToken.token == token).first()
+
+            if existing:
+                if existing.user_id == user_id:
+                    return True
+                logger.info(
+                    f"Reassigning FCM token from user {existing.user_id} to {user_id}")
+                existing.user_id = user_id
+            else:
+                self.db.add(FCMToken(user_id=user_id, token=token))
+
+            self.db.commit()
+            return True
+        except Exception as e:
+            logger.error(f"Error registering FCM token: {str(e)}")
+            self.db.rollback()
+            return False
+
+    def get_tokens(self, user_id: UUID) -> List[str]:
+        """Every device token registered for a user."""
+        try:
+            rows = self.db.query(FCMToken.token).filter(
+                FCMToken.user_id == user_id).all()
+            return [row.token for row in rows]
+        except Exception as e:
+            logger.error(f"Error getting FCM tokens: {str(e)}")
+            return []
+
+    def remove(self, user_id: UUID, token: str) -> bool:
+        """Drop a single device's token — used on logout.
+
+        Scoped to the owner so a stolen token can't be used to silence someone
+        else's notifications.
+        """
+        try:
+            deleted = self.db.query(FCMToken).filter(
+                FCMToken.user_id == user_id,
+                FCMToken.token == token,
+            ).delete(synchronize_session=False)
+            self.db.commit()
+            return deleted > 0
+        except Exception as e:
+            logger.error(f"Error removing FCM token: {str(e)}")
+            self.db.rollback()
+            return False
+
+    def remove_tokens(self, tokens: Sequence[str]) -> int:
+        """Drop tokens FCM has told us are dead. Returns the number removed."""
+        if not tokens:
+            return 0
+        try:
+            deleted = self.db.query(FCMToken).filter(
+                FCMToken.token.in_(list(tokens))).delete(synchronize_session=False)
+            self.db.commit()
+            return deleted
+        except Exception as e:
+            logger.error(f"Error pruning FCM tokens: {str(e)}")
+            self.db.rollback()
+            return 0

--- a/backend/app/repositories/user.py
+++ b/backend/app/repositories/user.py
@@ -107,45 +107,6 @@ class UserRepository:
             return True
         return False
 
-    def get_user_fcm_token(self, user_id: str) -> Optional[str]:
-        """Get user's FCM token for web notifications"""
-        try:
-            user = self.db.query(User).filter(User.id == user_id).first()
-            return user.fcm_token_web if user else None
-        except Exception as e:
-            logger.error(f"Error getting user FCM token: {str(e)}")
-            return None
-
-    def update_fcm_token(self, user_id: str, token: str) -> bool:
-        """Update user's FCM token"""
-        try:
-            user = self.db.query(User).filter(User.id == user_id).first()
-            if not user:
-                return False
-
-            user.fcm_token_web = token
-            self.db.commit()
-            return True
-        except Exception as e:
-            logger.error(f"Error updating FCM token: {str(e)}")
-            self.db.rollback()
-            return False
-
-    def clear_fcm_token(self, user_id: str) -> bool:
-        """Clear user's FCM token"""
-        try:
-            user = self.db.query(User).filter(User.id == user_id).first()
-            if not user:
-                return False
-
-            user.fcm_token_web = None
-            self.db.commit()
-            return True
-        except Exception as e:
-            logger.error(f"Error clearing FCM token: {str(e)}")
-            self.db.rollback()
-            return False
-            
     def get_first_admin_by_org(self, organization_id: UUID) -> Optional[User]:
         """Get the first admin user in an organization"""
         try:

--- a/backend/app/services/firebase.py
+++ b/backend/app/services/firebase.py
@@ -14,14 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import firebase_admin
-from firebase_admin import credentials, messaging, initialize_app, get_app
+from firebase_admin import credentials, initialize_app, get_app
 from app.core.config import settings
-import json
-from app.repositories.user import UserRepository
 from app.core.logger import get_logger
 import os
-from firebase_admin.exceptions import FirebaseError
 
 logger = get_logger(__name__)
 
@@ -65,46 +61,3 @@ def initialize_firebase():
     except Exception as e:
         logger.error(f"Error initializing Firebase: {str(e)}")
         logger.warning("Continuing without Firebase initialization")
-        
-
-
-async def send_firebase_notification(notification, db):
-    """Send notification through Firebase Cloud Messaging"""
-    try:
-        # Get user's FCM token from database
-        user_repo = UserRepository(db)
-        user_token = user_repo.get_user_fcm_token(notification.user_id)
-        
-        if not user_token:
-            logger.warning(f"No FCM token found for user {notification.user_id}")
-            return
-
-        # Create the message payload
-        try:
-            message = messaging.Message(
-                notification=messaging.Notification(
-                    title=notification.title,
-                    body=notification.message,
-                ),
-                data={
-                    "type": notification.type,
-                    "id": str(notification.id),
-                    "metadata": json.dumps(notification.metadata)
-                },
-                token=user_token,
-            )
-        except Exception as e:
-            logger.error(f"Error creating Firebase message payload: {str(e)}")
-            return
-
-        try:
-            response = messaging.send(message)
-            logger.info(f"Successfully sent notification {notification.id} to user {notification.user_id}: {response}")
-        except FirebaseError as e:
-            error_msg = str(e.cause) if e.cause else str(e)
-            logger.error(f"Firebase API error while sending notification {notification.id}: {error_msg}")
-        except Exception as e:
-            logger.error(f"Unexpected error sending notification {notification.id}: {str(e)}")
-
-    except Exception as e:
-        logger.error(f"Error in send_firebase_notification: {str(e)}")

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -16,20 +16,41 @@ limitations under the License.
 
 import json
 
-from app.models.user import User
 from app.models.notification import Notification
+from app.repositories.fcm_token import FCMTokenRepository
 from app.core.logger import get_logger
 from firebase_admin import messaging
 
 logger = get_logger(__name__)
 
+# Errors that identify the *token* as dead rather than the send as failed: the
+# browser revoked the subscription or cleared site data (Unregistered), or the
+# token belongs to a different Firebase project (SenderIdMismatch). Retrying
+# these never succeeds, so the row is pruned and the browser re-registers on
+# its next load.
+#
+# InvalidArgumentError is deliberately NOT here. FCM also returns it for a bad
+# *message* — an oversized data payload, say — which fails identically for
+# every token in the batch and would prune every device the user owns.
+DEAD_TOKEN_ERRORS = (
+    messaging.UnregisteredError,
+    messaging.SenderIdMismatchError,
+)
+
 
 async def send_fcm_notification(user_id: str, notification: Notification, db):
-    """Send FCM notification to user"""
+    """Push a notification to every browser the user has signed in on."""
     try:
-        # Get user's FCM token
-        user = db.query(User).filter(User.id == user_id).first()
-        if not user or not user.fcm_token_web:
+        token_repo = FCMTokenRepository(db)
+        tokens = token_repo.get_tokens(user_id)
+        if not tokens:
+            # Logged, not silent: an account with notifications enabled but no
+            # registered device looks identical to a broken push pipeline from
+            # the outside, and used to leave no trace at all.
+            logger.info(
+                f"No FCM tokens registered for user {user_id}; "
+                f"skipping push for notification {notification.id}"
+            )
             return
 
         metadata = notification.notification_metadata or {}
@@ -42,30 +63,58 @@ async def send_fcm_notification(user_id: str, notification: Notification, db):
         # the metadata so a click can deep-link to /conversations?session=<id>;
         # metadata is JSON (str() produced a Python repr the frontend could
         # never parse).
-        message = messaging.Message(
-            data={
-                'title': notification.title or '',
-                'body': notification.message or '',
-                'type': notification.type,
-                'notification_id': str(notification.id),
-                'session_id': str(metadata.get('session_id') or ''),
-                'metadata': json.dumps(metadata, default=str)
-            },
-            token=user.fcm_token_web,
-            # These are web-push tokens, so the priority knob is the WebPush
-            # `Urgency` header — NOT AndroidConfig/APNSConfig, which only apply
-            # to native FCM SDK tokens and are ignored for web push. High
-            # urgency asks the push service to deliver promptly even while the
-            # device is idle / in battery-saver instead of batching it; TTL
-            # keeps it deliverable for a day if the device is offline.
-            webpush=messaging.WebpushConfig(
-                headers={'Urgency': 'high', 'TTL': '86400'},
-            ),
-        )
+        data = {
+            'title': notification.title or '',
+            'body': notification.message or '',
+            'type': notification.type,
+            'notification_id': str(notification.id),
+            'session_id': str(metadata.get('session_id') or ''),
+            'metadata': json.dumps(metadata, default=str)
+        }
 
-        # Send message
-        response = messaging.send(message)
-        logger.info(f"Successfully sent FCM notification: {response}")
+        messages = [
+            messaging.Message(
+                data=data,
+                token=token,
+                # These are web-push tokens, so the priority knob is the WebPush
+                # `Urgency` header — NOT AndroidConfig/APNSConfig, which only
+                # apply to native FCM SDK tokens and are ignored for web push.
+                # High urgency asks the push service to deliver promptly even
+                # while the device is idle / in battery-saver instead of
+                # batching it; TTL keeps it deliverable for a day if the device
+                # is offline.
+                webpush=messaging.WebpushConfig(
+                    headers={'Urgency': 'high', 'TTL': '86400'},
+                ),
+            )
+            for token in tokens
+        ]
+
+        # send_each reports per-token outcomes, so one dead device does not
+        # stop the others from being delivered to.
+        batch = messaging.send_each(messages)
+
+        dead_tokens = []
+        for token, result in zip(tokens, batch.responses):
+            if result.success:
+                continue
+            if isinstance(result.exception, DEAD_TOKEN_ERRORS):
+                dead_tokens.append(token)
+            else:
+                logger.error(
+                    f"Failed to send FCM notification {notification.id} to a device "
+                    f"of user {user_id}: {str(result.exception)}"
+                )
+
+        if dead_tokens:
+            removed = token_repo.remove_tokens(dead_tokens)
+            logger.info(
+                f"Pruned {removed} dead FCM token(s) for user {user_id}")
+
+        logger.info(
+            f"Sent FCM notification {notification.id} to {batch.success_count}/"
+            f"{len(tokens)} device(s) of user {user_id}"
+        )
 
     except Exception as e:
         logger.error(f"Failed to send FCM notification: {str(e)}")

--- a/backend/app/services/user.py
+++ b/backend/app/services/user.py
@@ -37,6 +37,12 @@ DEAD_TOKEN_ERRORS = (
     messaging.SenderIdMismatchError,
 )
 
+# send_each rejects a longer list outright. Chunking keeps an account that has
+# somehow accumulated more devices than this from raising before a single
+# message is sent — which would also stop the dead-token pruning below from
+# ever running, leaving that user permanently without push.
+FCM_SEND_BATCH_SIZE = 500
+
 
 async def send_fcm_notification(user_id: str, notification: Notification, db):
     """Push a notification to every browser the user has signed in on."""
@@ -92,19 +98,24 @@ async def send_fcm_notification(user_id: str, notification: Notification, db):
 
         # send_each reports per-token outcomes, so one dead device does not
         # stop the others from being delivered to.
-        batch = messaging.send_each(messages)
-
         dead_tokens = []
-        for token, result in zip(tokens, batch.responses):
-            if result.success:
-                continue
-            if isinstance(result.exception, DEAD_TOKEN_ERRORS):
-                dead_tokens.append(token)
-            else:
-                logger.error(
-                    f"Failed to send FCM notification {notification.id} to a device "
-                    f"of user {user_id}: {str(result.exception)}"
-                )
+        delivered = 0
+        for start in range(0, len(messages), FCM_SEND_BATCH_SIZE):
+            chunk = messages[start:start + FCM_SEND_BATCH_SIZE]
+            batch = messaging.send_each(chunk)
+            delivered += batch.success_count
+
+            for token, result in zip(tokens[start:start + FCM_SEND_BATCH_SIZE],
+                                     batch.responses):
+                if result.success:
+                    continue
+                if isinstance(result.exception, DEAD_TOKEN_ERRORS):
+                    dead_tokens.append(token)
+                else:
+                    logger.error(
+                        f"Failed to send FCM notification {notification.id} to a device "
+                        f"of user {user_id}: {str(result.exception)}"
+                    )
 
         if dead_tokens:
             removed = token_repo.remove_tokens(dead_tokens)
@@ -112,7 +123,7 @@ async def send_fcm_notification(user_id: str, notification: Notification, db):
                 f"Pruned {removed} dead FCM token(s) for user {user_id}")
 
         logger.info(
-            f"Sent FCM notification {notification.id} to {batch.success_count}/"
+            f"Sent FCM notification {notification.id} to {delivered}/"
             f"{len(tokens)} device(s) of user {user_id}"
         )
 

--- a/backend/tests/api/test_users.py
+++ b/backend/tests/api/test_users.py
@@ -22,6 +22,7 @@ from unittest.mock import patch, MagicMock
 from app.database import Base, get_db
 from fastapi import FastAPI, HTTPException
 from app.models.user import User, UserGroup
+from app.models.fcm_token import FCMToken
 from app.models.organization import Organization
 from app.models.role import Role
 from app.models.permission import Permission, role_permissions
@@ -450,26 +451,61 @@ def test_delete_nonexistent_user(client: TestClient):
     response = client.delete(f"/api/v1/users/{nonexistent_id}")
     assert response.status_code == 404
 
-def test_update_fcm_token(client: TestClient, test_user: User):
-    """Test updating FCM token"""
-    token_data = {
-        "token": "test_fcm_token_123"
-    }
-    response = client.post("/api/v1/users/token/fcm-token", json=token_data)
+def test_register_fcm_token(client: TestClient, test_user: User, db: Session):
+    """Registering a token stores a row for this device"""
+    response = client.post("/api/v1/users/token/fcm-token",
+                           json={"token": "test_fcm_token_123"})
     assert response.status_code == 200
-    data = response.json()
-    assert data["message"] == "FCM token updated successfully"
+    assert response.json()["message"] == "FCM token registered successfully"
 
-def test_clear_fcm_token(client: TestClient, test_user: User, db: Session):
-    """Test clearing FCM token"""
-    # First set a token
-    test_user.fcm_token_web = "test_token"
+    tokens = db.query(FCMToken).filter(FCMToken.user_id == test_user.id).all()
+    assert [t.token for t in tokens] == ["test_fcm_token_123"]
+
+
+def test_register_fcm_token_is_idempotent(client: TestClient, test_user: User, db: Session):
+    """Re-posting the same token on every app load must not pile up rows"""
+    for _ in range(3):
+        response = client.post("/api/v1/users/token/fcm-token",
+                               json={"token": "same_token"})
+        assert response.status_code == 200
+
+    assert db.query(FCMToken).filter(FCMToken.user_id == test_user.id).count() == 1
+
+
+def test_register_fcm_token_keeps_other_devices(client: TestClient, test_user: User, db: Session):
+    """A second device adds a token instead of replacing the first"""
+    client.post("/api/v1/users/token/fcm-token", json={"token": "phone_token"})
+    client.post("/api/v1/users/token/fcm-token", json={"token": "laptop_token"})
+
+    tokens = {t.token for t in db.query(FCMToken).filter(
+        FCMToken.user_id == test_user.id).all()}
+    assert tokens == {"phone_token", "laptop_token"}
+
+
+def test_clear_fcm_token_only_removes_that_device(client: TestClient, test_user: User, db: Session):
+    """Signing out on one device must leave the user's other devices on push"""
+    db.add_all([
+        FCMToken(user_id=test_user.id, token="phone_token"),
+        FCMToken(user_id=test_user.id, token="laptop_token"),
+    ])
     db.commit()
 
-    response = client.delete("/api/v1/users/token/fcm-token")
+    response = client.request("DELETE", "/api/v1/users/token/fcm-token",
+                              json={"token": "laptop_token"})
     assert response.status_code == 200
-    data = response.json()
-    assert data["message"] == "FCM token cleared successfully" 
+    assert response.json()["message"] == "FCM token cleared successfully"
+
+    tokens = [t.token for t in db.query(FCMToken).filter(
+        FCMToken.user_id == test_user.id).all()]
+    assert tokens == ["phone_token"]
+
+
+def test_clear_unknown_fcm_token_succeeds(client: TestClient, test_user: User):
+    """Logging out twice, or after the token was pruned, is not an error"""
+    response = client.request("DELETE", "/api/v1/users/token/fcm-token",
+                              json={"token": "never_registered"})
+    assert response.status_code == 200
+
 
 @pytest.fixture
 def foreign_role(db) -> Role:

--- a/backend/tests/repositories/test_fcm_token.py
+++ b/backend/tests/repositories/test_fcm_token.py
@@ -58,6 +58,30 @@ class TestRegister:
         repo.register(test_user.id, "laptop_token")
         assert set(repo.get_tokens(test_user.id)) == {"phone_token", "laptop_token"}
 
+    def test_survives_a_lost_insert_race(self, repo, test_user, db, monkeypatch):
+        """Two tabs post the same token at once; the loser must still succeed.
+
+        The client posts on every app load, so a concurrent duplicate insert is
+        routine — failing it would leave that browser unregistered.
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        real_commit = db.commit
+        calls = {"n": 0}
+
+        def commit_once_conflicting():
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # Simulate the other tab having committed the row first.
+                raise IntegrityError("duplicate", None, Exception("conflict"))
+            return real_commit()
+
+        monkeypatch.setattr(db, "commit", commit_once_conflicting)
+        assert repo.register(test_user.id, "raced_token") is True
+        monkeypatch.undo()
+
+        assert repo.get_tokens(test_user.id) == ["raced_token"]
+
     def test_reassigns_shared_browser(self, repo, test_user, other_user):
         """FCM hands the same token to a browser whichever account signs in, so
         the row moves rather than delivering to the previous owner."""

--- a/backend/tests/repositories/test_fcm_token.py
+++ b/backend/tests/repositories/test_fcm_token.py
@@ -1,0 +1,117 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+from uuid import uuid4
+
+from app.models.fcm_token import FCMToken
+from app.models.user import User
+from app.repositories.fcm_token import FCMTokenRepository
+
+
+@pytest.fixture
+def repo(db):
+    return FCMTokenRepository(db)
+
+
+@pytest.fixture
+def other_user(db, test_organization, test_role) -> User:
+    user = User(
+        email="other@example.com",
+        hashed_password="x",
+        full_name="Other User",
+        organization_id=test_organization.id,
+        role_id=test_role.id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+class TestRegister:
+    def test_stores_token(self, repo, test_user):
+        assert repo.register(test_user.id, "phone_token") is True
+        assert repo.get_tokens(test_user.id) == ["phone_token"]
+
+    def test_is_idempotent(self, repo, test_user):
+        """The client posts on every app load — that must not create duplicates"""
+        for _ in range(3):
+            repo.register(test_user.id, "phone_token")
+        assert repo.get_tokens(test_user.id) == ["phone_token"]
+
+    def test_keeps_other_devices(self, repo, test_user):
+        repo.register(test_user.id, "phone_token")
+        repo.register(test_user.id, "laptop_token")
+        assert set(repo.get_tokens(test_user.id)) == {"phone_token", "laptop_token"}
+
+    def test_reassigns_shared_browser(self, repo, test_user, other_user):
+        """FCM hands the same token to a browser whichever account signs in, so
+        the row moves rather than delivering to the previous owner."""
+        repo.register(test_user.id, "shared_browser_token")
+        repo.register(other_user.id, "shared_browser_token")
+
+        assert repo.get_tokens(test_user.id) == []
+        assert repo.get_tokens(other_user.id) == ["shared_browser_token"]
+
+
+class TestGetTokens:
+    def test_empty_for_unknown_user(self, repo):
+        assert repo.get_tokens(uuid4()) == []
+
+
+class TestRemove:
+    def test_removes_only_that_device(self, repo, test_user):
+        repo.register(test_user.id, "phone_token")
+        repo.register(test_user.id, "laptop_token")
+
+        assert repo.remove(test_user.id, "laptop_token") is True
+        assert repo.get_tokens(test_user.id) == ["phone_token"]
+
+    def test_unknown_token_is_not_an_error(self, repo, test_user):
+        assert repo.remove(test_user.id, "never_registered") is False
+
+    def test_cannot_remove_another_users_token(self, repo, test_user, other_user):
+        repo.register(other_user.id, "their_token")
+
+        assert repo.remove(test_user.id, "their_token") is False
+        assert repo.get_tokens(other_user.id) == ["their_token"]
+
+
+class TestRemoveTokens:
+    def test_prunes_listed_tokens(self, repo, test_user):
+        repo.register(test_user.id, "live")
+        repo.register(test_user.id, "dead_one")
+        repo.register(test_user.id, "dead_two")
+
+        assert repo.remove_tokens(["dead_one", "dead_two"]) == 2
+        assert repo.get_tokens(test_user.id) == ["live"]
+
+    def test_empty_list_is_a_no_op(self, repo, test_user):
+        repo.register(test_user.id, "live")
+        assert repo.remove_tokens([]) == 0
+        assert repo.get_tokens(test_user.id) == ["live"]
+
+
+class TestCascade:
+    def test_tokens_die_with_the_user(self, db, repo, other_user):
+        repo.register(other_user.id, "doomed_token")
+
+        db.delete(other_user)
+        db.commit()
+
+        assert db.query(FCMToken).filter(
+            FCMToken.token == "doomed_token").first() is None

--- a/backend/tests/service/test_firebase.py
+++ b/backend/tests/service/test_firebase.py
@@ -15,40 +15,10 @@ limitations under the License.
 """
 
 import pytest
+from firebase_admin import credentials
 from unittest.mock import patch, MagicMock, call, create_autospec
-from app.services.firebase import initialize_firebase, send_firebase_notification
-from firebase_admin import messaging, credentials
-from app.models.notification import Notification
-from uuid import uuid4
-import json
+from app.services.firebase import initialize_firebase
 import os
-from firebase_admin.exceptions import FirebaseError
-
-@pytest.fixture
-def mock_db():
-    """Create a mock database session"""
-    db = MagicMock()
-    return db
-
-@pytest.fixture
-def mock_notification():
-    """Create a mock notification"""
-    user_id = uuid4()
-    return Notification(
-        id=uuid4(),
-        user_id=user_id,
-        title="Test Notification",
-        message="This is a test notification",
-        type="test",
-        metadata={"key": "value"}
-    )
-
-@pytest.fixture
-def mock_user_repo():
-    """Create a mock user repository"""
-    repo = MagicMock()
-    repo.get_user_fcm_token.return_value = "test_fcm_token"
-    return repo
 
 @pytest.fixture(autouse=True)
 def mock_logger():
@@ -130,78 +100,3 @@ def test_initialize_firebase_failure(mock_logger):
         # Assert that error was logged but function continued without raising
         mock_logger.error.assert_called_with(f"Error initializing Firebase: {error_msg}")
         mock_logger.warning.assert_called_with("Continuing without Firebase initialization")
-
-@pytest.mark.asyncio
-async def test_send_firebase_notification_success(mock_db, mock_notification, mock_user_repo, mock_logger):
-    """Test successful sending of Firebase notification"""
-    with patch('app.services.firebase.UserRepository') as mock_user_repo_class, \
-         patch('firebase_admin.messaging.send') as mock_send:
-        
-        # Configure mocks
-        mock_user_repo_class.return_value = mock_user_repo
-        mock_send.return_value = "message_id"
-        
-        # Execute
-        await send_firebase_notification(mock_notification, mock_db)
-        
-        # Assert
-        mock_user_repo.get_user_fcm_token.assert_called_once_with(mock_notification.user_id)
-        mock_send.assert_called_once()
-        mock_logger.info.assert_called_once_with(
-            f"Successfully sent notification {mock_notification.id} to user {mock_notification.user_id}: message_id"
-        )
-        
-        # Verify the message structure
-        call_args = mock_send.call_args[0][0]
-        assert isinstance(call_args, messaging.Message)
-        assert call_args.token == "test_fcm_token"
-        assert call_args.notification.title == mock_notification.title
-        assert call_args.notification.body == mock_notification.message
-        assert call_args.data["type"] == mock_notification.type
-        assert call_args.data["id"] == str(mock_notification.id)
-        assert json.loads(call_args.data["metadata"]) == mock_notification.metadata
-
-@pytest.mark.asyncio
-async def test_send_firebase_notification_no_token(mock_db, mock_notification, mock_user_repo, mock_logger):
-    """Test sending Firebase notification when user has no FCM token"""
-    with patch('app.services.firebase.UserRepository') as mock_user_repo_class, \
-         patch('firebase_admin.messaging.send') as mock_send:
-        
-        # Configure mock to return no token
-        mock_user_repo.get_user_fcm_token.return_value = None
-        mock_user_repo_class.return_value = mock_user_repo
-        
-        # Execute
-        await send_firebase_notification(mock_notification, mock_db)
-        
-        # Assert
-        mock_user_repo.get_user_fcm_token.assert_called_once_with(mock_notification.user_id)
-        mock_send.assert_not_called()
-        mock_logger.warning.assert_called_once_with(
-            f"No FCM token found for user {mock_notification.user_id}"
-        )
-
-@pytest.mark.asyncio
-async def test_send_firebase_notification_failure(mock_db, mock_notification, mock_user_repo, mock_logger):
-    """Test handling of Firebase notification sending failure"""
-    with patch('app.services.firebase.UserRepository') as mock_user_repo_class, \
-         patch('firebase_admin.messaging.send') as mock_send:
-
-        # Configure mocks
-        mock_user_repo_class.return_value = mock_user_repo
-        error_msg = "Failed to send message"
-        
-        def raise_error(*args, **kwargs):
-            raise FirebaseError(code='messaging/failed', message=error_msg)
-        
-        mock_send.side_effect = raise_error
-
-        # Execute
-        await send_firebase_notification(mock_notification, mock_db)
-
-        # Assert
-        mock_user_repo.get_user_fcm_token.assert_called_once_with(mock_notification.user_id)
-        mock_send.assert_called_once()
-        mock_logger.error.assert_called_once_with(
-            f"Firebase API error while sending notification {mock_notification.id}: {error_msg}"
-        ) 

--- a/backend/tests/services/test_user.py
+++ b/backend/tests/services/test_user.py
@@ -105,6 +105,47 @@ async def test_send_fcm_notification_reaches_every_device(mock_db, user_id, samp
 
 
 @pytest.mark.asyncio
+async def test_send_fcm_notification_chunks_beyond_the_batch_limit(
+        mock_db, user_id, sample_notification, token_repo):
+    """send_each rejects >500 messages outright.
+
+    Without chunking that raises before anything is sent, and because pruning
+    only reads per-token responses from a successful call, the account could
+    never recover.
+    """
+    token_repo.get_tokens.return_value = [f"token_{i}" for i in range(750)]
+
+    with patch('app.services.user.messaging') as mock_messaging:
+        mock_messaging.send_each.side_effect = [
+            batch_response(*([True] * 500)),
+            batch_response(*([True] * 250)),
+        ]
+
+        await send_fcm_notification(user_id, sample_notification, mock_db)
+
+        assert mock_messaging.send_each.call_count == 2
+        assert [len(c[0][0]) for c in mock_messaging.send_each.call_args_list] == [500, 250]
+        token_repo.remove_tokens.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_fcm_notification_prunes_across_chunks(
+        mock_db, user_id, sample_notification, token_repo):
+    """A dead token in a later chunk is still matched to the right token."""
+    token_repo.get_tokens.return_value = [f"token_{i}" for i in range(501)]
+
+    with patch('app.services.user.messaging') as mock_messaging:
+        mock_messaging.send_each.side_effect = [
+            batch_response(*([True] * 500)),
+            batch_response(real_messaging.UnregisteredError("gone")),
+        ]
+
+        await send_fcm_notification(user_id, sample_notification, mock_db)
+
+        token_repo.remove_tokens.assert_called_once_with(["token_500"])
+
+
+@pytest.mark.asyncio
 async def test_send_fcm_notification_no_tokens_is_logged(mock_db, user_id, sample_notification, token_repo):
     """A user with no registered device leaves a trace instead of failing silently"""
     token_repo.get_tokens.return_value = []

--- a/backend/tests/services/test_user.py
+++ b/backend/tests/services/test_user.py
@@ -17,11 +17,13 @@ limitations under the License.
 import json
 
 import pytest
-from unittest.mock import Mock, patch, AsyncMock, MagicMock
+from unittest.mock import Mock, patch
 from uuid import uuid4
 
+from firebase_admin import messaging as real_messaging
+from firebase_admin.exceptions import InvalidArgumentError, UnavailableError
+
 from app.services.user import send_fcm_notification
-from app.models.user import User
 from app.models.notification import Notification, NotificationType
 
 
@@ -32,25 +34,8 @@ def mock_db():
 
 
 @pytest.fixture
-def sample_user():
-    """Create a sample user with FCM token"""
-    user = Mock(spec=User)
-    user.id = uuid4()
-    user.email = "test@example.com"
-    user.full_name = "Test User"
-    user.fcm_token_web = "test_fcm_token_123"
-    return user
-
-
-@pytest.fixture
-def sample_user_no_token():
-    """Create a sample user without FCM token"""
-    user = Mock(spec=User)
-    user.id = uuid4()
-    user.email = "test@example.com"
-    user.full_name = "Test User"
-    user.fcm_token_web = None
-    return user
+def user_id():
+    return str(uuid4())
 
 
 @pytest.fixture
@@ -58,134 +43,151 @@ def sample_notification():
     """Create a sample notification"""
     notification = Mock(spec=Notification)
     notification.id = 1
-    notification.type = NotificationType.KNOWLEDGE_PROCESSED
+    notification.type = NotificationType.SYSTEM
     notification.title = "Test Notification"
     notification.message = "This is a test notification"
     notification.notification_metadata = {"key": "value"}
     return notification
 
 
-@pytest.mark.asyncio
-async def test_send_fcm_notification_success(mock_db, sample_user, sample_notification):
-    """Test successful FCM notification sending"""
-    # Setup mock database query
-    mock_query = Mock()
-    mock_query.filter.return_value.first.return_value = sample_user
-    mock_db.query.return_value = mock_query
-    
-    # Mock Firebase messaging
-    with patch('app.services.user.messaging') as mock_messaging:
-        mock_messaging.Message = Mock()
-        mock_messaging.Notification = Mock()
-        mock_messaging.send.return_value = "message_id_123"
-        
-        # Call the function
-        await send_fcm_notification(str(sample_user.id), sample_notification, mock_db)
-        
-        # Verify database query was called correctly
-        mock_db.query.assert_called_once_with(User)
-        mock_query.filter.assert_called_once()
-        mock_query.filter.return_value.first.assert_called_once()
-        
-        # Verify Firebase message was created correctly: data-only (a
-        # notification payload would make the web SDK show a duplicate copy)
-        mock_messaging.Message.assert_called_once()
-        mock_messaging.Notification.assert_not_called()
-        data = mock_messaging.Message.call_args[1]['data']
-        assert data['title'] == sample_notification.title
-        assert data['body'] == sample_notification.message
+def batch_response(*successes):
+    """Fake a messaging.BatchResponse with one entry per token."""
+    responses = []
+    for success in successes:
+        result = Mock()
+        result.success = success is True
+        result.exception = None if success is True else success
+        responses.append(result)
+    batch = Mock()
+    batch.responses = responses
+    batch.success_count = sum(1 for s in successes if s is True)
+    return batch
 
-        # Verify message was sent
-        mock_messaging.send.assert_called_once()
+
+@pytest.fixture
+def token_repo():
+    """Patch the repository and hand back the instance the service will use."""
+    with patch('app.services.user.FCMTokenRepository') as repo_cls:
+        repo = repo_cls.return_value
+        repo.get_tokens.return_value = ["token_a"]
+        repo.remove_tokens.return_value = 1
+        yield repo
 
 
 @pytest.mark.asyncio
-async def test_send_fcm_notification_user_not_found(mock_db, sample_notification):
-    """Test FCM notification when user doesn't exist"""
-    # Setup mock database query to return None
-    mock_query = Mock()
-    mock_query.filter.return_value.first.return_value = None
-    mock_db.query.return_value = mock_query
-    
-    # Mock Firebase messaging
+async def test_send_fcm_notification_success(mock_db, user_id, sample_notification, token_repo):
+    """A registered device gets exactly one message"""
     with patch('app.services.user.messaging') as mock_messaging:
-        # Call the function
-        await send_fcm_notification("non_existent_user_id", sample_notification, mock_db)
-        
-        # Verify database query was called
-        mock_db.query.assert_called_once_with(User)
-        
-        # Verify Firebase messaging was not called since user doesn't exist
-        mock_messaging.Message.assert_not_called()
-        mock_messaging.send.assert_not_called()
+        mock_messaging.send_each.return_value = batch_response(True)
+
+        await send_fcm_notification(user_id, sample_notification, mock_db)
+
+        mock_messaging.send_each.assert_called_once()
+        assert len(mock_messaging.send_each.call_args[0][0]) == 1
+        token_repo.remove_tokens.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_send_fcm_notification_no_fcm_token(mock_db, sample_user_no_token, sample_notification):
-    """Test FCM notification when user has no FCM token"""
-    # Setup mock database query
-    mock_query = Mock()
-    mock_query.filter.return_value.first.return_value = sample_user_no_token
-    mock_db.query.return_value = mock_query
-    
-    # Mock Firebase messaging
+async def test_send_fcm_notification_reaches_every_device(mock_db, user_id, sample_notification, token_repo):
+    """The whole point of the per-device table: a user with three signed-in
+    browsers gets three messages, not one."""
+    token_repo.get_tokens.return_value = ["phone", "laptop", "tablet"]
+
     with patch('app.services.user.messaging') as mock_messaging:
-        # Call the function
-        await send_fcm_notification(str(sample_user_no_token.id), sample_notification, mock_db)
-        
-        # Verify database query was called
-        mock_db.query.assert_called_once_with(User)
-        
-        # Verify Firebase messaging was not called since user has no FCM token
-        mock_messaging.Message.assert_not_called()
-        mock_messaging.send.assert_not_called()
+        mock_messaging.send_each.return_value = batch_response(True, True, True)
+
+        await send_fcm_notification(user_id, sample_notification, mock_db)
+
+        messages = mock_messaging.send_each.call_args[0][0]
+        assert len(messages) == 3
+        assert [call.kwargs['token'] for call in mock_messaging.Message.call_args_list] == [
+            "phone", "laptop", "tablet"]
 
 
 @pytest.mark.asyncio
-async def test_send_fcm_notification_firebase_exception(mock_db, sample_user, sample_notification):
-    """Test FCM notification error handling when Firebase throws an exception"""
-    # Setup mock database query
-    mock_query = Mock()
-    mock_query.filter.return_value.first.return_value = sample_user
-    mock_db.query.return_value = mock_query
-    
-    # Mock Firebase messaging to raise an exception
-    with patch('app.services.user.messaging') as mock_messaging:
-        mock_messaging.Message = Mock()
-        mock_messaging.Notification = Mock()
-        mock_messaging.send.side_effect = Exception("Firebase error")
-        
-        # Mock logger to verify error logging
-        with patch('app.services.user.logger') as mock_logger:
-            # Call the function
-            await send_fcm_notification(str(sample_user.id), sample_notification, mock_db)
-            
-            # Verify error was logged
-            mock_logger.error.assert_called_once()
-            assert "Failed to send FCM notification" in str(mock_logger.error.call_args)
+async def test_send_fcm_notification_no_tokens_is_logged(mock_db, user_id, sample_notification, token_repo):
+    """A user with no registered device leaves a trace instead of failing silently"""
+    token_repo.get_tokens.return_value = []
+
+    with patch('app.services.user.messaging') as mock_messaging, \
+            patch('app.services.user.logger') as mock_logger:
+        await send_fcm_notification(user_id, sample_notification, mock_db)
+
+        mock_messaging.send_each.assert_not_called()
+        assert mock_logger.info.called
+        assert "No FCM tokens registered" in mock_logger.info.call_args[0][0]
 
 
 @pytest.mark.asyncio
-async def test_send_fcm_notification_message_structure(mock_db, sample_user, sample_notification):
-    """Test that FCM message is structured correctly"""
-    # Setup mock database query
-    mock_query = Mock()
-    mock_query.filter.return_value.first.return_value = sample_user
-    mock_db.query.return_value = mock_query
-    
-    # Mock Firebase messaging
+async def test_send_fcm_notification_prunes_dead_tokens(mock_db, user_id, sample_notification, token_repo):
+    """Tokens FCM reports as dead are deleted so the browser can re-register"""
+    token_repo.get_tokens.return_value = ["live", "unregistered", "wrong_project"]
+
     with patch('app.services.user.messaging') as mock_messaging:
-        mock_message_instance = Mock()
-        mock_messaging.Message.return_value = mock_message_instance
-        mock_messaging.send.return_value = "message_id_123"
-        
-        # Call the function
-        await send_fcm_notification(str(sample_user.id), sample_notification, mock_db)
-        
-        # Verify message was created with correct parameters: data-only payload
-        # (title/body in data so the web SDK doesn't auto-display a duplicate),
-        # metadata as JSON (not a Python repr), session_id flattened for SW
-        # deep links, and high-urgency webpush delivery.
+        mock_messaging.send_each.return_value = batch_response(
+            True,
+            real_messaging.UnregisteredError("token no longer valid"),
+            real_messaging.SenderIdMismatchError("wrong sender"),
+        )
+
+        await send_fcm_notification(user_id, sample_notification, mock_db)
+
+        token_repo.remove_tokens.assert_called_once_with(
+            ["unregistered", "wrong_project"])
+
+
+@pytest.mark.asyncio
+async def test_send_fcm_notification_keeps_tokens_on_payload_rejection(
+        mock_db, user_id, sample_notification, token_repo):
+    """A bad message (oversized payload) is rejected for every token at once.
+
+    Pruning on that would unregister every device the user owns over a fault
+    that has nothing to do with their tokens.
+    """
+    token_repo.get_tokens.return_value = ["phone", "laptop"]
+
+    with patch('app.services.user.messaging') as mock_messaging, \
+            patch('app.services.user.logger') as mock_logger:
+        mock_messaging.send_each.return_value = batch_response(
+            InvalidArgumentError("message is too big"),
+            InvalidArgumentError("message is too big"),
+        )
+
+        await send_fcm_notification(user_id, sample_notification, mock_db)
+
+        token_repo.remove_tokens.assert_not_called()
+        assert mock_logger.error.called
+
+
+@pytest.mark.asyncio
+async def test_send_fcm_notification_keeps_tokens_on_transient_errors(
+        mock_db, user_id, sample_notification, token_repo):
+    """A network blip must not cost the user their registration"""
+    token_repo.get_tokens.return_value = ["live", "flaky"]
+
+    with patch('app.services.user.messaging') as mock_messaging, \
+            patch('app.services.user.logger') as mock_logger:
+        mock_messaging.send_each.return_value = batch_response(
+            True, UnavailableError("try again"))
+
+        await send_fcm_notification(user_id, sample_notification, mock_db)
+
+        token_repo.remove_tokens.assert_not_called()
+        assert mock_logger.error.called
+
+
+@pytest.mark.asyncio
+async def test_send_fcm_notification_message_structure(mock_db, user_id, sample_notification, token_repo):
+    """Data-only payload (title/body in data so the web SDK doesn't auto-display
+    a duplicate), metadata as JSON (not a Python repr), session_id flattened for
+    SW deep links, and high-urgency webpush delivery."""
+    sample_notification.notification_metadata = {"session_id": "abc-123"}
+
+    with patch('app.services.user.messaging') as mock_messaging:
+        mock_messaging.send_each.return_value = batch_response(True)
+
+        await send_fcm_notification(user_id, sample_notification, mock_db)
+
         mock_messaging.WebpushConfig.assert_called_once_with(
             headers={'Urgency': 'high', 'TTL': '86400'}
         )
@@ -195,119 +197,72 @@ async def test_send_fcm_notification_message_structure(mock_db, sample_user, sam
                 'body': sample_notification.message,
                 'type': sample_notification.type,
                 'notification_id': str(sample_notification.id),
-                'session_id': '',
-                'metadata': json.dumps(sample_notification.notification_metadata)
+                'session_id': 'abc-123',
+                'metadata': json.dumps({"session_id": "abc-123"})
             },
-            token=sample_user.fcm_token_web,
+            token="token_a",
             webpush=mock_messaging.WebpushConfig.return_value,
         )
 
 
 @pytest.mark.asyncio
-async def test_send_fcm_notification_with_none_metadata(mock_db, sample_user):
-    """Test FCM notification when notification metadata is None"""
-    # Create notification with None metadata
+async def test_send_fcm_notification_with_none_metadata(mock_db, user_id, token_repo):
+    """Missing metadata falls back to an empty object, not a crash"""
     notification = Mock(spec=Notification)
     notification.id = 1
     notification.type = NotificationType.SYSTEM
     notification.title = "Test Notification"
     notification.message = "This is a test notification"
     notification.notification_metadata = None
-    
-    # Setup mock database query
-    mock_query = Mock()
-    mock_query.filter.return_value.first.return_value = sample_user
-    mock_db.query.return_value = mock_query
-    
-    # Mock Firebase messaging
+
     with patch('app.services.user.messaging') as mock_messaging:
-        mock_messaging.Message = Mock()
-        mock_messaging.Notification = Mock()
-        mock_messaging.send.return_value = "message_id_123"
-        
-        # Call the function
-        await send_fcm_notification(str(sample_user.id), notification, mock_db)
-        
-        # Verify message was created with correct data (metadata should be '{}')
-        call_args = mock_messaging.Message.call_args
-        assert call_args[1]['data']['metadata'] == str({})
+        mock_messaging.send_each.return_value = batch_response(True)
+
+        await send_fcm_notification(user_id, notification, mock_db)
+
+        data = mock_messaging.Message.call_args.kwargs['data']
+        assert data['session_id'] == ''
+        assert data['metadata'] == '{}'
 
 
 @pytest.mark.asyncio
-async def test_send_fcm_notification_different_notification_types(mock_db, sample_user):
-    """Test FCM notification with different notification types"""
-    notification_types = [
-        NotificationType.KNOWLEDGE_PROCESSED,
-        NotificationType.KNOWLEDGE_FAILED,
-        NotificationType.SYSTEM,
-        NotificationType.CHAT
-    ]
-    
-    # Setup mock database query
-    mock_query = Mock()
-    mock_query.filter.return_value.first.return_value = sample_user
-    mock_db.query.return_value = mock_query
-    
-    for notification_type in notification_types:
-        # Create notification with specific type
+async def test_send_fcm_notification_different_notification_types(mock_db, user_id, token_repo):
+    """Every notification type is forwarded as-is"""
+    for notification_type in NotificationType:
         notification = Mock(spec=Notification)
         notification.id = 1
         notification.type = notification_type
-        notification.title = f"Test {notification_type.value}"
-        notification.message = f"This is a {notification_type.value} notification"
-        notification.notification_metadata = {"type": notification_type.value}
-        
-        # Mock Firebase messaging
+        notification.title = "Test"
+        notification.message = "Test message"
+        notification.notification_metadata = {}
+
         with patch('app.services.user.messaging') as mock_messaging:
-            mock_messaging.Message = Mock()
-            mock_messaging.Notification = Mock()
-            mock_messaging.send.return_value = "message_id_123"
-            
-            # Call the function
-            await send_fcm_notification(str(sample_user.id), notification, mock_db)
-            
-            # Verify message was created with correct type
-            call_args = mock_messaging.Message.call_args
-            assert call_args[1]['data']['type'] == notification_type
+            mock_messaging.send_each.return_value = batch_response(True)
+
+            await send_fcm_notification(user_id, notification, mock_db)
+
+            assert mock_messaging.Message.call_args.kwargs['data']['type'] == notification_type
 
 
 @pytest.mark.asyncio
-async def test_send_fcm_notification_database_exception(sample_notification):
-    """Test FCM notification when database query throws an exception"""
-    # Create mock database that raises an exception
-    mock_db = Mock()
-    mock_db.query.side_effect = Exception("Database connection error")
-    
-    # Mock logger to verify error logging
-    with patch('app.services.user.logger') as mock_logger:
-        # Call the function
-        await send_fcm_notification("test_user_id", sample_notification, mock_db)
-        
-        # Verify error was logged
-        mock_logger.error.assert_called_once()
-        assert "Failed to send FCM notification" in str(mock_logger.error.call_args)
+async def test_send_fcm_notification_firebase_exception(mock_db, user_id, sample_notification, token_repo):
+    """A thrown send never propagates to the caller creating the notification"""
+    with patch('app.services.user.messaging') as mock_messaging, \
+            patch('app.services.user.logger') as mock_logger:
+        mock_messaging.send_each.side_effect = Exception("Firebase error")
+
+        await send_fcm_notification(user_id, sample_notification, mock_db)
+
+        assert mock_logger.error.called
 
 
 @pytest.mark.asyncio
-async def test_send_fcm_notification_success_logging(mock_db, sample_user, sample_notification):
-    """Test that successful FCM notification sending is logged"""
-    # Setup mock database query
-    mock_query = Mock()
-    mock_query.filter.return_value.first.return_value = sample_user
-    mock_db.query.return_value = mock_query
-    
-    # Mock Firebase messaging
-    with patch('app.services.user.messaging') as mock_messaging:
-        mock_messaging.Message = Mock()
-        mock_messaging.Notification = Mock()
-        mock_messaging.send.return_value = "message_id_123"
-        
-        # Mock logger to verify success logging
-        with patch('app.services.user.logger') as mock_logger:
-            # Call the function
-            await send_fcm_notification(str(sample_user.id), sample_notification, mock_db)
-            
-            # Verify success was logged
-            mock_logger.info.assert_called_once()
-            assert "Successfully sent FCM notification" in str(mock_logger.info.call_args)
-            assert "message_id_123" in str(mock_logger.info.call_args)
+async def test_send_fcm_notification_database_exception(sample_notification, user_id):
+    """A repository failure is swallowed and logged"""
+    with patch('app.services.user.FCMTokenRepository') as repo_cls, \
+            patch('app.services.user.logger') as mock_logger:
+        repo_cls.side_effect = Exception("Database error")
+
+        await send_fcm_notification(user_id, sample_notification, Mock())
+
+        assert mock_logger.error.called

--- a/frontend/src/__tests__/pwa/register.spec.ts
+++ b/frontend/src/__tests__/pwa/register.spec.ts
@@ -1,0 +1,117 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const toast = vi.fn(() => 'toast-id') as ReturnType<typeof vi.fn> & { dismiss: unknown }
+  toast.dismiss = vi.fn()
+  return { toast, registerSW: vi.fn() }
+})
+
+vi.mock('vue-sonner', () => ({ toast: mocks.toast }))
+vi.mock('virtual:pwa-register', () => ({ registerSW: mocks.registerSW }))
+
+type RegisterOptions = { immediate?: boolean; onNeedRefresh?: () => void }
+
+const reload = vi.fn()
+
+/** Show the update prompt and return the action the Reload button runs. */
+async function clickableUpdateAction(updateSW: () => Promise<void>) {
+  let options: RegisterOptions = {}
+  mocks.registerSW.mockImplementation((opts: RegisterOptions) => {
+    options = opts
+    return updateSW
+  })
+
+  const { setupPWA } = await import('@/pwa/register')
+  setupPWA()
+  options.onNeedRefresh?.()
+
+  // promptForUpdate imports vue-sonner lazily — let that microtask settle.
+  await vi.waitFor(() => expect(mocks.toast).toHaveBeenCalled())
+  const toastOptions = mocks.toast.mock.calls[0][1] as {
+    action: { onClick: () => void }
+  }
+  return toastOptions.action.onClick
+}
+
+describe('PWA update prompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        getRegistrations: vi.fn().mockResolvedValue([]),
+        ready: new Promise(() => {}),
+        addEventListener: vi.fn(),
+      },
+      configurable: true,
+    })
+
+    Object.defineProperty(window, 'location', {
+      value: { pathname: '/', reload },
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not reload while the new worker is still activating', async () => {
+    // Regression: registerSW's updateSW ignores its reloadPage argument and
+    // only posts SKIP_WAITING without awaiting activation, so it resolves
+    // within a tick. Reloading on that resolution beat the handshake — the
+    // document came back on the OLD worker with the new one still waiting, and
+    // the prompt reappeared on every load. The reload must be left to
+    // registerSW's own `controlling` listener.
+    const updateSW = vi.fn().mockResolvedValue(undefined)
+    const onClick = await clickableUpdateAction(updateSW)
+
+    onClick()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(updateSW).toHaveBeenCalled()
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('forces a reload if the worker never takes control', async () => {
+    const updateSW = vi.fn().mockResolvedValue(undefined)
+    const onClick = await clickableUpdateAction(updateSW)
+
+    vi.useFakeTimers()
+    onClick()
+
+    vi.advanceTimersByTime(3999)
+    expect(reload).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismisses the toast when Reload is clicked', async () => {
+    const updateSW = vi.fn().mockResolvedValue(undefined)
+    const onClick = await clickableUpdateAction(updateSW)
+
+    onClick()
+
+    expect(mocks.toast.dismiss).toHaveBeenCalledWith('toast-id')
+  })
+})

--- a/frontend/src/__tests__/services/firebase-unregister.spec.ts
+++ b/frontend/src/__tests__/services/firebase-unregister.spec.ts
@@ -1,0 +1,89 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  // Never resolves — stands in for getSWRegistration()'s 8s timeout when no
+  // service worker is ready.
+  getSWRegistration: vi.fn(() => new Promise<undefined>(() => {})),
+  isSupported: vi.fn().mockResolvedValue(true),
+  clearFCMToken: vi.fn(),
+}))
+
+vi.mock('@/pwa/register', () => ({
+  getSWRegistration: mocks.getSWRegistration,
+  isShopifyEmbedded: () => false,
+}))
+vi.mock('firebase/messaging', () => ({
+  isSupported: mocks.isSupported,
+  getMessaging: vi.fn(() => ({})),
+  getToken: vi.fn(),
+  deleteToken: vi.fn().mockResolvedValue(true),
+  onMessage: vi.fn(),
+}))
+vi.mock('@/services/user', () => ({
+  userService: { clearFCMToken: mocks.clearFCMToken, updateFCMToken: vi.fn() },
+}))
+
+describe('unregisterFCMToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    Object.defineProperty(window, 'Notification', {
+      value: { permission: 'granted' },
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('gives up rather than holding logout open on a stalled service worker', async () => {
+    // Regression: logout awaits this, and getSWRegistration only settles after
+    // an 8s timeout when no worker is ready — so signing out appeared to hang.
+    // A browser with no ready worker cannot display a push anyway, and the row
+    // is pruned server-side on its next failed send.
+    const { unregisterFCMToken } = await import('@/services/firebase')
+
+    vi.useFakeTimers()
+    let settled = false
+    const pending = unregisterFCMToken().then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(2999)
+    expect(settled).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    await pending
+    expect(settled).toBe(true)
+  })
+
+  it('does nothing when notification permission was never granted', async () => {
+    Object.defineProperty(window, 'Notification', {
+      value: { permission: 'default' },
+      configurable: true,
+    })
+    const { unregisterFCMToken } = await import('@/services/firebase')
+
+    await unregisterFCMToken()
+
+    expect(mocks.getSWRegistration).not.toHaveBeenCalled()
+    expect(mocks.clearFCMToken).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/composables/useAuth.ts
+++ b/frontend/src/composables/useAuth.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { userService } from '@/services/user'
+import { unregisterFCMToken } from '@/services/firebase'
 import { authService } from '@/services/auth'
 
 export function useAuth() {
@@ -28,8 +29,9 @@ export function useAuth() {
   const logout = async () => {
     try {
       isLoggingOut.value = true
-      // Clear FCM token first
-      await userService.clearFCMToken()
+      // Unregister this device's push token first — only this one, so the
+      // user's other signed-in devices keep receiving notifications.
+      await unregisterFCMToken()
       // Then proceed with normal logout
       await authService.logout()
       router.push('/login')

--- a/frontend/src/pwa/register.ts
+++ b/frontend/src/pwa/register.ts
@@ -27,6 +27,14 @@ export const isShopifyEmbedded = (): boolean => {
 }
 
 /**
+ * How long to wait for the new worker to take control before forcing a reload.
+ * Activation is normally well under a second; this only covers a worker that
+ * fails to activate or a browser that withholds controllerchange, so the user
+ * is never stranded on the old build.
+ */
+const UPDATE_TAKEOVER_TIMEOUT_MS = 4000
+
+/**
  * Offer the new build rather than forcing it: an agent mid-reply should not
  * have the page reloaded under them. vue-sonner is imported lazily so the
  * registration path stays off the startup critical path.
@@ -34,23 +42,25 @@ export const isShopifyEmbedded = (): boolean => {
 async function promptForUpdate(reload: (reloadPage?: boolean) => Promise<void>) {
   try {
     const { toast } = await import('vue-sonner')
-    toast('A new version of ChatterMate is available', {
+    const id = toast('A new version of ChatterMate is available', {
       description: 'Reload to pick up the latest changes.',
       duration: Number.POSITIVE_INFINITY,
       action: {
         label: 'Reload',
-        onClick: async () => {
-          // reload() hands SKIP_WAITING to the waiting worker, but its own
-          // page-refresh depends on a controllerchange that doesn't fire
-          // reliably when the SW already claimed this client — verified: the
-          // new worker activated and precached the new build while the open
-          // document kept running the old CSS. Reload explicitly so the
-          // document actually picks the new assets up.
-          try {
-            await reload(true)
-          } finally {
-            window.location.reload()
-          }
+        onClick: () => {
+          // Do NOT reload here. registerSW's updateSW ignores its reloadPage
+          // argument and only posts SKIP_WAITING, without awaiting activation
+          // — it resolves within a tick. The page refresh is done by the
+          // `controlling` listener registerSW arms just before it calls us.
+          //
+          // Reloading here raced that handshake and always won: the document
+          // came back under the OLD worker with the new one still in `waiting`,
+          // so the next load re-dispatched `waiting` and the prompt returned.
+          // That is why the toast reappeared on every release and no amount of
+          // clicking Reload cleared it.
+          toast.dismiss(id)
+          void reload()
+          window.setTimeout(() => window.location.reload(), UPDATE_TAKEOVER_TIMEOUT_MS)
         },
       },
     })

--- a/frontend/src/services/firebase.ts
+++ b/frontend/src/services/firebase.ts
@@ -149,10 +149,15 @@ export const refreshFCMToken = async (): Promise<void> => {
  * deleteToken() must still run — otherwise a shared computer keeps rendering
  * the signed-out account's notifications. Killing the subscription at FCM
  * makes the next send fail as Unregistered, which prunes the row server-side.
+ *
+ * Bounded by UNREGISTER_TIMEOUT_MS so signing out is never held up by it: it
+ * waits on getSWRegistration(), which only settles after an 8s timeout when no
+ * worker is ready. Giving up early is safe — a browser with no ready worker
+ * cannot display a push anyway, and the row is pruned on its next failed send.
  */
-export const unregisterFCMToken = async (): Promise<void> => {
-  if (!('Notification' in window) || Notification.permission !== 'granted') return
+const UNREGISTER_TIMEOUT_MS = 3000
 
+const unregisterThisDevice = async (): Promise<void> => {
   try {
     const token = await getCurrentToken()
     if (token) await userService.clearFCMToken(token)
@@ -168,4 +173,13 @@ export const unregisterFCMToken = async (): Promise<void> => {
   } catch (err) {
     console.error('Failed to delete FCM token:', err)
   }
+}
+
+export const unregisterFCMToken = async (): Promise<void> => {
+  if (!('Notification' in window) || Notification.permission !== 'granted') return
+
+  await Promise.race([
+    unregisterThisDevice(),
+    new Promise<void>((resolve) => setTimeout(resolve, UNREGISTER_TIMEOUT_MS)),
+  ])
 }

--- a/frontend/src/services/firebase.ts
+++ b/frontend/src/services/firebase.ts
@@ -65,32 +65,39 @@ export const getMessagingIfSupported = async (): Promise<Messaging | null> => {
   return getMessaging(initializeFirebase() ?? undefined)
 }
 
-// Last token synced to the backend — skips the per-page-load POST when getToken
-// returns the same value (it almost always does).
-const FCM_TOKEN_KEY = 'cm-fcm-token-synced'
-
-// Mint an FCM token against the app service worker and store it server-side.
-// Requires notification permission to already be granted.
-const registerFCMToken = async (): Promise<boolean> => {
+// The token for this browser install, or null if push can't run here (no
+// support, no service worker, permission not granted).
+const getCurrentToken = async (): Promise<string | null> => {
   const messaging = await getMessagingIfSupported()
-  if (!messaging) return false
+  if (!messaging) return null
 
   // Reuse the app service worker so Firebase never registers a second one;
   // without a registration (dev, failed install) there is nothing to bind to.
   const serviceWorkerRegistration = await getSWRegistration()
-  if (!serviceWorkerRegistration) return false
+  if (!serviceWorkerRegistration) return null
 
   const { getToken } = await import('firebase/messaging')
-  const token = await getToken(messaging, {
+  return await getToken(messaging, {
     vapidKey: getFirebaseVapidKey(),
     serviceWorkerRegistration,
   })
-  // Keyed per user so a re-login on the same browser still syncs its token
-  const synced = `${userService.getUserId()}:${token}`
-  if (localStorage.getItem(FCM_TOKEN_KEY) !== synced) {
-    await userService.updateFCMToken(token)
-    localStorage.setItem(FCM_TOKEN_KEY, synced)
-  }
+}
+
+// Mint an FCM token against the app service worker and store it server-side.
+// Requires notification permission to already be granted.
+//
+// This posts on every call rather than caching "already synced" in
+// localStorage. FCM returns the same token for the life of a browser install,
+// so a cache keyed on it never invalidates — and the server value can change
+// without the client knowing (a logout elsewhere used to clear it, and dead
+// tokens get pruned server-side). A stale cache meant the device believed it
+// was registered while the server had nothing, and push stayed dead until site
+// data was cleared. One small POST per app load is the cheaper failure mode.
+const registerFCMToken = async (): Promise<boolean> => {
+  const token = await getCurrentToken()
+  if (!token) return false
+
+  await userService.updateFCMToken(token)
   return true
 }
 
@@ -130,5 +137,35 @@ export const refreshFCMToken = async (): Promise<void> => {
     await registerFCMToken()
   } catch (err) {
     console.error('Failed to refresh FCM token:', err)
+  }
+}
+
+/**
+ * Drop this browser's token on logout — server-side and at FCM.
+ *
+ * Only this device is unregistered; other devices the user is signed in on
+ * keep working. The two steps are independent on purpose: if the token can't
+ * be read (service worker not ready), the server row can't be named, but
+ * deleteToken() must still run — otherwise a shared computer keeps rendering
+ * the signed-out account's notifications. Killing the subscription at FCM
+ * makes the next send fail as Unregistered, which prunes the row server-side.
+ */
+export const unregisterFCMToken = async (): Promise<void> => {
+  if (!('Notification' in window) || Notification.permission !== 'granted') return
+
+  try {
+    const token = await getCurrentToken()
+    if (token) await userService.clearFCMToken(token)
+  } catch (err) {
+    console.error('Failed to clear FCM token server-side:', err)
+  }
+
+  try {
+    const messaging = await getMessagingIfSupported()
+    if (!messaging) return
+    const { deleteToken } = await import('firebase/messaging')
+    await deleteToken(messaging)
+  } catch (err) {
+    console.error('Failed to delete FCM token:', err)
   }
 }

--- a/frontend/src/services/user.ts
+++ b/frontend/src/services/user.ts
@@ -73,13 +73,16 @@ export const userService = {
     return response.data
   },
 
-  async clearFCMToken(): Promise<unknown> {
+  // Unregisters one device. The token is required: clearing every token for
+  // the account would knock the user's other signed-in devices off push.
+  async clearFCMToken(token: string): Promise<unknown> {
     try {
-      const response = await api.delete('/users/token/fcm-token')
+      const response = await api.delete('/users/token/fcm-token', { data: { token } })
       return response.data
     } catch (error) {
       console.error('Failed to clear FCM token:', error)
-      // throw error
+      // Never block logout on this — a token left behind is pruned server-side
+      // on its next failed delivery.
     }
   },
 


### PR DESCRIPTION
## Description

Push notifications stopped reaching a signed-in phone and never came back. Two causes.

`users.fcm_token_web` held one token for the whole account, so signing in on a second device overwrote the first one's token and signing out anywhere cleared it for every device. Replaced with an `fcm_tokens` table, one row per browser: logout removes only the token it names, and sends fan out to every device. Tokens FCM reports as dead are now pruned instead of being swallowed, and a push skipped for want of a token is logged — that early return was silent, which is why the logs showed nothing.

The client then never recovered, because it skipped the POST whenever localStorage said the token was already synced. FCM returns the same token for the life of a browser install, so that cache never invalidated while the server value could change behind its back. It now posts on every load, so devices that are already stuck fix themselves on their next visit.

Also in here: the "new version of ChatterMate is available" toast reappearing on every page load. `registerSW`'s `updateSW` ignores its `reloadPage` argument and only posts SKIP_WAITING without awaiting activation, so the explicit reload beat the handshake — the page came back on the old worker with the new one still waiting. The reload belongs to registerSW's own `controlling` listener.

Deploy note: migration `fcm_tokens_per_device_001` copies existing tokens across and then drops `users.fcm_token_web`, so the backend has to go out with it. Anyone currently seeing the update toast will get it once more with the old handler and need a single manual refresh before the fix takes effect.

## Related issues

<!-- e.g. Closes #123 -->

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [ ] Documentation

## Checklist

- [x] All commits are signed off (DCO) — `git commit -s` (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] My contribution is licensed under Apache-2.0
- [x] Tests added/updated where relevant and the suite passes
- [ ] Documentation updated where relevant