### PR TITLE
Stop agno evaluating model-supplied field types

### DIFF
--- a/backend/app/utils/agno_eval_guard.py
+++ b/backend/app/utils/agno_eval_guard.py
@@ -1,0 +1,75 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# Runtime guard for the pinned agno==1.7.6 (GHSA-77rh-m34w-rv36, fixed
+# upstream in 2.3.24). Remove this module with the agno 2.x upgrade.
+#
+# agno turns a user-input field's type name back into a Python type by calling
+# eval() on a string it did not produce: in agno.models.base the string is the
+# `field_type` of a `get_user_input` tool call, i.e. text the model wrote, and
+# in agno.tools.function it is read back from a stored run response. A tool
+# named get_user_input is all it takes to reach that eval, and MCP connectors
+# register tools under whatever name the server advertises, so a hostile or
+# prompt-injected connector could run arbitrary Python inside the backend.
+#
+# Both modules look `eval` up as a global name, so binding a module-level `eval`
+# shadows the builtin for those two modules only. The replacement never
+# evaluates anything: it maps a bare builtin type name to the type and refuses
+# everything else.
+
+import agno.models.base
+import agno.tools.function
+
+from app.core.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Every type UserInputField.to_dict can emit (it writes type.__name__). Nothing
+# else was ever a valid field type, so refusing it changes no legitimate path.
+_FIELD_TYPES = {t.__name__: t for t in (str, int, float, bool, list, dict, tuple, set, bytes)}
+
+_GUARDED_MODULES = (agno.models.base, agno.tools.function)
+
+
+class UnsafeFieldTypeError(NameError):
+    """Raised for any field_type that is not a plain builtin type name.
+
+    A NameError on purpose: agno's model loop catches (NameError, SyntaxError)
+    around its eval and falls back to str, so a rejected value degrades exactly
+    the way an unknown name always did — the run continues, nothing executes.
+    """
+
+
+def resolve_field_type(expr, *_args, **_kwargs):
+    """Drop-in for eval() that only ever maps a type name to the type.
+
+    Accepts eval's optional globals/locals so any call shape agno uses works.
+    """
+    if isinstance(expr, str):
+        field_type = _FIELD_TYPES.get(expr.strip())
+        if field_type is not None:
+            return field_type
+    # agno swallows the error and carries on with str, so without this line a
+    # blocked payload would leave no trace at all. Nothing legitimate reaches
+    # here, which makes every one of these worth seeing.
+    logger.warning(f"Blocked an unsafe user-input field type: {expr!r}")
+    raise UnsafeFieldTypeError(f"Unsupported user-input field type: {expr!r}")
+
+
+def install_eval_guard() -> None:
+    """Shadow eval in the agno modules that hand model-supplied text to it."""
+    for module in _GUARDED_MODULES:
+        module.eval = resolve_field_type

--- a/backend/app/utils/agno_patches.py
+++ b/backend/app/utils/agno_patches.py
@@ -46,6 +46,7 @@ limitations under the License.
 from agno.models.base import Model
 
 from app.core.logger import get_logger
+from app.utils.agno_eval_guard import install_eval_guard
 
 logger = get_logger(__name__)
 
@@ -116,6 +117,10 @@ def _strip_tools(self, kwargs: dict) -> dict:
 
 def apply_agno_patches() -> None:
     """Apply all agno runtime patches. Safe to call more than once."""
+    # Idempotent on its own, so it sits before the flag check: the guard must be
+    # in place whichever call reaches here first.
+    install_eval_guard()
+
     if getattr(Model.create_tool_call_limit_error_result, _PATCHED_FLAG, False):
         return
 

