### PR TITLE
Apply the configured timeout to STDIO MCP tools

### DIFF
--- a/backend/app/api/mcp_tool.py
+++ b/backend/app/api/mcp_tool.py
@@ -35,7 +35,7 @@ from app.models.schemas.mcp_tool import (
     MCPToolToAgentCreate, MCPToolToAgentResponse,
     AgentMCPToolsResponse, MCPToolTestResponse
 )
-from app.tools.mcp_manager import MCPToolsManager
+from app.tools.mcp_manager import INTERACTIVE_CONNECT_BUDGET_SECONDS, MCPToolsManager
 from sqlalchemy.orm import Session
 from uuid import UUID
 
@@ -182,7 +182,11 @@ async def test_mcp_tool(
                 detail="Not authorized to access this MCP tool"
             )
 
-        return await MCPToolsManager().test_tool_config(mcp_tool)
+        # A request is waiting on this, so cap it no matter how generous the
+        # tool's own timeout is — a hung server must not hold the worker and
+        # its DB session for minutes.
+        manager = MCPToolsManager(connect_budget=INTERACTIVE_CONNECT_BUDGET_SECONDS)
+        return await manager.test_tool_config(mcp_tool)
 
     except HTTPException as e:
         raise e

--- a/backend/app/api/mcp_tool.py
+++ b/backend/app/api/mcp_tool.py
@@ -35,7 +35,7 @@ from app.models.schemas.mcp_tool import (
     MCPToolToAgentCreate, MCPToolToAgentResponse,
     AgentMCPToolsResponse, MCPToolTestResponse
 )
-from app.tools.mcp_manager import INTERACTIVE_CONNECT_BUDGET_SECONDS, MCPToolsManager
+from app.tools.mcp_manager import TEST_CONNECT_BUDGET_SECONDS, MCPToolsManager
 from sqlalchemy.orm import Session
 from uuid import UUID
 
@@ -185,7 +185,7 @@ async def test_mcp_tool(
         # A request is waiting on this, so cap it no matter how generous the
         # tool's own timeout is — a hung server must not hold the worker and
         # its DB session for minutes.
-        manager = MCPToolsManager(connect_budget=INTERACTIVE_CONNECT_BUDGET_SECONDS)
+        manager = MCPToolsManager(connect_budget=TEST_CONNECT_BUDGET_SECONDS)
         return await manager.test_tool_config(mcp_tool)
 
     except HTTPException as e:

--- a/backend/app/tools/mcp_manager.py
+++ b/backend/app/tools/mcp_manager.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import asyncio
 from datetime import timedelta
+from time import monotonic
 from typing import List, Optional
 from agno.tools.mcp import MCPTools, SSEClientParams, StreamableHTTPClientParams
 from app.database import SessionLocal
@@ -25,13 +26,51 @@ from app.core.logger import get_logger
 
 logger = get_logger(__name__)
 
-CONNECT_TIMEOUT_SECONDS = 10.0
+# Per-request read timeout for the MCP client session when a tool doesn't
+# configure one. It governs the startup handshake and every later tool call,
+# so it has to cover a cold `npx` launch (registry resolution + download) as
+# well as a slow query. agno's own default is 5s, which npx-launched servers
+# routinely exceed — hence the intermittent handshake failures this replaces.
+DEFAULT_TIMEOUT_SECONDS = 30
+
+# Headroom for process spawn on top of the requests the handshake itself
+# makes, so the outer guard never fires before the per-request timeout does.
+CONNECT_TIMEOUT_MARGIN_SECONDS = 10.0
+
+# Bringing a tool up costs two sequential requests — initialize, then
+# list_tools — each entitled to the full per-request timeout.
+HANDSHAKE_REQUESTS = 2
+
+# Ceiling on how long an interactive caller (a chat turn, the Test button)
+# waits for connectors, however generous the per-tool timeouts are. Without
+# it a connector that spawns but never speaks would stall a live reply for
+# minutes. Background callers pass no ceiling: the ticket investigation
+# worker is already bounded by its own wall-clock budget.
+INTERACTIVE_CONNECT_BUDGET_SECONDS = 60.0
+
+
+def _session_timeout(config) -> int:
+    """Per-request read timeout for the MCP session, on every transport.
+    Bounds the startup handshake and each individual tool call."""
+    return config.timeout or DEFAULT_TIMEOUT_SECONDS
+
+
+def _connect_timeout(config) -> float:
+    """Wall-clock budget for bringing a tool up, kept above what the handshake
+    can legitimately spend so a slow-but-healthy server isn't cut off by the
+    outer guard."""
+    return _session_timeout(config) * HANDSHAKE_REQUESTS + CONNECT_TIMEOUT_MARGIN_SECONDS
 
 
 class MCPToolsManager:
     """Manager class for handling MCP tools initialization and cleanup"""
 
-    def __init__(self):
+    def __init__(self, connect_budget: Optional[float] = None):
+        """connect_budget caps the total time spent connecting this manager's
+        tools. Interactive callers pass one so a hanging connector can't stall
+        a reply; background callers leave it None and let each tool have its
+        configured budget."""
+        self.connect_budget = connect_budget
         self.mcp_tools: List[MCPTools] = []
         # Names of tools that connected, and {name, error} for those that
         # didn't. Unlike mcp_tools (cleared on cleanup) these survive the run,
@@ -86,13 +125,28 @@ class MCPToolsManager:
     async def _initialize_from_configs(self, configs) -> List[MCPTools]:
         """Build + connect each configured tool, keeping only the ones that
         come up with functions available."""
+        deadline = (
+            monotonic() + self.connect_budget if self.connect_budget is not None else None
+        )
         try:
             # Initialize each MCP tool asynchronously
             for mcp_tool_config in configs:
                 try:
+                    connect_timeout = self._budgeted_connect_timeout(mcp_tool_config, deadline)
+                    if connect_timeout <= 0:
+                        # Earlier connectors ate the budget. Say so rather than
+                        # reporting this one as a connection failure.
+                        logger.warning(f"Skipping MCP tool {mcp_tool_config.name}: connect budget exhausted")
+                        self.failed_tools.append({
+                            "name": mcp_tool_config.name,
+                            "error": "Skipped — the earlier connectors used up the time available",
+                        })
+                        continue
                     logger.debug(f"Initializing MCP tool: {mcp_tool_config.name}")
                     mcp_tool = self._build_tool(mcp_tool_config)
-                    await self._connect_and_register(mcp_tool, mcp_tool_config.name)
+                    await self._connect_and_register(
+                        mcp_tool, mcp_tool_config.name, connect_timeout
+                    )
                 except Exception as e:
                     logger.error(f"Failed to initialize MCP tool {mcp_tool_config.name}: {e}")
                     import traceback
@@ -105,6 +159,14 @@ class MCPToolsManager:
 
         logger.debug(f"Initialized {len(self.mcp_tools)} MCP tools")
         return self.mcp_tools
+
+    def _budgeted_connect_timeout(self, config, deadline: Optional[float]) -> float:
+        """The tool's own connect budget, trimmed to whatever is left of the
+        manager's overall one."""
+        connect_timeout = _connect_timeout(config)
+        if deadline is None:
+            return connect_timeout
+        return min(connect_timeout, deadline - monotonic())
 
     @classmethod
     def _build_tool(cls, config) -> Optional[MCPTools]:
@@ -157,7 +219,11 @@ class MCPToolsManager:
                 # Values may hold credentials (API keys, tokens) — log names only
                 logger.debug(f"Environment variables configured: {list(env_vars_for_process.keys())}")
 
-        return MCPTools(command_str, env=env_vars_for_process)
+        return MCPTools(
+            command_str,
+            env=env_vars_for_process,
+            timeout_seconds=_session_timeout(config),
+        )
 
     async def test_tool_config(self, config) -> dict:
         """Connect to a configured tool once and report what happened — backs
@@ -165,9 +231,14 @@ class MCPToolsManager:
         build/connect path as a real run, so the reported error is exactly
         what a run would record. Never raises."""
         failures_before = len(self.failed_tools)
+        deadline = (
+            monotonic() + self.connect_budget if self.connect_budget is not None else None
+        )
         try:
             mcp_tool = self._build_tool(config)
-            connected = await self._connect_and_register(mcp_tool, config.name)
+            connected = await self._connect_and_register(
+                mcp_tool, config.name, self._budgeted_connect_timeout(config, deadline)
+            )
         except Exception as e:
             return {"success": False, "functions": [], "error": str(e)}
         if connected:
@@ -187,7 +258,7 @@ class MCPToolsManager:
             logger.warning(f"Remote MCP tool {config.name} missing URL, skipping")
             return None
         headers = config.headers or None
-        timeout = config.timeout or 30
+        timeout = _session_timeout(config)
         sse_read_timeout = config.sse_read_timeout or 300
         if config.transport_type == MCPTransportType.SSE:
             server_params = SSEClientParams(
@@ -196,7 +267,12 @@ class MCPToolsManager:
                 timeout=timeout,
                 sse_read_timeout=sse_read_timeout,
             )
-            return MCPTools(url=config.url, transport="sse", server_params=server_params)
+            return MCPTools(
+                url=config.url,
+                transport="sse",
+                server_params=server_params,
+                timeout_seconds=timeout,
+            )
         server_params = StreamableHTTPClientParams(
             url=config.url,
             headers=headers,
@@ -206,9 +282,16 @@ class MCPToolsManager:
                 config.terminate_on_close if config.terminate_on_close is not None else True
             ),
         )
