### PR TITLE
Backend security dependency upgrades

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,6 +49,7 @@ try:
 except ImportError:
     print("Enterprise models not available")
 from app.api import session_to_agent
+from app.workers.chat_auto_closer import run_auto_closer_loop
 
 logger = get_logger(__name__)
 
@@ -60,7 +61,7 @@ async def lifespan(app: FastAPI):
     verify_encryption_key()
     verify_secret_configuration()
     initialize_firebase()
-    await startup_event()
+    await startup_event(app)
     yield
     # Shutdown
     pass
@@ -84,17 +85,19 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-@app.on_event("startup")
-async def startup_event():
-    """Configure Socket.IO on startup"""
+async def startup_event(api: FastAPI):
+    """Configure Socket.IO on startup. Called from lifespan() with the FastAPI
+    instance; the on_event registration it used to carry never ran once a
+    custom lifespan was set. The module-level `app` is rebound to the Socket.IO
+    ASGI wrapper below, so the instance has to be passed in."""
     configure_socketio(cors_origins)
-    
+
     # Start CORS listener for multi-worker synchronization
     initialize_cors_listener()
-    
-    # Start chat auto-closer background task, AI chat will auto close after 1 day
-    from app.workers.chat_auto_closer import run_auto_closer_loop
-    asyncio.create_task(run_auto_closer_loop())
+
+    # Start chat auto-closer background task, AI chat will auto close after 1 day.
+    # Held on app.state so the task cannot be garbage-collected mid-run.
+    api.state.auto_closer_task = asyncio.create_task(run_auto_closer_loop())
 
 # Include routers
 app.include_router(

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -114,8 +114,10 @@ uv
 
 # Web Crawling
 httpx
-pyOpenSSL==26.0.0
-cryptography==46.0.3
+# pyOpenSSL and cryptography move together: each pyOpenSSL release bounds the
+# cryptography versions it accepts (26.4 needs >=49,<51).
+pyOpenSSL==26.4.0
+cryptography==50.0.1
 # 0.7.x hard-required sentence-transformers (and with it torch); 0.9 dropped that.
 crawl4ai>=0.9
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,9 +1,12 @@
 # Web Framework
-# Pin fastapi/starlette: fastapi 0.138.0 breaks error-handling behavior relied on
-# by the session takeover tests (returns 200/422 instead of 403/404/400/500).
-# fastapi 0.135.1 only requires starlette>=0.46.0 (no upper bound), so pin starlette too.
-fastapi==0.135.1
-starlette==0.52.1
+# fastapi and starlette are pinned for reproducible builds; bump them together and
+# run the API suite. fastapi only requires starlette>=0.46.0 (no upper bound).
+# starlette must stay >=1.3.1: that release enforces the request.form() limits
+# for urlencoded bodies (GHSA-82w8-qh3p-5jfq).
+# (The earlier "fastapi 0.138.0 breaks error handling" note was the takeover
+# tests' route-swap hack becoming live, not a framework regression; the hack is gone.)
+fastapi==0.137.2
+starlette==1.6.0
 uvicorn
 python-socketio
 websockets

--- a/backend/tests/api/test_session_to_agent.py
+++ b/backend/tests/api/test_session_to_agent.py
@@ -17,7 +17,7 @@ limitations under the License.
 import pytest
 from fastapi.testclient import TestClient
 from app.database import get_db
-from fastapi import FastAPI, status, HTTPException, Depends
+from fastapi import FastAPI, status
 from app.models.user import User
 from app.models.role import Role
 from app.models.permission import Permission, role_permissions
@@ -31,7 +31,6 @@ from app.core.auth import get_current_user, require_permissions
 from typing import Generator
 from datetime import datetime
 from app.models.schemas.chat import ChatDetailResponse, CustomerInfo, AgentInfo, Message
-from sqlalchemy.orm import Session
 from tests.conftest import engine, TestingSessionLocal, create_tables, Base
 from app.models.organization import Organization
 from app.repositories.session_to_agent import SessionToAgentRepository
@@ -301,34 +300,21 @@ def mock_chat_response(test_agent, test_customer) -> ChatDetailResponse:
     )
 
 @pytest.fixture
-def client(user_with_manage_chats_permission, mock_chat_response) -> TestClient:
-    """Create test client with mocked dependencies"""
+def client(user_with_manage_chats_permission) -> TestClient:
+    """Create test client with mocked dependencies.
+
+    The takeover endpoint itself is the real one: these tests assert on the
+    status codes it raises (403/404/400/500), so it must not be swapped for a
+    stub. Do not rebuild the sub-router's routes here — the app copied them at
+    include time, and on current FastAPI a late swap would replace the endpoint
+    under test.
+    """
     async def override_get_current_user():
         return user_with_manage_chats_permission
 
-    async def mock_takeover_chat(
-        session_id: str,
-        current_user: User = Depends(get_current_user),
-        db: Session = Depends(get_db)
-    ) -> ChatDetailResponse:
-        # Create a new instance of ChatDetailResponse with the mock data
-        return mock_chat_response
-
     app.dependency_overrides[get_current_user] = override_get_current_user
     app.dependency_overrides[get_db] = lambda: TestingSessionLocal()
