### PR TITLE
Drop the unused torch/transformers stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies. Bump pip's per-request timeout and retry count so
-# the large torch/opencv/onnxruntime wheel downloads survive slow links and the
+# the large opencv/onnxruntime wheel downloads survive slow links and the
 # heavier amd64/x86_64 wheels don't abort with ReadTimeoutError.
 ENV PIP_DEFAULT_TIMEOUT=120
 COPY backend/requirements.txt .
@@ -20,7 +20,7 @@ RUN pip install --no-cache-dir --retries 10 -r requirements.txt
 # Node.js + npx and uv/uvx for STDIO MCP servers (npx @elastic/mcp-server-…,
 # uvx mcp-server-…). Copied from the official images instead of apt, which
 # only ships an EOL Node 18 on bookworm. Kept below the pip layer so an
-# upstream node/uv tag bump can't invalidate the torch-sized wheel cache.
+# upstream node/uv tag bump can't invalidate the cached pip layer.
 COPY --from=node:22-slim /usr/local/bin/node /usr/local/bin/node
 COPY --from=node:22-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
@@ -36,11 +36,7 @@ COPY backend/assets ./assets
 
 # Create required directories including cache directories
 RUN mkdir -p uploads/agents && \
-    mkdir -p .cache/huggingface/transformers && \
-    mkdir -p .cache/huggingface/sentence_transformers && \
     mkdir -p .cache/huggingface/hub && \
-    mkdir -p .cache/torch && \
-    mkdir -p .cache/pytorch_transformers && \
     chmod -R 755 .cache
 
 # Make startup script executable
@@ -51,13 +47,8 @@ ENV PYTHONPATH=/app
 ENV PORT=8000
 # Set HuggingFace cache directories
 ENV HF_HOME=/app/.cache/huggingface
-ENV TRANSFORMERS_CACHE=/app/.cache/huggingface/transformers
-ENV SENTENCE_TRANSFORMERS_HOME=/app/.cache/huggingface/sentence_transformers
 ENV HF_HUB_CACHE=/app/.cache/huggingface/hub
 ENV HF_HUB_DISABLE_TELEMETRY=1
-# Set PyTorch cache directories
-ENV TORCH_HOME=/app/.cache/torch
-ENV PYTORCH_TRANSFORMERS_CACHE=/app/.cache/pytorch_transformers
 
 # Expose the port
 EXPOSE 8000

--- a/Dockerfile.backend.prod
+++ b/Dockerfile.backend.prod
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies. Bump pip's per-request timeout and retry count so
-# the large torch/opencv/onnxruntime wheel downloads survive slow links and the
+# the large opencv/onnxruntime wheel downloads survive slow links and the
 # heavier amd64/x86_64 wheels don't abort with ReadTimeoutError.
 ENV PIP_DEFAULT_TIMEOUT=120
 COPY backend/requirements.txt .
@@ -21,7 +21,7 @@ RUN crawl4ai-setup
 # Node.js + npx and uv/uvx for STDIO MCP servers (npx @elastic/mcp-server-…,
 # uvx mcp-server-…). Copied from the official images instead of apt, which
 # only ships an EOL Node 18 on bookworm. Kept below the pip layer so an
-# upstream node/uv tag bump can't invalidate the torch-sized wheel cache.
+# upstream node/uv tag bump can't invalidate the cached pip layer.
 COPY --from=node:22-slim /usr/local/bin/node /usr/local/bin/node
 COPY --from=node:22-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
@@ -38,11 +38,7 @@ COPY backend/assets ./assets
 # Create required directories including cache directories
 RUN mkdir -p uploads/agents && \
     mkdir -p temp && \
-    mkdir -p .cache/huggingface/transformers && \
-    mkdir -p .cache/huggingface/sentence_transformers && \
     mkdir -p .cache/huggingface/hub && \
-    mkdir -p .cache/torch && \
-    mkdir -p .cache/pytorch_transformers && \
     chmod -R 755 .cache && \
     chmod -R 755 temp
 
@@ -56,13 +52,8 @@ ENV ENVIRONMENT=production
 
 # Set HuggingFace cache directories
 ENV HF_HOME=/app/.cache/huggingface