-        return MCPTools(url=config.url, transport="streamable-http", server_params=server_params)
+        return MCPTools(
+            url=config.url,
+            transport="streamable-http",
+            server_params=server_params,
+            timeout_seconds=timeout,
+        )
 
-    async def _connect_and_register(self, mcp_tool: Optional[MCPTools], name: str) -> bool:
+    async def _connect_and_register(
+        self, mcp_tool: Optional[MCPTools], name: str, connect_timeout: float
+    ) -> bool:
         """Connect a built tool, verify it exposes functions, and register it
         for use + cleanup. Failed tools are torn down, never registered."""
         if mcp_tool is None:
@@ -218,13 +301,13 @@ class MCPToolsManager:
             })
             return False
         try:
-            await asyncio.wait_for(mcp_tool.__aenter__(), timeout=CONNECT_TIMEOUT_SECONDS)
+            await asyncio.wait_for(mcp_tool.__aenter__(), timeout=connect_timeout)
             logger.debug(f"Entered MCP tool context: {name}")
         except asyncio.TimeoutError:
             logger.error(f"Timeout connecting to MCP tool {name}")
             self.failed_tools.append({
                 "name": name,
-                "error": f"Timed out after {CONNECT_TIMEOUT_SECONDS:.0f}s connecting to the server",
+                "error": f"Timed out after {connect_timeout:.0f}s connecting to the server",
             })
             await self._abort_tool(mcp_tool)
             return False
@@ -364,7 +447,9 @@ class ChatAgentMCPMixin:
         mcp_manager = None
         if agent_id and org_id:
             try:
-                mcp_manager = MCPToolsManager()
+                mcp_manager = MCPToolsManager(
+                    connect_budget=INTERACTIVE_CONNECT_BUDGET_SECONDS
+                )
                 mcp_tools = await mcp_manager.initialize_mcp_tools(agent_id, org_id)
             except Exception as e:
                 logger.error(f"Failed to initialize MCP tools: {e}")

--- a/backend/app/tools/mcp_manager.py
+++ b/backend/app/tools/mcp_manager.py
@@ -48,6 +48,13 @@ HANDSHAKE_REQUESTS = 2
 # worker is already bounded by its own wall-clock budget.
 INTERACTIVE_CONNECT_BUDGET_SECONDS = 60.0
 