-    
-    # Override the takeover_chat endpoint
-    session_to_agent_router.router.routes = [
-        route for route in session_to_agent_router.router.routes 
-        if route.path_format != "/{session_id}/takeover"
-    ]
-    session_to_agent_router.router.add_api_route(
-        "/{session_id}/takeover",
-        mock_takeover_chat,
-        methods=["POST"],
-        response_model=ChatDetailResponse
-    )
-    
+
     return TestClient(app)
 
 @pytest.fixture
@@ -384,24 +370,7 @@ def test_takeover_chat_invalid_session(client, db, user_with_manage_chats_permis
     """Test chat takeover with invalid session ID"""
     # Test takeover with invalid session ID
     invalid_session_id = str(uuid4())
-    
-    # Override the takeover_chat endpoint to raise 404
-    async def mock_takeover_chat(*args, **kwargs):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Chat session not found"
-        )
-    session_to_agent_router.router.routes = [
-        route for route in session_to_agent_router.router.routes 
-        if route.path_format != "/{session_id}/takeover"
-    ]
-    session_to_agent_router.router.add_api_route(
-        "/{session_id}/takeover",
-        mock_takeover_chat,
-        methods=["POST"],
-        response_model=ChatDetailResponse
-    )
-    
+
     response = client.post(
         f"/api/v1/session-to-agent/{invalid_session_id}/takeover"
     )

--- a/backend/tests/api/test_static_mounts.py
+++ b/backend/tests/api/test_static_mounts.py
@@ -1,0 +1,73 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main  # noqa: F401 — the static mounts are added when main is imported
+from app.core.application import app
+
+# Escapes that must never reach a file outside the mounted directory, in the
+# encodings a proxy will happily pass through untouched.
+TRAVERSALS = [
+    "/assets/../requirements.txt",
+    "/assets/%2e%2e/requirements.txt",
+    "/assets/..%2frequirements.txt",
+    "/assets/%2e%2e%2frequirements.txt",
+    "/assets//etc/passwd",
+    "/api/v1/uploads/../requirements.txt",
+]
+
+
+@pytest.fixture(scope="module")
+def client():
+    return TestClient(app)
+
+
+class TestStaticMounts:
+    """The widget bundle is served straight off disk by StaticFiles, so these
+    mounts are the app's only file-serving surface and worth pinning down."""
+
+    def test_widget_bundle_is_served(self, client):
+        response = client.get("/assets/widget.js")
+
+        assert response.status_code == 200
+        assert response.content, "widget.js served empty"
+
+    def test_uploaded_file_is_served(self, client, tmp_path):
+        uploaded = Path("uploads") / "static-mount-probe.txt"
+        uploaded.write_text("probe")
+        try:
+            response = client.get("/api/v1/uploads/static-mount-probe.txt")
+        finally:
+            uploaded.unlink(missing_ok=True)
+
+        assert response.status_code == 200
+        assert response.text == "probe"
+
+    def test_missing_file_is_a_404_not_a_route_fallthrough(self, client):
+        response = client.get("/assets/does-not-exist.js")
+
+        assert response.status_code == 404
+
+    @pytest.mark.parametrize("path", TRAVERSALS)
+    def test_traversal_cannot_escape_the_mounted_directory(self, client, path):
+        response = client.get(path)
+
+        assert response.status_code != 200, f"{path} escaped the mount"
+        assert "fastapi" not in response.text.lower(), f"{path} leaked requirements.txt"

