### PR TITLE
Tell the AI how to query each MCP source

### DIFF
--- a/backend/alembic/versions/add_mcp_usage_guidance_001.py
+++ b/backend/alembic/versions/add_mcp_usage_guidance_001.py
@@ -1,0 +1,49 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Add mcp_tools.usage_guidance
+
+Operator-written notes on what an MCP source holds and how to query it.
+Reaches the model as agno per-toolkit instructions so investigations stop
+inventing index and field names (#318). Nullable with no server default, so
+existing rows stay NULL and their prompts are unchanged.
+
+Revision ID: add_mcp_usage_guidance_001
+Revises: add_openai_compat_ai_model_001
+Create Date: 2026-09-08 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'add_mcp_usage_guidance_001'
+down_revision: Union[str, None] = 'add_openai_compat_ai_model_001'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'mcp_tools',
+        sa.Column('usage_guidance', sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('mcp_tools', 'usage_guidance')

--- a/backend/alembic/versions/add_mcp_usage_guidance_001.py
+++ b/backend/alembic/versions/add_mcp_usage_guidance_001.py
@@ -38,7 +38,18 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _has_column() -> bool:
+    """Development databases are shared between feature branches, so the column
+    can already exist by the time this runs. Adding it twice would abort the
+    upgrade."""
+    inspector = sa.inspect(op.get_bind())
+    return any(c['name'] == 'usage_guidance'
+               for c in inspector.get_columns('mcp_tools'))
+
+
 def upgrade() -> None:
+    if _has_column():
+        return
     op.add_column(
         'mcp_tools',
         sa.Column('usage_guidance', sa.Text(), nullable=True),
@@ -46,4 +57,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column('mcp_tools', 'usage_guidance')
+    if _has_column():
+        op.drop_column('mcp_tools', 'usage_guidance')

--- a/backend/app/models/mcp_tool.py
+++ b/backend/app/models/mcp_tool.py
@@ -32,6 +32,10 @@ class MCPTool(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)  # Display name for the MCP server
     description = Column(Text)  # Optional description of what this MCP server does
+    # What this source holds and how to query it. Reaches the model as agno
+    # per-toolkit instructions, in the system prompt — unlike `description`,
+    # which is a preset-populated UI subtitle the model never sees.
+    usage_guidance = Column(Text)
     transport_type = Column(SQLEnum(MCPTransportType), nullable=False)
     enabled = Column(Boolean, default=True, nullable=False)
     

--- a/backend/app/models/schemas/mcp_tool.py
+++ b/backend/app/models/schemas/mcp_tool.py
@@ -34,6 +34,11 @@ class MCPTransportTypeEnum(str, Enum):
 # an API key exactly once.
 SECRET_MASK = "********"
 
+# Ceiling on a connector's usage guidance. Enforced here so an over-long value
+# is a clean 422, and again at injection so a row written before this existed
+# can never blow the prompt.
+MAX_USAGE_GUIDANCE_CHARS = 2000
+
 
 def mask_secret_values(values: Optional[Dict[str, str]]) -> Optional[Dict[str, str]]:
     """Replace every value with the mask, keeping the keys so the operator can
@@ -64,6 +69,10 @@ def unmask_secret_values(
 class MCPToolBase(BaseModel):
     name: str = Field(..., min_length=1, max_length=255, description="Display name for the MCP server")
     description: Optional[str] = Field(None, description="Optional description of what this MCP server does")
+    usage_guidance: Optional[str] = Field(
+        None, max_length=MAX_USAGE_GUIDANCE_CHARS,
+        description="What this source holds and how to query it — given to the AI as tool guidance",
+    )
     transport_type: MCPTransportTypeEnum
     enabled: bool = Field(default=True, description="Whether this MCP tool is enabled")
     
@@ -99,6 +108,10 @@ class MCPToolCreate(MCPToolBase):
 class MCPToolUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=255)
     description: Optional[str] = None
+    usage_guidance: Optional[str] = Field(
+        None, max_length=MAX_USAGE_GUIDANCE_CHARS,
+        description="What this source holds and how to query it — given to the AI as tool guidance",
+    )
     transport_type: Optional[MCPTransportTypeEnum] = None
     enabled: Optional[bool] = None
     
@@ -119,6 +132,8 @@ class MCPToolResponse(BaseModel):
     id: int
     name: str
     description: Optional[str]
+    # Deliberately not masked — guidance is prompt text, not a credential.
+    usage_guidance: Optional[str]
     transport_type: MCPTransportTypeEnum
     enabled: bool
     

--- a/backend/app/services/ticket_investigation.py
+++ b/backend/app/services/ticket_investigation.py
@@ -80,6 +80,12 @@ class EvidenceRecorder:
         self.seq = 0
         self.tool_calls = 0
         self.hypothesis_id: Optional[UUID] = None
+        # Per-hypothesis tool-call outcomes: {hypothesis_id: [total, errored]}.
+        # A verdict is only worth as much as the evidence under it, and a run
+        # where every query failed must not be able to assert a fact (#318).
+        self.calls_by_hypothesis: dict = {}
+        # Run-level totals, for the dashboard's connector banner.
+        self.failed_tool_calls = 0
         # tool function name -> configured connector (MCP server) name.
         self.connector_by_function: dict = {}
         # In-memory digest for RCA synthesis, mirroring the persisted rows.
@@ -129,6 +135,13 @@ class EvidenceRecorder:
             raise
         finally:
             self.tool_calls += 1
+            if error:
+                self.failed_tool_calls += 1
+            if self.hypothesis_id is not None:
+                tally = self.calls_by_hypothesis.setdefault(self.hypothesis_id, [0, 0])
+                tally[0] += 1
+                if error:
+                    tally[1] += 1
             duration_ms = int((time.monotonic() - started) * 1000)
             try:
                 input_text = json.dumps(arguments, default=str)
@@ -149,6 +162,49 @@ class EvidenceRecorder:
                 f"[E{self.seq}] {function_name}({input_snippet[:300]}) -> "
                 + (f"ERROR: {error[:200]}" if error else (result_snippet or "")[:500])
             )
+
+
+    def tool_outcomes(self, hypothesis_id: UUID) -> tuple:
+        """(total, errored) tool calls made while testing this hypothesis."""
+        total, errored = self.calls_by_hypothesis.get(hypothesis_id, [0, 0])
+        return total, errored
+
+
+def enforce_evidence_backed_verdict(
+    hypothesis: InvestigationHypothesis, recorder: "EvidenceRecorder"
+) -> bool:
+    """Downgrade a definite verdict that no successful query supports.
+
+    The model returns status and confidence as free text, and nothing else
+    checks them against what actually happened. A run whose every search
+    errored — a missing index, a rejected client version — can still come back
+    "the record does not exist, validated, 0.90", which a support agent would
+    reasonably act on. Tool errors are the absence of evidence, never evidence
+    of absence.
+
+    Only fires when the phase made tool calls and every one of them failed;
+    a hypothesis reasoned from ticket context alone is left as the model
+    returned it. Returns True when it changed the verdict.
+    """
+    total, errored = recorder.tool_outcomes(hypothesis.id)
+    if not total or errored < total:
+        return False
+    if str(hypothesis.status) == HypothesisStatus.INCONCLUSIVE.value:
+        return False
+
+    original = str(hypothesis.status)
+    confidence = hypothesis.confidence
+    hypothesis.status = HypothesisStatus.INCONCLUSIVE
+    hypothesis.confidence = 0.0
+    # The model's own conclusion is dropped rather than kept: it reads as a
+    # finding, and the RCA writer would quote it as one.
+    hypothesis.conclusion = (
+        f"Not tested — all {total} tool call{'' if total == 1 else 's'} in this phase "
+        f"failed, so no evidence was gathered. The tester reported "
+        f"\"{original}\"{f' at {confidence:.2f} confidence' if confidence is not None else ''}, "
+        "which nothing supports. Check the connector errors in the evidence log."
+    )
+    return True
 
 
 def hypotheses_digest(hypotheses: List[InvestigationHypothesis]) -> str:
@@ -221,6 +277,11 @@ async def run_investigation_phases(
             hypothesis.status = verdict.status
             hypothesis.confidence = max(0.0, min(1.0, verdict.confidence))
             hypothesis.conclusion = verdict.conclusion
+            if enforce_evidence_backed_verdict(hypothesis, recorder):
+                logger.warning(
+                    f"H{hypothesis.idx} claimed '{verdict.status}' with every tool "
+                    f"call failing; forced to inconclusive"
+                )
         else:
             hypothesis.status = HypothesisStatus.INCONCLUSIVE
             hypothesis.confidence = 0.0

--- a/backend/app/tools/guardrailed_db_toolkit.py
+++ b/backend/app/tools/guardrailed_db_toolkit.py
@@ -44,6 +44,32 @@ logger = get_logger(__name__)
 
 MAX_RESULT_CHARS = 4000
 
+# The catalogue is put in the system prompt, so it has to stay proportionate
+# to the rest of it — a connector with hundreds of allowlisted tables gets
+# trimmed and the agent falls back on list_database_tables for the rest.
+MAX_CATALOGUE_CHARS = 1500
+
+# Front-loading the catalogue saves the run a tool call: the investigator's
+# first move was otherwise always list_database_tables, spending one of its
+# max_tool_calls_per_run just to learn which tables exist (#318). agno renders
+# this into the SYSTEM message (Toolkit.instructions + add_instructions).
+_DB_TOOLKIT_INSTRUCTIONS = """<data_source name="Database">
+`query_database` reads these connectors (read-only, allowlisted tables only):
+{sources}
+Call `describe_database_table` for a table's columns before querying it. Any
+table not listed is not queryable — do not attempt it.
+</data_source>"""
+
+
+def _trim_to_line(text: str, limit: int) -> str:
+    """Trim to whole lines. Cutting mid-name would leave a half-written table
+    in the prompt that reads as a real one, and the model would spend a call
+    querying it — the exact waste this catalogue exists to avoid."""
+    if len(text) <= limit:
+        return text
+    kept, _, _ = text[:limit].rpartition("\n")
+    return (kept or "") + "\n(list truncated — call list_database_tables for the rest)"
+
 
 class GuardrailedDBTools(Toolkit):
     """Read-only, allowlisted SQL access for AI investigations."""
@@ -65,6 +91,25 @@ class GuardrailedDBTools(Toolkit):
         self.register(self.list_database_tables)
         self.register(self.describe_database_table)
         self.register(self.query_database)
+        self._set_prompt_catalogue()
+
+    def _set_prompt_catalogue(self) -> None:
+        """Front-load the table catalogue into the system prompt.
+
+        Never raises: a malformed row_scope on one connector must cost this
+        prompt optimisation, not the whole toolkit — the caller
+        (_build_db_tools) turns any exception here into "no database tools at
+        all", which is far worse than one extra list_database_tables call.
+        """
+        if not self.configs:
+            return
+        try:
+            self.instructions = _DB_TOOLKIT_INSTRUCTIONS.format(
+                sources=_trim_to_line(self._source_catalogue(), MAX_CATALOGUE_CHARS)
+            )
+            self.add_instructions = True
+        except Exception as e:
+            logger.error(f"Could not build the DB catalogue for the prompt: {e}")
 
     def _config(self, connector: str) -> Optional[DBConnectorConfig]:
         if connector in self.configs:
@@ -161,6 +206,11 @@ class GuardrailedDBTools(Toolkit):
     async def list_database_tables(self) -> str:
         """List the database connectors you may query and the tables each one
         allows. Access is read-only; only these tables are queryable."""
+        return self._source_catalogue()
+
+    def _source_catalogue(self) -> str:
+        """The connector/table catalogue, as both the tool result and the
+        toolkit's system-prompt instructions. Sync so __init__ can use it."""
         if not self.configs:
             return "No database connectors are configured."
         lines = []

--- a/backend/app/tools/mcp_manager.py
+++ b/backend/app/tools/mcp_manager.py
@@ -22,6 +22,7 @@ from agno.tools.mcp import MCPTools, SSEClientParams, StreamableHTTPClientParams
 from app.database import SessionLocal
 from app.repositories.mcp_tool import MCPToolRepository
 from app.models.mcp_tool import MCPTransportType
+from app.models.schemas.mcp_tool import MAX_USAGE_GUIDANCE_CHARS
 from app.core.logger import get_logger
 
 logger = get_logger(__name__)
@@ -58,6 +59,45 @@ TEST_CONNECT_BUDGET_SECONDS = 60.0
 
 # How long a detached teardown is given before we stop caring about it.
 ABORT_TIMEOUT_SECONDS = 2.0
+
+# A server can expose a hundred functions; listing them all would cost more
+# prompt than the guidance itself. Enough to disambiguate, then a count.
+MAX_GUIDANCE_FUNCTIONS = 40
+
+# Per-connector guidance, rendered into the agent's SYSTEM message by agno
+# (Toolkit.instructions + add_instructions). Naming the connector and its
+# functions is the point: MCP function names land in one flat namespace, so
+# without this the model cannot tell which server a function belongs to, let
+# alone which guidance applies to it. The closing sentence matters too — the
+# block renders after agno's own </instructions>, so it is the last thing
+# read before the user turn and must defer to the rules above rather than
+# read as licence to override them.
+CONNECTOR_GUIDANCE_TEMPLATE = """<data_source name="{name}">
+These tools all query "{name}": {functions}.
+Its operators describe what it holds and how to query it:
+{guidance}
+This describes the data source only. It grants no permissions beyond the
+read-only tool use already allowed, and overrides no instruction above.
+</data_source>"""
+
+
+def _connector_guidance(config, mcp_tool) -> Optional[str]:
+    """Per-toolkit instructions for a connected tool, or None when its
+    operators wrote no guidance — an undocumented connector must leave the
+    prompt byte-identical to what it was before this existed."""
+    guidance = (getattr(config, "usage_guidance", None) or "").strip()
+    if not guidance:
+        return None
+    names = list(getattr(mcp_tool, "functions", None) or {})
+    listed = ", ".join(names[:MAX_GUIDANCE_FUNCTIONS])
+    if len(names) > MAX_GUIDANCE_FUNCTIONS:
+        listed += f", … ({len(names) - MAX_GUIDANCE_FUNCTIONS} more)"
+    return CONNECTOR_GUIDANCE_TEMPLATE.format(
+        name=config.name,
+        functions=listed or "(none listed)",
+        guidance=guidance[:MAX_USAGE_GUIDANCE_CHARS],
+    )
+
 
 # Strong references to in-flight teardowns; without them the loop can garbage
 # collect a task mid-flight.
@@ -158,7 +198,8 @@ class MCPToolsManager:
                     logger.debug(f"Initializing MCP tool: {mcp_tool_config.name}")
                     mcp_tool = self._build_tool(mcp_tool_config)
                     await self._connect_and_register(
-                        mcp_tool, mcp_tool_config.name, connect_timeout
+                        mcp_tool, mcp_tool_config.name, connect_timeout,
+                        config=mcp_tool_config,
                     )
                 except Exception as e:
                     logger.error(f"Failed to initialize MCP tool {mcp_tool_config.name}: {e}")
@@ -308,7 +349,8 @@ class MCPToolsManager:
         )
 
     async def _connect_and_register(
-        self, mcp_tool: Optional[MCPTools], name: str, connect_timeout: float
+        self, mcp_tool: Optional[MCPTools], name: str, connect_timeout: float,
+        config=None,
     ) -> bool:
         """Connect a built tool, verify it exposes functions, and register it
         for use + cleanup. Failed tools are torn down, never registered."""
@@ -345,6 +387,14 @@ class MCPToolsManager:
             # Configured display name — lets consumers (e.g. the investigation
             # evidence log) attribute each tool call to its connector.
             mcp_tool._connector_name = name
+            # agno Toolkit hook: collected in Agent._add_tool and rendered
+            # into the SYSTEM message. Set only after a successful connect, so
+            # guidance never describes a source that isn't actually there.
+            if config is not None:
+                guidance = _connector_guidance(config, mcp_tool)
+                if guidance:
+                    mcp_tool.instructions = guidance
+                    mcp_tool.add_instructions = True
             self.mcp_tools.append(mcp_tool)
             self.connected_tool_names.append(name)
             return True

--- a/backend/app/workers/ticket_investigator.py
+++ b/backend/app/workers/ticket_investigator.py
@@ -470,11 +470,19 @@ async def _process_investigation(db, run, service: TicketService, ticket: Ticket
     # of its configured MCP tools (missing npx, bad key, unreachable server)
     # must be visible on the dashboard, not just in worker logs (issue #271).
     configured_tool_ids = settings_row.investigation_mcp_tool_ids or []
-    if configured_tool_ids:
+    # Also reported when the org has no MCP connectors at all: a
+    # DB-connector-only run can still have every query fail, and that must not
+    # render as a clean run (#318).
+    if configured_tool_ids or recorder.tool_calls:
         run.connector_status = {
             "configured": len(configured_tool_ids),
             "loaded": len(mcp_manager.connected_tool_names),
             "failed": mcp_manager.failed_tools,
+            # A connector can load cleanly and then error on every query. That
+            # leaves loaded == configured with no provider errors, so the run
+            # looks healthy while resting on nothing (#318).
+            "tool_calls": recorder.tool_calls,
+            "tool_calls_failed": recorder.failed_tool_calls,
             # A connector can come up perfectly and still be unusable if the
             # provider refuses its tools; that must show next to the
             # connection failures, not only in worker logs (#303).

--- a/backend/tests/api/test_mcp_tool.py
+++ b/backend/tests/api/test_mcp_tool.py
@@ -33,7 +33,8 @@ from app.models.agent import Agent, AgentType
 from app.models.mcp_tool import MCPTransportType
 from app.repositories.mcp_tool import MCPToolRepository
 from app.models.schemas.mcp_tool import (
-    MCPToolCreate, MCPToolUpdate, MCPToolToAgentCreate, SECRET_MASK
+    MCPToolCreate, MCPToolUpdate, MCPToolToAgentCreate,
+    MAX_USAGE_GUIDANCE_CHARS, SECRET_MASK,
 )
 from app.models.ticket_settings import OrganizationTicketSettings
 
@@ -421,3 +422,56 @@ def test_update_rejects_clearing_the_stdio_command(client: TestClient, db):
     bad = client.put(f"/api/mcp/{tool_id}", json={"command": ""})
     assert bad.status_code == 400
     assert "Command is required" in bad.json()["detail"]
+
+
+GUIDANCE = "Indices: app-logs-*. Order id is fields.order_ref, not order_id."
+
+
+def test_usage_guidance_round_trips_and_is_not_masked(client: TestClient, db):
+    """Guidance is prompt text, not a credential — masking it would make the
+    edit form unable to show the operator what they wrote."""
+    mcp_api.HAS_ENTERPRISE = False
+
+    resp = client.post("/api/mcp", json={
+        "name": "GuidedTool",
+        "transport_type": MCPTransportType.HTTP.value,
+        "url": "https://example.com/mcp",
+        "usage_guidance": GUIDANCE,
+        "enabled": True,
+    })
+    assert resp.status_code == 200
+    assert resp.json()["usage_guidance"] == GUIDANCE
+    tool_id = resp.json()["id"]
+
+    assert client.get(f"/api/mcp/{tool_id}").json()["usage_guidance"] == GUIDANCE
+
+    updated = client.put(f"/api/mcp/{tool_id}", json={"usage_guidance": "Replaced."})
+    assert updated.status_code == 200
+    assert updated.json()["usage_guidance"] == "Replaced."
+
+
+def test_usage_guidance_defaults_to_none(client: TestClient, db):
+    """A connector nobody has documented must stay untouched."""
+    mcp_api.HAS_ENTERPRISE = False
+
+    resp = client.post("/api/mcp", json={
+        "name": "UndocumentedTool",
+        "transport_type": MCPTransportType.HTTP.value,
+        "url": "https://example.com/mcp",
+        "enabled": True,
+    })
+    assert resp.status_code == 200
+    assert resp.json()["usage_guidance"] is None
+
+
+def test_overlong_usage_guidance_is_rejected(client: TestClient, db):
+    mcp_api.HAS_ENTERPRISE = False
+
+    resp = client.post("/api/mcp", json={
+        "name": "TooMuchGuidance",
+        "transport_type": MCPTransportType.HTTP.value,
+        "url": "https://example.com/mcp",
+        "usage_guidance": "x" * (MAX_USAGE_GUIDANCE_CHARS + 1),
+        "enabled": True,
+    })
+    assert resp.status_code == 422

--- a/backend/tests/services/test_ticket_investigation.py
+++ b/backend/tests/services/test_ticket_investigation.py
@@ -18,6 +18,7 @@ RCA synthesis/versioning.
 """
 
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest
 
@@ -38,6 +39,7 @@ from app.models.schemas.investigation import (
 from app.models.ticket import Ticket, TicketPriority, TicketSource, TicketStatus
 from app.services.ticket_investigation import (
     EvidenceRecorder,
+    enforce_evidence_backed_verdict,
     redact_snippet,
     run_investigation_phases,
     synthesize_and_store_rca,
@@ -303,3 +305,138 @@ class TestRcaSynthesis:
         )
         assert result is None
         assert db.query(RCADocument).count() == 0
+
+
+class TestEvidenceBackedVerdicts:
+    """Tool errors are the absence of evidence, never evidence of absence.
+
+    A run whose every search failed could still report "the record does not
+    exist — validated, 0.90", which a support agent would act on (#318).
+    """
+
+    @staticmethod
+    def _agent_claiming(status, confidence=0.9):
+        return _FakeAgent(
+            plan=HypothesisPlan(hypotheses=[HypothesisSpec(title="H", rationale="r")]),
+            verdict=HypothesisVerdict(
+                status=status, confidence=confidence,
+                conclusion="No record of the order exists in any index.",
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_verdict_is_downgraded_when_every_tool_call_failed(
+        self, db, run, ticket, recorder
+    ):
+        async def failing_tool(**kwargs):
+            raise RuntimeError("index_not_found_exception: no such index [app-logs-*]")
+
+        agent = self._agent_claiming("validated")
+
+        async def test_hypothesis(context, title, rationale, **kwargs):
+            for _ in range(3):
+                with pytest.raises(RuntimeError):
+                    await recorder.tool_hook("search_logs", failing_tool, {"q": "x"})
+            return agent.verdict
+
+        agent.test_hypothesis = test_hypothesis
+        hypotheses, _ = await run_investigation_phases(
+            db, run, ticket, agent, "context", [object()], recorder
+        )
+
+        assert hypotheses[0].status == HypothesisStatus.INCONCLUSIVE
+        assert hypotheses[0].confidence == 0.0
+        assert "all 3 tool calls in this phase failed" in hypotheses[0].conclusion
+        # The model's claim is recorded, but its wording is not — the RCA
+        # writer would otherwise quote "no record exists" as a finding.
+        assert "validated" in hypotheses[0].conclusion
+        assert "No record of the order exists" not in hypotheses[0].conclusion
+
+    @pytest.mark.asyncio
+    async def test_an_invalidated_verdict_is_downgraded_too(self, db, run, ticket, recorder):
+        """The reported case: 'the record does not exist' is a claim of
+        absence, and absence is exactly what a failed search cannot prove."""
+        async def failing_tool(**kwargs):
+            raise RuntimeError("boom")
+
+        agent = self._agent_claiming("invalidated")
+
+        async def test_hypothesis(context, title, rationale, **kwargs):
+            with pytest.raises(RuntimeError):
+                await recorder.tool_hook("search_logs", failing_tool, {})
+            return agent.verdict
+
+        agent.test_hypothesis = test_hypothesis
+        hypotheses, _ = await run_investigation_phases(
+            db, run, ticket, agent, "context", [object()], recorder
+        )
+
+        assert hypotheses[0].status == HypothesisStatus.INCONCLUSIVE
+        assert "all 1 tool call in this phase failed" in hypotheses[0].conclusion
+
+    @pytest.mark.asyncio
+    async def test_a_verdict_survives_when_one_call_succeeded(self, db, run, ticket, recorder):
+        """Partial failure still leaves real evidence; only a total washout
+        removes the basis for a finding."""
+        async def failing_tool(**kwargs):
+            raise RuntimeError("boom")
+
+        async def working_tool(**kwargs):
+            return "1 hit: status 500"
+
+        agent = self._agent_claiming("validated")
+
+        async def test_hypothesis(context, title, rationale, **kwargs):
+            with pytest.raises(RuntimeError):
+                await recorder.tool_hook("search_logs", failing_tool, {})
+            await recorder.tool_hook("search_logs", working_tool, {})
+            return agent.verdict
+
+        agent.test_hypothesis = test_hypothesis
+        hypotheses, _ = await run_investigation_phases(
+            db, run, ticket, agent, "context", [object()], recorder
+        )
+
+        assert hypotheses[0].status == "validated"
+        assert hypotheses[0].confidence == 0.9
+
+    @pytest.mark.asyncio
+    async def test_a_hypothesis_with_no_tool_calls_is_left_alone(
+        self, db, run, ticket, recorder
+    ):
+        """Reasoning from the ticket alone is legitimate — the instructions
+        explicitly allow it when there are no tools."""
+        agent = self._agent_claiming("validated")
+        hypotheses, _ = await run_investigation_phases(
+            db, run, ticket, agent, "context", [], recorder
+        )
+
+        assert hypotheses[0].status == "validated"
+        assert hypotheses[0].confidence == 0.9
+
+    def test_the_rule_leaves_an_already_inconclusive_verdict_untouched(self, recorder):
+        hypothesis = InvestigationHypothesis(
+            id=uuid4(), run_id=uuid4(), ticket_id=uuid4(), idx=1, title="H",
+            status=HypothesisStatus.INCONCLUSIVE, confidence=0.4, conclusion="Not enough.",
+        )
+        recorder.calls_by_hypothesis[hypothesis.id] = [2, 2]
+
+        assert enforce_evidence_backed_verdict(hypothesis, recorder) is False
+        assert hypothesis.conclusion == "Not enough."
+
+    @pytest.mark.asyncio
+    async def test_the_run_reports_how_many_calls_errored(self, db, recorder, run):
+        """connector_status is what the dashboard reads; a connector that
+        loads and then errors on every query shows up nowhere else."""
+        async def failing_tool(**kwargs):
+            raise RuntimeError("boom")
+
+        async def working_tool(**kwargs):
+            return "ok"
+
+        with pytest.raises(RuntimeError):
+            await recorder.tool_hook("t", failing_tool, {})
+        await recorder.tool_hook("t", working_tool, {})
+
+        assert recorder.tool_calls == 2
+        assert recorder.failed_tool_calls == 1

--- a/backend/tests/tools/test_guardrailed_db_toolkit.py
+++ b/backend/tests/tools/test_guardrailed_db_toolkit.py
@@ -1,0 +1,106 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""
+ChatterMate - Guardrailed DB toolkit: the system-prompt table catalogue.
+
+The investigator's first move used to be list_database_tables, spending one of
+its max_tool_calls_per_run just to learn which tables exist. The catalogue is
+now front-loaded into the toolkit's instructions (#318).
+"""
+
+import pytest
+
+from app.services.db_connector_service import DBConnectorConfig
+from app.tools.guardrailed_db_toolkit import MAX_CATALOGUE_CHARS, GuardrailedDBTools
+
+
+def _config(name="prod", tables=None, row_scope=None, engine="postgresql"):
+    return DBConnectorConfig(
+        id=None, organization_id=None, name=name, engine=engine,
+        host="h", port=5432, database="d", username="u", password="p",
+        allowed_tables=tables if tables is not None else ["public.orders", "public.users"],
+        row_scope=row_scope or {},
+    )
+
+
+def test_catalogue_names_each_connector_its_engine_and_its_tables():
+    toolkit = GuardrailedDBTools([_config()])
+
+    assert toolkit.add_instructions is True
+    assert "prod [postgresql]" in toolkit.instructions
+    assert "public.orders" in toolkit.instructions
+    assert "public.users" in toolkit.instructions
+
+
+def test_catalogue_carries_the_row_scope_annotation():
+    """The agent must not waste a call trying to widen a scoped table."""
+    toolkit = GuardrailedDBTools(
+        [_config(row_scope={"public.orders": "customer_email"})]
+    )
+
+    assert "auto-scoped to this ticket's customer by customer_email" in toolkit.instructions
+
+
+@pytest.mark.asyncio
+async def test_the_tool_still_returns_exactly_what_the_prompt_carries():
+    """list_database_tables is a registered tool the model already calls; the
+    sync/async split must not have changed a byte of its output."""
+    toolkit = GuardrailedDBTools([_config()])
+
+    catalogue = toolkit._source_catalogue()
+    assert await toolkit.list_database_tables() == catalogue
+    assert catalogue in toolkit.instructions
+
+
+def test_no_connectors_means_no_instructions():
+    """The toolkit is only built when there is at least one config, but an
+    empty catalogue must never reach the prompt as noise."""
+    toolkit = GuardrailedDBTools([])
+
+    assert toolkit.instructions is None
+    assert toolkit.add_instructions is False
+
+
+def test_a_huge_allowlist_is_capped_on_a_line_boundary():
+    """A mid-name cut would leave a half-written table the model would try to
+    query, wasting exactly the call this catalogue is meant to save."""
+    toolkit = GuardrailedDBTools([
+        _config(name="a", tables=[f"public.table_{i}" for i in range(400)]),
+        _config(name="b", tables=["public.orders"]),
+    ])
+
+    assert len(toolkit.instructions) < MAX_CATALOGUE_CHARS + 400
+    assert "list truncated" in toolkit.instructions
+    # Every surviving line is a whole one, never a severed table name.
+    for line in toolkit.instructions.splitlines():
+        assert not line.endswith("public.table_") and not line.endswith("public.tabl")
+
+
+def test_a_broken_row_scope_costs_the_catalogue_not_the_toolkit():
+    """_build_db_tools turns any constructor exception into "no database tools
+    at all" — so a bad row must degrade to one extra tool call instead."""
+    broken = _config()
+    broken.row_scope = "not-a-dict"
+
+    toolkit = GuardrailedDBTools([broken])
+
+    assert toolkit.instructions is None
+    assert toolkit.add_instructions is False
+    # The tools themselves are still registered and usable.
+    assert {"list_database_tables", "describe_database_table", "query_database"} <= set(
+        toolkit.functions
+    )

--- a/backend/tests/tools/test_mcp_manager.py
+++ b/backend/tests/tools/test_mcp_manager.py
@@ -27,6 +27,8 @@ from uuid import uuid4
 from app.models.mcp_tool import MCPTransportType
 from app.tools.mcp_manager import (
     CHAT_CONNECT_BUDGET_SECONDS,
+    CONNECTOR_GUIDANCE_TEMPLATE,
+    MAX_GUIDANCE_FUNCTIONS,
     CONNECT_TIMEOUT_MARGIN_SECONDS,
     DEFAULT_TIMEOUT_SECONDS,
     HANDSHAKE_REQUESTS,
@@ -982,3 +984,189 @@ class TestChatAgentMCPMixin:
         agent = TestAgent()
         agent.__del__()  # Should not raise
 
+
+
+# --- Per-connector usage guidance (#318) -------------------------------------
+#
+# The model never sees a connector's name or description; MCP function names
+# arrive in one flat namespace shared by every connected server. Guidance is
+# what tells it which source a function belongs to and which fields to query.
+
+def _guided_config(guidance, name="Elastic prod", functions=None):
+    config = MagicMock()
+    config.name = name
+    config.transport_type = MCPTransportType.STDIO
+    config.timeout = None
+    config.command = "npx"
+    config.args = ["-y", "@elastic/mcp-server-elasticsearch"]
+    config.env_vars = {}
+    config.usage_guidance = guidance
+    return config
+
+
+async def _connect(manager, config, functions=("search", "esql")):
+    """Run a config through the real build/connect path with MCPTools mocked,
+    and hand back the toolkit instance the manager registered."""
+    with patch("app.tools.mcp_manager.SessionLocal") as mock_sess_local, \
+         patch("app.tools.mcp_manager.MCPToolRepository") as mock_repo_cls, \
+         patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
+        mock_sess_local.return_value.__enter__.return_value = MagicMock()
+        mock_repo = MagicMock()
+        mock_repo.get_by_ids.return_value = [config]
+        mock_repo_cls.return_value = mock_repo
+
+        instance = AsyncMock()
+        instance.functions = {name: MagicMock() for name in functions}
+        instance.instructions = None
+        instance.add_instructions = False
+        mock_mcp_tools_cls.return_value = instance
+
+        await manager.initialize_mcp_tools_by_ids(str(uuid4()), [1])
+        return instance
+
+
+@pytest.mark.asyncio
+async def test_guidance_becomes_toolkit_instructions_naming_the_connector():
+    config = _guided_config("Order id is fields.order_ref, not order_id.")
+    instance = await _connect(MCPToolsManager(), config)
+
+    assert instance.add_instructions is True
+    assert "Order id is fields.order_ref" in instance.instructions
+    # The connector name and its functions are what bind the guidance to the
+    # right tools in a namespace shared with every other connector.
+    assert "Elastic prod" in instance.instructions
+    assert "search" in instance.instructions and "esql" in instance.instructions
+
+
+@pytest.mark.asyncio
+async def test_a_connector_without_guidance_leaves_the_prompt_untouched():
+    """The regression fence for every org that never opts in."""
+    instance = await _connect(MCPToolsManager(), _guided_config(None))
+
+    assert instance.instructions is None
+    assert instance.add_instructions is False
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_guidance_injects_nothing():
+    instance = await _connect(MCPToolsManager(), _guided_config("   \n  "))
+
+    assert instance.instructions is None
+    assert instance.add_instructions is False
+
+
+@pytest.mark.asyncio
+async def test_guidance_is_truncated_to_the_schema_limit():
+    from app.models.schemas.mcp_tool import MAX_USAGE_GUIDANCE_CHARS
+
+    instance = await _connect(MCPToolsManager(), _guided_config("x" * 5000))
+
+    assert "x" * MAX_USAGE_GUIDANCE_CHARS in instance.instructions
+    assert "x" * (MAX_USAGE_GUIDANCE_CHARS + 1) not in instance.instructions
+
+
+@pytest.mark.asyncio
+async def test_the_function_list_is_capped_for_a_large_server():
+    names = [f"tool_{i}" for i in range(MAX_GUIDANCE_FUNCTIONS + 10)]
+    instance = await _connect(MCPToolsManager(), _guided_config("Guidance."), functions=names)
+
+    assert "(10 more)" in instance.instructions
+    assert f"tool_{MAX_GUIDANCE_FUNCTIONS + 5}" not in instance.instructions
+
+
+@pytest.mark.asyncio
+async def test_a_connector_that_fails_to_connect_carries_no_guidance():
+    """Guidance must never describe a source that isn't actually there."""
+    manager = MCPToolsManager()
+    config = _guided_config("Indices: app-logs-*.")
+
+    with patch("app.tools.mcp_manager.SessionLocal") as mock_sess_local, \
+         patch("app.tools.mcp_manager.MCPToolRepository") as mock_repo_cls, \
+         patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
+        mock_sess_local.return_value.__enter__.return_value = MagicMock()
+        mock_repo = MagicMock()
+        mock_repo.get_by_ids.return_value = [config]
+        mock_repo_cls.return_value = mock_repo
+
+        instance = AsyncMock()
+        instance.functions = {}  # connected, but exposed nothing
+        instance.instructions = None
+        instance.add_instructions = False
+        mock_mcp_tools_cls.return_value = instance
+
+        tools = await manager.initialize_mcp_tools_by_ids(str(uuid4()), [1])
+
+    assert tools == []
+    assert instance.instructions is None
+    assert instance.add_instructions is False
+
+
+@pytest.mark.asyncio
+async def test_chat_agents_get_connector_guidance_too():
+    """Connectors are shared between investigations and chat agents, and the
+    guidance is documentation about the source — it applies on both paths."""
+    manager = MCPToolsManager()
+    config = _guided_config("Indices: app-logs-*.")
+
+    with patch("app.tools.mcp_manager.SessionLocal") as mock_sess_local, \
+         patch("app.tools.mcp_manager.MCPToolRepository") as mock_repo_cls, \
+         patch("app.tools.mcp_manager.MCPTools") as mock_mcp_tools_cls:
+        mock_sess_local.return_value.__enter__.return_value = MagicMock()
+        mock_repo = MagicMock()
+        mock_repo.get_agent_mcp_tools.return_value = [config]
+        mock_repo_cls.return_value = mock_repo
+
+        instance = AsyncMock()
+        instance.functions = {"search": MagicMock()}
+        instance.instructions = None
+        instance.add_instructions = False
+        mock_mcp_tools_cls.return_value = instance
+
+        await manager.initialize_mcp_tools(str(uuid4()), str(uuid4()))
+
+    assert instance.add_instructions is True
+    assert "Indices: app-logs-*." in instance.instructions
+
+
+def test_agno_still_renders_toolkit_instructions_into_the_system_message():
+    """Contract test against the real agno library, not a mock.
+
+    Every other test here mocks MCPTools, so they would all keep passing if
+    agno renamed or dropped `Toolkit.add_instructions` — and the feature would
+    silently do nothing. This pins the one assumption the whole thing rests
+    on: guidance set on a toolkit reaches the SYSTEM prompt, after the agent's
+    own instructions. If an agno upgrade breaks this, fail here and loudly.
+    """
+    from agno.agent import Agent
+    from agno.models.openai import OpenAIChat
+    from agno.tools.toolkit import Toolkit
+
+    class _Connector(Toolkit):
+        def __init__(self):
+            super().__init__(name="MCPTools")
+            self.register(self.search_logs)
+
+        def search_logs(self, q: str) -> str:
+            """Search logs."""
+            return "ok"
+
+    toolkit = _Connector()
+    toolkit.instructions = CONNECTOR_GUIDANCE_TEMPLATE.format(
+        name="Elastic prod", functions="search_logs", guidance="Order id is fields.order_ref."
+    )
+    toolkit.add_instructions = True
+
+    agent = Agent(
+        name="t",
+        tools=[toolkit],
+        instructions="BASE RULES.",
+        markdown=False,
+        model=OpenAIChat(id="gpt-4o-mini", api_key="not-used-no-request-is-made"),
+    )
+    agent.determine_tools_for_model(model=agent.model, session_id="s1")
+    system_message = agent.get_system_message(session_id="s1").content
+
+    assert "Order id is fields.order_ref." in system_message
+    assert "Elastic prod" in system_message
+    # After the agent's own instructions, so the base rules are read first.
+    assert system_message.index("</instructions>") < system_message.index("data_source")

--- a/frontend/src/__tests__/components/common/GuidanceTextarea.spec.ts
+++ b/frontend/src/__tests__/components/common/GuidanceTextarea.spec.ts
@@ -1,0 +1,88 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import GuidanceTextarea from '@/components/common/GuidanceTextarea.vue'
+import { MAX_GUIDANCE_CHARS } from '@/utils/mcp'
+
+const EXAMPLE = 'Indices: app-logs-*.\nOrder id is fields.order_ref.'
+
+function mountIt(modelValue: string | null = '', example = EXAMPLE) {
+  return mount(GuidanceTextarea, {
+    props: { modelValue, label: 'How to query this source', hint: 'A hint.', example },
+    global: { stubs: { 'font-awesome-icon': true } },
+  })
+}
+
+describe('GuidanceTextarea', () => {
+  it('emits what the operator types', async () => {
+    const wrapper = mountIt()
+    await wrapper.find('textarea').setValue('app-logs-*')
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['app-logs-*'])
+  })
+
+  it('caps input at the limit the backend enforces', () => {
+    expect(mountIt().find('textarea').attributes('maxlength')).toBe(String(MAX_GUIDANCE_CHARS))
+  })
+
+  it('keeps the example hidden until asked for', async () => {
+    const wrapper = mountIt()
+    expect(wrapper.find('.guidance-example').exists()).toBe(false)
+
+    await wrapper.find('.example-toggle').trigger('click')
+    expect(wrapper.find('.example-text').text()).toContain('fields.order_ref')
+  })
+
+  it('offers the example as a starting point only while the field is empty', async () => {
+    const empty = mountIt('')
+    await empty.find('.example-toggle').trigger('click')
+    expect(empty.find('.example-use').exists()).toBe(true)
+
+    await empty.find('.example-use').trigger('click')
+    expect(empty.emitted('update:modelValue')?.[0]).toEqual([EXAMPLE])
+
+    // With real work in the box the button is gone, so it can never clobber it.
+    const written = mountIt('my own notes')
+    await written.find('.example-toggle').trigger('click')
+    expect(written.find('.example-use').exists()).toBe(false)
+  })
+
+  it('warns as the operator approaches the limit', async () => {
+    const under = mountIt('x'.repeat(10))
+    expect(under.find('.guidance-count').classes()).not.toContain('near')
+
+    const near = mountIt('x'.repeat(MAX_GUIDANCE_CHARS))
+    expect(near.find('.guidance-count').classes()).toContain('near')
+  })
+
+  it('hides the disclosure entirely when no example is supplied', () => {
+    expect(mountIt('', '').find('.example-toggle').exists()).toBe(false)
+  })
+
+  it('survives the null the API returns for an undocumented connector', async () => {
+    const wrapper = mountIt(null)
+    expect(wrapper.find('.guidance-count').text()).toContain('0 /')
+
+    // And still offers the example, since the field is effectively empty.
+    await wrapper.find('.example-toggle').trigger('click')
+    expect(wrapper.find('.example-use').exists()).toBe(true)
+  })
+
+  it('labels the textarea for screen readers', () => {
+    expect(mountIt().find('textarea').attributes('aria-label')).toBe('How to query this source')
+  })
+})

--- a/frontend/src/__tests__/components/tickets/TicketConnectorsSection.spec.ts
+++ b/frontend/src/__tests__/components/tickets/TicketConnectorsSection.spec.ts
@@ -1,0 +1,120 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import TicketConnectorsSection from '@/components/tickets/TicketConnectorsSection.vue'
+import { mcpService } from '@/services/mcp'
+import type { MCPTool } from '@/types/mcp'
+
+vi.mock('@/services/mcp', () => ({
+  mcpService: {
+    getOrganizationMCPTools: vi.fn(),
+    createMCPTool: vi.fn(),
+    updateMCPTool: vi.fn(),
+    deleteMCPTool: vi.fn(),
+    getMCPToolReferences: vi.fn(),
+  },
+}))
+vi.mock('vue-sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+const CONNECTOR: MCPTool = {
+  id: 7,
+  name: 'Elastic prod',
+  transport_type: 'http',
+  enabled: true,
+  url: 'https://kibana/api/agent_builder/mcp',
+  usage_guidance: 'Order id is fields.order_ref.',
+  organization_id: 'org-1',
+  created_at: '2026-09-01T00:00:00Z',
+  updated_at: '2026-09-01T00:00:00Z',
+}
+
+function mountIt(connectors: MCPTool[] = []) {
+  vi.mocked(mcpService.getOrganizationMCPTools).mockResolvedValue(connectors)
+  return mount(TicketConnectorsSection, {
+    props: { selectedIds: [] },
+    global: { stubs: { 'font-awesome-icon': true } },
+  })
+}
+
+describe('TicketConnectorsSection guidance', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('sends the guidance the operator wrote when creating a connector', async () => {
+    vi.mocked(mcpService.createMCPTool).mockResolvedValue({ ...CONNECTOR, id: 9 })
+    const wrapper = mountIt()
+    await flushPromises()
+
+    await wrapper.findAll('.preset-tile').at(-1)!.trigger('click')
+    await wrapper.find('.field-input').setValue('Elastic prod')
+    await wrapper.find('.guidance-input').setValue('Order id is fields.order_ref.')
+    await wrapper.find('.connect-btn').trigger('click')
+    await flushPromises()
+
+    expect(vi.mocked(mcpService.createMCPTool).mock.calls[0][0]).toMatchObject({
+      usage_guidance: 'Order id is fields.order_ref.',
+    })
+  })
+
+  it('sends null rather than an empty string when no guidance is written', async () => {
+    vi.mocked(mcpService.createMCPTool).mockResolvedValue({ ...CONNECTOR, id: 9 })
+    const wrapper = mountIt()
+    await flushPromises()
+
+    await wrapper.findAll('.preset-tile').at(-1)!.trigger('click')
+    await wrapper.find('.field-input').setValue('Bare connector')
+    await wrapper.find('.connect-btn').trigger('click')
+    await flushPromises()
+
+    expect(vi.mocked(mcpService.createMCPTool).mock.calls[0][0].usage_guidance).toBeNull()
+  })
+
+  it('never seeds guidance from a preset description', async () => {
+    /**
+     * A preset's `desc` is a one-line marketing subtitle ("Errors, issues and
+     * traces"). Letting it become prompt text is exactly the failure this
+     * field exists to fix, so it must stay empty even though `description`
+     * is filled.
+     */
+    const wrapper = mountIt()
+    await flushPromises()
+
+    await wrapper.findAll('.preset-tile')[0].trigger('click')
+
+    expect((wrapper.find('.guidance-input').element as HTMLTextAreaElement).value).toBe('')
+    expect((wrapper.find('.field-input').element as HTMLInputElement).value).toBe('Grafana')
+  })
+
+  it('loads existing guidance into the edit form and marks the row as guided', async () => {
+    const wrapper = mountIt([CONNECTOR])
+    await flushPromises()
+
+    expect(wrapper.find('.guided-tag').exists()).toBe(true)
+
+    await wrapper.find('.row-btn').trigger('click')
+    expect((wrapper.find('.guidance-input').element as HTMLTextAreaElement).value).toBe(
+      'Order id is fields.order_ref.',
+    )
+  })
+
+  it('shows no guided chip for an undocumented connector', async () => {
+    const wrapper = mountIt([{ ...CONNECTOR, usage_guidance: null }])
+    await flushPromises()
+
+    expect(wrapper.find('.guided-tag').exists()).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/components/tickets/TicketInvestigationPanel.spec.ts
+++ b/frontend/src/__tests__/components/tickets/TicketInvestigationPanel.spec.ts
@@ -84,3 +84,64 @@ describe('TicketInvestigationPanel connector warning', () => {
     expect(wrapper.find('.connector-warning').exists()).toBe(false)
   })
 })
+
+describe('TicketInvestigationPanel errored tool calls', () => {
+  /**
+   * A connector can come up, load its tools, and then error on every query.
+   * That reports loaded === configured with no provider errors, so before
+   * #318 the run rendered completely clean with a confident wrong answer.
+   */
+  it('warns when every tool call errored, even with all connectors loaded', () => {
+    const wrapper = mountPanel({
+      connector_status: {
+        configured: 1,
+        loaded: 1,
+        failed: [],
+        tool_calls: 3,
+        tool_calls_failed: 3,
+      },
+    })
+
+    const text = wrapper.find('.connector-warning').text()
+    expect(text).toContain('3 of 3 tool calls errored')
+    expect(text).toContain('no finding here is evidence-backed')
+  })
+
+  it('reports a partial failure without claiming nothing was gathered', () => {
+    const wrapper = mountPanel({
+      connector_status: {
+        configured: 1,
+        loaded: 1,
+        failed: [],
+        tool_calls: 4,
+        tool_calls_failed: 1,
+      },
+    })
+
+    const text = wrapper.find('.connector-warning').text()
+    expect(text).toContain('1 of 4 tool calls errored')
+    expect(text).not.toContain('evidence-backed')
+  })
+
+  it('stays silent on a clean run', () => {
+    const wrapper = mountPanel({
+      connector_status: {
+        configured: 2,
+        loaded: 2,
+        failed: [],
+        tool_calls: 5,
+        tool_calls_failed: 0,
+      },
+    })
+
+    expect(wrapper.find('.connector-warning').exists()).toBe(false)
+  })
+
+  it('handles a run recorded before these counts existed', () => {
+    const wrapper = mountPanel({
+      connector_status: { configured: 1, loaded: 1, failed: [] },
+    })
+
+    expect(wrapper.find('.connector-warning').exists()).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/composables/useMCPTools.spec.ts
+++ b/frontend/src/__tests__/composables/useMCPTools.spec.ts
@@ -80,3 +80,46 @@ describe('useMCPTools connection test', () => {
     expect(testingToolId.value).toBeNull()
   })
 })
+
+describe('useMCPTools guidance', () => {
+  it('carries guidance through the create form and clears it on reset', () => {
+    const { createForm, resetCreateForm, applyPreset, mcpPresets } = useMCPTools('agent-1')
+
+    createForm.usage_guidance = 'Order id is fields.order_ref.'
+    resetCreateForm()
+    expect(createForm.usage_guidance).toBe('')
+
+    // A preset's own description must never become prompt text.
+    applyPreset(mcpPresets[0])
+    expect(createForm.usage_guidance).toBe('')
+    expect(createForm.description).toBe(mcpPresets[0].description)
+  })
+
+  it('loads a connector\'s stored guidance when editing it', () => {
+    const { createForm, startEdit } = useMCPTools('agent-1')
+
+    startEdit({
+      id: 3,
+      name: 'Elastic',
+      transport_type: 'http',
+      enabled: true,
+      usage_guidance: 'Indices: app-logs-*.',
+      organization_id: 'o',
+      created_at: '',
+      updated_at: '',
+    } as any)
+
+    expect(createForm.usage_guidance).toBe('Indices: app-logs-*.')
+  })
+
+  it('turns a null guidance from the API into an empty field', () => {
+    const { createForm, startEdit } = useMCPTools('agent-1')
+
+    startEdit({
+      id: 4, name: 'Bare', transport_type: 'http', enabled: true,
+      usage_guidance: null, organization_id: 'o', created_at: '', updated_at: '',
+    } as any)
+
+    expect(createForm.usage_guidance).toBe('')
+  })
+})

--- a/frontend/src/components/agent/AgentMCPToolsTab.vue
+++ b/frontend/src/components/agent/AgentMCPToolsTab.vue
@@ -18,6 +18,12 @@ limitations under the License.
 import { onMounted, ref } from 'vue'
 import { useMCPTools } from '@/composables/useMCPTools'
 import type { MCPTransportType } from '@/types/mcp'
+import {
+  CONNECTOR_GUIDANCE_EXAMPLE,
+  CONNECTOR_GUIDANCE_HINT,
+  CONNECTOR_GUIDANCE_LABEL,
+} from '@/utils/mcp'
+import GuidanceTextarea from '@/components/common/GuidanceTextarea.vue'
 
 const props = defineProps<{
   agentId: string
@@ -298,8 +304,16 @@ onMounted(() => {
                   type="text" 
                   placeholder="What does this tool do?"
                 >
+                <small class="field-hint">A label for your team. The AI doesn't read this.</small>
               </div>
             </div>
+            <GuidanceTextarea
+              v-model="createForm.usage_guidance"
+              :label="CONNECTOR_GUIDANCE_LABEL"
+              :hint="CONNECTOR_GUIDANCE_HINT"
+              :example="CONNECTOR_GUIDANCE_EXAMPLE"
+              :rows="5"
+            />
           </div>
 
           <!-- Transport Type -->

--- a/frontend/src/components/common/GuidanceTextarea.vue
+++ b/frontend/src/components/common/GuidanceTextarea.vue
@@ -1,0 +1,181 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+/**
+ * A textarea for prompt text an AI reads, rather than a label a human reads.
+ * Monospace because the content is index globs and field names, and it ships
+ * a worked example behind a disclosure — a placeholder vanishes on the first
+ * keystroke, which is exactly when the operator still needs the shape.
+ */
+import { computed, ref } from 'vue'
+import { MAX_GUIDANCE_CHARS } from '@/utils/mcp'
+
+const props = withDefaults(
+  defineProps<{
+    // Nullable: the API returns null for a connector nobody has documented,
+    // and callers bind that straight through.
+    modelValue: string | null | undefined
+    label: string
+    hint: string
+    placeholder?: string
+    example?: string
+    rows?: number
+    maxlength?: number
+  }>(),
+  { placeholder: '', example: '', rows: 6, maxlength: MAX_GUIDANCE_CHARS },
+)
+
+const emit = defineEmits<{ (e: 'update:modelValue', value: string): void }>()
+
+const showExample = ref(false)
+const text = computed(() => props.modelValue ?? '')
+const isNearLimit = computed(() => text.value.length > props.maxlength * 0.9)
+</script>
+
+<template>
+  <div class="guidance">
+    <span class="guidance-label">{{ label }}</span>
+    <p class="guidance-hint">{{ hint }}</p>
+    <textarea
+      class="guidance-input"
+      :value="text"
+      :aria-label="label"
+      :rows="rows"
+      :maxlength="maxlength"
+      :placeholder="placeholder"
+      @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
+    ></textarea>
+    <div class="guidance-foot">
+      <button v-if="example" type="button" class="example-toggle" @click="showExample = !showExample">
+        <font-awesome-icon :icon="['fas', showExample ? 'chevron-up' : 'chevron-down']" />
+        {{ showExample ? 'Hide example' : 'See an example' }}
+      </button>
+      <span v-else></span>
+      <span class="guidance-count mono" :class="{ near: isNearLimit }">
+        {{ text.length }} / {{ maxlength }}
+      </span>
+    </div>
+    <div v-if="example && showExample" class="guidance-example">
+      <pre class="example-text mono">{{ example }}</pre>
+      <!-- Offered only while the field is empty, so it can never overwrite
+           something the operator actually wrote. -->
+      <button
+        v-if="!text.length"
+        type="button"
+        class="example-use"
+        @click="emit('update:modelValue', example)"
+      >
+        Use as a starting point
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.guidance {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.guidance-label {
+  font-size: 11px;
+  color: var(--faint);
+}
+.guidance-hint {
+  font-size: 11.5px;
+  color: var(--muted);
+  line-height: 1.5;
+  margin: 0;
+}
+.guidance-input {
+  padding: 9px 11px;
+  min-height: 130px;
+  background: var(--bg2);
+  border: 1px solid var(--o10);
+  border-radius: 9px;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.55;
+  outline: none;
+  resize: vertical;
+}
+.guidance-input:focus {
+  border-color: var(--accent-ink);
+}
+.guidance-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.example-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-size: 11.5px;
+  cursor: pointer;
+}
+.example-toggle:hover {
+  color: var(--text);
+}
+.guidance-count {
+  font-size: 10.5px;
+  color: var(--muted2);
+}
+.guidance-count.near {
+  color: var(--c-warn);
+}
+.guidance-example {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 11px 13px;
+  background: var(--surface);
+  border: 1px solid var(--o07);
+  border-radius: 9px;
+}
+.example-text {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.6;
+  color: var(--text3);
+  white-space: pre-wrap;
+  overflow-x: auto;
+  max-width: 100%;
+}
+.example-use {
+  padding: 5px 11px;
+  background: var(--o05);
+  border: 1px solid var(--o10);
+  border-radius: 8px;
+  color: var(--muted);
+  font-size: 11.5px;
+  cursor: pointer;
+}
+.example-use:hover {
+  color: var(--text);
+}
+.mono {
+  font-family: var(--font-mono);
+}
+</style>

--- a/frontend/src/components/tickets/TicketConnectorsSection.vue
+++ b/frontend/src/components/tickets/TicketConnectorsSection.vue
@@ -19,7 +19,17 @@ import { onMounted, reactive, ref } from 'vue'
 import { toast } from 'vue-sonner'
 import { mcpService } from '@/services/mcp'
 import type { MCPTool, MCPToolReferences, MCPTransportType } from '@/types/mcp'
-import { DEFAULT_MCP_TIMEOUT, SECRET_MASK, clampMCPTimeout, linesToRecord, recordToLines } from '@/utils/mcp'
+import {
+  CONNECTOR_GUIDANCE_EXAMPLE,
+  CONNECTOR_GUIDANCE_HINT,
+  CONNECTOR_GUIDANCE_LABEL,
+  DEFAULT_MCP_TIMEOUT,
+  SECRET_MASK,
+  clampMCPTimeout,
+  linesToRecord,
+  recordToLines,
+} from '@/utils/mcp'
+import GuidanceTextarea from '@/components/common/GuidanceTextarea.vue'
 import grafanaLogo from '@/assets/grafana-logo.svg'
 import elasticsearchLogo from '@/assets/elasticsearch-logo.svg'
 import sentryLogo from '@/assets/sentry-logo.svg'
@@ -109,6 +119,7 @@ const form = reactive({
   args: '',
   envLines: '',
   timeout: DEFAULT_MCP_TIMEOUT,
+  usageGuidance: '',
 })
 
 function applyPreset(preset: (typeof PRESETS)[0] | null) {
@@ -122,6 +133,10 @@ function applyPreset(preset: (typeof PRESETS)[0] | null) {
     args: preset?.args || '',
     envLines: preset?.envLines || '',
     timeout: DEFAULT_MCP_TIMEOUT,
+    // Never seeded from the preset: its `desc` is a one-line marketing
+    // subtitle, and shipping that as prompt text is the exact failure this
+    // field exists to fix.
+    usageGuidance: '',
   })
   editingId.value = null
   showForm.value = true
@@ -140,6 +155,7 @@ function startEdit(connector: MCPTool) {
     args: (connector.args || []).join(' '),
     envLines: recordToLines(connector.env_vars),
     timeout: connector.timeout ?? DEFAULT_MCP_TIMEOUT,
+    usageGuidance: connector.usage_guidance || '',
   })
   editingId.value = connector.id
   showForm.value = true
@@ -175,6 +191,7 @@ function formPayload() {
     args: isRemote ? [] : form.args.trim().split(/\s+/).filter(Boolean),
     env_vars: isRemote ? {} : linesToRecord(form.envLines),
     timeout: clampMCPTimeout(form.timeout),
+    usage_guidance: form.usageGuidance.trim() || null,
   }
 }
 
@@ -332,6 +349,15 @@ onMounted(fetchConnectors)
           />
           <span class="field-note">Handshake and per-call limit. Raise it for slow first launches.</span>
         </label>
+        <div class="form-field wide">
+          <GuidanceTextarea
+            v-model="form.usageGuidance"
+            :label="CONNECTOR_GUIDANCE_LABEL"
+            :hint="CONNECTOR_GUIDANCE_HINT"
+            :example="CONNECTOR_GUIDANCE_EXAMPLE"
+            :rows="5"
+          />
+        </div>
       </div>
       <div class="form-actions">
         <button class="cancel-btn" @click="cancelForm">Cancel</button>
@@ -358,6 +384,7 @@ onMounted(fetchConnectors)
               {{ connector.name }}
               <span class="transport-tag mono">{{ connector.transport_type }}</span>
               <span v-if="!connector.enabled" class="disabled-tag mono">disabled</span>
+              <span v-if="connector.usage_guidance" class="guided-tag mono" title="The AI has guidance for this source">guided</span>
             </div>
             <div class="connector-sub mono">
               {{ connector.url || [connector.command, ...(connector.args || [])].join(' ') }}
@@ -658,12 +685,18 @@ onMounted(fetchConnectors)
   border-radius: 6px;
   text-transform: uppercase;
 }
-.disabled-tag {
+.disabled-tag,
+.guided-tag {
   font-size: 9.5px;
-  color: var(--faint);
   background: var(--o05);
   padding: 1px 7px;
   border-radius: 6px;
+}
+.disabled-tag {
+  color: var(--faint);
+}
+.guided-tag {
+  color: var(--muted);
 }
 .connector-sub {
   font-size: 10.5px;

--- a/frontend/src/components/tickets/TicketInvestigationPanel.vue
+++ b/frontend/src/components/tickets/TicketInvestigationPanel.vue
@@ -58,6 +58,12 @@ const tokenLabel = computed(() => {
   return total >= 1000 ? `${(total / 1000).toFixed(1)}k tokens` : `${total} tokens`
 })
 
+// How many of the run's tool calls failed. Surfaced because a verdict resting
+// on failed queries is worth nothing, however confident it reads (#318).
+const erroredCalls = computed(() => run.value?.connector_status?.tool_calls_failed || 0)
+const totalCalls = computed(() => run.value?.connector_status?.tool_calls || 0)
+const allCallsFailed = computed(() => totalCalls.value > 0 && erroredCalls.value === totalCalls.value)
+
 // A run that finished with fewer MCP connectors than configured produced its
 // answer without the evidence those tools were meant to gather. So did a run
 // whose connectors all came up but whose tools the provider refused — that one
@@ -67,7 +73,10 @@ const connectorWarning = computed(() => {
   if (!status) return null
   const missingConnectors = status.loaded < status.configured
   const refusedTools = !!status.provider_errors?.length
-  if (!missingConnectors && !refusedTools) return null
+  // A connector can come up, load its tools, and then error on every query.
+  // That reports loaded === configured with no provider errors, so it needs
+  // its own check or the run renders as healthy (#318).
+  if (!missingConnectors && !refusedTools && !erroredCalls.value) return null
   return status
 })
 </script>
@@ -117,6 +126,11 @@ const connectorWarning = computed(() => {
       <ul v-if="connectorWarning.provider_errors?.length" class="connector-warning__list">
         <li v-for="reason in connectorWarning.provider_errors" :key="reason">{{ reason }}</li>
       </ul>
+      <div v-if="erroredCalls" class="connector-warning__calls">
+        {{ erroredCalls }} of {{ totalCalls }} tool call{{ totalCalls === 1 ? '' : 's' }} errored<template
+          v-if="allCallsFailed"
+        > — nothing was gathered, so no finding here is evidence-backed</template>.
+      </div>
     </div>
 
     <div v-if="investigation.hypotheses.length" class="hypothesis-list">
@@ -132,6 +146,10 @@ const connectorWarning = computed(() => {
 </template>
 
 <style scoped>
+.connector-warning__calls {
+  margin-top: 6px;
+  font-weight: var(--font-weight-semibold);
+}
 .investigation-panel {
   background: var(--surface);
   border: 1px solid var(--o08);

--- a/frontend/src/composables/useMCPTools.ts
+++ b/frontend/src/composables/useMCPTools.ts
@@ -39,6 +39,7 @@ export function useMCPTools(agentId: string) {
   const createForm = reactive<MCPToolCreate>({
     name: '',
     description: '',
+    usage_guidance: '',
     transport_type: 'stdio' as MCPTransportType,
     enabled: true,
     command: '',
@@ -115,6 +116,7 @@ export function useMCPTools(agentId: string) {
     Object.assign(createForm, {
       name: tool.name,
       description: tool.description || '',
+      usage_guidance: tool.usage_guidance || '',
       transport_type: tool.transport_type,
       enabled: tool.enabled,
       command: tool.command || '',
@@ -222,6 +224,9 @@ export function useMCPTools(agentId: string) {
   const applyPreset = (preset: typeof mcpPresets[0]) => {
     Object.assign(createForm, {
       ...preset,
+      // Presets describe themselves for humans; that copy must never become
+      // prompt text the AI treats as a description of the real source.
+      usage_guidance: '',
       enabled: true
     })
   }
@@ -232,6 +237,7 @@ export function useMCPTools(agentId: string) {
     Object.assign(createForm, {
       name: '',
       description: '',
+      usage_guidance: '',
       transport_type: 'stdio' as MCPTransportType,
       enabled: true,
       command: '',

--- a/frontend/src/types/mcp.ts
+++ b/frontend/src/types/mcp.ts
@@ -20,6 +20,8 @@ export interface MCPTool {
   id: number
   name: string
   description?: string
+  /** Prompt text: what this source holds and how to query it. */
+  usage_guidance?: string | null
   transport_type: MCPTransportType
   enabled: boolean
   
@@ -43,6 +45,8 @@ export interface MCPTool {
 export interface MCPToolCreate {
   name: string
   description?: string
+  /** Prompt text: what this source holds and how to query it. */
+  usage_guidance?: string | null
   transport_type: MCPTransportType
   enabled: boolean
   
@@ -62,6 +66,8 @@ export interface MCPToolCreate {
 export interface MCPToolUpdate {
   name?: string
   description?: string
+  /** Prompt text: what this source holds and how to query it. */
+  usage_guidance?: string | null
   enabled?: boolean
   
   // STDIO transport fields

--- a/frontend/src/types/ticket.ts
+++ b/frontend/src/types/ticket.ts
@@ -136,6 +136,9 @@ export interface InvestigationRun {
     failed: { name: string; error: string }[]
     /** Hard provider rejections seen during the run. */
     provider_errors?: string[]
+    /** Tool calls attempted, and how many of them errored. */
+    tool_calls?: number
+    tool_calls_failed?: number
   } | null
   started_at?: string | null
   finished_at?: string | null

--- a/frontend/src/utils/mcp.ts
+++ b/frontend/src/utils/mcp.ts
@@ -80,13 +80,21 @@ export const CONNECTOR_GUIDANCE_HINT =
   'Optional — leave it blank and the AI explores blind.'
 
 /**
- * The third line is the point of the example: a query against a field that
- * does not exist returns zero hits rather than an error, so the AI reads a
- * clean "no results" and concludes the record is absent. Operators need to
- * know that is worth warning about.
+ * Deliberately written as instructions, not as a description. Tested against a
+ * real MCP server and a real model: naming the field ("Order id is
+ * fields.order_ref") got the right index but a bare keyword query and a false
+ * "no such order". Telling it what to *do* ("query app-logs-* with
+ * fields.order_ref:<ref> — always name that field") found the record in one
+ * call. Operators copy this example, so it has to model the phrasing that
+ * works.
+ *
+ * The last line matters just as much: a query against a field that does not
+ * exist returns zero hits rather than an error, so without the warning the AI
+ * reads a clean "no results" and concludes the record is absent.
  */
 export const CONNECTOR_GUIDANCE_EXAMPLE = `Indices: app-logs-* (one doc per request), payment-logs-* (Stripe webhooks).
-Order id is fields.order_ref on app-logs-*, metadata.order on payment-logs-*.
-There is no order_id field — matching on it returns zero hits, not an error.
+To find an order, query app-logs-* with \`fields.order_ref:<the reference>\` —
+always name that field explicitly; a bare keyword search matches nothing.
 Timestamps are @timestamp, UTC, 30-day retention.
-Query with the ES|QL tool; the search tool is not enabled on this cluster.`
+There is no order_id field; matching on it returns zero hits rather than an
+error, so an empty result is not evidence the order is absent.`

--- a/frontend/src/utils/mcp.ts
+++ b/frontend/src/utils/mcp.ts
@@ -59,3 +59,34 @@ export function linesToRecord(lines: string): Record<string, string> {
   }
   return result
 }
+
+/**
+ * Ceiling on a connector's usage guidance. Must match MAX_USAGE_GUIDANCE_CHARS
+ * in the backend schema — if it drifts, the operator hits a bare 422 toast
+ * instead of the textarea stopping them.
+ */
+export const MAX_GUIDANCE_CHARS = 2000
+
+/**
+ * Copy for the connector guidance field. Lives here because the field appears
+ * in two structurally unrelated forms — the investigation connector list and
+ * the agent MCP tools modal — and the wording must not drift between them.
+ */
+export const CONNECTOR_GUIDANCE_LABEL = 'How to query this source'
+
+export const CONNECTOR_GUIDANCE_HINT =
+  'Given to the AI whenever it uses this connector. Name the indices, projects or ' +
+  'tables it should reach for, and the fields that identify a customer or an order. ' +
+  'Optional — leave it blank and the AI explores blind.'
+
+/**
+ * The third line is the point of the example: a query against a field that
+ * does not exist returns zero hits rather than an error, so the AI reads a
+ * clean "no results" and concludes the record is absent. Operators need to
+ * know that is worth warning about.
+ */
+export const CONNECTOR_GUIDANCE_EXAMPLE = `Indices: app-logs-* (one doc per request), payment-logs-* (Stripe webhooks).
+Order id is fields.order_ref on app-logs-*, metadata.order on payment-logs-*.
+There is no order_id field — matching on it returns zero hits, not an error.
+Timestamps are @timestamp, UTC, 30-day retention.
+Query with the ES|QL tool; the search tool is not enabled on this cluster.`


### PR DESCRIPTION
Part of #318.

Investigations were inventing index and field names from the wording of the ticket. A query against a field that doesn't exist returns zero hits *silently*, so the model reads a clean "no results" and concludes the record is absent.

The cause: the model never learns what a connector is. `MCPTools` was handed only transport plumbing, so the connector's name and description never reached it — just raw function names in one flat namespace shared by every connected server.

**What's here**

- New `mcp_tools.usage_guidance`: free text saying what the source holds and how to query it. Editable in both connector forms.
- It reaches the model through agno's per-toolkit `instructions` hook, so it lands in the system prompt alongside the connector's name and its own function names.
- `GuardrailedDBTools` gets the same treatment, generated from the allowlist it already holds — the investigator no longer spends a call from `max_tool_calls_per_run` on `list_database_tables` just to learn what exists.

A connector nobody has documented leaves the prompt byte-identical, and guidance is only attached after a successful connect.

**Also fixes the confidence bug from #318**

The hypothesis verdict was copied straight from the model with nothing checking it against what happened, so a run whose every search errored could report "the record does not exist, validated, 0.90". A definite verdict whose supporting calls all failed is now forced to inconclusive, and the run reports "N of N tool calls errored". Nothing surfaced this before — the connector warning only fired when a connector failed to *load*, so one that connected and then errored on every query rendered as a healthy run.

**Tested with a real MCP server and a real model.** Without guidance it invented a `checkout-logs` index, burned 3 calls on it and declared the order absent at 0.9. With guidance it used the real indices and found the record in one call. Phrasing matters: describing the schema only fixed index choice, so the worked example in the UI is written as instructions.

Still open on #318 and deliberately left out: the org-level guidance field and the L1 re-run button.