--- a/backend/tests/utils/test_agno_eval_guard.py
+++ b/backend/tests/utils/test_agno_eval_guard.py
@@ -1,0 +1,136 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest import mock
+
+import agno.models.base
+import agno.tools.function
+import pytest
+from agno.tools.function import UserInputField
+
+from app.utils.agno_eval_guard import (
+    _FIELD_TYPES,
+    UnsafeFieldTypeError,
+    install_eval_guard,
+    resolve_field_type,
+)
+from app.utils.agno_patches import apply_agno_patches
+
+# What an attacker would put in `field_type`: code, attribute walks to reach
+# builtins, statement smuggling, and the empty/blank strings eval would choke on.
+INJECTIONS = [
+    "__import__('os').system('true')",
+    "str.__class__",
+    "().__class__.__bases__[0]",
+    "int; import os",
+    "os.system",
+    "",
+    "   ",
+]
+
+
+@pytest.fixture(autouse=True)
+def guarded():
+    # Production installs the guard at import of agno_utils; every test here
+    # runs with it in place, exactly like the app does.
+    install_eval_guard()
+
+
+@pytest.mark.parametrize("name, expected", list(_FIELD_TYPES.items()))
+def test_resolves_builtin_type_names(name, expected):
+    assert resolve_field_type(name) is expected
+
+
+def test_tolerates_surrounding_whitespace():
+    assert resolve_field_type("  int\n") is int
+
+
+def test_accepts_the_globals_and_locals_eval_takes():
+    assert resolve_field_type("float", {}, {}) is float
+
+
+@pytest.mark.parametrize("expr", INJECTIONS + [None, 42, int, ["str"]])
+def test_rejects_anything_but_an_allowed_name(expr):
+    with pytest.raises(UnsafeFieldTypeError):
+        resolve_field_type(expr)
+
+
+def test_rejection_is_a_name_error_so_agno_falls_back_to_str():
+    # agno.models.base wraps its eval in `except (NameError, SyntaxError)` and
+    # substitutes str. Subclassing NameError keeps that fallback intact.
+    assert issubclass(UnsafeFieldTypeError, NameError)
+
+
+def test_a_blocked_payload_is_logged(caplog):
+    # agno turns the error into a silent str fallback, so the log line is the
+    # only evidence an injection was attempted.
+    with caplog.at_level("WARNING"), pytest.raises(UnsafeFieldTypeError):
+        resolve_field_type("__import__('os').system('true')")
+
+    assert "Blocked an unsafe user-input field type" in caplog.text
+
+
+def test_a_valid_type_name_logs_nothing(caplog):
+    with caplog.at_level("WARNING"):
+        resolve_field_type("int")
+
+    assert caplog.text == ""
+
+
+def test_nothing_is_executed():
+    with mock.patch("os.system") as system, pytest.raises(UnsafeFieldTypeError):
+        resolve_field_type("__import__('os').system('true')")
+    system.assert_not_called()
+
+
+def test_guard_shadows_eval_in_both_agno_modules():
+    assert agno.models.base.eval is resolve_field_type
+    assert agno.tools.function.eval is resolve_field_type
+
+
+def test_apply_agno_patches_installs_the_guard():
+    for module in (agno.models.base, agno.tools.function):
+        del module.eval
+    apply_agno_patches()
+    assert agno.models.base.eval is resolve_field_type
+    assert agno.tools.function.eval is resolve_field_type
+
+
+def test_install_is_idempotent():
+    install_eval_guard()
+    install_eval_guard()
+    assert agno.tools.function.eval is resolve_field_type
+
+
+def test_from_dict_resolves_a_plain_type_name():
+    field = UserInputField.from_dict(
+        {"name": "quantity", "field_type": "int", "description": None, "value": None}
+    )
+    assert field.field_type is int
+
+
+@pytest.mark.parametrize("field_type", list(_FIELD_TYPES.values()))
+def test_to_dict_from_dict_round_trip(field_type):
+    original = UserInputField(name="f", field_type=field_type, description="d", value=None)
+    assert UserInputField.from_dict(original.to_dict()) == original
+
+
+@pytest.mark.parametrize("expr", INJECTIONS)
+def test_from_dict_refuses_code(expr):
+    payload = {"name": "f", "field_type": expr, "description": None, "value": None}
+    with mock.patch("os.system") as system, pytest.raises(UnsafeFieldTypeError):
+        UserInputField.from_dict(payload)
+    system.assert_not_called()

