### PR TITLE
Stop returning exception text in 200 responses

### DIFF
--- a/backend/app/api/agent.py
+++ b/backend/app/api/agent.py
@@ -54,6 +54,9 @@ logger = get_logger(__name__)
 UPLOAD_DIR = "uploads/agents"
 
 ALLOWED_MIME_TYPES = {'image/jpeg', 'image/png', 'image/webp'}
+# The stored name's extension comes from the validated content type, never from
+# the caller's filename — nothing user-supplied reaches the path that way.
+MIME_EXTENSIONS = {'image/jpeg': '.jpg', 'image/png': '.png', 'image/webp': '.webp'}
 MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
 
 # Model for instruction generation request
@@ -113,8 +116,7 @@ async def save_file(file: UploadFile, organization_id: UUID) -> str:
             detail="Invalid image file"
         )
 
-    file_ext = os.path.splitext(file.filename)[1].lower()
-    file_name = f"{uuid4()}{file_ext}"
+    file_name = f"{uuid4()}{MIME_EXTENSIONS[file.content_type]}"
     
     if settings.S3_FILE_STORAGE:
         folder = f"agents/{organization_id}"

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -53,6 +53,10 @@ except ImportError:
     HAS_ENTERPRISE = False
 
 router = APIRouter()
+
+# Shown in place of the database error when a source's page table can't be read.
+# The real reason is logged; it must not travel to the caller.
+PAGES_UNREADABLE = "Could not read this source's pages"
 logger = get_logger(__name__)
 
 # Add this near the top of the file with other constants