--- a/backend/tests/api/test_webhook_form_limits.py
+++ b/backend/tests/api/test_webhook_form_limits.py
@@ -1,0 +1,120 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main  # noqa: F401 — ensures routers are registered on the FastAPI app
+from app.core.application import app
+from app.core.auth import get_current_user, get_current_organization
+from app.database import get_db
+from app.repositories.channels import ChannelAccountRepository
+
+# Starlette's own defaults for request.form(); a body past either one is refused.
+MAX_FIELDS = 1000
+MAX_FIELD_BYTES = 1024 * 1024
+
+
+@pytest.fixture
+def client(db, test_user, test_organization):
+    async def override_user():
+        return test_user
+
+    async def override_org():
+        return test_organization
+
+    def override_db():
+        yield db
+
+    app.dependency_overrides[get_current_user] = override_user
+    app.dependency_overrides[get_current_organization] = override_org
+    app.dependency_overrides[get_db] = override_db
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def sms_account(db, test_organization):
+    return ChannelAccountRepository(db).create_account(
+        organization_id=test_organization.id, channel_type="sms",
+        external_account_id="+15550001111",
+        credentials={"api_key": "k", "api_secret": "s"},
+        display_name="SMS", settings={"provider": "vonage"})
+
+
+@pytest.fixture
+def email_account(db, test_organization):
+    return ChannelAccountRepository(db).create_account(
+        organization_id=test_organization.id, channel_type="email",
+        external_account_id="support@example.com",
+        credentials={"api_key": "k"},
+        display_name="Email", settings={})
+
+
+def sms_url(account):
+    return f"/api/v1/webhooks/sms/vonage/{account.id}?token={account.webhook_secret}"
+
+
+def email_url(account):
+    return f"/api/v1/webhooks/email/{account.id}?token={account.webhook_secret}"
+
+
+class TestWebhookFormLimits:
+    """Providers post urlencoded bodies to these routes. Starlette enforces the
+    form field-count and field-size caps (it silently ignored them for
+    urlencoded bodies before 1.3.1, which was the DoS). What matters here is the
+    status we answer with: a 5xx tells Twilio and friends to redeliver, so an
+    oversized body has to come back as a 4xx or one bad request becomes a
+    retry storm.
+    """
+
+    def test_normal_form_body_is_still_processed(self, client, sms_account):
+        with patch("app.api.webhooks.sms.process_channel_message", AsyncMock()) as proc:
+            response = client.post(sms_url(sms_account), data={
+                "msisdn": "+44700", "to": sms_account.external_account_id,
+                "text": "hello", "messageId": "m1"})
+
+        assert response.status_code == 200
+        proc.assert_awaited_once()
+        assert proc.await_args.args[1].text == "hello"
+
+    def test_too_many_fields_is_rejected_without_a_retry_signal(self, client, sms_account):
+        payload = {f"f{i}": "v" for i in range(MAX_FIELDS + 500)}
+
+        with patch("app.api.webhooks.sms.process_channel_message", AsyncMock()) as proc:
+            response = client.post(sms_url(sms_account), data=payload)
+
+        assert response.status_code == 400
+        assert response.status_code < 500, "5xx would make the provider redeliver"
+        proc.assert_not_awaited()
+
+    def test_oversized_field_is_rejected(self, client, sms_account):
+        payload = {"text": "x" * (MAX_FIELD_BYTES + 1024)}
+
+        with patch("app.api.webhooks.sms.process_channel_message", AsyncMock()) as proc:
+            response = client.post(sms_url(sms_account), data=payload)
+
+        assert response.status_code == 400
+        proc.assert_not_awaited()
+
+    def test_email_webhook_rejects_an_oversized_body_too(self, client, email_account):
+        payload = {f"f{i}": "v" for i in range(MAX_FIELDS + 500)}
+
+        response = client.post(email_url(email_account), data=payload)
+
+        assert response.status_code == 400

--- a/backend/tests/test_lifespan.py
+++ b/backend/tests/test_lifespan.py
@@ -1,0 +1,50 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.application import app as api
+from app.main import lifespan
+
+
+@pytest.mark.asyncio
+async def test_lifespan_runs_every_startup_step_once():
+    with (
+        patch("app.main.verify_encryption_key") as verify_key,
+        patch("app.main.verify_secret_configuration") as verify_secrets,
+        patch("app.main.initialize_firebase") as init_firebase,
+        patch("app.main.configure_socketio") as configure_socketio,
+        patch("app.main.initialize_cors_listener") as cors_listener,
+        patch("app.main.run_auto_closer_loop", new=AsyncMock()) as auto_closer,
+    ):
+        async with lifespan(api):
+            task = api.state.auto_closer_task
+        await task
+
+    verify_key.assert_called_once_with()
+    verify_secrets.assert_called_once_with()
+    init_firebase.assert_called_once_with()
+    configure_socketio.assert_called_once()
+    cors_listener.assert_called_once_with()
+    auto_closer.assert_awaited_once_with()
+
+
+def test_startup_work_is_not_left_on_the_dead_on_event_list():
+    # Starlette 1.x dropped on_event; FastAPI keeps a compatibility list that a
+    # custom lifespan never runs, so anything registered there is silently dead.
+    assert not api.router.on_startup


### PR DESCRIPTION
starlette 1.6.0 with fastapi 0.137.2, and cryptography 50.0.1 with pyOpenSSL 26.4.0.

starlette >= 1.3.1 is the one that matters: before it, `request.form()`'s field-count and field-size caps were silently ignored for urlencoded bodies, which is exactly what the SMS and email webhooks receive (GHSA-82w8-qh3p-5jfq). pyOpenSSL capped cryptography below 47, so those two have to move together.

starlette 1.x removed `on_event`, and `main.py` had an `@app.on_event("startup")` that had been dead since we set a custom `lifespan` — `lifespan()` already awaited the same function. It's folded in properly now, with the auto-closer task held on `app.state` so it can't be garbage-collected mid-run.

The requirements comment claimed fastapi 0.138 "breaks error handling" in the session-takeover tests. It doesn't. Those tests rebuilt the sub-router's routes with a stub after the app had already copied them: dead code on the old FastAPI, and on a newer one it replaced the very endpoint under test, which is where the 200s and 422s came from. The stub is gone and the tests exercise the real endpoint.

New tests for the surfaces this touches: the webhook form limits, which fail on the old starlette and pass on the new one, and the static mounts including several traversal shapes.

Tested locally: full backend suite, plus a real boot against an isolated database — routes, docs, static files, the Socket.IO handshake, CORS, and Firebase's service-account key parsing under the new cryptography.