-ENV TRANSFORMERS_CACHE=/app/.cache/huggingface/transformers
-ENV SENTENCE_TRANSFORMERS_HOME=/app/.cache/huggingface/sentence_transformers
 ENV HF_HUB_CACHE=/app/.cache/huggingface/hub
 ENV HF_HUB_DISABLE_TELEMETRY=1
-# Set PyTorch cache directories
-ENV TORCH_HOME=/app/.cache/torch
-ENV PYTORCH_TRANSFORMERS_CACHE=/app/.cache/pytorch_transformers
 
 # Expose the port
 EXPOSE 8000

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -265,7 +265,6 @@ class Settings(BaseSettings):
     )
 
     # Embedding Model Configuration
-    EMBEDDING_MODEL_ID: str = os.getenv("EMBEDDING_MODEL_ID", "sentence-transformers/all-MiniLM-L6-v2")
     EMBEDDING_BATCH_SIZE: int = int(os.getenv("EMBEDDING_BATCH_SIZE", "32"))
     EMBEDDING_MAX_WORKERS: int = int(os.getenv("EMBEDDING_MAX_WORKERS", "4"))
     

--- a/backend/app/knowledge/crawl4ai_fallback.py
+++ b/backend/app/knowledge/crawl4ai_fallback.py
@@ -29,7 +29,7 @@ try:
     logger.info("✓ Crawl4AI module loaded successfully")
 except ImportError:
     CRAWL4AI_AVAILABLE = False
-    logger.warning("⚠️  Crawl4AI not installed. Install with: pip install crawl4ai>=0.7.0")
+    logger.warning("⚠️  Crawl4AI not installed. Install with: pip install crawl4ai>=0.9")
 
 # Note: We use threading for async compatibility instead of nest_asyncio
 # This avoids conflicts with uvloop and other event loop implementations

--- a/backend/app/knowledge/enhanced_website_reader.py
+++ b/backend/app/knowledge/enhanced_website_reader.py
@@ -692,7 +692,7 @@ class EnhancedWebsiteReader(WebsiteReader):
                         else:
                             logger.warning(f"Crawl4AI extraction failed, keeping BeautifulSoup result")
                     else:
-                        logger.warning(f"⚠️  Crawl4AI not available for JS-heavy site. Install with: pip install crawl4ai>=0.7.0")
+                        logger.warning(f"⚠️  Crawl4AI not available for JS-heavy site. Install with: pip install crawl4ai>=0.9")
                         logger.warning(f"   Falling back to BeautifulSoup (may have incomplete content)")
 
                 # If the content is still a bot-challenge interstitial (the browser
@@ -751,7 +751,7 @@ class EnhancedWebsiteReader(WebsiteReader):
                             else:
                                 logger.error(f"Crawl4AI fallback failed for {current_url}")
                         else:
-                            logger.warning(f"⚠️  Crawl4AI not available. Install with: pip install crawl4ai>=0.7.0")
+                            logger.warning(f"⚠️  Crawl4AI not available. Install with: pip install crawl4ai>=0.9")
                         
                         # Final check
                         if not content or len(content) < self.min_content_length:
@@ -868,7 +868,7 @@ class EnhancedWebsiteReader(WebsiteReader):
                 except Exception as crawl_error:
                     logger.error(f"Crawl4AI fallback error: {str(crawl_error)}", exc_info=True)
             else:
-                logger.warning(f"⚠️  Crawl4AI not available to retry failed request. Install with: pip install crawl4ai>=0.7.0")
+                logger.warning(f"⚠️  Crawl4AI not available to retry failed request. Install with: pip install crawl4ai>=0.9")
             
             # Final failure
             self._failed_crawls += 1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -90,11 +90,7 @@ boto3
 
 groq
 
---extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.8.0+cpu
-transformers==4.57.1
-sentence-transformers==5.1.1
-
+# Embeddings run on fastembed (ONNX); no torch/transformers stack is installed.
 fastembed==0.7.3
 
 # Shopify API
@@ -117,7 +113,8 @@ uv
 httpx
 pyOpenSSL==26.0.0
 cryptography==46.0.3
