### PR TITLE
Stop 5xx responses carrying our own error text

### DIFF
--- a/backend/app/api/channels/telegram.py
+++ b/backend/app/api/channels/telegram.py
@@ -23,6 +23,7 @@ from app.api.channels.accounts import get_org_account_or_404, to_account_out
 from app.channels import telegram as telegram_api
 from app.core.auth import get_current_organization, require_permissions
 from app.core.config import settings
+from app.core.error_handlers import ClientSafeHTTPException
 from app.database import get_db
 from app.models.channels import ChannelType
 from app.models.organization import Organization
@@ -81,7 +82,7 @@ async def connect_telegram(
         detail = f"Failed to register Telegram webhook: {webhook_error}"
         if "https" in webhook_error.lower():
             detail += " — set BACKEND_URL to a public HTTPS URL (e.g. your ngrok domain)"
-        raise HTTPException(status_code=502, detail=detail)
+        raise ClientSafeHTTPException(status_code=502, detail=detail)
 
     logger.info(f"Connected Telegram bot @{bot.get('username')} for org {organization.id}")
     return to_account_out(db, account)

--- a/backend/app/api/channels/whatsapp_messaging.py
+++ b/backend/app/api/channels/whatsapp_messaging.py
@@ -32,6 +32,7 @@ from sqlalchemy.orm import Session
 from app.api.channels.accounts import get_org_account_or_404
 from app.channels import get_adapter
 from app.channels.meta_base import fetch_message_templates, graph_detail, graph_get
+from app.core.error_handlers import ClientSafeHTTPException
 from app.core.auth import (
     CHAT_MANAGE_PERMISSIONS,
     INBOX_PERMISSIONS,
@@ -82,8 +83,8 @@ async def _fetch_all_templates(waba_id: str, access_token: str) -> list[Template
     owns the HTTP error surface)."""
     ok, data = await fetch_message_templates(waba_id, access_token)
     if not ok:
-        raise HTTPException(status_code=502,
-                            detail=graph_detail(data, "Could not list templates"))
+        raise ClientSafeHTTPException(status_code=502,
+                                     detail=graph_detail(data, "Could not list templates"))
     return [TemplateOut(**template) for template in data]
 
 
@@ -127,7 +128,9 @@ async def start_whatsapp_conversation(
             customer_name=request.customer_name,
         )
     except OutboundError as e:
-        raise HTTPException(status_code=e.status_code, detail=e.detail)
+        # OutboundError details are written for the operator ("Recipient not on
+        # WhatsApp"), so they survive the 5xx sanitizer.
+        raise ClientSafeHTTPException(status_code=e.status_code, detail=e.detail)
     return OutboundConversationOut(session_id=session_id)
 
 
@@ -154,7 +157,7 @@ async def send_whatsapp_template(
         components=request.components,
     )
     if not result.ok:
-        raise HTTPException(status_code=502, detail=result.error or "Template send failed")
+        raise ClientSafeHTTPException(status_code=502, detail=result.error or "Template send failed")
     return {"status": "sent", "external_message_id": result.external_message_id}
 
 

--- a/backend/app/api/help_center_public.py
+++ b/backend/app/api/help_center_public.py
@@ -31,6 +31,7 @@ from sqlalchemy.orm import Session
 
 from app.api.help_center_images import router as help_center_images_router
 from app.core.config import settings
+from app.core.error_handlers import ClientSafeHTTPException, install_error_handlers
 from app.database import get_db
 from app.models.faq import FAQ
 from app.models.help_center import HelpCenterSettings
@@ -73,6 +74,7 @@ from app.services.help_center_seo import (
 from app.services.public_rate_limit import allow_request
 
 public_app = FastAPI(title="ChatterMate Help Center", docs_url=None, redoc_url=None, openapi_url=None)
+install_error_handlers(public_app)
 # Serve ONLY help-center images on this app, so relative logo/article-image paths
 # resolve on a subdomain/custom-domain origin (host dispatch). Scoped to the
 # help_center/ subtree — the help center must never expose chat_attachments,
@@ -331,7 +333,7 @@ async def ask(payload: AskRequest, request: Request, db: Session = Depends(get_d
     # answer_question manages its own short sessions around the slow LLM call.
     answer = await answer_question(row.organization_id, row.agent_id, payload.question)
     if not answer:
-        raise HTTPException(status_code=503, detail="Could not answer right now — please try again.")
+        raise ClientSafeHTTPException(status_code=503, detail="Could not answer right now — please try again.")
     return {"answer": answer}
 
 

--- a/backend/app/core/application.py
+++ b/backend/app/core/application.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 
 from fastapi import FastAPI
+from app.core.error_handlers import install_error_handlers
 from app.core.logger import get_logger
 
 logger = get_logger(__name__)
@@ -25,6 +26,9 @@ app = FastAPI(
     description="AI-Powered Customer Support Platform",
     version="1.0.0"
 )
+
+# 5xx bodies must not carry our own error text; see error_handlers.
+install_error_handlers(app)
 
 def initialize_cors_listener():
     """

--- a/backend/app/core/error_handlers.py
+++ b/backend/app/core/error_handlers.py
@@ -1,0 +1,73 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exception_handlers import http_exception_handler
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.responses import Response
+
+from app.core.logger import get_logger
+
+logger = get_logger(__name__)
+
+# What a 5xx answers with instead of the server's own error text.
+INTERNAL_ERROR_DETAIL = "Internal server error"
+
+
+class ClientSafeHTTPException(HTTPException):
+    """A 5xx whose detail is meant for the caller and holds nothing internal.
+
+    Raise this for a message we wrote ourselves, or an upstream provider's own
+    wording that the operator has to act on — "Recipient not on WhatsApp" is
+    useless in a log and essential on screen. Every other 5xx is assumed to be
+    carrying server internals and has its detail replaced, which is what makes
+    the widespread `detail=str(e)` safe by default.
+    """
+
+
+async def sanitized_http_exception_handler(
+    request: Request, exc: StarletteHTTPException
+) -> Response:
+    """Answer 5xx with a fixed message and keep the real one in the log.
+
+    Routes across the API raise `HTTPException(500, detail=str(e))`, which hands
+    the caller whatever the exception happened to carry — SQL fragments, file
+    paths, connection strings. None of it is actionable for a client, and a 5xx
+    means the fault is ours, so the body gets a constant and the original goes to
+    the log together with the route that produced it.
+
+    4xx detail is written for the caller ("Agent not found", "Invalid token") and
+    is passed through untouched, as is any `ClientSafeHTTPException`.
+    """
+    if exc.status_code < 500 or isinstance(exc, ClientSafeHTTPException):
+        return await http_exception_handler(request, exc)
+
+    logger.error(
+        f"{request.method} {request.url.path} -> {exc.status_code}: {exc.detail}"
+    )
+    return await http_exception_handler(
+        request,
+        StarletteHTTPException(
+            status_code=exc.status_code,
+            detail=INTERNAL_ERROR_DETAIL,
+            headers=exc.headers,
+        ),
+    )
+
+
+def install_error_handlers(app: FastAPI) -> None:
+    """Register the sanitizer. Called for every FastAPI instance we serve."""
+    app.add_exception_handler(StarletteHTTPException, sanitized_http_exception_handler)

--- a/backend/tests/core/test_error_handlers.py
+++ b/backend/tests/core/test_error_handlers.py
@@ -1,0 +1,115 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.core.error_handlers import (
+    INTERNAL_ERROR_DETAIL,
+    ClientSafeHTTPException,
+    install_error_handlers,
+)
+
+# What a leaked `detail=str(e)` looks like in practice: the text carries the
+# connection string, the SQL, the file path — none of it the caller's business.
+LEAKED = 'relation "users" does not exist at postgresql://admin:hunter2@10.0.0.4/app'
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    install_error_handlers(app)
+
+    @app.get("/boom")
+    def boom():
+        raise HTTPException(status_code=500, detail=LEAKED)
+
+    @app.get("/unavailable")
+    def unavailable():
+        raise HTTPException(status_code=503, detail=LEAKED)
+
+    @app.get("/missing")
+    def missing():
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    @app.get("/upstream")
+    def upstream():
+        raise ClientSafeHTTPException(status_code=502, detail="Recipient not on WhatsApp")
+
+    @app.get("/unauthorized")
+    def unauthorized():
+        raise HTTPException(
+            status_code=401, detail="Not authenticated", headers={"WWW-Authenticate": "Bearer"}
+        )
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestSanitizedHttpExceptions:
+    def test_a_500_does_not_hand_the_caller_our_error_text(self, client):
+        response = client.get("/boom")
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == INTERNAL_ERROR_DETAIL
+        assert "postgresql://" not in response.text
+        assert "users" not in response.text
+
+    def test_every_5xx_is_covered_not_just_500(self, client):
+        response = client.get("/unavailable")
+
+        assert response.status_code == 503
+        assert response.json()["detail"] == INTERNAL_ERROR_DETAIL
+
+    def test_the_real_reason_is_logged_with_the_route(self, client, caplog):
+        with caplog.at_level("ERROR"):
+            client.get("/boom")
+
+        assert LEAKED in caplog.text, "the original detail must survive in the log"
+        assert "/boom" in caplog.text, "the log must say which route produced it"
+
+    def test_4xx_detail_is_written_for_the_caller_and_kept(self, client):
+        response = client.get("/missing")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Agent not found"
+
+    def test_4xx_headers_survive(self, client):
+        response = client.get("/unauthorized")
+
+        assert response.status_code == 401
+        assert response.headers["WWW-Authenticate"] == "Bearer"
+        assert response.json()["detail"] == "Not authenticated"
+
+    def test_a_deliberate_5xx_message_still_reaches_the_caller(self, client):
+        # Upstream wording the operator has to act on is useless in a log only.
+        response = client.get("/upstream")
+
+        assert response.status_code == 502
+        assert response.json()["detail"] == "Recipient not on WhatsApp"
+
+    def test_validation_errors_are_untouched(self, client):
+        # 422 bodies name the offending field; they carry nothing internal.
+        app = client.app
+
+        @app.get("/typed")
+        def typed(count: int):
+            return {"count": count}
+
+        response = TestClient(app).get("/typed", params={"count": "not-a-number"})
+
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["loc"] == ["query", "count"]


### PR DESCRIPTION
`detail=str(e)` appears **462 times** across the API, so any 500 hands the caller whatever the exception happened to hold — SQL fragments, file paths, connection strings. CodeQL flags seven of them; patching those seven would close the alerts and leave the pattern everywhere else.

Instead a handler now replaces the detail on any 5xx with a constant and logs the original alongside the route that produced it. 4xx detail is written for the caller and passes through untouched.

Four places deliberately answer 5xx with something the operator has to act on — an upstream Meta message like "Recipient not on WhatsApp", or the help centre's own "please try again" line. Those raise `ClientSafeHTTPException`, which the handler leaves alone. Everything else is sanitized by default, so future `detail=str(e)` is safe without anyone having to remember this.

The handler is installed on both FastAPI apps we serve: the API and the public help centre.

Tested locally: seven new tests covering a sanitized 500, other 5xx codes, the original surviving in the log, 4xx detail and headers passing through, validation errors untouched, and the deliberate-message opt-out. Full backend suite otherwise unchanged.

One follow-up outside this repo: `enterprise/routes/proxy.py` raises two curated 502s ("Website returned empty or invalid content") that this handler will now replace. Switching them to `ClientSafeHTTPException` is a one-line change in enterprise_backend.
