### PR TITLE
Edit and delete MCP connectors from the UI

### DIFF
--- a/backend/app/api/mcp_tool.py
+++ b/backend/app/api/mcp_tool.py
@@ -33,7 +33,8 @@ except ImportError:
 from app.models.schemas.mcp_tool import (
     MCPToolCreate, MCPToolUpdate, MCPToolResponse,
     MCPToolToAgentCreate, MCPToolToAgentResponse,
-    AgentMCPToolsResponse, MCPToolTestResponse
+    AgentMCPToolsResponse, MCPToolTestResponse, MCPToolReferencesResponse,
+    MCPTransportTypeEnum, unmask_secret_values
 )
 from app.tools.mcp_manager import TEST_CONNECT_BUDGET_SECONDS, MCPToolsManager
 from sqlalchemy.orm import Session
@@ -130,6 +131,8 @@ async def get_mcp_tool(
 ):
     """Get a specific MCP tool"""
     try:
+        check_mcp_feature_access(current_user, db)
+
         mcp_tool_repo = MCPToolRepository(db)
         mcp_tool = mcp_tool_repo.get_mcp_tool(mcp_tool_id)
         
@@ -195,6 +198,45 @@ async def test_mcp_tool(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/{mcp_tool_id}/references", response_model=MCPToolReferencesResponse)
+async def get_mcp_tool_references(
+    mcp_tool_id: int,
+    current_user: User = Depends(require_permissions("manage_agents")),
+    db: Session = Depends(get_db)
+):
+    """What currently points at this connector, so a delete confirmation can
+    name what it is about to break. Deliberately ungated, like the delete it
+    precedes."""
+    try:
+        mcp_tool_repo = MCPToolRepository(db)
+        mcp_tool = mcp_tool_repo.get_mcp_tool(mcp_tool_id)
+
+        if not mcp_tool:
+            raise HTTPException(
+                status_code=404,
+                detail="MCP tool not found"
+            )
+
+        if mcp_tool.organization_id != current_user.organization_id:
+            raise HTTPException(
+                status_code=403,
+                detail="Not authorized to access this MCP tool"
+            )
+
+        return MCPToolReferencesResponse(
+            agents=mcp_tool_repo.get_mcp_tool_agent_names(mcp_tool_id),
+            used_in_investigations=mcp_tool_repo.is_used_in_investigations(
+                mcp_tool_id, current_user.organization_id
+            ),
+        )
+
+    except HTTPException as e:
+        raise e
+    except Exception as e:
+        logger.error(f"Error fetching MCP tool references: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.put("/{mcp_tool_id}", response_model=MCPToolResponse)
 async def update_mcp_tool(
     mcp_tool_id: int,
@@ -204,6 +246,8 @@ async def update_mcp_tool(
 ):
     """Update an existing MCP tool"""
     try:
+        check_mcp_feature_access(current_user, db)
+
         mcp_tool_repo = MCPToolRepository(db)
         mcp_tool = mcp_tool_repo.get_mcp_tool(mcp_tool_id)
         
@@ -222,7 +266,36 @@ async def update_mcp_tool(
         
         # Update MCP tool with provided fields
         update_dict = update_data.model_dump(exclude_unset=True)
+
+        # Secrets are masked on the way out, so a form that round-trips them
+        # untouched must leave the stored credential alone.
+        if 'env_vars' in update_dict:
+            update_dict['env_vars'] = unmask_secret_values(
+                update_dict['env_vars'], mcp_tool.env_vars
+            )
+        if 'headers' in update_dict:
+            update_dict['headers'] = unmask_secret_values(
+                update_dict['headers'], mcp_tool.headers
+            )
         
+        # transport_type is editable, and MCPToolUpdate carries none of the
+        # create-time validators, so check the state the update would leave
+        # behind — otherwise a connector can be saved with a transport it has
+        # no command or URL for and fails only mid-investigation.
+        transport = update_dict.get('transport_type', mcp_tool.transport_type)
+        transport = getattr(transport, 'value', transport)
+        if transport == MCPTransportTypeEnum.STDIO.value:
+            if not update_dict.get('command', mcp_tool.command):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Command is required for STDIO transport"
+                )
+        elif not update_dict.get('url', mcp_tool.url):
+            raise HTTPException(
+                status_code=400,
+                detail="URL is required for SSE/HTTP transport"
+            )
+
         # Check for name conflicts if name is being updated
         if 'name' in update_dict:
             existing = mcp_tool_repo.get_by_name(
@@ -251,7 +324,12 @@ async def delete_mcp_tool(
     current_user: User = Depends(require_permissions("manage_agents")),
     db: Session = Depends(get_db)
 ):
-    """Delete an MCP tool"""
+    """Delete an MCP tool.
+
+    Deliberately not behind check_mcp_feature_access: an org whose plan no
+    longer carries mcp_tools must still be able to remove its connectors,
+    otherwise a downgrade would strand their credentials in env_vars for good.
+    """
     try:
         mcp_tool_repo = MCPToolRepository(db)
         mcp_tool = mcp_tool_repo.get_mcp_tool(mcp_tool_id)

--- a/backend/app/models/schemas/mcp_tool.py
+++ b/backend/app/models/schemas/mcp_tool.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from datetime import datetime
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_serializer, validator
 from typing import List, Optional, Dict, Union
 from enum import Enum
 from uuid import UUID
@@ -26,6 +26,39 @@ class MCPTransportTypeEnum(str, Enum):
     STDIO = "stdio"
     SSE = "sse"
     HTTP = "http"
+
+
+# Stand-in sent to the client in place of stored environment/header values.
+# An update that sends it back means "keep what is stored", so correcting an
+# unrelated field never costs a credential rotation — providers typically show
+# an API key exactly once.
+SECRET_MASK = "********"
+
+
+def mask_secret_values(values: Optional[Dict[str, str]]) -> Optional[Dict[str, str]]:
+    """Replace every value with the mask, keeping the keys so the operator can
+    still see which variables are set."""
+    if not values:
+        return values
+    return {key: SECRET_MASK for key in values}
+
+
+def unmask_secret_values(
+    incoming: Optional[Dict[str, str]], stored: Optional[Dict[str, str]]
+) -> Optional[Dict[str, str]]:
+    """Resolve an incoming secret map against what is stored: a masked value
+    keeps the stored one, anything else is a deliberate replacement. A masked
+    key with nothing stored behind it is dropped rather than written empty."""
+    if not incoming:
+        return incoming
+    stored = stored or {}
+    resolved = {}
+    for key, value in incoming.items():
+        if value != SECRET_MASK:
+            resolved[key] = value
+        elif key in stored:
+            resolved[key] = stored[key]
+    return resolved
 
 
 class MCPToolBase(BaseModel):
@@ -66,6 +99,7 @@ class MCPToolCreate(MCPToolBase):
 class MCPToolUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=255)
     description: Optional[str] = None
+    transport_type: Optional[MCPTransportTypeEnum] = None
     enabled: Optional[bool] = None
     
     # STDIO transport fields
@@ -104,8 +138,21 @@ class MCPToolResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
+    @field_serializer("env_vars", "headers")
+    def _mask_secrets(self, values: Optional[Dict[str, str]], _info):
+        """Credentials never leave the server. The edit form round-trips the
+        mask, and the update endpoint resolves it back to the stored value."""
+        return mask_secret_values(values)
+
     class Config:
         from_attributes = True
+
+
+class MCPToolReferencesResponse(BaseModel):
+    """Where a connector is in use, so a delete confirmation can name what it
+    is about to break instead of asking blind."""
+    agents: List[str] = []
+    used_in_investigations: bool = False
 
 
 class MCPToolToAgentCreate(BaseModel):

--- a/backend/app/repositories/mcp_tool.py
+++ b/backend/app/repositories/mcp_tool.py
@@ -16,7 +16,9 @@ limitations under the License.
 
 from sqlalchemy.orm import Session, joinedload
 from typing import List, Optional
+from app.models.agent import Agent
 from app.models.mcp_tool import MCPTool, MCPToolToAgent, MCPTransportType
+from app.models.ticket_settings import OrganizationTicketSettings
 from uuid import UUID
 from app.core.logger import get_logger
 
@@ -88,11 +90,42 @@ class MCPToolRepository:
         self.db.refresh(mcp_tool)
         return mcp_tool
 
+    def _get_ticket_settings(self, organization_id: UUID) -> Optional[OrganizationTicketSettings]:
+        return self.db.query(OrganizationTicketSettings).filter(
+            OrganizationTicketSettings.organization_id == organization_id
+        ).first()
+
+    def is_used_in_investigations(self, mcp_tool_id: int, organization_id: UUID) -> bool:
+        """Whether the org's investigation connector selection points at this tool."""
+        settings = self._get_ticket_settings(organization_id)
+        return bool(settings and mcp_tool_id in (settings.investigation_mcp_tool_ids or []))
+
+    def get_mcp_tool_agent_names(self, mcp_tool_id: int) -> List[str]:
+        """Names of the agents this tool is linked to."""
+        rows = self.db.query(Agent.name)\
+            .join(MCPToolToAgent, MCPToolToAgent.agent_id == Agent.id)\
+            .filter(MCPToolToAgent.mcp_tool_id == mcp_tool_id)\
+            .order_by(Agent.name)\
+            .all()
+        return [name for (name,) in rows]
+
     def delete_mcp_tool(self, mcp_tool_id: int) -> bool:
-        """Delete an MCP tool"""
+        """Delete an MCP tool, along with every reference to it."""
         mcp_tool = self.get_mcp_tool(mcp_tool_id)
         if not mcp_tool:
             return False
+
+        # investigation_mcp_tool_ids is a plain JSON id list with no foreign
+        # key, so a deleted connector would otherwise stay "configured"
+        # forever and every later run would report fewer connectors loaded
+        # than configured — the exact signal #271 added to catch real
+        # failures. Agent links go with the tool via cascade.
+        settings = self._get_ticket_settings(mcp_tool.organization_id)
+        if settings and mcp_tool_id in (settings.investigation_mcp_tool_ids or []):
+            settings.investigation_mcp_tool_ids = [
+                tool_id for tool_id in settings.investigation_mcp_tool_ids
+                if tool_id != mcp_tool_id
+            ]
 
         self.db.delete(mcp_tool)
         self.db.commit()

--- a/backend/tests/api/test_mcp_tool.py
+++ b/backend/tests/api/test_mcp_tool.py
@@ -31,7 +31,11 @@ from app.models.role import Role
 from app.models.permission import Permission
 from app.models.agent import Agent, AgentType
 from app.models.mcp_tool import MCPTransportType
-from app.models.schemas.mcp_tool import MCPToolCreate, MCPToolUpdate, MCPToolToAgentCreate
+from app.repositories.mcp_tool import MCPToolRepository
+from app.models.schemas.mcp_tool import (
+    MCPToolCreate, MCPToolUpdate, MCPToolToAgentCreate, SECRET_MASK
+)
+from app.models.ticket_settings import OrganizationTicketSettings
 
 
 app = FastAPI()
@@ -257,3 +261,163 @@ def test_test_mcp_tool_endpoint_other_org_forbidden(client: TestClient, db):
 
     resp = client.post(f"/api/mcp/{other_org_tool.id}/test")
     assert resp.status_code == 403
+
+
+def test_secrets_are_masked_on_the_way_out(client: TestClient, db):
+    """Credentials must never reach the browser — the edit form only ever
+    sees the mask."""
+    mcp_api.HAS_ENTERPRISE = False
+
+    resp = client.post("/api/mcp", json={
+        "name": "MaskedTool",
+        "transport_type": MCPTransportType.STDIO.value,
+        "command": "uvx",
+        "env_vars": {"AWS_SECRET_ACCESS_KEY": "super-secret", "AWS_REGION": "us-east-1"},
+        "enabled": True,
+    })
+    assert resp.status_code == 200
+    tool_id = resp.json()["id"]
+
+    # Keys stay visible so the operator knows what is set; values do not.
+    assert resp.json()["env_vars"] == {
+        "AWS_SECRET_ACCESS_KEY": SECRET_MASK,
+        "AWS_REGION": SECRET_MASK,
+    }
+    assert client.get(f"/api/mcp/{tool_id}").json()["env_vars"] == {
+        "AWS_SECRET_ACCESS_KEY": SECRET_MASK,
+        "AWS_REGION": SECRET_MASK,
+    }
+
+
+def test_update_keeps_secrets_the_form_sent_back_masked(client: TestClient, db):
+    """Fixing a typo in an unrelated field must not cost a credential rotation."""
+    mcp_api.HAS_ENTERPRISE = False
+
+    resp = client.post("/api/mcp", json={
+        "name": "KeepSecret",
+        "transport_type": MCPTransportType.HTTP.value,
+        "url": "https://example.com/mpc",
+        "headers": {"Authorization": "ApiKey real-key"},
+        "enabled": True,
+    })
+    tool_id = resp.json()["id"]
+
+    # The form round-trips the mask and corrects only the URL typo.
+    upd = client.put(f"/api/mcp/{tool_id}", json={
+        "url": "https://example.com/mcp",
+        "headers": {"Authorization": SECRET_MASK},
+    })
+    assert upd.status_code == 200
+    assert upd.json()["url"] == "https://example.com/mcp"
+
+    stored = MCPToolRepository(db).get_mcp_tool(tool_id)
+    assert stored.headers == {"Authorization": "ApiKey real-key"}
+
+
+def test_update_replaces_a_secret_the_operator_retyped(client: TestClient, db):
+    mcp_api.HAS_ENTERPRISE = False
+
+    resp = client.post("/api/mcp", json={
+        "name": "RotateSecret",
+        "transport_type": MCPTransportType.HTTP.value,
+        "url": "https://example.com/mcp",
+        "headers": {"Authorization": "ApiKey old-key"},
+        "enabled": True,
+    })
+    tool_id = resp.json()["id"]
+
+    client.put(f"/api/mcp/{tool_id}", json={"headers": {"Authorization": "ApiKey new-key"}})
+
+    stored = MCPToolRepository(db).get_mcp_tool(tool_id)
+    assert stored.headers == {"Authorization": "ApiKey new-key"}
+
+
+def test_delete_clears_the_investigation_selection(client: TestClient, db):
+    """investigation_mcp_tool_ids has no foreign key, so a deleted connector
+    would otherwise stay 'configured' and every later run would report fewer
+    connectors loaded than configured."""
+    mcp_api.HAS_ENTERPRISE = False
+    user = db.query(User).first()
+
+    resp = client.post("/api/mcp", json={
+        "name": "Doomed",
+        "transport_type": MCPTransportType.HTTP.value,
+        "url": "https://example.com/mcp",
+        "enabled": True,
+    })
+    tool_id = resp.json()["id"]
+
+    settings = OrganizationTicketSettings(
+        organization_id=user.organization_id,
+        investigation_mcp_tool_ids=[tool_id, 999],
+    )
+    db.add(settings)
+    db.commit()
+
+    assert client.get(f"/api/mcp/{tool_id}/references").json()["used_in_investigations"] is True
+
+    assert client.delete(f"/api/mcp/{tool_id}").status_code == 200
+    db.refresh(settings)
+    assert settings.investigation_mcp_tool_ids == [999]
+
+
+def test_references_names_the_agents_using_the_tool(client: TestClient, db):
+    mcp_api.HAS_ENTERPRISE = False
+    user = db.query(User).first()
+    agent = _create_agent(db, user.organization_id)
+
+    resp = client.post("/api/mcp", json={
+        "name": "Referenced",
+        "transport_type": MCPTransportType.HTTP.value,
+        "url": "https://example.com/mcp",
+        "enabled": True,
+    })
+    tool_id = resp.json()["id"]
+    client.post("/api/mcp/agent-association", json={
+        "mcp_tool_id": tool_id, "agent_id": str(agent.id)
+    })
+
+    refs = client.get(f"/api/mcp/{tool_id}/references")
+    assert refs.status_code == 200
+    assert refs.json() == {"agents": [agent.name], "used_in_investigations": False}
+
+
+def test_update_rejects_a_transport_switch_with_nothing_to_connect_to(client: TestClient, db):
+    """The update path must not accept a state the create path rejects."""
+    mcp_api.HAS_ENTERPRISE = False
+
+    resp = client.post("/api/mcp", json={
+        "name": "SwitchMe",
+        "transport_type": MCPTransportType.STDIO.value,
+        "command": "uvx",
+        "enabled": True,
+    })
+    tool_id = resp.json()["id"]
+
+    bad = client.put(f"/api/mcp/{tool_id}", json={
+        "transport_type": MCPTransportType.HTTP.value, "url": ""
+    })
+    assert bad.status_code == 400
+    assert "URL is required" in bad.json()["detail"]
+
+    good = client.put(f"/api/mcp/{tool_id}", json={
+        "transport_type": MCPTransportType.HTTP.value, "url": "https://example.com/mcp"
+    })
+    assert good.status_code == 200
+    assert good.json()["transport_type"] == MCPTransportType.HTTP.value
+
+
+def test_update_rejects_clearing_the_stdio_command(client: TestClient, db):
+    mcp_api.HAS_ENTERPRISE = False
+
+    resp = client.post("/api/mcp", json={
+        "name": "NeedsCommand",
+        "transport_type": MCPTransportType.STDIO.value,
+        "command": "uvx",
+        "enabled": True,
+    })
+    tool_id = resp.json()["id"]
+
+    bad = client.put(f"/api/mcp/{tool_id}", json={"command": ""})
+    assert bad.status_code == 400
+    assert "Command is required" in bad.json()["detail"]

--- a/frontend/src/__tests__/utils/mcp.spec.ts
+++ b/frontend/src/__tests__/utils/mcp.spec.ts
@@ -20,6 +20,8 @@ import {
   MAX_MCP_TIMEOUT,
   MIN_MCP_TIMEOUT,
   clampMCPTimeout,
+  linesToRecord,
+  recordToLines,
 } from '@/utils/mcp'
 
 describe('clampMCPTimeout', () => {
@@ -44,5 +46,24 @@ describe('clampMCPTimeout', () => {
     expect(clampMCPTimeout(NaN)).toBe(DEFAULT_MCP_TIMEOUT)
     expect(clampMCPTimeout(0)).toBe(DEFAULT_MCP_TIMEOUT)
     expect(clampMCPTimeout(-5)).toBe(DEFAULT_MCP_TIMEOUT)
+  })
+})
+
+describe('KEY=value line editing', () => {
+  it('round-trips a record through the textarea form', () => {
+    const record = { AWS_REGION: 'us-east-1', AWS_ACCESS_KEY_ID: 'abc' }
+    expect(linesToRecord(recordToLines(record))).toEqual(record)
+  })
+
+  it('keeps a value containing "=" intact', () => {
+    expect(linesToRecord('Authorization=Bearer a=b')).toEqual({ Authorization: 'Bearer a=b' })
+  })
+
+  it('ignores lines without a key', () => {
+    expect(linesToRecord('novalue\n=orphan\nA=1')).toEqual({ A: '1' })
+  })
+
+  it('treats a missing record as empty', () => {
+    expect(recordToLines(undefined)).toBe('')
   })
 })

--- a/frontend/src/components/agent/AgentMCPToolsTab.vue
+++ b/frontend/src/components/agent/AgentMCPToolsTab.vue
@@ -32,12 +32,15 @@ const {
   showCreateModal,
   showLinkModal,
   showDeleteConfirm,
+  deleteReferences,
+  editingToolId,
   createForm,
   transportTypes,
   mcpPresets,
   fetchAgentMCPTools,
   fetchAvailableMCPTools,
-  createMCPTool,
+  saveMCPTool,
+  startEdit,
   linkMCPTool,
   unlinkMCPTool,
   deleteMCPTool,
@@ -94,16 +97,21 @@ const openCreateModal = () => {
   showCreateModal.value = true
 }
 
+const closeToolModal = () => {
+  showCreateModal.value = false
+  resetCreateForm()
+}
+
 const openLinkModal = () => {
   fetchAvailableMCPTools()
   showLinkModal.value = true
 }
 
-const handleCreateTool = async () => {
+const handleSaveTool = async () => {
   try {
-    await createMCPTool()
+    await saveMCPTool()
   } catch (error) {
-    console.error('Error creating MCP tool:', error)
+    console.error('Error saving MCP tool:', error)
   }
 }
 
@@ -202,8 +210,26 @@ onMounted(() => {
               >
                 {{ testingToolId === tool.id ? 'Testing…' : 'Test' }}
               </button>
-              <button class="remove-button" @click="confirmDelete(tool.id)" title="Remove tool">
-                Remove
+              <button
+                class="test-button"
+                @click="startEdit(tool)"
+                title="Edit this connector"
+              >
+                Edit
+              </button>
+              <button
+                class="test-button"
+                @click="unlinkMCPTool(tool.id)"
+                title="Stop this agent using the connector, keeping it for other agents"
+              >
+                Unlink
+              </button>
+              <button
+                class="remove-button"
+                @click="confirmDelete(tool.id)"
+                title="Delete the connector for the whole organization"
+              >
+                Delete
               </button>
             </div>
           </div>
@@ -224,17 +250,17 @@ onMounted(() => {
       </div>
     </div>
 
-    <!-- Create MCP Tool Modal -->
-    <div v-if="showCreateModal" class="modal-overlay" @click.self="showCreateModal = false">
+    <!-- Create / Edit MCP Tool Modal -->
+    <div v-if="showCreateModal" class="modal-overlay" @click.self="closeToolModal">
       <div class="modal-content large">
         <div class="modal-header">
-          <h3>Create MCP tool</h3>
-          <button class="close-button" @click="showCreateModal = false">✕</button>
+          <h3>{{ editingToolId === null ? 'Create MCP tool' : 'Edit MCP tool' }}</h3>
+          <button class="close-button" @click="closeToolModal">✕</button>
         </div>
 
         <div class="modal-body">
-          <!-- Presets -->
-          <div class="form-section">
+          <!-- Presets — a starting point for a new tool only -->
+          <div v-if="editingToolId === null" class="form-section">
             <h4>Quick start presets</h4>
             <div class="presets-grid">
               <button
@@ -450,16 +476,16 @@ onMounted(() => {
         </div>
 
         <div class="modal-footer">
-          <button type="button" class="secondary-button" @click="showCreateModal = false">
+          <button type="button" class="secondary-button" @click="closeToolModal">
             Cancel
           </button>
           <button 
             type="button" 
             class="primary-button" 
-            @click="handleCreateTool"
+            @click="handleSaveTool"
             :disabled="!createForm.name.trim()"
           >
-            Create Tool
+            {{ editingToolId === null ? 'Create Tool' : 'Save Changes' }}
           </button>
         </div>
       </div>
@@ -543,7 +569,21 @@ onMounted(() => {
         </div>
         
         <div class="modal-body">
-          <p class="confirm-text">Are you sure you want to remove this MCP tool from the agent? This action cannot be undone.</p>
+          <p class="confirm-text">
+            This deletes the connector for the whole organization, along with its stored
+            credentials. To stop just this agent using it, close this and choose Unlink.
+          </p>
+          <ul
+            v-if="deleteReferences && (deleteReferences.agents.length || deleteReferences.used_in_investigations)"
+            class="confirm-refs"
+          >
+            <li v-if="deleteReferences.used_in_investigations">
+              It is selected for investigations — it will be deselected.
+            </li>
+            <li v-if="deleteReferences.agents.length">
+              Linked to {{ deleteReferences.agents.join(', ') }} — those links will be removed.
+            </li>
+          </ul>
         </div>
         
         <div class="modal-footer">
@@ -551,7 +591,7 @@ onMounted(() => {
             Cancel
           </button>
           <button type="button" class="danger-button" @click="deleteMCPTool">
-            Remove Tool
+            Delete Connector
           </button>
         </div>
       </div>
@@ -560,6 +600,14 @@ onMounted(() => {
 </template>
 
 <style scoped>
+.confirm-refs {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  font-size: 12px;
+  color: var(--muted2, var(--text-muted));
+  line-height: 1.6;
+}
+
 .mcp-tools-container {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/tickets/TicketConnectorsSection.vue
+++ b/frontend/src/components/tickets/TicketConnectorsSection.vue
@@ -18,8 +18,8 @@ limitations under the License.
 import { onMounted, reactive, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import { mcpService } from '@/services/mcp'
-import type { MCPTool, MCPTransportType } from '@/types/mcp'
-import { DEFAULT_MCP_TIMEOUT, clampMCPTimeout } from '@/utils/mcp'
+import type { MCPTool, MCPToolReferences, MCPTransportType } from '@/types/mcp'
+import { DEFAULT_MCP_TIMEOUT, SECRET_MASK, clampMCPTimeout, linesToRecord, recordToLines } from '@/utils/mcp'
 import grafanaLogo from '@/assets/grafana-logo.svg'
 import elasticsearchLogo from '@/assets/elasticsearch-logo.svg'
 import sentryLogo from '@/assets/sentry-logo.svg'
@@ -31,8 +31,13 @@ const emit = defineEmits<{ (e: 'update:selected-ids', ids: number[]): void }>()
 const connectors = ref<MCPTool[]>([])
 const isLoading = ref(true)
 const loadError = ref<string | null>(null)
-const isCreating = ref(false)
+const isSaving = ref(false)
 const showForm = ref(false)
+// Which connector the form is editing, or null when it is creating one.
+const editingId = ref<number | null>(null)
+const deleteTarget = ref<MCPTool | null>(null)
+const deleteRefs = ref<MCPToolReferences | null>(null)
+const isDeleting = ref(false)
 
 // One-click starting points for the common observability platforms. All
 // values are placeholders the user edits — any other platform with an MCP
@@ -118,17 +123,26 @@ function applyPreset(preset: (typeof PRESETS)[0] | null) {
     envLines: preset?.envLines || '',
     timeout: DEFAULT_MCP_TIMEOUT,
   })
+  editingId.value = null
   showForm.value = true
 }
 
-/** "KEY=value" lines -> record. Lines without '=' are ignored. */
-function parseLines(lines: string): Record<string, string> {
-  const result: Record<string, string> = {}
-  for (const line of lines.split('\n')) {
-    const idx = line.indexOf('=')
-    if (idx > 0) result[line.slice(0, idx).trim()] = line.slice(idx + 1).trim()
-  }
-  return result
+/** Load an existing connector into the same form. Secret values arrive
+ * masked; leaving them alone keeps the stored credential. */
+function startEdit(connector: MCPTool) {
+  Object.assign(form, {
+    name: connector.name,
+    description: connector.description || '',
+    transport: connector.transport_type,
+    url: connector.url || '',
+    headerLines: recordToLines(connector.headers),
+    command: connector.command || '',
+    args: (connector.args || []).join(' '),
+    envLines: recordToLines(connector.env_vars),
+    timeout: connector.timeout ?? DEFAULT_MCP_TIMEOUT,
+  })
+  editingId.value = connector.id
+  showForm.value = true
 }
 
 async function fetchConnectors() {
@@ -144,32 +158,91 @@ async function fetchConnectors() {
   }
 }
 
-async function createConnector() {
+/** The form's fields as an API payload. Fields belonging to the other
+ * transport are cleared so a switched connector carries no stale command or
+ * URL alongside its new one. */
+function formPayload() {
+  const isRemote = form.transport !== 'stdio'
+  return {
+    name: form.name.trim(),
+    // Sent even when empty: an omitted key cannot clear a stored description.
+    description: form.description.trim(),
+    transport_type: form.transport,
+    enabled: true,
+    url: isRemote ? form.url.trim() : '',
+    headers: isRemote ? linesToRecord(form.headerLines) : {},
+    command: isRemote ? '' : form.command.trim(),
+    args: isRemote ? [] : form.args.trim().split(/\s+/).filter(Boolean),
+    env_vars: isRemote ? {} : linesToRecord(form.envLines),
+    timeout: clampMCPTimeout(form.timeout),
+  }
+}
+
+async function saveConnector() {
   if (!form.name.trim()) return
-  isCreating.value = true
+  isSaving.value = true
   try {
-    const isRemote = form.transport !== 'stdio'
-    const created = await mcpService.createMCPTool({
-      name: form.name.trim(),
-      description: form.description.trim() || undefined,
-      transport_type: form.transport,
-      enabled: true,
-      url: isRemote ? form.url.trim() : undefined,
-      headers: isRemote ? parseLines(form.headerLines) : undefined,
-      command: !isRemote ? form.command.trim() : undefined,
-      args: !isRemote ? form.args.trim().split(/\s+/).filter(Boolean) : undefined,
-      env_vars: !isRemote ? parseLines(form.envLines) : undefined,
-      timeout: clampMCPTimeout(form.timeout),
-    })
+    if (editingId.value !== null) {
+      const updated = await mcpService.updateMCPTool(editingId.value, formPayload())
+      await fetchConnectors()
+      showForm.value = false
+      editingId.value = null
+      toast.success(`${updated.name} updated`)
+      return
+    }
+    const created = await mcpService.createMCPTool(formPayload())
     await fetchConnectors()
     // New investigation connectors are opted in immediately.
     emit('update:selected-ids', [...props.selectedIds, created.id])
     showForm.value = false
     toast.success(`${created.name} connected`)
   } catch (err: any) {
-    toast.error(err.response?.data?.detail || 'Failed to create the connector')
+    const fallback = editingId.value !== null
+      ? 'Failed to update the connector'
+      : 'Failed to create the connector'
+    toast.error(err.response?.data?.detail || fallback)
   } finally {
-    isCreating.value = false
+    isSaving.value = false
+  }
+}
+
+function cancelForm() {
+  showForm.value = false
+  editingId.value = null
+}
+
+/** Ask what points at the connector before offering to delete it, so the
+ * confirmation can name what it is about to break. */
+async function requestDelete(connector: MCPTool) {
+  deleteTarget.value = connector
+  deleteRefs.value = null
+  try {
+    deleteRefs.value = await mcpService.getMCPToolReferences(connector.id)
+  } catch {
+    // Non-fatal — confirm without the reference list rather than blocking.
+  }
+}
+
+async function deleteConnector() {
+  const target = deleteTarget.value
+  if (!target) return
+  isDeleting.value = true
+  try {
+    await mcpService.deleteMCPTool(target.id)
+    if (editingId.value === target.id) cancelForm()
+    await fetchConnectors()
+    // The API drops the id from the org's selection itself; mirror that
+    // locally only when this connector was actually selected, so deleting an
+    // unselected one costs no settings write.
+    if (props.selectedIds.includes(target.id)) {
+      emit('update:selected-ids', props.selectedIds.filter((id) => id !== target.id))
+    }
+    deleteTarget.value = null
+    toast.success(`${target.name} removed`)
+  } catch (err: any) {
+    toast.error(err.response?.data?.detail || 'Failed to remove the connector')
+  } finally {
+    isDeleting.value = false
   }
 }
 
@@ -204,6 +277,7 @@ onMounted(fetchConnectors)
     </div>
 
     <div v-if="showForm" class="create-form">
+      <div v-if="editingId !== null" class="form-title">Editing {{ form.name || 'connector' }}</div>
       <div class="form-grid">
         <label class="form-field">
           <span class="field-label">Name</span>
@@ -225,6 +299,9 @@ onMounted(fetchConnectors)
           <label class="form-field wide">
             <span class="field-label">Headers (one per line, KEY=value)</span>
             <textarea v-model="form.headerLines" class="field-input mono" rows="2"></textarea>
+            <span v-if="editingId !== null" class="field-note">
+              Stored values show as {{ SECRET_MASK }} — leave them to keep the current credential.
+            </span>
           </label>
         </template>
         <template v-else>
@@ -239,6 +316,9 @@ onMounted(fetchConnectors)
           <label class="form-field wide">
             <span class="field-label">Environment (one per line, KEY=value)</span>
             <textarea v-model="form.envLines" class="field-input mono" rows="3"></textarea>
+            <span v-if="editingId !== null" class="field-note">
+              Stored values show as {{ SECRET_MASK }} — leave them to keep the current credential.
+            </span>
           </label>
         </template>
         <label class="form-field">
@@ -254,9 +334,10 @@ onMounted(fetchConnectors)
         </label>
       </div>
       <div class="form-actions">
-        <button class="cancel-btn" @click="showForm = false">Cancel</button>
-        <button class="connect-btn" :disabled="isCreating || !form.name.trim()" @click="createConnector">
-          {{ isCreating ? 'Connecting…' : 'Connect' }}
+        <button class="cancel-btn" @click="cancelForm">Cancel</button>
+        <button class="connect-btn" :disabled="isSaving || !form.name.trim()" @click="saveConnector">
+          <template v-if="editingId !== null">{{ isSaving ? 'Saving…' : 'Save changes' }}</template>
+          <template v-else>{{ isSaving ? 'Connecting…' : 'Connect' }}</template>
         </button>
       </div>
     </div>
@@ -264,28 +345,57 @@ onMounted(fetchConnectors)
     <div v-if="isLoading" class="state-note">Loading connectors…</div>
     <div v-else-if="loadError" class="state-note">{{ loadError }}</div>
     <div v-else-if="connectors.length" class="connector-list">
-      <label v-for="connector in connectors" :key="connector.id" class="connector-row">
-        <input
-          type="checkbox"
-          :checked="selectedIds.includes(connector.id)"
-          :disabled="!connector.enabled"
-          @change="toggleSelected(connector.id, ($event.target as HTMLInputElement).checked)"
-        />
-        <div class="connector-info">
-          <div class="connector-name">
-            {{ connector.name }}
-            <span class="transport-tag mono">{{ connector.transport_type }}</span>
-            <span v-if="!connector.enabled" class="disabled-tag mono">disabled</span>
+      <div v-for="connector in connectors" :key="connector.id" class="connector-row">
+        <label class="connector-select">
+          <input
+            type="checkbox"
+            :checked="selectedIds.includes(connector.id)"
+            :disabled="!connector.enabled"
+            @change="toggleSelected(connector.id, ($event.target as HTMLInputElement).checked)"
+          />
+          <div class="connector-info">
+            <div class="connector-name">
+              {{ connector.name }}
+              <span class="transport-tag mono">{{ connector.transport_type }}</span>
+              <span v-if="!connector.enabled" class="disabled-tag mono">disabled</span>
+            </div>
+            <div class="connector-sub mono">
+              {{ connector.url || [connector.command, ...(connector.args || [])].join(' ') }}
+            </div>
           </div>
-          <div class="connector-sub mono">
-            {{ connector.url || [connector.command, ...(connector.args || [])].join(' ') }}
-          </div>
+          <span class="use-label">Use in investigations</span>
+        </label>
+        <div class="row-actions">
+          <button class="row-btn" @click="startEdit(connector)">Edit</button>
+          <button class="row-btn danger" @click="requestDelete(connector)">Delete</button>
         </div>
-        <span class="use-label">Use in investigations</span>
-      </label>
+      </div>
     </div>
     <div v-else class="state-note">
       No connectors yet — connect one above so the AI can gather evidence from your logs and metrics.
+    </div>
+
+    <div v-if="deleteTarget" class="confirm-overlay" @click.self="deleteTarget = null">
+      <div class="confirm-box">
+        <h4 class="confirm-title">Delete {{ deleteTarget.name }}?</h4>
+        <p class="confirm-text">
+          Its stored credentials are deleted with it. This cannot be undone.
+        </p>
+        <ul v-if="deleteRefs && (deleteRefs.agents.length || deleteRefs.used_in_investigations)" class="confirm-refs">
+          <li v-if="deleteRefs.used_in_investigations">
+            It is selected for investigations — it will be deselected.
+          </li>
+          <li v-if="deleteRefs.agents.length">
+            Linked to {{ deleteRefs.agents.join(', ') }} — the link will be removed.
+          </li>
+        </ul>
+        <div class="form-actions">
+          <button class="cancel-btn" @click="deleteTarget = null">Cancel</button>
+          <button class="danger-btn" :disabled="isDeleting" @click="deleteConnector">
+            {{ isDeleting ? 'Deleting…' : 'Delete connector' }}
+          </button>
+        </div>
+      </div>
     </div>
 
     <div class="lock-note">
@@ -442,7 +552,91 @@ onMounted(fetchConnectors)
   background: var(--surface);
   border: 1px solid var(--o08);
   border-radius: 11px;
+}
+.connector-select {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
   cursor: pointer;
+}
+.row-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.row-btn {
+  padding: 5px 11px;
+  background: var(--o05);
+  border: 1px solid var(--o10);
+  border-radius: 8px;
+  color: var(--muted);
+  font-size: 11.5px;
+  cursor: pointer;
+}
+.row-btn:hover {
+  color: var(--text);
+}
+.row-btn.danger:hover {
+  color: var(--c-danger);
+  border-color: var(--c-danger);
+}
+.form-title {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 11px;
+}
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-modal);
+  background: var(--scrim);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+.confirm-box {
+  background: var(--bg2);
+  border: 1px solid var(--o10);
+  border-radius: 13px;
+  padding: 18px 20px;
+  max-width: 420px;
+  width: 100%;
+}
+.confirm-title {
+  font-family: var(--font-display);
+  font-size: 15px;
+  color: var(--text);
+  margin: 0 0 8px;
+}
+.confirm-text {
+  font-size: 12.5px;
+  color: var(--muted);
+  line-height: 1.5;
+  margin: 0;
+}
+.confirm-refs {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  font-size: 12px;
+  color: var(--muted2);
+  line-height: 1.6;
+}
+.danger-btn {
+  padding: 7px 16px;
+  background: var(--c-danger);
+  color: var(--on-dark);
+  border: none;
+  border-radius: 9px;
+  font-size: 12.5px;
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+}
+.danger-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 .connector-info {
   flex: 1;

--- a/frontend/src/composables/useMCPTools.ts
+++ b/frontend/src/composables/useMCPTools.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { ref, reactive } from 'vue'
 import { mcpService } from '@/services/mcp'
-import type { MCPTool, MCPToolCreate, MCPToolUpdate, MCPToolTestResult, MCPTransportType } from '@/types/mcp'
+import type { MCPTool, MCPToolCreate, MCPToolReferences, MCPToolTestResult, MCPTransportType } from '@/types/mcp'
 import { DEFAULT_MCP_TIMEOUT, clampMCPTimeout } from '@/utils/mcp'
 import { toast } from 'vue-sonner'
 
@@ -31,6 +31,9 @@ export function useMCPTools(agentId: string) {
   const showLinkModal = ref(false)
   const showDeleteConfirm = ref(false)
   const deleteTargetId = ref<number | null>(null)
+  const deleteReferences = ref<MCPToolReferences | null>(null)
+  // Which tool the form is editing, or null when it is creating one.
+  const editingToolId = ref<number | null>(null)
 
   // Form state for creating MCP tools
   const createForm = reactive<MCPToolCreate>({
@@ -106,27 +109,53 @@ export function useMCPTools(agentId: string) {
     }
   }
 
-  // Create a new MCP tool
-  const createMCPTool = async () => {
+  // Load an existing tool into the shared form. Secret values arrive masked;
+  // leaving them alone keeps the stored credential.
+  const startEdit = (tool: MCPTool) => {
+    Object.assign(createForm, {
+      name: tool.name,
+      description: tool.description || '',
+      transport_type: tool.transport_type,
+      enabled: tool.enabled,
+      command: tool.command || '',
+      args: [...(tool.args || [])],
+      env_vars: { ...(tool.env_vars || {}) },
+      url: tool.url || '',
+      headers: { ...(tool.headers || {}) },
+      timeout: tool.timeout ?? DEFAULT_MCP_TIMEOUT,
+      sse_read_timeout: tool.sse_read_timeout ?? 60,
+      terminate_on_close: tool.terminate_on_close ?? true
+    })
+    editingToolId.value = tool.id
+    showCreateModal.value = true
+  }
+
+  // Create a new MCP tool, or save the one being edited
+  const saveMCPTool = async () => {
+    const isEditing = editingToolId.value !== null
     try {
-      const newTool = await mcpService.createMCPTool({
-        ...createForm,
-        timeout: clampMCPTimeout(createForm.timeout),
-      })
-      
-      // Add to agent immediately
-      await mcpService.addMCPToolToAgent(newTool.id, agentId)
-      
+      const payload = { ...createForm, timeout: clampMCPTimeout(createForm.timeout) }
+
+      if (isEditing) {
+        await mcpService.updateMCPTool(editingToolId.value as number, payload)
+      } else {
+        const newTool = await mcpService.createMCPTool(payload)
+        // Add to agent immediately
+        await mcpService.addMCPToolToAgent(newTool.id, agentId)
+      }
+
       // Refresh agent tools
       await fetchAgentMCPTools()
-      
+
       // Reset form and close modal
       resetCreateForm()
       showCreateModal.value = false
-      
-      toast.success('MCP tool created and linked successfully')
+      editingToolId.value = null
+
+      toast.success(isEditing ? 'MCP tool updated successfully' : 'MCP tool created and linked successfully')
     } catch (err: any) {
-      const errorMessage = err.response?.data?.detail || 'Failed to create MCP tool'
+      const errorMessage = err.response?.data?.detail
+        || (isEditing ? 'Failed to update MCP tool' : 'Failed to create MCP tool')
       toast.error(errorMessage)
       throw err
     }
@@ -199,6 +228,7 @@ export function useMCPTools(agentId: string) {
 
   // Reset create form
   const resetCreateForm = () => {
+    editingToolId.value = null
     Object.assign(createForm, {
       name: '',
       description: '',
@@ -215,15 +245,23 @@ export function useMCPTools(agentId: string) {
     })
   }
 
-  // Confirm delete
-  const confirmDelete = (toolId: number) => {
+  // Confirm delete. This destroys the connector for the whole organization,
+  // so the dialog first asks what else points at it.
+  const confirmDelete = async (toolId: number) => {
     deleteTargetId.value = toolId
+    deleteReferences.value = null
     showDeleteConfirm.value = true
+    try {
+      deleteReferences.value = await mcpService.getMCPToolReferences(toolId)
+    } catch {
+      // Non-fatal — confirm without the reference list rather than blocking.
+    }
   }
 
   // Cancel delete
   const cancelDelete = () => {
     deleteTargetId.value = null
+    deleteReferences.value = null
     showDeleteConfirm.value = false
   }
 
@@ -304,6 +342,8 @@ export function useMCPTools(agentId: string) {
     showCreateModal,
     showLinkModal,
     showDeleteConfirm,
+    deleteReferences,
+    editingToolId,
     createForm,
     transportTypes,
     mcpPresets,
@@ -311,7 +351,8 @@ export function useMCPTools(agentId: string) {
     // Methods
     fetchAgentMCPTools,
     fetchAvailableMCPTools,
-    createMCPTool,
+    saveMCPTool,
+    startEdit,
     linkMCPTool,
     unlinkMCPTool,
     deleteMCPTool,

--- a/frontend/src/services/mcp.ts
+++ b/frontend/src/services/mcp.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import api from './api'
-import type { MCPTool, MCPToolCreate, MCPToolUpdate, MCPToolToAgent, AgentMCPTools, MCPToolTestResult } from '@/types/mcp'
+import type { MCPTool, MCPToolCreate, MCPToolUpdate, MCPToolToAgent, AgentMCPTools, MCPToolTestResult, MCPToolReferences } from '@/types/mcp'
 
 export const mcpService = {
   // MCP Tool management
@@ -38,6 +38,11 @@ export const mcpService = {
 
   async updateMCPTool(toolId: number, data: MCPToolUpdate): Promise<MCPTool> {
     const response = await api.put(`/mcp-tools/${toolId}`, data)
+    return response.data
+  },
+
+  async getMCPToolReferences(toolId: number): Promise<MCPToolReferences> {
+    const response = await api.get(`/mcp-tools/${toolId}/references`)
     return response.data
   },
 

--- a/frontend/src/types/mcp.ts
+++ b/frontend/src/types/mcp.ts
@@ -91,6 +91,12 @@ export interface AgentMCPTools {
   mcp_tools: MCPTool[]
 }
 
+/** What currently points at a connector — shown before deleting it. */
+export interface MCPToolReferences {
+  agents: string[]
+  used_in_investigations: boolean
+}
+
 export interface MCPToolTestResult {
   success: boolean
   functions: string[]

--- a/frontend/src/utils/mcp.ts
+++ b/frontend/src/utils/mcp.ts
@@ -34,3 +34,28 @@ export function clampMCPTimeout(value: number | undefined | null): number {
   }
   return Math.min(Math.max(Math.round(value), MIN_MCP_TIMEOUT), MAX_MCP_TIMEOUT)
 }
+
+/**
+ * What the API sends instead of a stored environment/header value. Sending it
+ * back unchanged keeps the stored credential, so editing an unrelated field
+ * never forces the operator to mint a new one — providers typically show an
+ * API key exactly once. Must match SECRET_MASK in the backend schema.
+ */
+export const SECRET_MASK = '********'
+
+/** Record -> "KEY=value" lines, for the textarea editors. */
+export function recordToLines(record: Record<string, string> | undefined | null): string {
+  return Object.entries(record || {})
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n')
+}
+
+/** "KEY=value" lines -> record. Lines without '=' are ignored. */
+export function linesToRecord(lines: string): Record<string, string> {
+  const result: Record<string, string> = {}
+  for (const line of lines.split('\n')) {
+    const idx = line.indexOf('=')
+    if (idx > 0) result[line.slice(0, idx).trim()] = line.slice(idx + 1).trim()
+  }
+  return result
+}


### PR DESCRIPTION
Closes #317.

Connectors were add-only. Fixing a typo meant making a second connector, and since environment values were never shown, that meant re-entering every credential — most providers show an API key once.

- Edit a connector from the investigation picker and the agent tab.
- Delete one, with a confirmation naming the agents and investigation settings that reference it.
- `env_vars` and `headers` come back masked and round-trip through the form: send the mask back, the stored value is kept. Credentials no longer reach the browser.

Two bugs found on the way:

- The agent tab's "Remove" button deleted the connector for the whole org while its confirmation said it only removed it from the agent. Split into Unlink and Delete.
- `investigation_mcp_tool_ids` is a JSON id list with no FK, so a deleted connector stayed "configured" and every later run reported fewer connectors loaded than configured. Delete now purges the reference in the same transaction.

`transport_type` is editable now, so the update path enforces the transport/command/URL consistency create already did. Delete is deliberately not behind the plan feature gate — a downgraded org still needs to remove its stored credentials.

Tested locally: edited a connector's timeout and confirmed the stored secret survived, deleted one and confirmed the id was purged from ticket settings, and confirmed a transport switch with a blank URL is rejected.