### PR TITLE
Guided re-run at any autonomy level

### DIFF
--- a/frontend/src/__tests__/components/tickets/InvestigationNoteForm.spec.ts
+++ b/frontend/src/__tests__/components/tickets/InvestigationNoteForm.spec.ts
@@ -1,0 +1,98 @@
+/*
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { mount, type VueWrapper } from '@vue/test-utils'
+import InvestigationNoteForm from '@/components/tickets/InvestigationNoteForm.vue'
+
+// attachTo puts the component in the real document so focus can be asserted,
+// and VTU only takes it back out on unmount — without this the forms pile up
+// and whichever mounted last owns document.activeElement.
+const mounted: VueWrapper[] = []
+afterEach(() => {
+  while (mounted.length) mounted.pop()!.unmount()
+})
+
+const mountForm = (props: Record<string, unknown> = {}, slots: Record<string, string> = {}) => {
+  const wrapper = mount(InvestigationNoteForm, {
+    props: { placeholder: 'Why?', submitLabel: 'Go', ...props },
+    slots,
+    attachTo: document.body,
+  })
+  mounted.push(wrapper)
+  return wrapper
+}
+
+describe('InvestigationNoteForm', () => {
+  it('trims the note before emitting', async () => {
+    const wrapper = mountForm()
+    await wrapper.find('textarea').setValue('   use fields.order_ref   ')
+    await wrapper.find('.submit-btn').trigger('click')
+
+    expect(wrapper.emitted('submit')?.[0]).toEqual(['use fields.order_ref'])
+  })
+
+  it('allows an empty note', async () => {
+    // Re-running unchanged is legitimate, and the reject flow has always
+    // permitted a reason-less rejection.
+    const wrapper = mountForm()
+    await wrapper.find('.submit-btn').trigger('click')
+
+    expect(wrapper.emitted('submit')?.[0]).toEqual([''])
+  })
+
+  it('submits on Cmd+Enter and Ctrl+Enter', async () => {
+    const meta = mountForm()
+    await meta.find('textarea').setValue('a')
+    await meta.find('textarea').trigger('keydown', { key: 'Enter', metaKey: true })
+    expect(meta.emitted('submit')?.[0]).toEqual(['a'])
+
+    const ctrl = mountForm()
+    await ctrl.find('textarea').setValue('b')
+    await ctrl.find('textarea').trigger('keydown', { key: 'Enter', ctrlKey: true })
+    expect(ctrl.emitted('submit')?.[0]).toEqual(['b'])
+  })
+
+  it('cancels on Escape', async () => {
+    const wrapper = mountForm()
+    await wrapper.find('textarea').trigger('keydown', { key: 'Escape' })
+
+    expect(wrapper.emitted('cancel')).toHaveLength(1)
+    expect(wrapper.emitted('submit')).toBeUndefined()
+  })
+
+  it('focuses the textarea so the operator can just type', () => {
+    // Mounted alone in this test, so activeElement can only be this one.
+    const wrapper = mountForm()
+    expect(document.activeElement).toBe(wrapper.find('textarea').element)
+  })
+
+  it('blocks a second submit while one is in flight', async () => {
+    const wrapper = mountForm({ busy: true })
+    expect(wrapper.find('.submit-btn').attributes('disabled')).toBeDefined()
+  })
+
+  it('colours the action by tone', () => {
+    expect(mountForm({ tone: 'danger' }).find('.submit-btn').classes()).toContain('danger')
+    // Accent is the default, so the panel's re-run needs no tone prop.
+    expect(mountForm().find('.submit-btn').classes()).toContain('accent')
+  })
+
+  it('renders extra controls passed by the caller', () => {
+    const wrapper = mountForm({}, { default: '<label class="extra">Re-run too</label>' })
+    expect(wrapper.find('.extra').exists()).toBe(true)
+  })
+})

--- a/frontend/src/__tests__/components/tickets/TicketInvestigationPanel.spec.ts
+++ b/frontend/src/__tests__/components/tickets/TicketInvestigationPanel.spec.ts
@@ -28,7 +28,7 @@ const baseRun: InvestigationRun = {
   tool_calls_used: 0,
 }
 
-const mountPanel = (run: Partial<InvestigationRun>) =>
+const mountPanel = (run: Partial<InvestigationRun>, props: Record<string, unknown> = {}) =>
   mount(TicketInvestigationPanel, {
     props: {
       investigation: {
@@ -36,6 +36,13 @@ const mountPanel = (run: Partial<InvestigationRun>) =>
         hypotheses: [],
         events: [],
       } as InvestigationDetail,
+      ...props,
+    },
+    global: {
+      stubs: {
+        'font-awesome-icon': true,
+        'router-link': { template: '<a><slot /></a>' },
+      },
     },
   })
 
@@ -143,5 +150,65 @@ describe('TicketInvestigationPanel errored tool calls', () => {
     })
 
     expect(wrapper.find('.connector-warning').exists()).toBe(false)
+  })
+})
+
+describe('TicketInvestigationPanel guided re-run', () => {
+  /**
+   * Below autonomy 2 no proposal is created, so the L2 approval banner never
+   * renders — and it held the only reject-with-feedback path. An L1 operator
+   * had no way to correct a run short of editing the ticket description.
+   */
+  it('offers a guided re-run when the user can start one', () => {
+    const wrapper = mountPanel({}, { canReinvestigate: true })
+    expect(wrapper.find('.rerun-btn').exists()).toBe(true)
+  })
+
+  it('is absent for a user who cannot manage tickets', () => {
+    expect(mountPanel({}, { canReinvestigate: false }).find('.panel-foot').exists()).toBe(false)
+    expect(mountPanel({}).find('.panel-foot').exists()).toBe(false)
+  })
+
+  it('disables the button with the reason a run is unavailable', () => {
+    const wrapper = mountPanel({}, {
+      canReinvestigate: true,
+      reinvestigateBlockedReason: 'This ticket is resolved — reopen it to investigate again',
+    })
+
+    const button = wrapper.find('.rerun-btn')
+    expect(button.attributes('disabled')).toBeDefined()
+    expect(button.attributes('title')).toContain('reopen it')
+  })
+
+  it('emits the trimmed note and closes the form', async () => {
+    const wrapper = mountPanel({}, { canReinvestigate: true })
+    await wrapper.find('.rerun-btn').trigger('click')
+
+    await wrapper.find('.note-input').setValue('  Use fields.order_ref, not order_id.  ')
+    await wrapper.find('.submit-btn').trigger('click')
+
+    expect(wrapper.emitted('reinvestigate')?.[0]).toEqual(['Use fields.order_ref, not order_id.'])
+    // Back to the button, so a second run needs a deliberate click.
+    expect(wrapper.find('.note-input').exists()).toBe(false)
+  })
+
+  it('lets the operator back out without starting a run', async () => {
+    const wrapper = mountPanel({}, { canReinvestigate: true })
+    await wrapper.find('.rerun-btn').trigger('click')
+    await wrapper.find('.cancel-btn').trigger('click')
+
+    expect(wrapper.emitted('reinvestigate')).toBeUndefined()
+    expect(wrapper.find('.rerun-btn').exists()).toBe(true)
+  })
+
+  it('links to settings only for someone who can edit them', async () => {
+    const allowed = mountPanel({}, { canReinvestigate: true, canEditSettings: true })
+    await allowed.find('.rerun-btn').trigger('click')
+    expect(allowed.find('.rerun-scope a').exists()).toBe(true)
+
+    const denied = mountPanel({}, { canReinvestigate: true, canEditSettings: false })
+    await denied.find('.rerun-btn').trigger('click')
+    expect(denied.find('.rerun-scope a').exists()).toBe(false)
+    expect(denied.find('.rerun-scope').text()).toContain('Ticketing settings')
   })
 })