-crawl4ai>=0.7.0
+# 0.7.x hard-required sentence-transformers (and with it torch); 0.9 dropped that.
+crawl4ai>=0.9
 
 # Help center (public SSR templates + custom-domain DNS verification)
 jinja2

--- a/backend/scripts/preload_models.py
+++ b/backend/scripts/preload_models.py
@@ -18,7 +18,6 @@ limitations under the License.
 import os
 import sys
 import logging
-from pathlib import Path
 
 # Add the app directory to the Python path
 sys.path.insert(0, '/app')
@@ -27,37 +26,8 @@ sys.path.insert(0, '/app')
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
-def preload_sentence_transformer():
-    """Preload the sentence transformer model to avoid runtime issues"""
-    try:
-        from sentence_transformers import SentenceTransformer
-        
-        # Get model ID from environment or use default
-        model_id = os.getenv("EMBEDDING_MODEL_ID", "sentence-transformers/all-MiniLM-L6-v2")
-        
-        logger.info(f"Preloading SentenceTransformer model: {model_id}")
-        
-        # Load the model (this will download it if not cached)
-        model = SentenceTransformer(model_id)
-        
-        # Test the model with a simple embedding to ensure it's working
-        test_text = "This is a test sentence to verify the model is working correctly."
-        embedding = model.encode(test_text)
-        
-        logger.info(f"Successfully preloaded model {model_id}. Embedding dimension: {len(embedding)}")
-        
-        # Clean up to free memory
-        del model
-        del embedding
-        
-        return True
-        
-    except Exception as e:
-        logger.error(f"Failed to preload SentenceTransformer model: {str(e)}")
-        return False
-
 def preload_agno_embedder():
-    """Preload the Agno embedder to ensure it's working"""
+    """Preload the fastembed model agno embeds with"""
     try:
         from agno.embedder.fastembed import FastEmbedEmbedder
         
@@ -86,25 +56,15 @@ def preload_agno_embedder():
         return False
 
 def main():
-    """Main function to preload all models"""
+    """Warm the embedding model cache so the first request does not pay for the download"""
     logger.info("Starting model preloading process...")
-    
-    success = True
-    
-    # Preload SentenceTransformer model
-    if not preload_sentence_transformer():
-        success = False
-    
-    # Preload Agno embedder
+
     if not preload_agno_embedder():
-        success = False
-    
-    if success:
-        logger.info("All models preloaded successfully!")
-        return 0
-    else:
-        logger.error("Some models failed to preload")
+        logger.error("Model preloading failed")
         return 1
+
+    logger.info("All models preloaded successfully!")
+    return 0
 
 if __name__ == "__main__":
     sys.exit(main()) 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -25,13 +25,8 @@ services:
       - LOG_LEVEL=info
       # HuggingFace caching configuration
       - HF_HOME=/app/.cache/huggingface
-      - TRANSFORMERS_CACHE=/app/.cache/huggingface/transformers
-      - SENTENCE_TRANSFORMERS_HOME=/app/.cache/huggingface/sentence_transformers
       - HF_HUB_CACHE=/app/.cache/huggingface/hub
       - HF_HUB_DISABLE_TELEMETRY=1
-      # PyTorch configuration
-      - TORCH_HOME=/app/.cache/torch
-      - PYTORCH_TRANSFORMERS_CACHE=/app/.cache/pytorch_transformers
       # Reduce parallelism to avoid conflicts
       - EMBEDDING_MAX_WORKERS=4
       - KB_MAX_WORKERS=4
@@ -54,7 +49,6 @@ services:
       - ./config:/app/config
       # Add caching volumes for models
       - huggingface_cache:/app/.cache/huggingface
-      - torch_cache:/app/.cache/torch
     healthcheck:
       test: ["CMD", "curl", "-X", "GET", "-f", "http://localhost:8000/health"]
       interval: 10s
@@ -72,13 +66,9 @@ services:
       - PYTHONUNBUFFERED=1
       # HuggingFace caching configuration (shared with backend)
       - HF_HOME=/app/.cache/huggingface
-      - TRANSFORMERS_CACHE=/app/.cache/huggingface/transformers
-      - SENTENCE_TRANSFORMERS_HOME=/app/.cache/huggingface/sentence_transformers
       - HF_HUB_CACHE=/app/.cache/huggingface/hub
       - HF_HUB_DISABLE_TELEMETRY=1
       # PyTorch configuration (shared with backend)