+# How long a detached teardown is given before we stop caring about it.
+ABORT_TIMEOUT_SECONDS = 2.0
+
+# Strong references to in-flight teardowns; without them the loop can garbage
+# collect a task mid-flight.
+_pending_teardowns: set = set()
+
 
 def _session_timeout(config) -> int:
     """Per-request read timeout for the MCP session, on every transport.
@@ -336,11 +343,28 @@ class MCPToolsManager:
 
     @staticmethod
     async def _abort_tool(mcp_tool: MCPTools) -> None:
-        """Best-effort teardown of a tool that failed to come up."""
+        """Best-effort teardown of a tool that failed to come up.
+
+        Detached deliberately. When a STDIO server never answers the
+        handshake, __aexit__ unwinds anyio scopes that were entered inside the
+        task asyncio.wait_for has already cancelled; that unwind cannot
+        process further cancellation, so awaiting it — even through another
+        wait_for — blocks until the child process happens to exit and defeats
+        the connect budget entirely.
+        """
+        task = asyncio.create_task(MCPToolsManager._close_quietly(mcp_tool))
+        _pending_teardowns.add(task)
+        task.add_done_callback(_pending_teardowns.discard)
+
+    @staticmethod
+    async def _close_quietly(mcp_tool: MCPTools) -> None:
+        """Exit a tool's context, swallowing whatever it throws on the way."""
         try:
-            await asyncio.wait_for(mcp_tool.__aexit__(None, None, None), timeout=2.0)
-        except Exception:
-            pass
+            await asyncio.wait_for(
+                mcp_tool.__aexit__(None, None, None), timeout=ABORT_TIMEOUT_SECONDS
+            )
+        except Exception as e:
+            logger.debug(f"MCP tool teardown after a failed connect did not finish: {e}")
 
     async def cleanup_mcp_tools(self):
         """

--- a/backend/app/tools/mcp_manager.py
+++ b/backend/app/tools/mcp_manager.py
@@ -41,12 +41,20 @@ CONNECT_TIMEOUT_MARGIN_SECONDS = 10.0
 # list_tools — each entitled to the full per-request timeout.
 HANDSHAKE_REQUESTS = 2
 
-# Ceiling on how long an interactive caller (a chat turn, the Test button)
-# waits for connectors, however generous the per-tool timeouts are. Without
-# it a connector that spawns but never speaks would stall a live reply for
-# minutes. Background callers pass no ceiling: the ticket investigation
-# worker is already bounded by its own wall-clock budget.
-INTERACTIVE_CONNECT_BUDGET_SECONDS = 60.0
+# Ceiling on connector setup for a live chat turn. A visitor is waiting on
+# the reply and create_async runs per turn, so a connector that spawns but
+# never speaks would otherwise make every message in the conversation hang.
+# Short on purpose: a connector too slow to start inside this is too slow to
+# be usable in a live chat regardless.
+CHAT_CONNECT_BUDGET_SECONDS = 15.0
+
+# The Test button's ceiling. Someone is deliberately waiting to find out
+# whether a connector comes up — including a cold `npx` launch — so it can be
+# far more patient than a chat turn while still bounding the request.
+TEST_CONNECT_BUDGET_SECONDS = 60.0
+
+# Background callers pass no ceiling at all: the ticket investigation worker
+# derives its own from the run's wall-clock budget.
 
 # How long a detached teardown is given before we stop caring about it.
 ABORT_TIMEOUT_SECONDS = 2.0
@@ -132,9 +140,7 @@ class MCPToolsManager:
     async def _initialize_from_configs(self, configs) -> List[MCPTools]:
         """Build + connect each configured tool, keeping only the ones that
         come up with functions available."""
-        deadline = (
-            monotonic() + self.connect_budget if self.connect_budget is not None else None
-        )
+        deadline = self._deadline()
         try:
             # Initialize each MCP tool asynchronously
             for mcp_tool_config in configs:
@@ -166,6 +172,13 @@ class MCPToolsManager:
 
         logger.debug(f"Initialized {len(self.mcp_tools)} MCP tools")
         return self.mcp_tools
+
+    def _deadline(self) -> Optional[float]:
+        """When this manager's overall connect budget runs out, or None when
+        it doesn't have one."""
+        if self.connect_budget is None:
+            return None
+        return monotonic() + self.connect_budget
 
     def _budgeted_connect_timeout(self, config, deadline: Optional[float]) -> float:
         """The tool's own connect budget, trimmed to whatever is left of the
@@ -238,9 +251,7 @@ class MCPToolsManager:
         build/connect path as a real run, so the reported error is exactly
         what a run would record. Never raises."""
         failures_before = len(self.failed_tools)