@@ -838,7 +842,7 @@ async def get_knowledge_by_agent(
 
                 except Exception as e:
                     logger.error(f"Error querying table {k.table_name}: {str(e)}")
-                    knowledge_data["error"] = "Could not read this source's pages"
+                    knowledge_data["error"] = PAGES_UNREADABLE
 
             result.append(knowledge_data)
 
@@ -1058,7 +1062,7 @@ async def get_knowledge_by_organization(
 
                 except Exception as e:
                     logger.error(f"Error querying table {k.table_name}: {str(e)}")
-                    knowledge_data["error"] = "Could not read this source's pages"
+                    knowledge_data["error"] = PAGES_UNREADABLE
 
             result.append(knowledge_data)
 

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -838,7 +838,7 @@ async def get_knowledge_by_agent(
 
                 except Exception as e:
                     logger.error(f"Error querying table {k.table_name}: {str(e)}")
-                    knowledge_data["error"] = f"Error accessing data: {str(e)}"
+                    knowledge_data["error"] = "Could not read this source's pages"
 
             result.append(knowledge_data)
 
@@ -1058,7 +1058,7 @@ async def get_knowledge_by_organization(
 
                 except Exception as e:
                     logger.error(f"Error querying table {k.table_name}: {str(e)}")
-                    knowledge_data["error"] = f"Error accessing data: {str(e)}"
+                    knowledge_data["error"] = "Could not read this source's pages"
 
             result.append(knowledge_data)
 
@@ -1109,7 +1109,7 @@ async def get_queue_status(
 
     except Exception as e:
         logger.error(f"Error getting queue status: {str(e)}")
-        return {"error": str(e)}
+        return {"error": "Could not read the queue status"}
 
 
 @router.get("/processor/status")
@@ -1157,7 +1157,7 @@ async def get_processor_status(
 
     except Exception as e:
         logger.error(f"Error getting processor status: {str(e)}")
-        return {"error": str(e)}
+        return {"error": "Could not read the processor status"}
 
 
 @router.delete("/{knowledge_id}")

--- a/backend/app/api/shopify.py
+++ b/backend/app/api/shopify.py
@@ -1039,7 +1039,7 @@ async def shopify_customers_data_request_webhook(
         logger.error(traceback.format_exc())
         return {
             "success": False,
-            "message": f"Error processing webhook: {str(e)}"
+            "message": "Error processing webhook"
         }
 
 @router.post("/webhooks/customers/redact")
@@ -1127,7 +1127,7 @@ async def shopify_customers_redact_webhook(
         logger.error(traceback.format_exc())
         return {
             "success": False,
-            "message": f"Error processing webhook: {str(e)}"
+            "message": "Error processing webhook"
         }
 
 @router.post("/webhooks/shop/redact")
@@ -1227,5 +1227,5 @@ async def shopify_shop_redact_webhook(
         logger.error(traceback.format_exc())
         return {
             "success": False,
-            "message": f"Error processing webhook: {str(e)}"
+            "message": "Error processing webhook"
         }

--- a/backend/app/core/socketio.py
+++ b/backend/app/core/socketio.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from urllib.parse import urlparse
+
 import socketio
 from socketio import AsyncServer
 from app.core.config import settings
@@ -52,7 +54,12 @@ def configure_socketio(cors_origins=None):
     if settings.REDIS_ENABLED:
         # Use rediss:// protocol if TLS is needed (ElastiCache)
         redis_url = settings.REDIS_URL
-        if redis_url and redis_url.startswith("redis://") and ".cache.amazonaws.com" in redis_url:
+        # Match the host itself: ".cache.amazonaws.com" anywhere in the string would
+        # also accept redis://evil.com/?x=.cache.amazonaws.com.
+        redis_host = urlparse(redis_url).hostname if redis_url else None
+        if redis_url and redis_url.startswith("redis://") and (
+            redis_host or ""
+        ).endswith(".cache.amazonaws.com"):
             redis_url = "rediss://" + redis_url[8:]
             logger.info(f"Using TLS for Redis connection: {redis_url}")
         

--- a/backend/app/core/socketio.py
+++ b/backend/app/core/socketio.py
@@ -24,6 +24,18 @@ from app.core.cors import get_cors_origins
 
 logger = get_logger(__name__)
 
+# ElastiCache endpoints terminate TLS, so a redis:// URL pointing at one has to be
+# upgraded to rediss://. Match the HOST: ".cache.amazonaws.com" anywhere in the
+# string would also accept redis://evil.com/?x=.cache.amazonaws.com.
+ELASTICACHE_HOST_SUFFIX = ".cache.amazonaws.com"
+
+
+def needs_elasticache_tls(redis_url: str | None) -> bool:
+    """True when this plaintext Redis URL points at an ElastiCache host."""
+    if not redis_url or not redis_url.startswith("redis://"):
+        return False
+    return (urlparse(redis_url).hostname or "").endswith(ELASTICACHE_HOST_SUFFIX)
+
 # Initialize Socket.IO server with basic config
 sio: AsyncServer = socketio.AsyncServer(
     async_mode='asgi',
@@ -54,12 +66,7 @@ def configure_socketio(cors_origins=None):
     if settings.REDIS_ENABLED:
         # Use rediss:// protocol if TLS is needed (ElastiCache)
         redis_url = settings.REDIS_URL
-        # Match the host itself: ".cache.amazonaws.com" anywhere in the string would
-        # also accept redis://evil.com/?x=.cache.amazonaws.com.
-        redis_host = urlparse(redis_url).hostname if redis_url else None
-        if redis_url and redis_url.startswith("redis://") and (
-            redis_host or ""
-        ).endswith(".cache.amazonaws.com"):
+        if needs_elasticache_tls(redis_url):
             redis_url = "rediss://" + redis_url[8:]
             logger.info(f"Using TLS for Redis connection: {redis_url}")
         

--- a/backend/tests/api/test_agent_photo_upload.py
+++ b/backend/tests/api/test_agent_photo_upload.py
@@ -1,0 +1,85 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import io
+import os
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException, UploadFile
+from PIL import Image
+
+from app.api.agent import save_file
+
+# A real 1x1 PNG, since save_file verifies the bytes with Pillow before storing.
+def _png_bytes() -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (1, 1)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _upload(filename: str, content_type: str = "image/png") -> UploadFile:
+    return UploadFile(
+        filename=filename,
+        file=io.BytesIO(_png_bytes()),
+        headers={"content-type": content_type},
+    )
+
+
+@pytest.mark.asyncio
+class TestAgentPhotoStoredName:
+    """The stored name must not inherit anything from the caller's filename.
+
+    It used to be `uuid4() + os.path.splitext(file.filename)[1]`, so the caller
+    chose the extension. The name now comes from the content type we already
+    validated, which keeps caller-supplied text out of the path entirely.
+    """
+
+    async def test_extension_comes_from_the_content_type(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with patch("app.api.agent.settings.S3_FILE_STORAGE", False):
+            path = await save_file(_upload("holiday snap.png"), uuid4())
+
+        assert path.endswith(".png")
+
+    async def test_a_lying_extension_is_ignored(self, tmp_path, monkeypatch):
+        # Caller says .php; the bytes and the content type say PNG.
+        monkeypatch.chdir(tmp_path)
+        with patch("app.api.agent.settings.S3_FILE_STORAGE", False):
+            path = await save_file(_upload("shell.php"), uuid4())
+
+        assert path.endswith(".png")
+        assert ".php" not in path
+
+    async def test_traversal_in_the_filename_cannot_reach_the_path(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        organization_id = uuid4()
+        with patch("app.api.agent.settings.S3_FILE_STORAGE", False):
+            path = await save_file(_upload("../../../../etc/passwd.png"), organization_id)
+
+        assert ".." not in path
+        assert path.endswith(".png")
+        # Everything written stays under the organization's own upload folder.
+        assert f"uploads/agents/{organization_id}" in path
+        written = os.path.join("uploads", "agents", str(organization_id))
+        assert len(os.listdir(written)) == 1
+
+    async def test_a_disallowed_content_type_is_refused(self):
+        with pytest.raises(HTTPException) as excinfo:
+            await save_file(_upload("payload.svg", content_type="image/svg+xml"), uuid4())
+
+        assert excinfo.value.status_code == 400

--- a/backend/tests/api/test_knowledge.py
+++ b/backend/tests/api/test_knowledge.py
@@ -35,7 +35,7 @@ from tests.conftest import engine, TestingSessionLocal, create_tables
 from datetime import datetime, timezone
 import io
 import os
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 from unittest.mock import MagicMock
 
 # Set enterprise flag to False
@@ -545,6 +545,33 @@ def test_get_processor_status(client: TestClient):
     assert "is_running" in data
     assert "last_run" in data
     assert "error" in data
+
+
+def test_processor_status_failure_does_not_return_the_exception(client: TestClient):
+    """A failure here used to answer 200 with {"error": str(e)}.
+
+    These routes report on infrastructure, so the exception text is a database
+    or Redis error — connection strings and SQL, handed to whoever asked. The
+    real reason belongs in the log only.
+    """
+    leak = "could not connect to postgresql://admin:hunter2@10.0.0.4/app"
+    with patch("app.api.knowledge.PROCESSOR_STATUS", new_callable=PropertyMock) as status:
+        status.side_effect = RuntimeError(leak)
+        response = client.get("/api/v1/knowledge/processor/status")
+
+    assert response.status_code == 200
+    body = response.text
+    assert "hunter2" not in body
+    assert "postgresql://" not in body
+
+
+def test_queue_status_failure_does_not_return_the_exception(client: TestClient, test_knowledge_queue):
+    leak = "relation \"knowledge_queue\" does not exist"
+    with patch("app.api.knowledge.KnowledgeQueueRepository") as repo:
+        repo.side_effect = RuntimeError(leak)
+        response = client.get(f"/api/v1/knowledge/queue/{test_knowledge_queue.id}")
+
+    assert "does not exist" not in response.text
 
 def test_delete_knowledge(client: TestClient, test_knowledge):
     """Test deleting knowledge"""

--- a/backend/tests/api/test_shopify_gdpr_webhooks.py
+++ b/backend/tests/api/test_shopify_gdpr_webhooks.py
@@ -1,0 +1,103 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.main  # noqa: F401 — registers the shopify router on the app
+from app.core.application import app
+from app.database import get_db
+
+# Shopify's three mandatory GDPR webhooks. They are unauthenticated apart from
+# the HMAC, so what they say on failure is public.
+WEBHOOKS = [
+    "/api/v1/shopify/webhooks/customers/data_request",
+    "/api/v1/shopify/webhooks/customers/redact",
+    "/api/v1/shopify/webhooks/shop/redact",
+]
+
+VALID_PAYLOAD = {
+    "shop_id": 1,
+    "shop_domain": "example.myshopify.com",
+    "customer": {"id": 2, "email": "someone@example.com", "phone": "+15550000000"},
+    "orders_requested": [],
+    "orders_to_redact": [],
+}
+
+
+@pytest.fixture
+def client(db):
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def signed():
+    """Accept the HMAC, so the tests exercise what happens after it."""
+    with patch(
+        "app.api.shopify.ShopifyHelperService.verify_shopify_webhook", return_value=True
+    ) as verify:
+        yield verify
+
+
+@pytest.mark.parametrize("url", WEBHOOKS)
+class TestShopifyGdprWebhooks:
+    def test_an_unsigned_request_is_rejected(self, client, url):
+        with patch(
+            "app.api.shopify.ShopifyHelperService.verify_shopify_webhook", return_value=False
+        ):
+            response = client.post(url, json=VALID_PAYLOAD)
+
+        assert response.status_code == 401
+
+    def test_a_signed_request_is_acknowledged(self, client, signed, url):
+        response = client.post(url, json=VALID_PAYLOAD)
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    def test_malformed_json_is_a_400(self, client, signed, url):
+        response = client.post(
+            url, content=b"{not json", headers={"Content-Type": "application/json"}
+        )
+
+        assert response.status_code == 400
+
+    def test_a_failure_does_not_echo_the_exception(self, client, signed, url):
+        """A JSON array parses fine, then payload.get() raises inside the handler.
+
+        The reply used to be f"Error processing webhook: {str(e)}", handing the
+        caller our exception text on an endpoint that anyone on the internet can
+        reach. Shopify only needs the acknowledgement.
+        """
+        response = client.post(
+            url, content=json.dumps([]).encode(), headers={"Content-Type": "application/json"}
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is False
+        assert body["message"] == "Error processing webhook"
+        # The AttributeError's text must not travel with it.
+        assert "attribute" not in response.text
+        assert "list" not in response.text

--- a/backend/tests/core/test_socketio_redis_tls.py
+++ b/backend/tests/core/test_socketio_redis_tls.py
@@ -1,0 +1,59 @@
+"""
+Copyright 2024-2026 ChatterMate
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+
+from app.core.socketio import needs_elasticache_tls
+
+
+class TestNeedsElasticacheTls:
+    """Whether a plaintext Redis URL points at ElastiCache, so it must be upgraded.
+
+    The old check asked whether ".cache.amazonaws.com" appeared anywhere in the
+    URL, so a host that merely mentioned it in a query string or password passed.
+    """
+
+    @pytest.mark.parametrize("url", [
+        "redis://my-cluster.abc123.ng.0001.euw1.cache.amazonaws.com:6379/0",
+        "redis://cache.amazonaws.com.cache.amazonaws.com:6379",
+    ])
+    def test_real_elasticache_hosts_are_upgraded(self, url):
+        assert needs_elasticache_tls(url) is True
+
+    @pytest.mark.parametrize("url", [
+        # The host is the attacker's; the suffix only appears in the query.
+        "redis://evil.example/?x=.cache.amazonaws.com",
+        # ...or in the password.
+        "redis://user:.cache.amazonaws.com@evil.example:6379/0",
+        # ...or as a path segment.
+        "redis://evil.example:6379/.cache.amazonaws.com",
+        # A lookalike host that merely ends in a similar string.
+        "redis://notcache.amazonaws.com.evil.example:6379",
+    ])
+    def test_a_suffix_elsewhere_in_the_url_does_not_count(self, url):
+        assert needs_elasticache_tls(url) is False
+
+    def test_a_plain_local_redis_is_left_alone(self):
+        assert needs_elasticache_tls("redis://localhost:6379/0") is False
+
+    def test_an_already_tls_url_is_not_upgraded_again(self):
+        assert needs_elasticache_tls(
+            "rediss://my-cluster.euw1.cache.amazonaws.com:6379"
+        ) is False
+
+    @pytest.mark.parametrize("url", [None, "", "not a url"])
+    def test_missing_or_junk_urls_are_handled(self, url):
+        assert needs_elasticache_tls(url) is False


### PR DESCRIPTION
Takes the code scanning page from 12 open alerts to zero: nine fixed here, three dismissed with a reason.

**The seven stack-trace alerts were not covered by the 5xx handler in #332.** Those are ordinary 200 responses, not HTTPExceptions — the knowledge listing puts the database error in a per-source `error` field, the queue and processor status routes return `{"error": str(e)}`, and three Shopify GDPR webhooks echo it back in `message`. Each already logs the real reason, so the text was leaking for nothing. They now return a fixed message.

Two more from the same scan, both worth doing regardless of CodeQL:

- The agent photo's stored name took its extension from the caller's filename. It now comes from the content type validated a few lines above, so nothing caller-supplied reaches the path at all.
- The Redis TLS check matched `.cache.amazonaws.com` anywhere in the URL, which `redis://evil.com/?x=.cache.amazonaws.com` satisfies. It parses the host now.

The three I plan to dismiss rather than fix, once this merges:

- Two in `chattermate-test/server.js` — a local-only static harness, not deployed and not in CI. Rate-limiting and directory exposure are what it is for.
- `py/url-redirection` in `help_center_images.py` — the filename is regex-validated on entry and the redirect target is checked against a prefix allow-list immediately before use. CodeQL doesn't connect either guard.

Tested locally: four new tests on the stored upload name, including a filename claiming `.php` and one with traversal segments. The lying-extension case fails on main. Full backend suite otherwise unchanged.
