### PR TITLE
Stop re-adding an indexed URL from failing the source

### DIFF
--- a/backend/app/knowledge/enhanced_website_kb.py
+++ b/backend/app/knowledge/enhanced_website_kb.py
@@ -303,7 +303,7 @@ class EnhancedWebsiteKnowledgeBase(AgentKnowledge):
             total_duration = total_end_time - total_start_time
             logger.info(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Completed processing all {len(self.urls)} URLs with immediate embedding (Total time: {total_duration:.2f}s)")
 
-    def _raise_if_nothing_stored(self, total_documents: int) -> None:
+    def _raise_if_nothing_stored(self, total_documents: int, skipped_existing: int = 0) -> None:
         """Fail the run when it indexed nothing.
 
         A zero-page run used to be marked COMPLETED, which made a broken crawl
@@ -322,6 +322,18 @@ class EnhancedWebsiteKnowledgeBase(AgentKnowledge):
                 "“Checking your browser” page). Add the content manually with "
                 "Upload PDF or Text."
             )
+
+        # Every URL was already in the vector store, so there was nothing new to
+        # crawl. That is a no-op, not a failed read: the content is already there
+        # and the caller links this agent to it afterwards. Reporting the crawl
+        # errors here blamed the site ("may require JavaScript") for what was
+        # really a re-add of a source we had already indexed.
+        if skipped_existing > 0 and skipped_existing >= len(self.urls):
+            logger.info(
+                f"Nothing to crawl: all {skipped_existing} URL(s) are already in the "
+                "knowledge base; keeping the existing content."
+            )
+            return
 
         raise EmptyCrawlError(
             f"No content could be read from {self.urls[0] if self.urls else 'this source'}. "
@@ -373,15 +385,17 @@ class EnhancedWebsiteKnowledgeBase(AgentKnowledge):
 
         # Check if URLs exist in vector db
         urls_to_read = self.urls.copy()
+        skipped_existing = 0
         if not recreate and skip_existing:
             try:
                 urls_to_read = [url for url in self.urls if not self.vector_db.name_exists(name=url)]
-                skipped = len(self.urls) - len(urls_to_read)
-                if skipped > 0:
-                    logger.info(f"Skipping {skipped} already loaded URLs")
+                skipped_existing = len(self.urls) - len(urls_to_read)
+                if skipped_existing > 0:
+                    logger.info(f"Skipping {skipped_existing} already loaded URLs")
             except Exception as e:
                 logger.error(f"Error checking existing URLs: {str(e)}")
                 urls_to_read = self.urls.copy()
+                skipped_existing = 0
 
         # Process URLs in parallel with batched vector DB insertion
         total_documents = 0
@@ -532,7 +546,7 @@ class EnhancedWebsiteKnowledgeBase(AgentKnowledge):
 
         # A run that stored nothing is a failure. Raised before the COMPLETED
         # write below so the queue item cannot report success for an empty crawl.
-        self._raise_if_nothing_stored(total_documents)
+        self._raise_if_nothing_stored(total_documents, skipped_existing)
 
         # Mark as completed after all processing is done
         if self.queue_item and self.queue_repo:

--- a/backend/tests/knowledge/test_enhanced_website_kb.py
+++ b/backend/tests/knowledge/test_enhanced_website_kb.py
@@ -21,7 +21,11 @@ from agno.document.base import Document
 from app.core.config import settings
 from app.knowledge.crawl_scope import DEFAULT_CRAWL_SCOPE
 from app.knowledge.enhanced_website_kb import EnhancedWebsiteKnowledgeBase
-from app.knowledge.enhanced_website_reader import EnhancedWebsiteReader
+from app.knowledge.enhanced_website_reader import (
+    BotProtectionError,
+    EmptyCrawlError,
+    EnhancedWebsiteReader,
+)
 
 # Test Data
 TEST_URLS = [
@@ -48,6 +52,9 @@ def mock_reader():
     """Create a mock website reader"""
     mock = MagicMock(spec=EnhancedWebsiteReader)
     mock.read.return_value = TEST_DOCUMENTS
+    # The real reader declares this as an int defaulting to 0; left as a Mock it
+    # is truthy, which would read as "bot protection blocked every page".
+    mock._challenge_blocked = 0
     return mock
 
 class TestEnhancedWebsiteKnowledgeBase:
@@ -113,10 +120,6 @@ class TestEnhancedWebsiteKnowledgeBase:
         reason was marked COMPLETED, making a broken source look identical to a
         healthy one with no sub-pages.
         """
-        from app.knowledge.enhanced_website_reader import (
-            BotProtectionError,
-            EmptyCrawlError,
-        )
         reader = EnhancedWebsiteReader(max_links=5)
         kb = EnhancedWebsiteKnowledgeBase(urls=TEST_URLS, reader=reader)
 
@@ -138,6 +141,30 @@ class TestEnhancedWebsiteKnowledgeBase:
             kb._raise_if_nothing_stored(0)
         # The message names the source so the dashboard error is actionable.
         assert TEST_URLS[0] in str(excinfo.value)
+
+    def test_nothing_stored_because_everything_was_already_indexed(self):
+        """Skipping URLs we already hold is a no-op, not an unreadable source.
+
+        load() drops URLs already in the vector store, so a re-add reaches this
+        guard having stored nothing. Raising there failed the whole source and
+        blamed the site — "may require JavaScript" — for content already indexed.
+        """
+        reader = EnhancedWebsiteReader(max_links=5)
+        reader._challenge_blocked = 0
+        kb = EnhancedWebsiteKnowledgeBase(urls=TEST_URLS, reader=reader)
+
+        # Every URL skipped as already present → nothing to do, no error.
+        kb._raise_if_nothing_stored(0, skipped_existing=len(TEST_URLS))
+
+        # Some URLs were still meant to be read and yielded nothing → real failure.
+        with pytest.raises(EmptyCrawlError):
+            kb._raise_if_nothing_stored(0, skipped_existing=len(TEST_URLS) - 1)
+
+        # Bot protection keeps precedence over the skip shortcut: its message is
+        # the actionable one, and a blocked sitemap must still fail loudly.
+        reader._challenge_blocked = 2
+        with pytest.raises(BotProtectionError):
+            kb._raise_if_nothing_stored(0, skipped_existing=len(TEST_URLS))
     
     def test_document_lists_property(self, mock_reader):
         """Test the document_lists property"""
@@ -217,7 +244,22 @@ class TestEnhancedWebsiteKnowledgeBase:
         
         # Verify upsert was called once with the documents
         mock_vector_db.upsert.assert_called_once()
-    
+
+    def test_load_when_every_url_is_already_indexed(self, mock_vector_db, mock_reader):
+        """Re-adding a source that is fully indexed must not fail it.
+
+        Nothing is crawled and nothing is stored, which used to surface on the
+        queue item as "No content could be read ... may require JavaScript" even
+        though the content was sitting in the vector store the whole time.
+        """
+        kb = EnhancedWebsiteKnowledgeBase(urls=TEST_URLS, reader=mock_reader)
+        kb.vector_db = mock_vector_db
+        mock_vector_db.name_exists.return_value = True
+
+        kb.load(recreate=False)
+
+        mock_reader.read.assert_not_called()
+
     def test_load_with_existing_documents(self, mock_vector_db, mock_reader):
         """Test load method with existing documents"""
         kb = EnhancedWebsiteKnowledgeBase(urls=TEST_URLS, reader=mock_reader)


### PR DESCRIPTION
Re-adding a website source we had already indexed failed the whole source with:

> No content could be read from <url>. The page may be empty, require JavaScript, or be unreachable

Nothing was wrong with the site. `load()` skips URLs already in the vector store, and when that leaves nothing to crawl the run reaches the empty-crawl guard having stored zero documents, so it raised. It fails in about 7ms without a single network request, and the message sends you off investigating JavaScript rendering.

The guard now takes the number of URLs skipped as already indexed. When that accounts for every URL there was nothing to do, so the run keeps the existing content and completes. Bot protection is still checked first and still wins, and a run that meant to read pages and got none still fails exactly as before.

Worth knowing while looking at this: the browser fallback is fine. It extracted ~18k chars on 5 of 5 direct attempts from a site that 403s plain HTTP, and every crawl succeeded once the vector rows were cleared first.

Tested locally: two regression tests that both fail on main; full backend suite; and the real path — first add indexes the page, re-add now completes and keeps the content, where it previously failed 4 out of 4.

Separately and not fixed here: a genuine crawl returned nothing on roughly 2 of 10 live runs against a bot-protected site, taking ~8s. That one's message is accurate and it needs its own look.