--- a/backend/tests/utils/test_agno_eval_guard_integration.py
+++ b/backend/tests/utils/test_agno_eval_guard_integration.py
@@ -1,0 +1,107 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest import mock
+
+import pytest
+from agno.models.base import Model
+from agno.tools.function import Function, FunctionCall
+
+from app.utils.agno_eval_guard import resolve_field_type
+from app.utils.agno_patches import apply_agno_patches
+
+# The vulnerable path (GHSA-77rh-m34w-rv36) is agno's own tool-call loop, not
+# our code: it evaluates the field_type of any tool call named get_user_input.
+# The unit tests cover the replacement in isolation; this drives agno's real
+# run_function_calls to prove the guard is actually in the loop's way.
+
+PAYLOAD = "__import__('os').system('touch /tmp/chattermate-agno-rce')"
+
+
+class _StubModel(Model):
+    """Concrete Model — run_function_calls is defined on the base class."""
+
+    def __init__(self):
+        self.id = "stub"
+        self.name = "Stub"
+
+    def invoke(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def ainvoke(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def invoke_stream(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def ainvoke_stream(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def parse_provider_response(self, response, **kwargs):
+        raise NotImplementedError
+
+    def parse_provider_response_delta(self, response):
+        raise NotImplementedError
+
+
+def user_input_call(field_type: str) -> FunctionCall:
+    """The tool call a model (or a hostile MCP server) can ask for."""
+    return FunctionCall(
+        function=Function(name="get_user_input"),
+        arguments={
+            "user_input_fields": [
+                {"field_name": "amount", "field_type": field_type, "field_description": "how many"}
+            ]
+        },
+        call_id="call_1",
+    )
+
+
+def run(function_call: FunctionCall):
+    apply_agno_patches()
+    model = _StubModel()
+    responses = list(model.run_function_calls([function_call], function_call_results=[]))
+    schemas = [
+        field
+        for response in responses
+        for execution in (response.tool_executions or [])
+        for field in (execution.user_input_schema or [])
+    ]
+    return schemas
+
+
+@pytest.mark.parametrize("field_type, expected", [("int", int), ("str", str), ("bool", bool)])
+def test_legitimate_field_types_still_resolve_through_agnos_loop(field_type, expected):
+    schemas = run(user_input_call(field_type))
+
+    assert [field.field_type for field in schemas] == [expected]
+
+
+def test_injected_code_is_not_executed_and_the_run_continues():
+    with mock.patch("os.system") as system:
+        schemas = run(user_input_call(PAYLOAD))
+
+    system.assert_not_called()
+    # agno catches NameError around its eval and falls back to str, so the run
+    # carries on with a harmless type instead of dying or executing anything.
+    assert [field.field_type for field in schemas] == [str]
+
+
+def test_the_guard_is_the_callable_agnos_module_reaches_for():
+    apply_agno_patches()
+    import agno.models.base as agno_base
+
+    assert agno_base.eval is resolve_field_type


### PR DESCRIPTION
agno 1.7.6 passes the `field_type` string of a `get_user_input` tool call straight to `eval()` (GHSA-77rh-m34w-rv36, critical). We never register agno's user-input tools, but MCP connectors register tools under whatever name the server advertises, so a hostile or prompt-injected connector can reach it.

The upstream fix only exists in agno 2.x, which is a migration of its own. Until then the two agno modules that call `eval` get a module-level `eval` that maps a builtin type name to the type and refuses everything else. Rejections raise a `NameError` subclass, which is exactly what agno already catches around that call, so a blocked value degrades to `str` the way an unknown type name always did — the run continues and nothing executes.

Blocked payloads are logged. agno swallows the error, so otherwise an attempt would leave no trace at all.

Tested locally: unit tests for the allow-list and the injection shapes, plus one that drives agno's real `run_function_calls` with a payload and asserts nothing ran. Full backend suite green.

Delete this module with the agno 2.x upgrade, along with `agno_patches.py`.