--- a/frontend/src/components/tickets/InvestigationNoteForm.vue
+++ b/frontend/src/components/tickets/InvestigationNoteForm.vue
@@ -1,0 +1,133 @@
+<!--
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<script setup lang="ts">
+/**
+ * A note that steers the next investigation. Used by the L2 approval banner
+ * when rejecting a proposal, and by the investigation panel for a plain
+ * guided re-run — the two differ only in wording and button colour, so the
+ * autofocus, the keyboard shortcuts and the trim live here rather than twice.
+ */
+import { onMounted, ref } from 'vue'
+
+withDefaults(
+  defineProps<{
+    placeholder: string
+    submitLabel: string
+    tone?: 'danger' | 'accent'
+    busy?: boolean
+  }>(),
+  { tone: 'accent', busy: false },
+)
+
+const emit = defineEmits<{
+  (e: 'submit', note: string): void
+  (e: 'cancel'): void
+}>()
+
+const note = ref('')
+const input = ref<HTMLTextAreaElement | null>(null)
+
+onMounted(() => input.value?.focus())
+
+// An empty note is allowed: re-running unchanged is a legitimate thing to
+// want, and the reject flow has always permitted a reason-less rejection.
+const submit = () => emit('submit', note.value.trim())
+</script>
+
+<template>
+  <div class="note-form">
+    <textarea
+      ref="input"
+      v-model="note"
+      class="note-input"
+      :placeholder="placeholder"
+      @keydown.esc.stop="emit('cancel')"
+      @keydown.enter.meta.stop.prevent="submit"
+      @keydown.enter.ctrl.stop.prevent="submit"
+    ></textarea>
+    <slot />
+    <div class="note-actions">
+      <button type="button" class="cancel-btn" @click="emit('cancel')">Cancel</button>
+      <button
+        type="button"
+        class="submit-btn"
+        :class="tone"
+        :disabled="busy"
+        @click="submit"
+      >
+        {{ submitLabel }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.note-form {
+  background: var(--surface);
+  border: 1px solid var(--o08);
+  border-radius: 11px;
+  padding: 12px;
+}
+.note-input {
+  width: 100%;
+  min-height: 68px;
+  resize: vertical;
+  background: var(--bg2);
+  border: 1px solid var(--o10);
+  border-radius: 9px;
+  padding: 9px 11px;
+  color: var(--text);
+  font-size: 12.5px;
+  line-height: 1.5;
+  outline: none;
+}
+.note-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 9px;
+  margin-top: 10px;
+}
+.cancel-btn {
+  padding: 7px 13px;
+  background: var(--o05);
+  border: 1px solid var(--o10);
+  color: var(--muted);
+  border-radius: 9px;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.submit-btn {
+  padding: 7px 15px;
+  border: none;
+  border-radius: 9px;
+  font-size: 12.5px;
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+}
+.submit-btn.danger {
+  background: var(--c-danger);
+  color: var(--on-light, #fff);
+}
+.submit-btn.accent {
+  background: var(--accent-solid);
+  color: var(--on-accent-solid);
+}
+.submit-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/frontend/src/components/tickets/TicketApprovalBanner.vue
+++ b/frontend/src/components/tickets/TicketApprovalBanner.vue
@@ -17,6 +17,7 @@ limitations under the License.
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { InvestigationHypothesis, TicketProposal } from '@/types/ticket'
+import InvestigationNoteForm from './InvestigationNoteForm.vue'
 
 const props = defineProps<{
   proposal: TicketProposal
@@ -30,7 +31,6 @@ const emit = defineEmits<{
 }>()
 
 const isRejecting = ref(false)
-const rejectReason = ref('')
 const reinvestigate = ref(true)
 const isSubmitting = ref(false)
 
@@ -52,9 +52,9 @@ function approve() {
   emit('approve')
 }
 
-function submitReject() {
+function submitReject(reason: string) {
   isSubmitting.value = true
-  emit('reject', rejectReason.value.trim(), reinvestigate.value)
+  emit('reject', reason, reinvestigate.value)
 }
 </script>
 
@@ -102,23 +102,20 @@ function submitReject() {
             Approve &amp; resolve
           </button>
         </template>
-        <div v-else class="reject-form">
-          <textarea
-            v-model="rejectReason"
-            class="reject-input"
-            placeholder="Why is this wrong? Your reason guides the next investigation…"
-          ></textarea>
+        <InvestigationNoteForm
+          v-else
+          placeholder="Why is this wrong? Your note guides the next investigation…"
+          submit-label="Reject proposal"
+          tone="danger"
+          :busy="isSubmitting"
+          @cancel="isRejecting = false"
+          @submit="submitReject"
+        >
           <label class="reinvestigate-row">
             <input v-model="reinvestigate" type="checkbox" />
             Re-run the investigation with this feedback
           </label>
-          <div class="reject-actions">
-            <button class="cancel-btn" @click="isRejecting = false">Cancel</button>
-            <button class="reject-confirm" :disabled="isSubmitting" @click="submitReject">
-              Reject proposal
-            </button>
-          </div>
-        </div>
+        </InvestigationNoteForm>
       </div>
       <div v-else class="banner-sub">
         You don't have permission to approve AI actions on tickets.
@@ -285,29 +282,9 @@ function submitReject() {
   margin-right: 9px;
 }
 .approve-btn:disabled,
-.reject-btn:disabled,
-.reject-confirm:disabled {
+.reject-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-.reject-form {
-  background: var(--surface);
-  border: 1px solid var(--o08);
-  border-radius: 11px;
-  padding: 12px;
-}
-.reject-input {
-  width: 100%;
-  min-height: 68px;
-  resize: vertical;
-  background: var(--bg2);
-  border: 1px solid var(--o10);
-  border-radius: 9px;
-  padding: 9px 11px;
-  color: var(--text);
-  font-size: 12.5px;
-  line-height: 1.5;
-  outline: none;
 }
 .reinvestigate-row {
   display: flex;
@@ -316,31 +293,6 @@ function submitReject() {
   margin-top: 9px;
   font-size: 12px;
   color: var(--text3);
-  cursor: pointer;
-}
-.reject-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 9px;
-  margin-top: 10px;
-}
-.cancel-btn {
-  padding: 7px 13px;
-  background: var(--o05);
-  border: 1px solid var(--o10);
-  color: var(--muted);
-  border-radius: 9px;
-  font-size: 12.5px;
-  cursor: pointer;
-}
-.reject-confirm {
-  padding: 7px 15px;
-  background: var(--c-danger);
-  color: var(--on-light, #fff);
-  border: none;
-  border-radius: 9px;
-  font-size: 12.5px;
-  font-weight: var(--font-weight-semibold);
   cursor: pointer;
 }
 </style>

--- a/frontend/src/components/tickets/TicketInvestigationPanel.vue
+++ b/frontend/src/components/tickets/TicketInvestigationPanel.vue
@@ -15,11 +15,33 @@ limitations under the License.
 -->
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import type { InvestigationDetail } from '@/types/ticket'
 import HypothesisCard from './HypothesisCard.vue'
+import InvestigationNoteForm from './InvestigationNoteForm.vue'
 
-const props = defineProps<{ investigation: InvestigationDetail }>()
+const props = defineProps<{
+  investigation: InvestigationDetail
+  /** Whether this user can start another run right now. */
+  canReinvestigate?: boolean
+  /** Why they can't, shown as a tooltip on the disabled button. */
+  reinvestigateBlockedReason?: string | null
+  /** Gates the deep link to settings, which needs manage_organization. */
+  canEditSettings?: boolean
+}>()
+
+const emit = defineEmits<{ (e: 'reinvestigate', note: string): void }>()
+
+// A guided re-run belongs here rather than only in the L2 approval banner:
+// below autonomy 2 no proposal is ever created, so that banner never renders
+// and an L1 operator had no way to correct a run short of editing the ticket
+// description (#318).
+const isNoting = ref(false)
+
+function submitRerun(note: string) {
+  isNoting.value = false
+  emit('reinvestigate', note)
+}
 
 const run = computed(() => props.investigation.run)
 const isActive = computed(() => ['pending', 'running'].includes(run.value?.status || ''))
@@ -142,10 +164,66 @@ const connectorWarning = computed(() => {
       />
     </div>
     <p v-else-if="!isActive" class="empty-note">No hypotheses were generated in this run.</p>
+
+    <div v-if="canReinvestigate" class="panel-foot">
+      <button
+        v-if="!isNoting"
+        class="rerun-btn"
+        :disabled="!!reinvestigateBlockedReason"
+        :title="reinvestigateBlockedReason || 'Run again with a note telling the AI what to do differently'"
+        @click="isNoting = true"
+      >
+        <font-awesome-icon :icon="['fas', 'rotate-right']" />
+        Re-run with guidance…
+      </button>
+      <template v-else>
+        <InvestigationNoteForm
+          placeholder="What should the AI do differently this time? e.g. &quot;The order id is fields.order_ref, not order_id — search app-logs-* from 14:00 UTC on the 3rd.&quot;"
+          submit-label="Re-run investigation"
+          @cancel="isNoting = false"
+          @submit="submitRerun"
+        />
+        <p class="rerun-scope">
+          Applies to this run only. To tell the AI this every time, put it on the connector under
+          <router-link v-if="canEditSettings" to="/settings/ticketing">Ticketing settings</router-link>
+          <span v-else>Ticketing settings</span>.
+        </p>
+      </template>
+    </div>
   </div>
 </template>
 
 <style scoped>
+.panel-foot {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--o07);
+}
+.rerun-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 14px;
+  background: transparent;
+  border: 1px solid var(--o12);
+  color: var(--text3);
+  border-radius: 10px;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+.rerun-btn:hover:not(:disabled) {
+  color: var(--text);
+}
+.rerun-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.rerun-scope {
+  margin: 8px 0 0;
+  font-size: 11.5px;
+  color: var(--muted);
+  line-height: 1.5;
+}
 .connector-warning__calls {
   margin-top: 6px;
   font-weight: var(--font-weight-semibold);

--- a/frontend/src/views/TicketDetailView.vue
+++ b/frontend/src/views/TicketDetailView.vue
@@ -44,6 +44,12 @@ const {
 
 const canManage = permissionChecks.canManageTickets()
 const canApprove = permissionChecks.canApproveTicketActions()
+// Only gates the deep link to Ticketing settings, which that role owns.
+const canEditSettings = permissionChecks.canManageOrganization()
+
+// Shared by the header's Investigate button and the panel's guided re-run, so
+// the two can't drift into disagreeing about why a run is unavailable.
+const RESOLVED_TOOLTIP = 'This ticket is resolved — reopen it to investigate again'
 
 // The banner shows a pending proposal always; a decided one only while the
 // ticket still reflects that decision (approved → resolved states).
@@ -210,7 +216,7 @@ async function submitResolve() {
                 :disabled="isReopenable"
                 :title="
                   isReopenable
-                    ? 'This ticket is resolved — reopen it to investigate again'
+                    ? RESOLVED_TOOLTIP
                     : 'Run an AI investigation (hypotheses + evidence + RCA)'
                 "
                 @click="investigate()"
@@ -319,6 +325,10 @@ async function submitResolve() {
         <TicketInvestigationPanel
           v-if="investigation?.run"
           :investigation="investigation"
+          :can-reinvestigate="canManage && !hasActiveRun"
+          :reinvestigate-blocked-reason="isReopenable ? RESOLVED_TOOLTIP : null"
+          :can-edit-settings="canEditSettings"
+          @reinvestigate="(note: string) => investigate(note)"
         />
 
         <TicketRcaDoc


### PR DESCRIPTION
Closes the last open item on #318.

The only way to re-run an investigation with feedback lived inside the L2 approval banner's reject flow. Below autonomy 2 no proposal is ever created, so that banner never renders — an L1 operator who watched a run search the wrong index had no way to correct it short of editing the ticket description.

Frontend only. `POST /tickets/{id}/investigate` already accepts `context_note` and `useTicketDetail.investigate(contextNote?)` already forwards it; the Investigate button just called it with no arguments.

- New `InvestigationNoteForm`, extracted from the banner's reject form. Autofocus, Esc to cancel, Cmd/Ctrl+Enter to submit and the trim now live in one place instead of two. The banner keeps its "re-run with this feedback" checkbox through the slot and picks up the keyboard handling for free.
- The investigation panel gets "Re-run with guidance…", under the hypothesis list next to the two states that motivate it — an empty result and a connector warning. It mirrors the header Investigate button's conditions and shares the resolved-ticket tooltip so the two can't drift.
- The scope note says the guidance applies to this run only and points at the connector field for anything permanent. The settings link renders as plain text without `manage_organization`.

An empty note is allowed — re-running unchanged is legitimate, and the reject flow has always permitted a reason-less rejection.

**Verified in the browser.** On an open ticket the form opens focused, Esc closes it, and submitting sends `{"run_type":"investigation","context_note":"The order id is fields.order_ref, not order_id."}` to the right endpoint, trimmed. On a resolved ticket the button is disabled with the same tooltip as Investigate. The banner's reject flow still renders with its checkbox. Both themes check out.

I captured the investigate request rather than letting it fire — that org is on autonomy 3, so a real run could have auto-resolved the ticket and messaged the customer.

14 new tests; 556 passing.