-        deadline = (
-            monotonic() + self.connect_budget if self.connect_budget is not None else None
-        )
+        deadline = self._deadline()
         try:
             mcp_tool = self._build_tool(config)
             connected = await self._connect_and_register(
@@ -472,7 +483,7 @@ class ChatAgentMCPMixin:
         if agent_id and org_id:
             try:
                 mcp_manager = MCPToolsManager(
-                    connect_budget=INTERACTIVE_CONNECT_BUDGET_SECONDS
+                    connect_budget=CHAT_CONNECT_BUDGET_SECONDS
                 )
                 mcp_tools = await mcp_manager.initialize_mcp_tools(agent_id, org_id)
             except Exception as e:

--- a/backend/app/workers/ticket_investigator.py
+++ b/backend/app/workers/ticket_investigator.py
@@ -53,6 +53,10 @@ TRIAGE_WALL_SECONDS = 120
 # model server_defaults so behaviour can't drift between them).
 DEFAULT_MAX_WALL_SECONDS = 600
 DEFAULT_AUTO_RESOLVE_CONFIDENCE = 0.85
+# Share of a run's wall budget the connectors may spend coming up. Generous
+# per-connector timeouts are what make slow `npx` servers usable, but a run
+# that spends all its time connecting produces no hypotheses at all.
+CONNECT_BUDGET_SHARE = 0.25
 
 
 async def _build_triage_context(db, service: TicketService, ticket: Ticket):
@@ -432,7 +436,8 @@ async def _process_investigation(db, run, service: TicketService, ticket: Ticket
 
     from app.tools.mcp_manager import MCPToolsManager
 
-    mcp_manager = MCPToolsManager()
+    wall_seconds = run.max_wall_seconds or DEFAULT_MAX_WALL_SECONDS
+    mcp_manager = MCPToolsManager(connect_budget=wall_seconds * CONNECT_BUDGET_SHARE)
     hypotheses = []
     partial = False
     try:
@@ -441,7 +446,7 @@ async def _process_investigation(db, run, service: TicketService, ticket: Ticket
                 db, run, service, ticket, agent, context_message, settings_row,
                 recorder, mcp_manager
             ),
-            timeout=run.max_wall_seconds or DEFAULT_MAX_WALL_SECONDS,
+            timeout=wall_seconds,
         )
         partial = budget_exhausted
     except asyncio.TimeoutError:

--- a/backend/tests/tools/test_mcp_manager.py
+++ b/backend/tests/tools/test_mcp_manager.py
@@ -31,6 +31,7 @@ from app.tools.mcp_manager import (
     HANDSHAKE_REQUESTS,
     MCPToolsManager,
     _connect_timeout,
+    _pending_teardowns,
     _session_timeout,
     cleanup_mcp_tools,
     initialize_mcp_tools,
@@ -822,6 +823,29 @@ async def test_connect_budget_is_shared_across_tools():
     assert tools == []
     assert [failure["name"] for failure in manager.failed_tools] == ["First", "Second"]
     assert "Skipped" in manager.failed_tools[-1]["error"]
+
+
+@pytest.mark.asyncio
+async def test_abort_does_not_block_on_a_hanging_teardown():
+    """A STDIO server that never answered leaves __aexit__ unwinding anyio
+    scopes that can't take a further cancellation. Awaiting that would hold
+    the caller long past its connect budget, so the teardown runs detached."""
+    tool = MagicMock()
+    started = asyncio.Event()
+
+    async def never_finishes(*args):
+        started.set()
+        await asyncio.sleep(3600)
+
+    tool.__aexit__ = never_finishes
+
+    # Returns promptly even though the teardown itself never will...
+    await asyncio.wait_for(MCPToolsManager._abort_tool(tool), timeout=1.0)
+    # ...and the teardown really was started, not skipped.
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    for task in list(_pending_teardowns):
+        task.cancel()
 
 
 def test_no_connect_budget_leaves_the_tool_timeout_intact():

--- a/backend/tests/tools/test_mcp_manager.py
+++ b/backend/tests/tools/test_mcp_manager.py
@@ -21,9 +21,20 @@ ChatterMate - MCP Manager Tests
 import pytest
 import asyncio
 from unittest.mock import patch, AsyncMock, MagicMock
+from time import monotonic
 from uuid import uuid4
 
-from app.tools.mcp_manager import MCPToolsManager, initialize_mcp_tools, cleanup_mcp_tools
+from app.models.mcp_tool import MCPTransportType
+from app.tools.mcp_manager import (
+    CONNECT_TIMEOUT_MARGIN_SECONDS,
+    DEFAULT_TIMEOUT_SECONDS,
+    HANDSHAKE_REQUESTS,
+    MCPToolsManager,
+    _connect_timeout,
+    _session_timeout,
+    cleanup_mcp_tools,
+    initialize_mcp_tools,
+)
 
 
 @pytest.mark.asyncio
@@ -45,6 +56,7 @@ async def test_initialize_mcp_tools_stdio_success():
     mock_tool_config.transport_type = type("T", (), {"__eq__": lambda s, o: False})()  # placeholder
     from app.models.mcp_tool import MCPTransportType
     mock_tool_config.transport_type = MCPTransportType.STDIO
+    mock_tool_config.timeout = None
     mock_tool_config.command = "npx"
     mock_tool_config.args = ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
     mock_tool_config.env_vars = {"FOO": "bar"}
@@ -83,6 +95,7 @@ async def test_initialize_mcp_tools_stdio_missing_dirs_skips():
     mock_tool_config = MagicMock()
     from app.models.mcp_tool import MCPTransportType
     mock_tool_config.transport_type = MCPTransportType.STDIO
+    mock_tool_config.timeout = None
     mock_tool_config.name = "FS Tool"
     mock_tool_config.command = "npx"
     mock_tool_config.args = ["-y", "@modelcontextprotocol/server-filesystem"]  # no dirs after package
@@ -159,6 +172,7 @@ async def test_initialize_mcp_tools_filesystem_with_env_dirs():
     mock_tool_config = MagicMock()
     mock_tool_config.name = "FS Tool"
     mock_tool_config.transport_type = MCPTransportType.STDIO
+    mock_tool_config.timeout = None
     mock_tool_config.command = "npx"
     mock_tool_config.args = ["-y", "@modelcontextprotocol/server-filesystem"]  # No dirs in args
     mock_tool_config.env_vars = {"ALLOWED_DIRECTORIES": "/tmp, /home"}  # Dirs in env
@@ -192,6 +206,7 @@ async def test_initialize_mcp_tools_filesystem_empty_env_dirs():
     mock_tool_config = MagicMock()
     mock_tool_config.name = "FS Tool"
     mock_tool_config.transport_type = MCPTransportType.STDIO
+    mock_tool_config.timeout = None
     mock_tool_config.command = "npx"
     mock_tool_config.args = ["-y", "@modelcontextprotocol/server-filesystem"]
     mock_tool_config.env_vars = {"ALLOWED_DIRECTORIES": ""}  # Empty dirs
@@ -220,6 +235,7 @@ async def test_initialize_mcp_tools_uvx_command():
     mock_tool_config = MagicMock()
     mock_tool_config.name = "Python Tool"
     mock_tool_config.transport_type = MCPTransportType.STDIO
+    mock_tool_config.timeout = None
     mock_tool_config.command = "uvx"
     mock_tool_config.args = ["python-mcp-server"]
     mock_tool_config.env_vars = {}
@@ -253,6 +269,7 @@ async def test_initialize_mcp_tools_connection_timeout():
     mock_tool_config = MagicMock()
     mock_tool_config.name = "Slow Tool"
     mock_tool_config.transport_type = MCPTransportType.STDIO
+    mock_tool_config.timeout = None
     mock_tool_config.command = "npx"
     mock_tool_config.args = ["-y", "slow-package"]
     mock_tool_config.env_vars = {}
@@ -287,6 +304,7 @@ async def test_initialize_mcp_tools_package_not_found():
     mock_tool_config = MagicMock()
     mock_tool_config.name = "Missing Tool"
     mock_tool_config.transport_type = MCPTransportType.STDIO
+    mock_tool_config.timeout = None
     mock_tool_config.command = "npx"
     mock_tool_config.args = ["-y", "nonexistent"]
     mock_tool_config.env_vars = {}
@@ -321,6 +339,7 @@ async def test_initialize_mcp_tools_no_functions_loaded():
     mock_tool_config = MagicMock()
     mock_tool_config.name = "Empty Tool"
     mock_tool_config.transport_type = MCPTransportType.STDIO
+    mock_tool_config.timeout = None
     mock_tool_config.command = "npx"
     mock_tool_config.args = ["-y", "empty-package"]
     mock_tool_config.env_vars = {}
@@ -348,17 +367,16 @@ async def test_initialize_mcp_tools_no_functions_loaded():
 
 @pytest.mark.asyncio
 async def test_initialize_mcp_tools_sse_transport():
-    """Test SSE transport (not implemented)"""
+    """A remote tool that can't be reached is excluded and recorded."""
     manager = MCPToolsManager()
     agent_id = str(uuid4())
     org_id = str(uuid4())
 
-    mock_tool_config = MagicMock()
-    mock_tool_config.name = "SSE Tool"
-    mock_tool_config.transport_type = MCPTransportType.SSE
+    mock_tool_config = _remote_config(MCPTransportType.SSE, name="SSE Tool")
 
     with patch("app.tools.mcp_manager.SessionLocal") as mock_sess_local, \
-         patch("app.tools.mcp_manager.MCPToolRepository") as mock_repo_cls:
+         patch("app.tools.mcp_manager.MCPToolRepository") as mock_repo_cls, \
+         patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
 
         mock_db = MagicMock()
         mock_sess_local.return_value.__enter__.return_value = mock_db
@@ -366,24 +384,29 @@ async def test_initialize_mcp_tools_sse_transport():
         mock_repo.get_agent_mcp_tools.return_value = [mock_tool_config]
         mock_repo_cls.return_value = mock_repo
 
+        mock_mcp_instance = MagicMock()
+        mock_mcp_instance.__aenter__ = AsyncMock(side_effect=Exception("connection refused"))
+        mock_mcp_instance.__aexit__ = AsyncMock()
+        mock_mcp_tools_cls.return_value = mock_mcp_instance
+
         tools = await manager.initialize_mcp_tools(agent_id, org_id)
 
         assert tools == []
+        assert manager.failed_tools[-1]["name"] == "SSE Tool"
 
 
 @pytest.mark.asyncio
 async def test_initialize_mcp_tools_http_transport():
-    """Test HTTP transport (not implemented)"""
+    """A remote tool that can't be reached is excluded and recorded."""
     manager = MCPToolsManager()
     agent_id = str(uuid4())
     org_id = str(uuid4())
 
-    mock_tool_config = MagicMock()
-    mock_tool_config.name = "HTTP Tool"
-    mock_tool_config.transport_type = MCPTransportType.HTTP
+    mock_tool_config = _remote_config(MCPTransportType.HTTP, name="HTTP Tool")
 
     with patch("app.tools.mcp_manager.SessionLocal") as mock_sess_local, \
-         patch("app.tools.mcp_manager.MCPToolRepository") as mock_repo_cls:
+         patch("app.tools.mcp_manager.MCPToolRepository") as mock_repo_cls, \
+         patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
 
         mock_db = MagicMock()
         mock_sess_local.return_value.__enter__.return_value = mock_db
@@ -391,9 +414,15 @@ async def test_initialize_mcp_tools_http_transport():
         mock_repo.get_agent_mcp_tools.return_value = [mock_tool_config]
         mock_repo_cls.return_value = mock_repo
 
+        mock_mcp_instance = MagicMock()
+        mock_mcp_instance.__aenter__ = AsyncMock(side_effect=Exception("connection refused"))
+        mock_mcp_instance.__aexit__ = AsyncMock()
+        mock_mcp_tools_cls.return_value = mock_mcp_instance
+
         tools = await manager.initialize_mcp_tools(agent_id, org_id)
 
         assert tools == []
+        assert manager.failed_tools[-1]["name"] == "HTTP Tool"
 
 
 @pytest.mark.asyncio
@@ -406,6 +435,7 @@ async def test_initialize_mcp_tools_missing_command():
     mock_tool_config = MagicMock()
     mock_tool_config.name = "Bad Tool"
     mock_tool_config.transport_type = MCPTransportType.STDIO
+    mock_tool_config.timeout = None
     mock_tool_config.command = None
     mock_tool_config.args = None
 
@@ -529,13 +559,14 @@ async def test_cleanup_mcp_tools_unexpected_error():
 # ==================== Failure tracking + connection test ====================
 
 
-def _stdio_config(name="Elasticsearch", command="npx", args=None, env_vars=None):
+def _stdio_config(name="Elasticsearch", command="npx", args=None, env_vars=None, timeout=None):
     config = MagicMock()
     config.name = name
     config.transport_type = MCPTransportType.STDIO
     config.command = command
     config.args = args if args is not None else ["-y", "@elastic/mcp-server-elasticsearch"]
     config.env_vars = env_vars or {}
+    config.timeout = timeout
     return config
 
 
@@ -662,7 +693,7 @@ async def test_test_tool_config_timeout():
         await asyncio.sleep(60)
 
     with patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls, \
-         patch("app.tools.mcp_manager.CONNECT_TIMEOUT_SECONDS", 0.01):
+         patch("app.tools.mcp_manager._connect_timeout", return_value=0.01):
         mock_mcp_instance = MagicMock()
         mock_mcp_instance.__aenter__ = MagicMock(side_effect=hang)
         mock_mcp_instance.__aexit__ = AsyncMock()
@@ -709,6 +740,114 @@ async def test_test_tool_config_no_functions():
 
         assert result["success"] is False
         assert "no tools" in result["error"]
+
+
+def _remote_config(transport, name="Remote", url="https://example.com/mcp", timeout=None):
+    config = MagicMock()
+    config.name = name
+    config.transport_type = transport
+    config.url = url
+    config.headers = None
+    config.timeout = timeout
+    config.sse_read_timeout = None
+    config.terminate_on_close = True
+    return config
+
+
+def test_stdio_tool_uses_configured_timeout():
+    """The configured timeout reaches the MCP session on the STDIO path.
+    Without it agno falls back to its 5s default, which npx-launched servers
+    straddle — the same config then connects or times out at random."""
+    with patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
+        MCPToolsManager._build_tool(_stdio_config(timeout=120))
+
+    assert mock_mcp_tools_cls.call_args.kwargs["timeout_seconds"] == 120
+
+
+def test_stdio_tool_defaults_timeout_when_unset():
+    with patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
+        MCPToolsManager._build_tool(_stdio_config(timeout=None))
+
+    assert mock_mcp_tools_cls.call_args.kwargs["timeout_seconds"] == DEFAULT_TIMEOUT_SECONDS
+
+
+@pytest.mark.parametrize("transport", [MCPTransportType.SSE, MCPTransportType.HTTP])
+def test_remote_tool_passes_timeout_to_session(transport):
+    """Remote transports need timeout_seconds too: agno takes the *min* of it
+    and the transport timeout, so leaving it unset pins the session to 5s no
+    matter what the server params say."""
+    with patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
+        MCPToolsManager._build_tool(_remote_config(transport, timeout=90))
+
+    assert mock_mcp_tools_cls.call_args.kwargs["timeout_seconds"] == 90
+
+
+def test_connect_budget_covers_the_whole_handshake():
+    """The outer guard has to sit above what the handshake can legitimately
+    spend — initialize and list_tools each get the full per-request timeout —
+    otherwise raising the timeout changes nothing, the guard just fires first."""
+    config = _stdio_config(timeout=120)
+
+    assert _connect_timeout(config) > _session_timeout(config) * HANDSHAKE_REQUESTS
+    assert _connect_timeout(config) == 120 * HANDSHAKE_REQUESTS + CONNECT_TIMEOUT_MARGIN_SECONDS
+
+
+def test_connect_budget_caps_a_generous_per_tool_timeout():
+    """An interactive caller's ceiling wins over the tool's own budget, so a
+    connector that spawns but never speaks can't stall a live reply."""
+    manager = MCPToolsManager(connect_budget=12.0)
+    config = _stdio_config(timeout=300)
+
+    assert manager._budgeted_connect_timeout(config, monotonic() + 12.0) <= 12.0
+
+
+@pytest.mark.asyncio
+async def test_connect_budget_is_shared_across_tools():
+    """The ceiling is for the whole set: once it's gone the remaining tools
+    are reported as skipped rather than silently retried at full budget."""
+    manager = MCPToolsManager(connect_budget=0.05)
+    first, second = _stdio_config(name="First"), _stdio_config(name="Second")
+
+    async def slow_connect():
+        await asyncio.sleep(0.2)
+
+    with patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
+        mock_instance = MagicMock()
+        mock_instance.__aenter__ = MagicMock(side_effect=slow_connect)
+        mock_instance.__aexit__ = AsyncMock()
+        mock_mcp_tools_cls.return_value = mock_instance
+
+        tools = await manager._initialize_from_configs([first, second])
+
+    assert tools == []
+    assert [failure["name"] for failure in manager.failed_tools] == ["First", "Second"]
+    assert "Skipped" in manager.failed_tools[-1]["error"]
+
+
+def test_no_connect_budget_leaves_the_tool_timeout_intact():
+    """Background callers (the investigation worker) get the full budget —
+    they're bounded by their own wall clock instead."""
+    manager = MCPToolsManager()
+    config = _stdio_config(timeout=300)
+
+    assert manager._budgeted_connect_timeout(config, None) == _connect_timeout(config)
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_error_reports_configured_budget():
+    manager = MCPToolsManager()
+
+    with patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls, \
+         patch("app.tools.mcp_manager._connect_timeout", return_value=130.0):
+        mock_instance = MagicMock()
+        mock_instance.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError())
+        mock_instance.__aexit__ = AsyncMock()
+        mock_mcp_tools_cls.return_value = mock_instance
+
+        result = await manager.test_tool_config(_stdio_config(timeout=120))
+
+    assert result["success"] is False
+    assert "130s" in result["error"]
 
 
 class TestChatAgentMCPMixin:

--- a/backend/tests/tools/test_mcp_manager.py
+++ b/backend/tests/tools/test_mcp_manager.py
@@ -26,10 +26,12 @@ from uuid import uuid4
 
 from app.models.mcp_tool import MCPTransportType
 from app.tools.mcp_manager import (
+    CHAT_CONNECT_BUDGET_SECONDS,
     CONNECT_TIMEOUT_MARGIN_SECONDS,
     DEFAULT_TIMEOUT_SECONDS,
     HANDSHAKE_REQUESTS,
     MCPToolsManager,
+    TEST_CONNECT_BUDGET_SECONDS,
     _connect_timeout,
     _pending_teardowns,
     _session_timeout,
@@ -823,6 +825,12 @@ async def test_connect_budget_is_shared_across_tools():
     assert tools == []
     assert [failure["name"] for failure in manager.failed_tools] == ["First", "Second"]
     assert "Skipped" in manager.failed_tools[-1]["error"]
+
+
+def test_chat_turn_gets_a_tighter_budget_than_the_test_button():
+    """create_async runs per chat turn with a visitor waiting, so it can't
+    inherit the patience the Test button needs for a cold npx launch."""
+    assert CHAT_CONNECT_BUDGET_SECONDS < TEST_CONNECT_BUDGET_SECONDS
 
 
 @pytest.mark.asyncio

--- a/frontend/src/__tests__/utils/mcp.spec.ts
+++ b/frontend/src/__tests__/utils/mcp.spec.ts
@@ -1,0 +1,48 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_MCP_TIMEOUT,
+  MAX_MCP_TIMEOUT,
+  MIN_MCP_TIMEOUT,
+  clampMCPTimeout,
+} from '@/utils/mcp'
+
+describe('clampMCPTimeout', () => {
+  it('keeps a value the API accepts', () => {
+    expect(clampMCPTimeout(120)).toBe(120)
+  })
+
+  it('pulls an over-range value down to the maximum', () => {
+    // A number input's max doesn't block submission, and the 422 that would
+    // come back carries a validation payload rather than a readable message.
+    expect(clampMCPTimeout(900)).toBe(MAX_MCP_TIMEOUT)
+  })
+
+  it('rounds a fractional value to whole seconds', () => {
+    expect(clampMCPTimeout(45.6)).toBe(46)
+    expect(clampMCPTimeout(0.4)).toBe(MIN_MCP_TIMEOUT)
+  })
+
+  it('falls back to the default when the field is empty or nonsense', () => {
+    expect(clampMCPTimeout(undefined)).toBe(DEFAULT_MCP_TIMEOUT)
+    expect(clampMCPTimeout(null)).toBe(DEFAULT_MCP_TIMEOUT)
+    expect(clampMCPTimeout(NaN)).toBe(DEFAULT_MCP_TIMEOUT)
+    expect(clampMCPTimeout(0)).toBe(DEFAULT_MCP_TIMEOUT)
+    expect(clampMCPTimeout(-5)).toBe(DEFAULT_MCP_TIMEOUT)
+  })
+})

--- a/frontend/src/components/agent/AgentMCPToolsTab.vue
+++ b/frontend/src/components/agent/AgentMCPToolsTab.vue
@@ -370,7 +370,7 @@ onMounted(() => {
           <!-- HTTP/SSE Configuration -->
           <div v-else-if="createForm.transport_type === 'http' || createForm.transport_type === 'sse'" class="form-section">
             <h4>{{ createForm.transport_type.toUpperCase() }} Configuration</h4>
-            <div class="form-grid">
+            <div class="form-grid single">
               <div class="form-group">
                 <label for="url">Server URL *</label>
                 <input 
@@ -379,17 +379,6 @@ onMounted(() => {
                   type="url" 
                   placeholder="https://example.com/mcp"
                   required
-                >
-              </div>
-              <div class="form-group">
-                <label for="timeout">Timeout (seconds)</label>
-                <input 
-                  id="timeout"
-                  v-model.number="createForm.timeout" 
-                  type="number" 
-                  min="1" 
-                  max="300"
-                  placeholder="30"
                 >
               </div>
             </div>
@@ -433,6 +422,28 @@ onMounted(() => {
                     <button type="button" @click="removeHeader(key)" class="remove-button">×</button>
                   </div>
                 </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Applies to every transport -->
+          <div class="form-section">
+            <h4>Connection</h4>
+            <div class="form-grid">
+              <div class="form-group">
+                <label for="timeout">Timeout (seconds)</label>
+                <input 
+                  id="timeout"
+                  v-model.number="createForm.timeout" 
+                  type="number" 
+                  min="1" 
+                  max="300"
+                  placeholder="30"
+                >
+                <small class="field-hint">
+                  Applies to the startup handshake and to each tool call. Raise it for
+                  <code>npx</code> servers that download the package on first launch.
+                </small>
               </div>
             </div>
           </div>
@@ -987,6 +998,11 @@ onMounted(() => {
   gap: 14px;
 }
 
+/* one field on the row — don't leave it stranded at half width */
+.form-grid.single {
+  grid-template-columns: 1fr;
+}
+
 .form-group {
   margin-bottom: 0;
 }
@@ -1003,6 +1019,18 @@ onMounted(() => {
   color: var(--text3);
   margin-bottom: 8px;
   font-weight: 500;
+}
+
+.field-hint {
+  display: block;
+  font-size: 12.5px;
+  color: var(--muted2);
+  margin-top: 8px;
+  line-height: 1.5;
+}
+
+.field-hint code {
+  font-size: 12px;
 }
 
 .req {

--- a/frontend/src/components/tickets/TicketConnectorsSection.vue
+++ b/frontend/src/components/tickets/TicketConnectorsSection.vue
@@ -19,6 +19,7 @@ import { onMounted, reactive, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import { mcpService } from '@/services/mcp'
 import type { MCPTool, MCPTransportType } from '@/types/mcp'
+import { DEFAULT_MCP_TIMEOUT, clampMCPTimeout } from '@/utils/mcp'
 import grafanaLogo from '@/assets/grafana-logo.svg'
 import elasticsearchLogo from '@/assets/elasticsearch-logo.svg'
 import sentryLogo from '@/assets/sentry-logo.svg'
@@ -96,6 +97,7 @@ const form = reactive({
   command: '',
   args: '',
   envLines: '',
+  timeout: DEFAULT_MCP_TIMEOUT,
 })
 
 function applyPreset(preset: (typeof PRESETS)[0] | null) {
@@ -108,6 +110,7 @@ function applyPreset(preset: (typeof PRESETS)[0] | null) {
     command: preset?.command || '',
     args: preset?.args || '',
     envLines: preset?.envLines || '',
+    timeout: DEFAULT_MCP_TIMEOUT,
   })
   showForm.value = true
 }
@@ -150,6 +153,7 @@ async function createConnector() {
       command: !isRemote ? form.command.trim() : undefined,
       args: !isRemote ? form.args.trim().split(/\s+/).filter(Boolean) : undefined,
       env_vars: !isRemote ? parseLines(form.envLines) : undefined,
+      timeout: clampMCPTimeout(form.timeout),
     })
     await fetchConnectors()
     // New investigation connectors are opted in immediately.
@@ -231,6 +235,17 @@ onMounted(fetchConnectors)
             <textarea v-model="form.envLines" class="field-input mono" rows="3"></textarea>
           </label>
         </template>
+        <label class="form-field">
+          <span class="field-label">Timeout (seconds)</span>
+          <input
+            v-model.number="form.timeout"
+            type="number"
+            min="1"
+            max="300"
+            class="field-input"
+          />
+          <span class="field-note">Handshake and per-call limit. Raise it for slow first launches.</span>
+        </label>
       </div>
       <div class="form-actions">
         <button class="cancel-btn" @click="showForm = false">Cancel</button>
@@ -351,6 +366,11 @@ onMounted(fetchConnectors)
 .field-label {
   font-size: 11px;
   color: var(--faint);
+}
+.field-note {
+  font-size: 11px;
+  color: var(--muted2);
+  line-height: 1.45;
 }
 .field-input {
   padding: 8px 11px;

--- a/frontend/src/composables/useMCPTools.ts
+++ b/frontend/src/composables/useMCPTools.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { ref, reactive } from 'vue'
 import { mcpService } from '@/services/mcp'
 import type { MCPTool, MCPToolCreate, MCPToolUpdate, MCPToolTestResult, MCPTransportType } from '@/types/mcp'
+import { DEFAULT_MCP_TIMEOUT, clampMCPTimeout } from '@/utils/mcp'
 import { toast } from 'vue-sonner'
 
 export function useMCPTools(agentId: string) {
@@ -42,7 +43,7 @@ export function useMCPTools(agentId: string) {
     env_vars: {},
     url: '',
     headers: {},
-    timeout: 30,
+    timeout: DEFAULT_MCP_TIMEOUT,
     sse_read_timeout: 60,
     terminate_on_close: true
   })
@@ -108,7 +109,10 @@ export function useMCPTools(agentId: string) {
   // Create a new MCP tool
   const createMCPTool = async () => {
     try {
-      const newTool = await mcpService.createMCPTool(createForm)
+      const newTool = await mcpService.createMCPTool({
+        ...createForm,
+        timeout: clampMCPTimeout(createForm.timeout),
+      })
       
       // Add to agent immediately
       await mcpService.addMCPToolToAgent(newTool.id, agentId)
@@ -205,7 +209,7 @@ export function useMCPTools(agentId: string) {
       env_vars: {},
       url: '',
       headers: {},
-      timeout: 30,
+      timeout: DEFAULT_MCP_TIMEOUT,
       sse_read_timeout: 60,
       terminate_on_close: true
     })

--- a/frontend/src/utils/mcp.ts
+++ b/frontend/src/utils/mcp.ts
@@ -1,0 +1,36 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Connector timeout, in seconds. Bounds the MCP startup handshake and each
+ * later tool call. Cold `npx` launches resolve and download the package
+ * first, so the default is generous.
+ */
+export const DEFAULT_MCP_TIMEOUT = 30
+export const MIN_MCP_TIMEOUT = 1
+export const MAX_MCP_TIMEOUT = 300
+
+/**
+ * Keep the timeout inside the range the API accepts. A number input's
+ * min/max don't block submission, and the resulting 422 carries a validation
+ * payload rather than a message a toast can show.
+ */
+export function clampMCPTimeout(value: number | undefined | null): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_MCP_TIMEOUT
+  }
+  return Math.min(Math.max(Math.round(value), MIN_MCP_TIMEOUT), MAX_MCP_TIMEOUT)
+}


### PR DESCRIPTION
Fixes #302.

STDIO tools were built without `timeout_seconds`, so agno's 5s default governed the handshake. An `npx -y` server straddles that line, so the same connector connected or timed out at random. Remote transports were capped at 5s too — agno takes `min(timeout_seconds, params timeout)` and we never passed the first half.

- Pass the configured timeout on all three transports.
- Scale the outer connect guard with it instead of a fixed 10s, or raising the timeout changes nothing.
- Timeout is now editable for STDIO in both connector forms, and clamped client-side to the 1–300 range the API accepts.

Bigger timeouts mean a hanging connector can hold a caller for longer, so the manager takes an optional connect budget shared across its tools: 15s for a chat turn (it runs per turn, with a visitor waiting), 60s for the Test button, a quarter of the run's wall budget for ticket investigation. Tools past the deadline are reported as skipped, not as connection failures.

One separate bug found while testing: `_abort_tool` awaited `__aexit__`, which unwinds anyio scopes entered inside the task `wait_for` had already cancelled. That unwind can't take another cancellation, so the 2s guard around it never fired and the budget bought nothing — the request hung for over nine minutes. It runs detached now.

## Testing

Against a mock server that stalls a set number of seconds before answering the handshake — same server, only the configured timeout changed:

| `timeout` | Result |
|---|---|
| 30 | Connected, handshake took 8.23s |
| 5 | `Timed out while waiting for response to ClientRequest. Waited 5.0 seconds.` |

Second row is the error from the issue. Before this, every STDIO tool was pinned to that row.

Also checked through the UI: real `npx -y @modelcontextprotocol/server-filesystem` connects and lists 14 tools; a server that never answers now fails at 60s with `Timed out after 60s connecting to the server` and its child process is reaped; typing 900 into Timeout stores 300 rather than a 422.

Not done here: the npx mitigations (pin an exact version, `OTEL_SDK_DISABLED=true`) belong in the docs repo.