-      - TORCH_HOME=/app/.cache/torch
-      - PYTORCH_TRANSFORMERS_CACHE=/app/.cache/pytorch_transformers
       # Reduce parallelism to avoid conflicts
       - EMBEDDING_MAX_WORKERS=2
       - KB_MAX_WORKERS=2
@@ -101,7 +91,6 @@ services:
       - ./config:/app/config
       # Share the same caching volumes with backend
       - huggingface_cache:/app/.cache/huggingface
-      - torch_cache:/app/.cache/torch
     logging:
       driver: "json-file"
       options:
@@ -208,4 +197,3 @@ volumes:
   temp_data:
   # Add new volumes for model caching
   huggingface_cache:
-  torch_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,13 +32,8 @@ services:
       - ENVIRONMENT=development
       # HuggingFace caching configuration
       - HF_HOME=/app/.cache/huggingface
-      - TRANSFORMERS_CACHE=/app/.cache/huggingface/transformers
-      - SENTENCE_TRANSFORMERS_HOME=/app/.cache/huggingface/sentence_transformers
       - HF_HUB_CACHE=/app/.cache/huggingface/hub
       - HF_HUB_DISABLE_TELEMETRY=1
-      # PyTorch configuration
-      - TORCH_HOME=/app/.cache/torch
-      - PYTORCH_TRANSFORMERS_CACHE=/app/.cache/pytorch_transformers
       # Reduce parallelism to avoid conflicts
       - EMBEDDING_MAX_WORKERS=4
       - KB_MAX_WORKERS=4
@@ -56,7 +51,6 @@ services:
       - backend_assets:/app/assets
       # Add caching volumes for models
       - huggingface_cache:/app/.cache/huggingface
-      - torch_cache:/app/.cache/torch
     depends_on:
       db:
         condition: service_healthy
@@ -89,13 +83,9 @@ services:
       - ENVIRONMENT=development
       # HuggingFace caching configuration (shared with backend)
       - HF_HOME=/app/.cache/huggingface
-      - TRANSFORMERS_CACHE=/app/.cache/huggingface/transformers
-      - SENTENCE_TRANSFORMERS_HOME=/app/.cache/huggingface/sentence_transformers
       - HF_HUB_CACHE=/app/.cache/huggingface/hub
       - HF_HUB_DISABLE_TELEMETRY=1
       # PyTorch configuration (shared with backend)
-      - TORCH_HOME=/app/.cache/torch
-      - PYTORCH_TRANSFORMERS_CACHE=/app/.cache/pytorch_transformers
       # Reduce parallelism to avoid conflicts
       - EMBEDDING_MAX_WORKERS=2
       - KB_MAX_WORKERS=2
@@ -108,7 +98,6 @@ services:
       - ./config:/app/config
       # Share the same caching volumes with backend
       - huggingface_cache:/app/.cache/huggingface
-      - torch_cache:/app/.cache/torch
     depends_on:
       db:
         condition: service_healthy
@@ -227,4 +216,3 @@ volumes:
   backend_assets:
   # Add new volumes for model caching
   huggingface_cache:
-  torch_cache: 


### PR DESCRIPTION
Nothing in the backend imports torch, transformers or sentence-transformers. Embeddings run on fastembed (ONNX) through agno. The only thing touching them was a preload step warming a SentenceTransformer model nothing then used, and a dead `EMBEDDING_MODEL_ID` setting.

Removing them closes the transformers and torch advisories and takes roughly 1.5 GB out of the image. `crawl4ai`'s floor moves to 0.9 because 0.7.x hard-required sentence-transformers and would pull the whole stack back in.

Also drops the now-pointless model cache env vars and the torch cache volume from both Dockerfiles and both compose files. The fastembed cache (`HF_HOME`) stays — that one is still used.

Tested locally: full backend suite, and a boot with none of the three installed. Startup completes and the preload still warms the real embedder. Docker wasn't running here, so the image build itself is unverified.

The enterprise deploy templates still reference the ML stack; that's a separate change in enterprise_backend.
